### PR TITLE
Fix package loading race condition

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -153,7 +153,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       // exactly "toLoad * 2" times.
       var packageCounter = Object.keys(toLoad).length * 2;
 
-      window.pyodide._module.monitorRunDependencies = (n) => {
+      window.pyodide._module.monitorRunDependencies = () => {
         packageCounter--;
         if (packageCounter === 0) {
           for (let package in toLoad) {


### PR DESCRIPTION
There was a fairly hard-to-reproduce race condition in how packages are loaded.

After the full set of packages to load are resolved, each of them is "loaded" by adding `<script>` elements to the end of the document.  When these package `.js` files are run, the first thing they do is increment a global counter, and call the `monitorRunDependencies` callback.  When each is done, that counter is decremented, and the same `monitorRunDependencies` callback is called.  Our `monitorRunDependencies` callback assumes everything is done (and the Python is ready to call) when that counter reaches 0.  However, in rare cases, the first few packages load and finish before all of the packages have started running, i.e., the counter follows a pattern like "1 2 3 4 5 4 3 2 1 0 1 2 1 0".  There doesn't seem to be a good way to do this reliably given how emscripten's API around this works, so the solution, since we know exactly how many packages we expect to load, is to just wait for the callback to be called exactly `npackages * 2` times.

I'm hoping this will resolve some of the random failures we've seen in CI.

Thanks @acmiyaguchi for finding the bug and helping me find the solution.

Fixes #270.