### PR TITLE
Short-circuit rebuild - first attempt

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -355,12 +355,15 @@ def install_for_distribution(args):
 
 
 def build_wrap(args):
-    build_log_path = Path('build.log')
-    if not build_log_path.is_file():
-        capture_compile(args)
-    clean_out_native_artifacts()
-    replay_compile(args)
-    install_for_distribution(args)
+    if args.only_extras:
+        install_for_distribution(args)
+    else:
+        build_log_path = Path('build.log')
+        if not build_log_path.is_file():
+            capture_compile(args)
+        clean_out_native_artifacts()
+        replay_compile(args)
+        install_for_distribution(args)
 
 
 def make_parser(parser):
@@ -384,6 +387,9 @@ def make_parser(parser):
         parser.add_argument(
             '--target', type=str, nargs='?', default=common.TARGETPYTHON,
             help='The path to the target Python installation')
+        parser.add_argument(
+            '--only_extras', action='store', type=bool, default=False,
+            help='Installs the modified extras skipping the compilation step')
     return parser
 
 


### PR DESCRIPTION
Attempts to fix https://github.com/iodide-project/pyodide/issues/462

Gist of what's done here:

- `needs_partial_rebuild()` function checks if changes occur in the `extras` section of `meta.yaml`
- `patch` and `package_files` functions are modified to include a new argument - `only_extras` and `forced` respectively

- In case a partial rebuild is detected, only the following functions are called:
  * `patch`
  * `package_files`
- The functions `download_and_extract` and `compile` are not called in the shorter rebuild case.

After implementing this, I do notice that `matplotlib.data` and `matplotlib.js` get rebuilt. The modified `extra` files also get copied into the right location.

However, they do not reflect the changes that are done to those `extra` files. Thus, this doesn't work :/

I suspect that this is due to the fact that `compiling` also remakes versions of those `extra` files ending in `*.pyc` (does it really?) (which doesn't happen here I suppose?).

Any further pointers how to proceed from here? @mdboom @rth 

