### PR TITLE
Add altair + dependencies

### DIFF
--- a/packages/altair/meta.yaml
+++ b/packages/altair/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: altair
+  version: 4.0.0
+source:
+  sha256: 92dcd7b84c715f8e02bbdf37e36193a4af8138b5b064c05f237e6ed41573880a
+  url: https://files.pythonhosted.org/packages/00/db/8bb228681b548eea1dbcabb7be42c69ecf32f5e05afdfb8763fa3a66ed7e/altair-4.0.0.tar.gz
+requirements:
+  run:
+    - Jinja2
+    - entrypoints
+    - jsonschema
+    - pandas
+    - toolz
+test:
+  imports:
+  - altair

--- a/packages/entrypoints/meta.yaml
+++ b/packages/entrypoints/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: entrypoints
+  version: '0.3'
+source:
+  sha256: c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451
+  url: https://files.pythonhosted.org/packages/b4/ef/063484f1f9ba3081e920ec9972c96664e2edb9fdc3d8669b0e3b8fc0ad7c/entrypoints-0.3.tar.gz
+test:
+  imports:
+  - entrypoints

--- a/packages/importlib_metadata/meta.yaml
+++ b/packages/importlib_metadata/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: importlib_metadata
+  version: 1.3.0
+source:
+  sha256: 073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45
+  url: https://files.pythonhosted.org/packages/cb/bb/7a935a48bf751af244090a7bd558769942cf13a7eba874b8b25538f3db01/importlib_metadata-1.3.0.tar.gz
+requirements:
+  run:
+  - zipp
+test:
+  imports:
+  - importlib_metadata

--- a/packages/jsonschema/meta.yaml
+++ b/packages/jsonschema/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: jsonschema
+  version: 3.2.0
+source:
+  sha256: c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
+  url: https://files.pythonhosted.org/packages/69/11/a69e2a3c01b324a77d3a7c0570faa372e8448b666300c4117a516f8b1212/jsonschema-3.2.0.tar.gz
+requirements:
+    run:
+      - attrs
+      - importlib_metadata
+      - pyrsistent
+test:
+  imports:
+  - jsonschema

--- a/packages/pyrsistent/meta.yaml
+++ b/packages/pyrsistent/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: pyrsistent
+  version: 0.15.6
+source:
+  sha256: f3b280d030afb652f79d67c5586157c5c1355c9a58dfc7940566e28d28f3df1b
+  url: https://files.pythonhosted.org/packages/6c/6f/c1a2e8da80a0029f6b618d7e20e1a6f2a61dd04e2e54225309c2cc4268f7/pyrsistent-0.15.6.tar.gz
+test:
+  imports:
+  - pyrsistent

--- a/packages/zipp/meta.yaml
+++ b/packages/zipp/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: zipp
+  version: 0.6.0
+source:
+  sha256: 3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e
+  url: https://files.pythonhosted.org/packages/57/dd/585d728479d97d25aeeb9aa470d36a4ad8d0ba5610f84e14770128ce6ff7/zipp-0.6.0.tar.gz
+  requirements:
+    run:
+      - more-itertools
+  test:
+  imports:
+    - zipp


### PR DESCRIPTION
This is not quite complete, as altair is not yet displaying anything in iodide. I don't think this should be that hard, as it's just using vegaEmbed under the hood (which I've gotten working seperately). 

Likely we can just provide a small patch to detect that we're running in an iodide environment, and do something similar to what we do for matplotlib.

This might be useful as a reference:

https://altair-viz.github.io/user_guide/display_frontends.html#working-in-non-notebook-environments