### PR TITLE
Jsfunc decorator (WIP interface, interested in feedback)

### DIFF
--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -398,6 +398,7 @@ def as_nested_list(obj) -> List:
 def jsfunc(func):
     from pyodide_js._module import jsFuncWrapper
     import inspect
+
     sig = inspect.signature(func)
     arg_names = list(sig.parameters.keys())
     code = inspect.getdoc(func)

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 import sys
 from textwrap import dedent
-
+from pyodide_build.testing import run_in_pyodide
 sys.path.append(str(Path(__file__).parents[2] / "src" / "pyodide-py"))
 
 from pyodide import find_imports, eval_code  # noqa: E402
@@ -217,3 +217,26 @@ def test_keyboard_interrupt(selenium):
         `)
         """
     )
+
+@run_in_pyodide
+def test_jsfunc():
+    from pyodide._base import jsfunc
+    def f():
+        x = 2
+        @jsfunc
+        def g(y, z):
+            """
+                x++;
+                return x*y + z;
+            """
+            x # have to mention x in body of function
+
+        def h():
+            return x
+        return [g, h]
+    g, h = f()
+    assert h() == 2
+    assert g(2, 1) == 7
+    assert h() == 3
+    assert g(2, 1) == 9
+    assert h() == 4


### PR DESCRIPTION
This is a WIP toward #973.
This defines a method decorator `jsfunc`. If a function is decorated with `jsfunc`, then its docstring is treated as the source for a javascript function, the actual method body is thrown away. For example:
```python
@jsfunc
def is_promise(obj):
    """
    return Object.prototype.toString.call(obj) === "[object Promise]";
    """
```
In the case where the function uses no closure and no global variables everything works pretty nicely. The global variables will work correctly once #1167 is merged. To get closures to work correctly is a bit more tricky. The setup for the closure is produced at compile time. If the body of the function is just a string, then the compiler will have no way to know that a closure is desired. Currently the following is needed:
```python
from pyodide._base import jsfunc
def f():
    x = 2
    @jsfunc
    def g():
        """return x;"""
        x # have to mention x in body of function
    return g
f()() # ==> 2
```
Another option which is perhaps better would be:
```python
def f():
    # blah blah blah stuff
    @jsfunc
    def g():
         closure_vars(x, y, z) # closure_vars doesn't do anything and doesn't exist, just helps read code
         body("""return x + y + z;""") # body doesn't exist but it prevents dead code elimination
```
It's a bit error prone and annoying having to explicitly list all the variables in the closure, and if `x` is a local variable and also has a global binding either in the python `globals` or `builtins` or on the javascript `globalThis`, then forgetting to `closure_vars` it won't even cause a `ReferenceError`.

In order to avoid the need to do this, we would need to use a procedural macro, which of course do not exist in Python. People have been requesting macros to be added to Python for at least ten years and there is a draft proposal from September PEP 638 to add macros to Python, but it seems likely to be slated for Python 4.0 if it is accepted at all. The discussion about PEP 638 on various programming forms is quite contentious.

We have the option to patch the Python compiler to achieve the same effect of course. I'm not sure if this is desirable (too much complexity probably?), but it sounds fun. 