### PR TITLE
Update to latest (unreleased) emscripten version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ defaults: &defaults
     - EMSDK_NUM_CORES: 4
       EMCC_CORES: 4
       PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/dev/full/
+      PYODIDE_EMSCRIPTEN_VERSION: tot
+      PYODIDE_BINARYEN_VERSION: HEAD
 
 jobs:
   lint:

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -6,7 +6,7 @@ all: emsdk/.complete
 emsdk/.complete: ../Makefile.envs $(wildcard patches/*.patch)
 	if [ -d emsdk ]; then rm -rf emsdk; fi
 	git clone --depth 1 https://github.com/emscripten-core/emsdk.git
-	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
+	cd emsdk && ./emsdk update-tags && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	git clone https://github.com/WebAssembly/binaryen.git emsdk/binaryen
 	cd emsdk/binaryen && git checkout $(PYODIDE_BINARYEN_VERSION)
 	cat patches/*.patch | patch -p1

--- a/emsdk/patches/fix_emulate_pointers_dlsym.patch
+++ b/emsdk/patches/fix_emulate_pointers_dlsym.patch
@@ -1,8 +1,6 @@
-diff --git a/emsdk/binary/src/passes/FuncCastEmulation.cpp b/src/passes/FuncCastEmulation.cpp
-index 9d232c9..60d3990 100644
 --- a/emsdk/binaryen/src/passes/FuncCastEmulation.cpp
 +++ b/emsdk/binaryen/src/passes/FuncCastEmulation.cpp
-@@ -170,23 +170,86 @@ struct FuncCastEmulation : public Pass {
+@@ -171,21 +171,84 @@ struct FuncCastEmulation : public Pass {
        std::stoul(runner->options.getArgumentOrDefault("max-func-params", "16"));
      // we just need the one ABI function type for all indirect calls
      Signature ABIType(Type(std::vector<Type>(numParams, Type::i64)), Type::i64);
@@ -17,13 +15,13 @@ index 9d232c9..60d3990 100644
 +        auto& exportName=function->name;
 +        auto& exportValue=function->value;
 +        // don't create FPCAST emulation for javascript legalizer stubs
-+        // (used when javascript doesn't have 64 bit support, so 
++        // (used when javascript doesn't have 64 bit support, so
 +        // can't use fpcast emulation calls which need 64 bit support)
 +        if(module->getFunctionOrNull(exportValue) && strncmp(exportValue.str,"legalstub$",10)!=0 )
 +        {
 +          Name exportThunkName = std::string("byn$fpcast-emu$") + exportName.str;
-+          auto iter = funcThunks.find(exportValue);          
-+          if (iter == funcThunks.end()) 
++          auto iter = funcThunks.find(exportValue);
++          if (iter == funcThunks.end())
 +          {
 +            // an export without a thunk yet - make it and export it
 +            auto thunk = makeThunk(exportValue, module, numParams);
@@ -38,54 +36,52 @@ index 9d232c9..60d3990 100644
 +     }
 +    int exportCount=0;
 +    // Add a thunk for each function in the table, and do the call through it.
-     for (auto& table : module->tables) {
-       for (auto& segment : table->segments) {
-         for (auto& name : segment.data) {
--          auto iter = funcThunks.find(name);
--          if (iter == funcThunks.end()) {
--            auto thunk = makeThunk(name, module, numParams);
--            funcThunks[name] = thunk;
--            name = thunk;
--          } else {
--            name = iter->second;
-+          // don't create FPCAST emulation for javascript legalizer stubs
-+          // (used when javascript doesn't have 64 bit support, so
-+          // can't use fpcast emulation calls which need 64 bit support)
-+          if(strncmp(name.str,"legalstub$",10)!=0) {
-+            auto iter = funcThunks.find(name);
-+            if (iter == funcThunks.end()) {
-+              // we've already made thunks for exported funcionts so
-+              // this is a static function - make the thunk and make an anon export 
-+              // to it so that it can be called by pyodide
-+              Name orig_name(name);
-+              auto thunk = makeThunk(name, module, numParams);
-+              funcThunks[name] = thunk;
-+              exportCount+=1;
-+              char buffer[256];
-+              snprintf(buffer,256,"byn$fpcast-emu$__static_%d",exportCount);
-+              // first make the fpcast version of the function
-+              auto* export_ = new Export;
-+              export_->name = buffer;
-+              export_->value = thunk;
-+              export_->kind = ExternalKind::Function;
-+              module->addExport(export_);
-+              // now make the non-fpcast version
-+              snprintf(buffer,256,"__static_%d",exportCount);
-+              auto* export2_ = new Export;
-+              export2_->name = buffer;
-+              export2_->value = orig_name;
-+              export2_->kind = ExternalKind::Function;
-+              module->addExport(export2_);
-+              name = thunk;
-+            } else {
-+              name = iter->second;
-+            }
-           }
+     for (auto& segment : module->elementSegments) {
+       for (auto& name : segment->data) {
+-        auto iter = funcThunks.find(name);
+-        if (iter == funcThunks.end()) {
+-          auto thunk = makeThunk(name, module, numParams);
+-          funcThunks[name] = thunk;
+-          name = thunk;
+-        } else {
+-          name = iter->second;
++        // don't create FPCAST emulation for javascript legalizer stubs
++        // (used when javascript doesn't have 64 bit support, so
++        // can't use fpcast emulation calls which need 64 bit support)
++        if(strncmp(name.str,"legalstub$",10)!=0) {
++          auto iter = funcThunks.find(name);
++          if (iter == funcThunks.end()) {
++            // we've already made thunks for exported funcionts so
++            // this is a static function - make the thunk and make an anon export
++            // to it so that it can be called by pyodide
++            Name orig_name(name);
++            auto thunk = makeThunk(name, module, numParams);
++            funcThunks[name] = thunk;
++            exportCount+=1;
++            char buffer[256];
++            snprintf(buffer,256,"byn$fpcast-emu$__static_%d",exportCount);
++            // first make the fpcast version of the function
++            auto* export_ = new Export;
++            export_->name = buffer;
++            export_->value = thunk;
++            export_->kind = ExternalKind::Function;
++            module->addExport(export_);
++            // now make the non-fpcast version
++            snprintf(buffer,256,"__static_%d",exportCount);
++            auto* export2_ = new Export;
++            export2_->name = buffer;
++            export2_->value = orig_name;
++            export2_->kind = ExternalKind::Function;
++            module->addExport(export2_);
++            name = thunk;
++          } else {
++            name = iter->second;
++          }
          }
        }
      }
-
-+    // make exports for all export thunks    
+ 
++    // make exports for all export thunks
 +    for(auto& thunk: exportThunks) {
 +        auto* export_ = new Export;
 +        export_->name = thunk.first;

--- a/emsdk/patches/fix_emulate_pointers_dlsym.patch
+++ b/emsdk/patches/fix_emulate_pointers_dlsym.patch
@@ -1,6 +1,6 @@
 --- a/emsdk/binaryen/src/passes/FuncCastEmulation.cpp
 +++ b/emsdk/binaryen/src/passes/FuncCastEmulation.cpp
-@@ -171,21 +171,84 @@ struct FuncCastEmulation : public Pass {
+@@ -172,19 +172,82 @@ struct FuncCastEmulation : public Pass {
        std::stoul(runner->options.getArgumentOrDefault("max-func-params", "16"));
      // we just need the one ABI function type for all indirect calls
      Signature ABIType(Type(std::vector<Type>(numParams, Type::i64)), Type::i64);
@@ -36,50 +36,48 @@
 +     }
 +    int exportCount=0;
 +    // Add a thunk for each function in the table, and do the call through it.
-     for (auto& segment : module->elementSegments) {
-       for (auto& name : segment->data) {
--        auto iter = funcThunks.find(name);
--        if (iter == funcThunks.end()) {
--          auto thunk = makeThunk(name, module, numParams);
--          funcThunks[name] = thunk;
--          name = thunk;
--        } else {
--          name = iter->second;
-+        // don't create FPCAST emulation for javascript legalizer stubs
-+        // (used when javascript doesn't have 64 bit support, so
-+        // can't use fpcast emulation calls which need 64 bit support)
-+        if(strncmp(name.str,"legalstub$",10)!=0) {
-+          auto iter = funcThunks.find(name);
-+          if (iter == funcThunks.end()) {
-+            // we've already made thunks for exported funcionts so
-+            // this is a static function - make the thunk and make an anon export
-+            // to it so that it can be called by pyodide
-+            Name orig_name(name);
-+            auto thunk = makeThunk(name, module, numParams);
-+            funcThunks[name] = thunk;
-+            exportCount+=1;
-+            char buffer[256];
-+            snprintf(buffer,256,"byn$fpcast-emu$__static_%d",exportCount);
-+            // first make the fpcast version of the function
-+            auto* export_ = new Export;
-+            export_->name = buffer;
-+            export_->value = thunk;
-+            export_->kind = ExternalKind::Function;
-+            module->addExport(export_);
-+            // now make the non-fpcast version
-+            snprintf(buffer,256,"__static_%d",exportCount);
-+            auto* export2_ = new Export;
-+            export2_->name = buffer;
-+            export2_->value = orig_name;
-+            export2_->kind = ExternalKind::Function;
-+            module->addExport(export2_);
-+            name = thunk;
-+          } else {
-+            name = iter->second;
-+          }
-         }
+     ElementUtils::iterAllElementFunctionNames(module, [&](Name& name) {
+-      auto iter = funcThunks.find(name);
+-      if (iter == funcThunks.end()) {
+-        auto thunk = makeThunk(name, module, numParams);
+-        funcThunks[name] = thunk;
+-        name = thunk;
+-      } else {
+-        name = iter->second;
++      // don't create FPCAST emulation for javascript legalizer stubs
++      // (used when javascript doesn't have 64 bit support, so
++      // can't use fpcast emulation calls which need 64 bit support)
++      if(strncmp(name.str,"legalstub$",10)!=0) {
++        auto iter = funcThunks.find(name);
++        if (iter == funcThunks.end()) {
++          // we've already made thunks for exported funcionts so
++          // this is a static function - make the thunk and make an anon export
++          // to it so that it can be called by pyodide
++          Name orig_name(name);
++          auto thunk = makeThunk(name, module, numParams);
++          funcThunks[name] = thunk;
++          exportCount+=1;
++          char buffer[256];
++          snprintf(buffer,256,"byn$fpcast-emu$__static_%d",exportCount);
++          // first make the fpcast version of the function
++          auto* export_ = new Export;
++          export_->name = buffer;
++          export_->value = thunk;
++          export_->kind = ExternalKind::Function;
++          module->addExport(export_);
++          // now make the non-fpcast version
++          snprintf(buffer,256,"__static_%d",exportCount);
++          auto* export2_ = new Export;
++          export2_->name = buffer;
++          export2_->value = orig_name;
++          export2_->kind = ExternalKind::Function;
++          module->addExport(export2_);
++          name = thunk;
++        } else {
++          name = iter->second;
++        }
        }
-     }
+     });
  
 +    // make exports for all export thunks
 +    for(auto& thunk: exportThunks) {


### PR DESCRIPTION
This PR will perpetually be a draft, and when new emscripten releases are made,
a separate PR will do the update and incorporate necessary changes.

The goal is to always keep on top of upstream changes, so that it is easier to
pinpoint breakages. In particular, if a genuine emscripten regression is found,
we can report it and hopefully get it fixed/reverted before it lands in a
release.
