### PR TITLE
DOC Rename repo links under the Pyodide org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 <div align="center">
-  <a href="https://github.com/iodide-project/pyodide">
+  <a href="https://github.com/pyodide/pyodide">
   <img src="./docs/_static/img/pyodide-logo-readme.png" alt="Pyodide">
   </a>
 </div>
 
 
-[![Build Status](https://circleci.com/gh/iodide-project/pyodide.png)](https://circleci.com/gh/iodide-project/pyodide)
+[![Build Status](https://circleci.com/gh/pyodide/pyodide.png)](https://circleci.com/gh/pyodide/pyodide)
 [![Documentation Status](https://readthedocs.org/projects/pyodide/badge/?version=latest)](https://pyodide.readthedocs.io/?badge=latest)
 
 Python with the scientific stack, compiled to WebAssembly.
 
 ## What is Pyodide?
 
-**Pyodide** brings the Python 3.8 runtime to the browser via WebAssembly, along with the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and scikit-learn. The [`packages` directory](https://github.com/iodide-project/pyodide/tree/master/packages) lists over 75 packages which are currently available. In addition it's possible to install pure Python wheels from PyPi.
+**Pyodide** brings the Python 3.8 runtime to the browser via WebAssembly, along with the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and scikit-learn. The [`packages` directory](https://github.com/pyodide/pyodide/tree/master/packages) lists over 75 packages which are currently available. In addition it's possible to install pure Python wheels from PyPi.
 
 **Pyodide** provides transparent conversion of objects between Javascript and Python.
 When used inside a browser, Python has full access to the Web APIs.
@@ -38,7 +38,7 @@ These include:
   documentation.
 - Download a pre-built version from this
   repository's [releases
-  page](https://github.com/iodide-project/pyodide/releases/) and serve its contents with
+  page](https://github.com/pyodide/pyodide/releases/) and serve its contents with
   a web server.
 - [Build Pyodide from source](https://pyodide.org/en/latest/development/building-from-sources.html)
   - Build natively with `make`: primarily for Linux users who want to

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -46,9 +46,9 @@ experience, such as infrastructure or refactoring.
 
 ## Bugs & Issues
 
-We use [Github Issues](https://github.com/iodide-project/pyodide/issues) for
-announcing and discussing bugs and features. Use 
-[this link](https://github.com/iodide-project/pyodide/issues/new) to report a
+We use [Github Issues](https://github.com/pyodide/pyodide/issues) for
+announcing and discussing bugs and features. Use
+[this link](https://github.com/pyodide/pyodide/issues/new) to report a
 bug or issue. We provide a template to give you a guide for how to file
 optimally. If you have the chance, please search the existing issues before
 reporting a bug. It's possible that someone else has already reported your
@@ -74,7 +74,7 @@ to bring those changes into the source repository.
 Please make pull requests against the `master` branch.
 
 If you’re looking for a way to jump in and contribute, our list of
-[good first issues](https://github.com/iodide-project/pyodide/labels/good%20first%20issue)
+[good first issues](https://github.com/pyodide/pyodide/labels/good%20first%20issue)
 is a great place to start.
 
 If you’d like to fix a currently-filed issue, please take a look at the comment

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -146,11 +146,11 @@ Extra arguments to pass to the linker when building for WebAssembly.
 
 #### `build/library`
 
-Should be set to true for library packages. Library packages are packages that are needed for other packages but are not Python packages themselves. For library packages, the script specified in the `build/script` section is run to compile the library. See the [zlib meta.yaml](https://github.com/iodide-project/pyodide/blob/master/packages/zlib/meta.yaml) for an example of a library package specification.
+Should be set to true for library packages. Library packages are packages that are needed for other packages but are not Python packages themselves. For library packages, the script specified in the `build/script` section is run to compile the library. See the [zlib meta.yaml](https://github.com/pyodide/pyodide/blob/master/packages/zlib/meta.yaml) for an example of a library package specification.
 
 #### `build/sharedlibrary`
 
-Should be set to true for shared library packages. Shared library packages are packages that are needed for other packages, but are loaded dynamically when Pyodide is run. For shared library packages, the script specified in the `build/script` section is run to compile the library. The script should build the shared library and copy into into a subfolder of the source folder called `install`. Files or folders in this install folder will be packaged to make the Pyodide package. See the [CLAPACK meta.yaml](https://github.com/iodide-project/pyodide/blob/master/packages/CLAPACK/meta.yaml) for an example of a shared library specification.
+Should be set to true for shared library packages. Shared library packages are packages that are needed for other packages, but are loaded dynamically when Pyodide is run. For shared library packages, the script specified in the `build/script` section is run to compile the library. The script should build the shared library and copy into into a subfolder of the source folder called `install`. Files or folders in this install folder will be packaged to make the Pyodide package. See the [CLAPACK meta.yaml](https://github.com/pyodide/pyodide/blob/master/packages/CLAPACK/meta.yaml) for an example of a shared library specification.
 
 #### `build/script`
 

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -5,7 +5,7 @@ The Python scientific stack, compiled to WebAssembly.
 Pyodide brings the Python runtime to the browser via WebAssembly, along with
 the Python scientific stack including NumPy, Pandas, Matplotlib, parts of
 SciPy, and NetworkX. The [packages
-directory](https://github.com/iodide-project/pyodide/tree/master/packages)
+directory](https://github.com/pyodide/pyodide/tree/master/packages)
 lists over 75 packages which are currently available. In addition it's possible
 to install pure Python wheels from PyPi.
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,97 +15,97 @@ substitutions:
 ### Improvements to package loading and dynamic linking
 - {{ Enhancement }} Uses the emscripten preload plugin system to preload .so files in packages
 - {{ Enhancement }} Support for shared library packages. This is used for CLAPACK which makes scipy a lot smaller.
-  [#1236](https://github.com/iodide-project/pyodide/pull/1236)
+  [#1236](https://github.com/pyodide/pyodide/pull/1236)
 - {{ Fix }} Pyodide and included packages can now be used with Safari v14+.
   Safari v13 has also been observed to work on some (but not all) devices.
 
 ### Python / JS type conversions
 - {{ Feature }} A `JsProxy` of a Javascript `Promise` or other awaitable object is now a
   Python awaitable.
-  [#880](https://github.com/iodide-project/pyodide/pull/880)
+  [#880](https://github.com/pyodide/pyodide/pull/880)
 - {{ API }} Instead of automatically converting Python lists and dicts into Javascript, they
   are now wrapped in `PyProxy`. Added a new `toJs` API to `PyProxy` to request the
   conversion behavior that used to be implicit.
-  [#1167](https://github.com/iodide-project/pyodide/pull/1167)
+  [#1167](https://github.com/pyodide/pyodide/pull/1167)
 - {{ API }} Added `JsProxy.to_py` API to convert a Javascript object to Python.
-  [#1244](https://github.com/iodide-project/pyodide/pull/1244)
+  [#1244](https://github.com/pyodide/pyodide/pull/1244)
 - {{ Feature }} Flexible jsimports: it now possible to add custom Python
   "packages" backed by Javascript code, like the `js` package.  The `js` package
   is now implemented using this system.
-  [#1146](https://github.com/iodide-project/pyodide/pull/1146)
+  [#1146](https://github.com/pyodide/pyodide/pull/1146)
 - {{ Feature }} A `PyProxy` of a Python coroutine or awaitable is now an awaitable Javascript
   object. Awaiting a coroutine will schedule it to run on the Python event loop
   using `asyncio.ensure_future`.
-  [#1170](https://github.com/iodide-project/pyodide/pull/1170)
+  [#1170](https://github.com/pyodide/pyodide/pull/1170)
 - {{ Feature }} A `JsProxy` of a Javascript `Promise` or other awaitable object is now a
   Python awaitable.
-  [#880](https://github.com/iodide-project/pyodide/pull/880)
+  [#880](https://github.com/pyodide/pyodide/pull/880)
 - {{ Enhancement }} Made `PyProxy` of an iterable Python object an iterable Js object: defined the
   `[Symbol.iterator]` method, can be used like `for(let x of proxy)`.
   Made a `PyProxy` of a Python iterator an iterator: `proxy.next()` is
   translated to `next(it)`.
   Made a `PyProxy` of a Python generator into a Javascript generator:
   `proxy.next(val)` is translated to `gen.send(val)`.
-  [#1180](https://github.com/iodide-project/pyodide/pull/1180)
+  [#1180](https://github.com/pyodide/pyodide/pull/1180)
 - Updated `PyProxy` so that if the wrapped Python object supports `__getitem__`
   access, then the wrapper has `get`, `set`, `has`, and `delete` methods which do
   `obj[key]`, `obj[key] = val`, `key in obj` and `del obj[key]` respectively.
-  [#1175](https://github.com/iodide-project/pyodide/pull/1175)
+  [#1175](https://github.com/pyodide/pyodide/pull/1175)
 - {{ API }} The `pyodide.pyimport` function is deprecated in favor of using
-  `pyodide.globals.get('key')`. [#1367](https://github.com/iodide-project/pyodide/pull/1367)
+  `pyodide.globals.get('key')`. [#1367](https://github.com/pyodide/pyodide/pull/1367)
 - {{ API }} Added `PyProxy.getBuffer` API to allow direct access to Python
   buffers as Javascript TypedArrays.
-  [1215](https://github.com/iodide-project/pyodide/pull/1215)
+  [1215](https://github.com/pyodide/pyodide/pull/1215)
 
 ### Fixed
 - {{ Fix }} getattr and dir on JsProxy now report consistent results and include all
   names defined on the Python dictionary backing JsProxy.
-  [#1017](https://github.com/iodide-project/pyodide/pull/1017)
+  [#1017](https://github.com/pyodide/pyodide/pull/1017)
 - {{ Fix }} `JsProxy.__bool__` now produces more consistent results: both
   `bool(window)` and `bool(zero-arg-callback)` were `False` but now are `True`.
   Conversely, `bool(empty_js_set)` and `bool(empty_js_map)` were `True` but now
   are `False`.
-  [#1061](https://github.com/iodide-project/pyodide/pull/1061)
+  [#1061](https://github.com/pyodide/pyodide/pull/1061)
 - {{ Fix }} When calling a Javascript function from Python without keyword
   arguments, Pyodide no longer passes a `PyProxy`-wrapped `NULL` pointer as the
-  last argument. [#1033](https://github.com/iodide-project/pyodide/pull/1033)
+  last argument. [#1033](https://github.com/pyodide/pyodide/pull/1033)
 - {{ Fix }} JsBoundMethod is now a subclass of JsProxy, which fixes nested
   attribute access and various other strange bugs.
-  [#1124](https://github.com/iodide-project/pyodide/pull/1124)
+  [#1124](https://github.com/pyodide/pyodide/pull/1124)
 - {{ Fix }} Javascript functions imported like `from js import fetch` no longer
   trigger "invalid invocation" errors (issue
-  [#461](https://github.com/iodide-project/pyodide/issues/461)) and
+  [#461](https://github.com/pyodide/pyodide/issues/461)) and
   `js.fetch("some_url")` also works now (issue
-  [#768](https://github.com/iodide-project/pyodide/issues/461)).
-  [#1126](https://github.com/iodide-project/pyodide/pull/1126)
+  [#768](https://github.com/pyodide/pyodide/issues/461)).
+  [#1126](https://github.com/pyodide/pyodide/pull/1126)
 - {{ Fix }} Javascript bound method calls now work correctly with keyword arguments.
-  [#1138](https://github.com/iodide-project/pyodide/pull/1138)
+  [#1138](https://github.com/pyodide/pyodide/pull/1138)
 
 ### pyodide-py package
 
 - {{ Feature }} Added an `InteractiveConsole` with completion support to ease
   the integration of Pyodide REPL in webpages (used in console.html)
-  [#1125](https://github.com/iodide-project/pyodide/pull/1125) and
-  [#1155](https://github.com/iodide-project/pyodide/pull/1155)
+  [#1125](https://github.com/pyodide/pyodide/pull/1125) and
+  [#1155](https://github.com/pyodide/pyodide/pull/1155)
 - {{ Feature }} Added a Python event loop to support asyncio by scheduling
   coroutines to run as jobs on the browser event loop. This event loop is
   available by default and automatically enabled by any relevant asyncio API,
   so for instance `asyncio.ensure_future` works without any configuration.
-  [#1158](https://github.com/iodide-project/pyodide/pull/1158)
+  [#1158](https://github.com/pyodide/pyodide/pull/1158)
 - {{ API }} Removed `as_nested_list` API in favor of `JsProxy.to_py`.
-  [#1345](https://github.com/iodide-project/pyodide/pull/1345)
+  [#1345](https://github.com/pyodide/pyodide/pull/1345)
 
 
 ### pyodide-js
 
 - {{ API }} Removed iodide-specific code in `pyodide.js`. This breaks compatibility with
   iodide.
-  [#878](https://github.com/iodide-project/pyodide/pull/878),
-  [#981](https://github.com/iodide-project/pyodide/pull/981)
+  [#878](https://github.com/pyodide/pyodide/pull/878),
+  [#981](https://github.com/pyodide/pyodide/pull/981)
 - {{ API }} Removed the `pyodide.autocomplete` API, use Jedi directly instead.
-  [#1066](https://github.com/iodide-project/pyodide/pull/1066)
+  [#1066](https://github.com/pyodide/pyodide/pull/1066)
 - {{ API }} Removed `pyodide.repr` API.
-  [#1067](https://github.com/iodide-project/pyodide/pull/1067)
+  [#1067](https://github.com/pyodide/pyodide/pull/1067)
 - {{ Fix }} If `messageCallback` and `errorCallback` are supplied to
   `pyodide.loadPackage`, `pyodide.runPythonAsync` and
   `pyodide.loadPackagesFromImport`, then the messages are no longer
@@ -113,24 +113,24 @@ substitutions:
 - {{ Feature }} `runPythonAsync` now runs the code with `eval_code_async`. In
   particular, it is possible to use top level `await` inside of `runPythonAsync`.
 - `eval_code` now accepts separate `globals` and `locals` parameters.
-  [#1083](https://github.com/iodide-project/pyodide/pull/1083)
+  [#1083](https://github.com/pyodide/pyodide/pull/1083)
 - Added the `pyodide.setInterruptBuffer` API. This can be used to set a
   `SharedArrayBuffer` to be the keyboard interupt buffer. If Pyodide is running
   on a webworker, the main thread can signal to the webworker that it should
   raise a `KeyboardInterrupt` by writing to the interrupt buffer.
-  [#1148](https://github.com/iodide-project/pyodide/pull/1148) and
-  [#1173](https://github.com/iodide-project/pyodide/pull/1173)
+  [#1148](https://github.com/pyodide/pyodide/pull/1148) and
+  [#1173](https://github.com/pyodide/pyodide/pull/1173)
 
 ### micropip
 
 - {{ Feature }} `micropip` now supports installing wheels from relative URLs.
-  [#872](https://github.com/iodide-project/pyodide/pull/872)
+  [#872](https://github.com/pyodide/pyodide/pull/872)
 - {{ API }} `micropip.install` now returns a Python `Future` instead of a Javascript `Promise`.
 
 ### Build system
 
 - {{ Enhancement }} Updated to latest emscripten 2.0.13 with the updstream LLVM backend
-  [#1102](https://github.com/iodide-project/pyodide/pull/1102)
+  [#1102](https://github.com/pyodide/pyodide/pull/1102)
 - {{ API }} Use upstream `file_packager.py`, and stop checking package abi versions.
   The `PYODIDE_PACKAGE_ABI` environment variable is no longer used, but is
   still set as some packages use it to detect whether it is being built for
@@ -138,30 +138,30 @@ substitutions:
   is introduced for this purpose.
 
   As part of the change, Module.checkABI is no longer present.
-  [#991](https://github.com/iodide-project/pyodide/pull/991)
+  [#991](https://github.com/pyodide/pyodide/pull/991)
 - uglifyjs and lessc no longer need to be installed in the system during build
-  [#878](https://github.com/iodide-project/pyodide/pull/878).
+  [#878](https://github.com/pyodide/pyodide/pull/878).
 - {{ Enhancement }} Reduce the size of the core Pyodide package
-  [#987](https://github.com/iodide-project/pyodide/pull/987).
+  [#987](https://github.com/pyodide/pyodide/pull/987).
 
 ### REPL
 
 - {{ Fix }} In console.html: sync behavior, full stdout/stderr support, clean namespace,
   bigger font, correct result representation, clean traceback
-  [#1125](https://github.com/iodide-project/pyodide/pull/1125) and
-  [#1141](https://github.com/iodide-project/pyodide/pull/1141)
+  [#1125](https://github.com/pyodide/pyodide/pull/1125) and
+  [#1141](https://github.com/pyodide/pyodide/pull/1141)
 - {{ Fix }} Switched from ̀Jedi to rlcompleter for completion in
   `pyodide.console.InteractiveConsole` and so in `console.html`. This fixes
   some completion issues (see
-  [#821](https://github.com/iodide-project/pyodide/issues/821) and
-  [#1160](https://github.com/iodide-project/pyodide/issues/1160)
+  [#821](https://github.com/pyodide/pyodide/issues/821) and
+  [#1160](https://github.com/pyodide/pyodide/issues/1160)
 
 ### Packages
 
 - six, jedi and parso are no longer vendored in the main Pyodide package, and
   need to be loaded explicitly
-  [#1010](https://github.com/iodide-project/pyodide/pull/1010),
-  [#987](https://github.com/iodide-project/pyodide/pull/987).
+  [#1010](https://github.com/pyodide/pyodide/pull/1010),
+  [#987](https://github.com/pyodide/pyodide/pull/987).
 - Updated packages: bleach 3.3.0, packaging 20.8
 
 
@@ -181,60 +181,60 @@ by 0.16.1 with identical contents.
 ### Python and the standard library
 
 - Pyodide includes CPython 3.8.2
-  [#712](https://github.com/iodide-project/pyodide/pull/712)
+  [#712](https://github.com/pyodide/pyodide/pull/712)
 - ENH Patches for the threading module were removed in all packages. Importing
   the module, and a subset of functionality (e.g. locks) works, while starting
   a new thread will produce an exception, as expected.
-  [#796](https://github.com/iodide-project/pyodide/pull/796).
-  See [#237](https://github.com/iodide-project/pyodide/pull/237) for the current
+  [#796](https://github.com/pyodide/pyodide/pull/796).
+  See [#237](https://github.com/pyodide/pyodide/pull/237) for the current
   status of the threading support.
 - ENH The multiprocessing module is now included, and will not fail at import,
   thus avoiding the necessity to patch included packages. Starting a new
   process will produce an exception due to the limitation of the WebAssembly VM
   with the following message: `Resource temporarily unavailable`
-  [#796](https://github.com/iodide-project/pyodide/pull/796).
+  [#796](https://github.com/pyodide/pyodide/pull/796).
 
 ### Python / JS type conversions
 
 - FIX Only call `Py_INCREF()` once when proxied by PyProxy
-  [#708](https://github.com/iodide-project/pyodide/pull/708)
+  [#708](https://github.com/pyodide/pyodide/pull/708)
 - Javascript exceptions can now be raised and caught in Python. They are
   wrapped in pyodide.JsException.
-  [#891](https://github.com/iodide-project/pyodide/pull/891)
+  [#891](https://github.com/pyodide/pyodide/pull/891)
 
 ### pyodide-py package and micropip
 
 - The `pyodide.py` file was transformed to a pyodide-py package. The imports
   remain the same so this change is transparent to the users
-  [#909](https://github.com/iodide-project/pyodide/pull/909).
+  [#909](https://github.com/pyodide/pyodide/pull/909).
 - FIX Get last version from PyPi when installing a module via micropip
-  [#846](https://github.com/iodide-project/pyodide/pull/846).
+  [#846](https://github.com/pyodide/pyodide/pull/846).
 - Suppress REPL results returned by `pyodide.eval_code` by adding a semicolon
-  [#876](https://github.com/iodide-project/pyodide/pull/876).
+  [#876](https://github.com/pyodide/pyodide/pull/876).
 - Enable monkey patching of `eval_code` and `find_imports` to customize
   behavior of `runPython` and `runPythonAsync`
-  [#941](https://github.com/iodide-project/pyodide/pull/941).
+  [#941](https://github.com/pyodide/pyodide/pull/941).
 
 ### Build system
 
 - Updated docker image to Debian buster, resulting in smaller images.
-  [#815](https://github.com/iodide-project/pyodide/pull/815)
+  [#815](https://github.com/pyodide/pyodide/pull/815)
 - Pre-built docker images are now available as
   [`iodide-project/pyodide`](https://hub.docker.com/r/iodide/pyodide)
-  [#787](https://github.com/iodide-project/pyodide/pull/787)
+  [#787](https://github.com/pyodide/pyodide/pull/787)
 - Host Python is no longer compiled, reducing compilation time. This also
   implies that Python 3.8 is now required to build Pyodide. It can for instance
   be installed with conda.
-  [#830](https://github.com/iodide-project/pyodide/pull/830)
+  [#830](https://github.com/pyodide/pyodide/pull/830)
 - FIX Infer package tarball directory from source URL
-  [#687](https://github.com/iodide-project/pyodide/pull/687)
+  [#687](https://github.com/pyodide/pyodide/pull/687)
 - Updated to emscripten 1.38.44 and binaryen v86 (see related
-  [commits](https://github.com/iodide-project/pyodide/search?q=emscripten&type=commits))
+  [commits](https://github.com/pyodide/pyodide/search?q=emscripten&type=commits))
 - Updated default `--ldflags` argument to `pyodide_build` scripts to equal what
   Pyodide actually uses.
-  [#817](https://github.com/iodide-project/pyodide/pull/480)
+  [#817](https://github.com/pyodide/pyodide/pull/480)
 - Replace C lz4 implementation with the (upstream) Javascript implementation.
-  [#851](https://github.com/iodide-project/pyodide/pull/851)
+  [#851](https://github.com/pyodide/pyodide/pull/851)
 - Pyodide deployment URL can now be specified with the `PYODIDE_BASE_URL`
   environment variable during build. The `pyodide_dev.js` is no longer
   distributed. To get an equivalent behavior with `pyodide.js`, set
@@ -242,18 +242,18 @@ by 0.16.1 with identical contents.
   window.languagePluginUrl = './';
   ```
   before loading it.
-  [#855](https://github.com/iodide-project/pyodide/pull/855)
+  [#855](https://github.com/pyodide/pyodide/pull/855)
 - Build runtime C libraries (e.g. libxml) via package build system with correct
   dependency resolution
-  [#927](https://github.com/iodide-project/pyodide/pull/927)
+  [#927](https://github.com/pyodide/pyodide/pull/927)
 - Pyodide can now be built in a conda virtual environment
-  [#835](https://github.com/iodide-project/pyodide/pull/835)
+  [#835](https://github.com/pyodide/pyodide/pull/835)
 
 ### Other improvements
 
 - Modifiy MEMFS timestamp handling to support better caching. This in
   particular allows to import newly created Python modules without invalidating
-  import caches [#893](https://github.com/iodide-project/pyodide/pull/893)
+  import caches [#893](https://github.com/pyodide/pyodide/pull/893)
 
 ### Packages
 - New packages: freesasa, lxml, python-sat, traits, astropy, pillow,
@@ -272,7 +272,7 @@ by 0.16.1 with identical contents.
 ### Backward incompatible changes
 
 - Dropped support for loading .wasm files with incorrect MIME type, following
-  [#851](https://github.com/iodide-project/pyodide/pull/851)
+  [#851](https://github.com/pyodide/pyodide/pull/851)
 
 
 ### List of contributors

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -11,7 +11,7 @@ To include Pyodide in your project you can use the following CDN URL,
   https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/pyodide.js
 
 You can also download a release from
-[Github releases](https://github.com/iodide-project/pyodide/releases)
+[Github releases](https://github.com/pyodide/pyodide/releases)
 (or build it yourself), include its contents in your distribution, and import
 the `pyodide.js` file there from a `<script>` tag. See the following section on
 {ref}`serving_pyodide_packages` for more details.

--- a/packages/CLAPACK/patches/0005-remove-redundant-symbols.patch
+++ b/packages/CLAPACK/patches/0005-remove-redundant-symbols.patch
@@ -3,7 +3,7 @@ ported in scipy. It wouldn't be an issue if we were linking dynamically, but
 because of static linking otherwise we get errors at link time about symbols
 defined twice.
 
- - Roman Yurchak (https://github.com/iodide-project/pyodide/pull/238)
+ - Roman Yurchak (https://github.com/pyodide/pyodide/pull/238)
 diff --git a/Makefile.orig b/Makefile
 index 223f4da..69ac630 100644
 --- a/SRC/Makefile

--- a/packages/README.md
+++ b/packages/README.md
@@ -9,4 +9,4 @@ There are two categories of packages,
     root folder.
 
 Packages of the second category will be migrated to use a `meta.yaml` in the
-future (see [#713](https://github.com/iodide-project/pyodide/issues/713)).
+future (see [#713](https://github.com/pyodide/pyodide/issues/713)).

--- a/packages/micropip/micropip/setup.py
+++ b/packages/micropip/micropip/setup.py
@@ -8,6 +8,6 @@ setup(
     description="A small version of pip for running in pyodide",
     author="Michael Droettboom",
     author_email="mdroettboom@mozilla.com",
-    url="https://github.com/iodide-project/pyodide",
+    url="https://github.com/pyodide/pyodide",
     py_modules=["micropip"],
 )

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1145,10 +1145,10 @@ JsMethod_jsnew(PyObject* o, PyObject* args, PyObject* kwargs)
 }
 
 // clang-format off
-PyMethodDef JsMethod_jsnew_MethodDef = { 
+PyMethodDef JsMethod_jsnew_MethodDef = {
   "new",
   (PyCFunction)JsMethod_jsnew,
-  METH_VARARGS | METH_KEYWORDS 
+  METH_VARARGS | METH_KEYWORDS
 };
 // clang-format on
 
@@ -1268,7 +1268,7 @@ JsBuffer_cinit(PyObject* obj)
       PyExc_RuntimeError,
       "Unknown typed array type '%s'. This is a problem with Pyodide, please "
       "open an issue about it here: "
-      "https://github.com/iodide-project/pyodide/issues/new",
+      "https://github.com/pyodide/pyodide/issues/new",
       typename);
     free(typename);
     FAIL();


### PR DESCRIPTION
Checking the situation with CI following the org migration in https://github.com/pyodide/pyodide/issues/1217