### PR TITLE
MAINT Improve error handling

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -14,6 +14,9 @@ const JsRef Js_true = ((JsRef)(4));
 const JsRef Js_false = ((JsRef)(6));
 const JsRef Js_null = ((JsRef)(8));
 
+// For when the return value would be Option<JsRef>
+const JsRef Js_novalue = ((JsRef)(1000));
+
 JsRef
 hiwire_bool(bool boolean)
 {

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -44,6 +44,9 @@ extern const JsRef Js_true;
 extern const JsRef Js_false;
 extern const JsRef Js_null;
 
+// For when the return value would be Option<JsRef>
+extern const JsRef Js_novalue;
+
 #define hiwire_CLEAR(x)                                                        \
   do {                                                                         \
     hiwire_decref(x);                                                          \

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -131,7 +131,7 @@ static PyObject*
 JsProxy_GetAttr(PyObject* self, PyObject* attr)
 {
   PyObject* result = PyObject_GenericGetAttr(self, attr);
-  if (result != NULL) {
+  if (result != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError)) {
     return result;
   }
   PyErr_Clear();
@@ -1145,10 +1145,10 @@ JsMethod_jsnew(PyObject* o, PyObject* args, PyObject* kwargs)
 }
 
 // clang-format off
-PyMethodDef JsMethod_jsnew_MethodDef = { 
+PyMethodDef JsMethod_jsnew_MethodDef = {
   "new",
   (PyCFunction)JsMethod_jsnew,
-  METH_VARARGS | METH_KEYWORDS 
+  METH_VARARGS | METH_KEYWORDS
 };
 // clang-format on
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -279,7 +279,10 @@ _pyproxy_getitem(PyObject* pyobj, JsRef idkey)
 
   success = true;
 finally:
-  PyErr_Clear();
+  if (!success && (PyErr_ExceptionMatches(PyExc_KeyError) ||
+                   PyErr_ExceptionMatches(PyExc_IndexError))) {
+    PyErr_Clear();
+  }
   Py_CLEAR(pykey);
   Py_CLEAR(pyresult);
   if (!success) {

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -156,10 +156,16 @@ TEMP_EMJS_HELPER(() => {0, /* Magic, see comment */
      * @returns The Javascript object resulting from the conversion.
      */
     toJs(depth = -1) {
-      let idresult = _python2js_with_depth(_getPtr(this), depth);
-      let result = Module.hiwire.get_value(idresult);
-      Module.hiwire.decref(idresult);
-      return result;
+      let idresult;
+      try {
+        idresult = _python2js_with_depth(_getPtr(this), depth);
+      } catch (e) {
+        Module.fatal_error(e);
+      }
+      if (idresult === 0) {
+        _pythonexc2js();
+      }
+      return Module.hiwire.pop_value(idresult);
     }
     apply(jsthis, jsargs) {
       return Module.callPyObject(_getPtr(this), ...jsargs);

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -228,19 +228,24 @@ finally:
 }
 
 /**
- * Return x if x is not NULL.
+ * if x is NULL, fail
+ * if x is Js_novalue, do nothing
+ * in any other case, return x
  */
-#define RETURN_IF_SUCCEEDS(x)                                                  \
+#define RETURN_IF_HAS_VALUE(x)                                                 \
   do {                                                                         \
     JsRef _fresh_result = x;                                                   \
-    if (_fresh_result != NULL) {                                               \
+    FAIL_IF_NULL(_fresh_result);                                               \
+    if (_fresh_result != Js_novalue) {                                         \
       return _fresh_result;                                                    \
     }                                                                          \
   } while (0)
 
 /**
  * Convert x if x is an immutable python type for which there exists an
- * equivalent immutable Javascript type. Otherwise return NULL.
+ * equivalent immutable Javascript type. Otherwise return Js_novalue.
+ *
+ * Return type would be Option<JsRef>
  */
 static inline JsRef
 _python2js_immutable(PyObject* x)
@@ -258,12 +263,14 @@ _python2js_immutable(PyObject* x)
   } else if (PyUnicode_Check(x)) {
     return _python2js_unicode(x);
   }
-  return NULL;
+  return Js_novalue;
 }
 
 /**
  * If x is a wrapper around a Javascript object, unwrap the Javascript object
- * and return it. Otherwise, return NULL.
+ * and return it. Otherwise, return Js_novalue.
+ *
+ * Return type would be Option<JsRef>
  */
 static inline JsRef
 _python2js_proxy(PyObject* x)
@@ -273,7 +280,7 @@ _python2js_proxy(PyObject* x)
   } else if (JsException_Check(x)) {
     return JsException_AsJs(x);
   }
-  return NULL;
+  return Js_novalue;
 }
 
 /**
@@ -283,11 +290,8 @@ _python2js_proxy(PyObject* x)
 static JsRef
 _python2js_deep(PyObject* x, PyObject* cache, int depth)
 {
-  RETURN_IF_SUCCEEDS(_python2js_immutable(x));
-  FAIL_IF_ERR_OCCURRED();
-  RETURN_IF_SUCCEEDS(_python2js_proxy(x));
-  FAIL_IF_ERR_OCCURRED();
-
+  RETURN_IF_HAS_VALUE(_python2js_immutable(x));
+  RETURN_IF_HAS_VALUE(_python2js_proxy(x));
   if (PyList_Check(x) || PyTuple_Check(x)) {
     return _python2js_sequence(x, cache, depth);
   }
@@ -297,8 +301,9 @@ _python2js_deep(PyObject* x, PyObject* cache, int depth)
   if (PySet_Check(x)) {
     return _python2js_set(x, cache, depth);
   }
-  RETURN_IF_SUCCEEDS(_python2js_buffer(x));
-  PyErr_Clear();
+  if (PyObject_CheckBuffer(x)) {
+    return _python2js_buffer(x);
+  }
   return pyproxy_new(x);
 finally:
   return NULL;
@@ -379,11 +384,9 @@ finally:
 JsRef
 python2js(PyObject* x)
 {
-  RETURN_IF_SUCCEEDS(_python2js_immutable(x));
-  FAIL_IF_ERR_OCCURRED();
-  RETURN_IF_SUCCEEDS(_python2js_proxy(x));
-  FAIL_IF_ERR_OCCURRED();
-  RETURN_IF_SUCCEEDS(pyproxy_new(x));
+  RETURN_IF_HAS_VALUE(_python2js_immutable(x));
+  RETURN_IF_HAS_VALUE(_python2js_proxy(x));
+  RETURN_IF_HAS_VALUE(pyproxy_new(x));
 finally:
   if (PyErr_Occurred()) {
     if (!PyErr_ExceptionMatches(conversion_error)) {
@@ -418,7 +421,7 @@ python2js_with_depth(PyObject* x, int depth)
     hiwire_decref(obj);
   }
   Py_DECREF(cache);
-  if (result == NULL) {
+  if (result == NULL || result == Js_novalue) {
     if (PyErr_Occurred()) {
       if (!PyErr_ExceptionMatches(conversion_error)) {
         _PyErr_FormatFromCause(conversion_error,

--- a/src/core/python2js_buffer.c
+++ b/src/core/python2js_buffer.c
@@ -460,7 +460,6 @@ _python2js_buffer(PyObject* x)
 {
   PyObject* memoryview = PyMemoryView_FromObject(x);
   if (memoryview == NULL) {
-    PyErr_Clear();
     return NULL;
   }
 


### PR DESCRIPTION
I added a separate reserved hiwire value `Js_novalue` to use as a `None` result when the return value would be `Option<JsRef>` (as distinct from `NULL` which indicates an error). 

Mostly it's bad to say:
```py
try:
    # something
except: # catch anything!
    # handling code
```
and uses of `PyErr_Clear()` that aren't guarded by a conditional that checks if `PyErr_ExceptionMatches` a certain type of error are equivalent to this. We mostly don't do this already, but I fixed a few cases where we did. Also, I moved the buffer conversion behind a check for permission with `PyObject_CheckBuffer` so that we can throw an error when the buffer conversion fails rather than falling back to returning a `PyProxy`. This should make it easier to discover programming errors in our buffer conversion code.