### PR TITLE
MNT Update gitter channel name + smaller executioners in CI when possible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,6 @@ workflows:
             - test-packages-firefox
             - test-core-chrome
             - test-emsdk
-            - build-docs
           filters:
             branches:
               ignore: /.*/
@@ -337,7 +336,6 @@ workflows:
             - test-packages-firefox
             - test-core-chrome
             - test-emsdk
-            - build-docs
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ defaults: &defaults
 jobs:
   lint:
     <<: *defaults
+    resource_class: small
     steps:
       - checkout
 
@@ -41,6 +42,7 @@ jobs:
 
   build-docs:
     working_directory: ~/repo
+    resource_class: small
 
     docker:
       - image: cimg/python:3.8.2-node
@@ -225,6 +227,8 @@ jobs:
           path: /root/repo/build/benchmarks.json
 
   deploy-release:
+    resource_class: small
+
     docker:
       - image: cibuilds/github:0.13
 
@@ -255,6 +259,8 @@ jobs:
             aws s3api put-bucket-website --cli-input-json file://.circleci/s3-website-config.json
 
   deploy-s3:
+    resource_class: small
+
     docker:
       - image: circleci/python:3.7.7
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
 
   test-docs:
     working_directory: ~/repo
+    resource_class: small
 
     docker:
       - image: cimg/python:3.8.2-node
@@ -39,29 +40,6 @@ jobs:
       - run:
           name: Test docs
           command: pytest docs/sphinx_pyodide/tests
-
-  build-docs:
-    working_directory: ~/repo
-    resource_class: small
-
-    docker:
-      - image: cimg/python:3.8.2-node
-
-    steps:
-      - checkout
-
-      - run:
-          name: Install prerequisites
-          command: |
-            pip install -r docs/requirements-doc.txt
-            sudo npm install -g jsdoc
-
-      - run:
-          name: Build docs
-          command: python3 -m sphinx -M html docs docs/_build
-
-      - store_artifacts:
-          path: /home/circleci/repo/docs/_build/
 
   build-core:
     <<: *defaults
@@ -197,6 +175,7 @@ jobs:
 
   test-emsdk:
     <<: *defaults
+    resource_class: small
     steps:
       - attach_workspace:
           at: .
@@ -206,6 +185,7 @@ jobs:
 
   test-python:
     <<: *defaults
+    resource_class: small
     steps:
       - checkout
       - run:
@@ -288,7 +268,6 @@ workflows:
     jobs:
       - lint
       - test-docs
-      - build-docs
       - build-core:
           filters:
             tags:

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -150,7 +150,6 @@ clarification on what is and isn't permitted.
 
 ## Get in Touch
 
-- __Gitter:__ Pyodide currently shares the
-  [#iodide](https://gitter.im/iodide-project/iodide) channel over at gitter.im
+- __Gitter:__ [#pyodide](https://gitter.im/pyodide/community) channel at gitter.im
 
 [tl;drLegal entry]:https://tldrlegal.com/license/mozilla-public-license-2.0-(mpl-2)


### PR DESCRIPTION
A few maintenance changes,
 - Update Gitter channel name to https://gitter.im/pyodide/community
 - Use small (1 CPU, 2GB) instead of medium (2CPU, 4GB RAM) for executioners for CircleCI jobs when it doesn't matter https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes to save a bit of CI credits
 - Use ReadTheDocs for pre-rendering docs instead of CircleCI ~~(need to check if it works)~~, which tests exactly the same setup as for documentation deployment.