### PR TITLE
MAINT Dump traceback on fatal error

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -188,6 +188,22 @@ EM_JS_NUM(errcode, error_handling_init_js, (), {
   return 0;
 })
 
+PyObject*
+cause_fatal_error(PyObject* mod, PyObject* _args)
+{
+  EM_ASM(throw new Error("intentionally triggered fatal error!"););
+  Py_UNREACHABLE();
+}
+
+static PyMethodDef methods[] = {
+  {
+    "cause_fatal_error",
+    cause_fatal_error,
+    METH_NOARGS,
+  },
+  { NULL } /* Sentinel */
+};
+
 int
 error_handling_init(PyObject* core_module)
 {
@@ -204,6 +220,7 @@ error_handling_init(PyObject* core_module)
   // ConversionError is public
   FAIL_IF_MINUS_ONE(
     PyObject_SetAttrString(core_module, "ConversionError", conversion_error));
+  FAIL_IF_MINUS_ONE(PyModule_AddFunctions(core_module, methods));
 
   FAIL_IF_MINUS_ONE(error_handling_init_js());
 

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -189,7 +189,7 @@ EM_JS_NUM(errcode, error_handling_init_js, (), {
 })
 
 PyObject*
-cause_fatal_error(PyObject* mod, PyObject* _args)
+trigger_fatal_error(PyObject* mod, PyObject* _args)
 {
   EM_ASM(throw new Error("intentionally triggered fatal error!"););
   Py_UNREACHABLE();
@@ -197,8 +197,8 @@ cause_fatal_error(PyObject* mod, PyObject* _args)
 
 static PyMethodDef methods[] = {
   {
-    "cause_fatal_error",
-    cause_fatal_error,
+    "trigger_fatal_error",
+    trigger_fatal_error,
     METH_NOARGS,
   },
   { NULL } /* Sentinel */

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -414,8 +414,9 @@ globalThis.languagePluginLoader = (async () => {
     console.error("The cause of the fatal error was:")
     console.error(e);
     try {
+      let fd_stdout = 1;
       pyodide._module.__Py_DumpTraceback(
-          1, pyodide._module._PyGILState_GetThisThreadState());
+          fd_stdout, pyodide._module._PyGILState_GetThisThreadState());
       for (let [key, value] of Object.entries(Module.public_api)) {
         if (key.startsWith("_")) {
           // delete Module.public_api[key];

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -411,7 +411,8 @@ globalThis.languagePluginLoader = (async () => {
     }
     fatal_error_occurred = true;
     console.error(fatal_error_msg);
-    console.error("The cause of the fatal error was:\n", e);
+    console.error("The cause of the fatal error was:")
+    console.error(e);
     try {
       pyodide._module.__Py_DumpTraceback(
           1, pyodide._module._PyGILState_GetThisThreadState());

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -413,6 +413,8 @@ globalThis.languagePluginLoader = (async () => {
     console.error(fatal_error_msg);
     console.error("The cause of the fatal error was:\n", e);
     try {
+      pyodide._module.__Py_DumpTraceback(
+          1, pyodide._module._PyGILState_GetThisThreadState());
       for (let [key, value] of Object.entries(Module.public_api)) {
         if (key.startsWith("_")) {
           // delete Module.public_api[key];

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -481,12 +481,12 @@ def test_fatal_error(selenium_standalone):
             The cause of the fatal error was:
             {}
             Stack (most recent call first):
-            File "<exec>", line 8 in h
-            File "<exec>", line 6 in g
-            File "<exec>", line 4 in f
-            File "<exec>", line 9 in <module>
-            File "/lib/python3.8/site-packages/pyodide/_base.py", line 242 in run
-            File "/lib/python3.8/site-packages/pyodide/_base.py", line 344 in eval_code
+              File "<exec>", line 8 in h
+              File "<exec>", line 6 in g
+              File "<exec>", line 4 in f
+              File "<exec>", line 9 in <module>
+              File "/lib/python3.8/site-packages/pyodide/_base.py", line 242 in run
+              File "/lib/python3.8/site-packages/pyodide/_base.py", line 344 in eval_code
             """
         ).strip()
     )

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -450,3 +450,43 @@ def test_restore_state(selenium):
             import c
         """
     )
+
+
+@pytest.mark.skip_refcount_check
+def test_fatal_error(selenium_standalone):
+    assert selenium_standalone.run_js(
+        """
+        try {
+            pyodide.runPython(`
+                from _pyodide_core import trigger_fatal_error
+                def f():
+                    g()
+                def g():
+                    h()
+                def h():
+                    trigger_fatal_error()
+                f()
+            `);
+        } catch(e){
+            return e.toString();
+        }
+        """
+    )
+    assert (
+        selenium_standalone.logs
+        == dedent(
+            """
+            Python initialization complete
+            Pyodide has suffered a fatal error, refresh the page. Please report this to the Pyodide maintainers.
+            The cause of the fatal error was:
+            {}
+            Stack (most recent call first):
+            File "<exec>", line 8 in h
+            File "<exec>", line 6 in g
+            File "<exec>", line 4 in f
+            File "<exec>", line 9 in <module>
+            File "/lib/python3.8/site-packages/pyodide/_base.py", line 242 in run
+            File "/lib/python3.8/site-packages/pyodide/_base.py", line 344 in eval_code
+            """
+        ).strip()
+    )


### PR DESCRIPTION
Also added a `cause_fatal_error` method to trigger a fatal error for testing.