### PR TITLE
MAINT Set shm size to 2GB in run_docker

### DIFF
--- a/run_docker
+++ b/run_docker
@@ -74,6 +74,6 @@ exec docker run \
     -it --rm \
     -v $PWD:/src \
     --user root -e NB_UID=$UID -e NB_GID=$GID \
-    "${PYODIDE_DOCKER_IMAGE}" \
     --shm-size 2g \
+    "${PYODIDE_DOCKER_IMAGE}" \
     /bin/bash

--- a/run_docker
+++ b/run_docker
@@ -75,4 +75,5 @@ exec docker run \
     -v $PWD:/src \
     --user root -e NB_UID=$UID -e NB_GID=$GID \
     "${PYODIDE_DOCKER_IMAGE}" \
+    --shm-size 2g \
     /bin/bash


### PR DESCRIPTION
While investigating #1389 it turns out that when firefox is run in Docker it  needs a `/dev/shm` with at least 2GB as indicated in https://github.com/jlesage/docker-firefox#usage
>  Set the size of /dev/shm [...] NOTE: To avoid crashes, it is recommended to set this value to 2g.

This has no impact when running in CI, and I haven't seen any definite impact when running locally but it's good to follow the recommendations in any case.