### PR TITLE
MAINT Faster and more reliable WebWorker tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -102,10 +102,10 @@ class SeleniumWrapper:
                 f"{(build_dir / 'test.html').resolve()} " f"does not exist!"
             )
         self.driver.get(f"http://{server_hostname}:{server_port}/test.html")
+        self.run_js("Error.stackTraceLimit = Infinity;", pyodide_checks=False)
         if load_pyodide:
             self.run_js("await loadPyodide({ indexURL : './'});")
             self.save_state()
-        self.run_js("Error.stackTraceLimit = Infinity;", pyodide_checks=False)
         self.driver.set_script_timeout(20)
 
     @property

--- a/conftest.py
+++ b/conftest.py
@@ -81,7 +81,12 @@ class SeleniumWrapper:
     JavascriptException = JavascriptException
 
     def __init__(
-        self, server_port, server_hostname="127.0.0.1", server_log=None, build_dir=None
+        self,
+        server_port,
+        server_hostname="127.0.0.1",
+        server_log=None,
+        build_dir=None,
+        load_pyodide=True,
     ):
         if build_dir is None:
             build_dir = BUILD_PATH
@@ -97,9 +102,11 @@ class SeleniumWrapper:
                 f"{(build_dir / 'test.html').resolve()} " f"does not exist!"
             )
         self.driver.get(f"http://{server_hostname}:{server_port}/test.html")
-        self.run_js("Error.stackTraceLimit = Infinity;")
-        self.run_js("await loadPyodide({ indexURL : './'});")
-        self.save_state()
+        if load_pyodide:
+            self.run_js("await loadPyodide({ packageIndexURL : './'});")
+            self.save_state()
+        self.run_js("Error.stackTraceLimit = Infinity;", pyodide_checks=False)
+        self.driver.set_script_timeout(20)
 
     @property
     def logs(self):
@@ -144,17 +151,14 @@ class SeleniumWrapper:
             """
         )
 
-    def run_js(self, code):
+    def run_js(self, code, pyodide_checks=True):
+        """Run JavaScript code and check for pyodide errors"""
         if isinstance(code, str) and code.startswith("\n"):
             # we have a multiline string, fix indentation
             code = textwrap.dedent(code)
 
-        wrapper = """
-            let cb = arguments[arguments.length - 1];
-            let run = async () => { %s }
-            (async () => {
-                try {
-                    let result = await run();
+        if pyodide_checks:
+            check_code = """
                     if(globalThis.pyodide && pyodide._module && pyodide._module._PyErr_Occurred()){
                         try {
                             pyodide._module._pythonexc2js();
@@ -165,6 +169,17 @@ class SeleniumWrapper:
                             throw new Error(`Python exited with error flag set!`);
                         }
                     }
+           """
+        else:
+            check_code = ""
+
+        wrapper = """
+            let cb = arguments[arguments.length - 1];
+            let run = async () => { %s }
+            (async () => {
+                try {
+                    let result = await run();
+                    %s
                     cb([0, result]);
                 } catch (e) {
                     cb([1, e.toString(), e.stack]);
@@ -172,7 +187,7 @@ class SeleniumWrapper:
             })()
         """
 
-        retval = self.driver.execute_async_script(wrapper % code)
+        retval = self.driver.execute_async_script(wrapper % (code, check_code))
 
         if retval[0] == 0:
             return retval[1]
@@ -196,8 +211,7 @@ class SeleniumWrapper:
         return self.run_js(
             """
             let worker = new Worker( '{}' );
-            worker.postMessage({{ python: {!r} }});
-            return new Promise((res, rej) => {{
+            let res = new Promise((res, rej) => {{
                 worker.onerror = e => rej(e);
                 worker.onmessage = e => {{
                     if (e.data.results) {{
@@ -206,11 +220,14 @@ class SeleniumWrapper:
                        rej(e.data.error);
                     }}
                 }};
-            }})
+                worker.postMessage({{ python: {!r} }});
+            }});
+            return await res
             """.format(
                 f"http://{self.server_hostname}:{self.server_port}/webworker_dev.js",
                 code,
-            )
+            ),
+            pyodide_checks=False,
         )
 
     def load_package(self, packages):
@@ -289,7 +306,7 @@ def test_wrapper_check_for_memory_leaks(selenium):
 
 
 @contextlib.contextmanager
-def selenium_common(request, web_server_main):
+def selenium_common(request, web_server_main, load_pyodide=True):
     server_hostname, server_port, server_log = web_server_main
     if request.param == "firefox":
         cls = FirefoxWrapper
@@ -302,6 +319,7 @@ def selenium_common(request, web_server_main):
         server_port=server_port,
         server_hostname=server_hostname,
         server_log=server_log,
+        load_pyodide=load_pyodide,
     )
     try:
         yield selenium
@@ -312,6 +330,15 @@ def selenium_common(request, web_server_main):
 @pytest.fixture(params=["firefox", "chrome"], scope="function")
 def selenium_standalone(request, web_server_main):
     with selenium_common(request, web_server_main) as selenium:
+        try:
+            yield selenium
+        finally:
+            print(selenium.logs)
+
+
+@pytest.fixture(params=["firefox", "chrome"], scope="function")
+def selenium_webworker_standalone(request, web_server_main):
+    with selenium_common(request, web_server_main, load_pyodide=False) as selenium:
         try:
             yield selenium
         finally:

--- a/conftest.py
+++ b/conftest.py
@@ -103,7 +103,7 @@ class SeleniumWrapper:
             )
         self.driver.get(f"http://{server_hostname}:{server_port}/test.html")
         if load_pyodide:
-            self.run_js("await loadPyodide({ packageIndexURL : './'});")
+            self.run_js("await loadPyodide({ indexURL : './'});")
             self.save_state()
         self.run_js("Error.stackTraceLimit = Infinity;", pyodide_checks=False)
         self.driver.set_script_timeout(20)

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -185,8 +185,8 @@ def test_runpythonasync_numpy(selenium_standalone):
         )
 
 
-def test_runwebworker_numpy(selenium_standalone):
-    output = selenium_standalone.run_webworker(
+def test_runwebworker_numpy(selenium_webworker_standalone):
+    output = selenium_webworker_standalone.run_webworker(
         """
         import numpy as np
         x = np.zeros(5)

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -746,7 +746,6 @@ globalThis.loadPyodide = async function(config = {}) {
   // _createPyodideModule is specified in the Makefile by the linker flag:
   // `-s EXPORT_NAME="'_createPyodideModule'"`
   await _createPyodideModule(Module);
-  delete globalThis._createPyodideModule;
 
   // There is some work to be done between the module being "ready" and postRun
   // being called.

--- a/src/tests/test_webworker.py
+++ b/src/tests/test_webworker.py
@@ -1,8 +1,9 @@
 import pytest
 
 
-def test_runwebworker_different_package_name(selenium_standalone):
-    output = selenium_standalone.run_webworker(
+def test_runwebworker_different_package_name(selenium_webworker_standalone):
+    selenium = selenium_webworker_standalone
+    output = selenium.run_webworker(
         """
         import pyparsing
         pyparsing.__version__
@@ -11,8 +12,9 @@ def test_runwebworker_different_package_name(selenium_standalone):
     assert isinstance(output, str)
 
 
-def test_runwebworker_no_imports(selenium_standalone):
-    output = selenium_standalone.run_webworker(
+def test_runwebworker_no_imports(selenium_webworker_standalone):
+    selenium = selenium_webworker_standalone
+    output = selenium.run_webworker(
         """
         42
         """
@@ -20,30 +22,33 @@ def test_runwebworker_no_imports(selenium_standalone):
     assert output == 42
 
 
-def test_runwebworker_missing_import(selenium_standalone):
+def test_runwebworker_missing_import(selenium_webworker_standalone):
+    selenium = selenium_webworker_standalone
     msg = "ModuleNotFoundError"
-    with pytest.raises(selenium_standalone.JavascriptException, match=msg):
-        selenium_standalone.run_webworker(
+    with pytest.raises(selenium.JavascriptException, match=msg):
+        selenium.run_webworker(
             """
             import foo
             """
         )
 
 
-def test_runwebworker_exception(selenium_standalone):
+def test_runwebworker_exception(selenium_webworker_standalone):
+    selenium = selenium_webworker_standalone
     msg = "ZeroDivisionError"
-    with pytest.raises(selenium_standalone.JavascriptException, match=msg):
-        selenium_standalone.run_webworker(
+    with pytest.raises(selenium.JavascriptException, match=msg):
+        selenium.run_webworker(
             """
             42 / 0
             """
         )
 
 
-def test_runwebworker_exception_after_import(selenium_standalone):
+def test_runwebworker_exception_after_import(selenium_webworker_standalone):
+    selenium = selenium_webworker_standalone
     msg = "ZeroDivisionError"
-    with pytest.raises(selenium_standalone.JavascriptException, match=msg):
-        selenium_standalone.run_webworker(
+    with pytest.raises(selenium.JavascriptException, match=msg):
+        selenium.run_webworker(
             """
             import pyparsing
             42 / 0
@@ -51,8 +56,9 @@ def test_runwebworker_exception_after_import(selenium_standalone):
         )
 
 
-def test_runwebworker_micropip(selenium_standalone):
-    output = selenium_standalone.run_webworker(
+def test_runwebworker_micropip(selenium_webworker_standalone):
+    selenium = selenium_webworker_standalone
+    output = selenium.run_webworker(
         """
         import micropip
         await micropip.install('snowballstemmer')

--- a/src/webworker.js
+++ b/src/webworker.js
@@ -11,14 +11,14 @@ onmessage = async function(e) {
       }
     }
 
-    if (typeof self.pyodide !== "undefined") {
+    if (typeof self.__pyodideLoading === "undefined") {
       await loadPyodide({packageIndexURL : '{{ PYODIDE_BASE_URL }}'});
     }
-    self.postMessage(
-        {results : await self.pyodide.runPythonAsync(data.python)});
+    let res = await self.pyodide.runPythonAsync(data.python);
+    self.postMessage({results : res});
   } catch (e) {
     // if you prefer messages with the error
-    self.postMessage({error : e.message});
+    self.postMessage({error : e.stack});
     // if you prefer onerror events
     // setTimeout(() => { throw err; });
   }

--- a/src/webworker.js
+++ b/src/webworker.js
@@ -1,17 +1,19 @@
 importScripts('./pyodide.js')
 
 onmessage = async function(e) {
-  await loadPyodide({indexURL : '{{ PYODIDE_BASE_URL }}'});
-  const data = e.data;
-  for (let key of Object.keys(data)) {
-    if (key !== 'python') {
-      // Keys other than python must be arguments for the python script.
-      // Set them on self, so that `from js import key` works.
-      self[key] = data[key];
-    }
-  }
-
   try {
+    const data = e.data;
+    for (let key of Object.keys(data)) {
+      if (key !== 'python') {
+        // Keys other than python must be arguments for the python script.
+        // Set them on self, so that `from js import key` works.
+        self[key] = data[key];
+      }
+    }
+
+    if (typeof self.pyodide !== "undefined") {
+      await loadPyodide({packageIndexURL : '{{ PYODIDE_BASE_URL }}'});
+    }
     self.postMessage(
         {results : await self.pyodide.runPythonAsync(data.python)});
   } catch (e) {

--- a/src/webworker.js
+++ b/src/webworker.js
@@ -12,13 +12,13 @@ onmessage = async function(e) {
     }
 
     if (typeof self.__pyodideLoading === "undefined") {
-      await loadPyodide({packageIndexURL : '{{ PYODIDE_BASE_URL }}'});
+      await loadPyodide({indexURL : '{{ PYODIDE_BASE_URL }}'});
     }
     let res = await self.pyodide.runPythonAsync(data.python);
     self.postMessage({results : res});
   } catch (e) {
     // if you prefer messages with the error
-    self.postMessage({error : e.stack});
+    self.postMessage({error : e.message + '\n' + e.stack});
     // if you prefer onerror events
     // setTimeout(() => { throw err; });
   }


### PR DESCRIPTION
Refactors webworker test mechanism to hopefully be faster and more reliable (related to #1389 ).

 - previously in webworker tests Pyodide was loaded both on the main page and in the webworker. Now it is only loaded in the webworker. This results in approximately 25% speed up for `tests/test_webworker.py` for Chrome.
 - previously if there was an error while loading pyodide in the webworker, this lead to a deadlock, as far as I can tell, and we timed out after 30 sec. Thanks to https://github.com/pyodide/pyodide/pull/1363 we can now explicitly call `loadPyodide` when the first message is received and handle errors appropriately.
 - added `selenium_webworker_standalone` that is identical to `selenium_standalone` but doesn't call `loadPyodide` on the test.html page.
 - I also reduced the timeout from 30s to 20s for `driver.execute_async_script` so that CI takes less time when there are timeouts.  