### PR TITLE
Allow relative URLs in loadPackage

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -45,17 +45,11 @@ globalThis.loadPyodide = async function(config = {}) {
   const DEFAULT_CHANNEL = "default channel";
 
   // Regexp for validating package name and URI
-  const package_uri_regexp =
-      new RegExp('^https?://.*?([a-z0-9_][a-z0-9_\-]*).js$', 'i');
+  const package_uri_regexp = new RegExp('^.*?([^/]*).js$', 'i');
 
   let _uri_to_package_name = (package_uri) => {
-    if (package_uri_regexp.test(package_uri)) {
-      let match = package_uri_regexp.exec(package_uri);
-      // Get the regexp group corresponding to the package name
-      return match[1];
-    } else {
-      return null;
-    }
+    let match = package_uri_regexp.exec(package_uri);
+    return match ? match[1] : null;
   };
 
   let loadScript;
@@ -279,12 +273,14 @@ globalThis.loadPyodide = async function(config = {}) {
    * Load a package or a list of packages over the network. This makes the files
    * for the package available in the virtual filesystem. The package needs to
    * be imported from Python before it can be used.
-   * @param {String | Array} names package name, or URL. Can be either a single
-   * element, or an array
+   * @param {String | Array} names Package name or URL. Can be either a single
+   *    element, or an array. URLs can be absolute or relative. URLs must have
+   *    file name `<package-name>.js` and there must be a file called
+   *    `<package-name>.data` in the same directory.
    * @param {function} messageCallback A callback, called with progress messages
-   * (optional)
+   *    (optional)
    * @param {function} errorCallback A callback, called with error/warning
-   * messages (optional)
+   *    messages (optional)
    * @returns {Promise} Resolves to ``undefined`` when loading is complete
    */
   Module.loadPackage = async function(names, messageCallback, errorCallback) {

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -45,13 +45,10 @@ globalThis.loadPyodide = async function(config = {}) {
   const DEFAULT_CHANNEL = "default channel";
 
   // Regexp for validating package name and URI
-  const package_uri_regexp = new RegExp('^.*?([^/]*).js$', 'i');
+  const package_uri_regexp = /^.*?([^/]*)\.js$/
 
-  let _uri_to_package_name = (package_uri) => {
-    let match = package_uri_regexp.exec(package_uri);
-    return match ? match[1] : null;
-  };
-
+  let _uri_to_package_name =
+      (package_uri) => package_uri_regexp.exec(package_uri) ?.[1];
   let loadScript;
   if (self.document) { // browser
     loadScript = (url) => new Promise((res, rej) => {
@@ -93,7 +90,7 @@ globalThis.loadPyodide = async function(config = {}) {
     };
     for (let name of names) {
       const pkgname = _uri_to_package_name(name);
-      if (pkgname !== null) {
+      if (pkgname !== undefined) {
         if (toLoad.has(pkgname) && toLoad.get(pkgname) !== name) {
           errorCallback(`Loading same package ${pkgname} from ${name} and ${
               toLoad.get(pkgname)}`);

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -45,6 +45,11 @@ def test_load_from_url(selenium_standalone, web_server_secondary, active_server)
     selenium_standalone.run("import pytz")
 
 
+def test_load_relative_url(selenium_standalone):
+    selenium_standalone.load_package("./pytz.js")
+    selenium_standalone.run("import pytz")
+
+
 def test_list_loaded_urls(selenium_standalone):
     selenium = selenium_standalone
 


### PR DESCRIPTION
I updated `package_uri_regexp` to not demand that the URL begins with `https?://` so that we can load relative URLs. Now a string is considered a URL if it ends in ".js". I guess if we are worried about python packages named `something.js` we could change it so that to be considered a URL it also needs to have a slash somewhere (so then you would have to say `pyodide.loadPackage("./pytz.js")` rather than `pyodide.loadPackage("pytz.js")`. I also updated the API docs to be slightly more specific about what a URL should look like.