### PR TITLE
run_docker: Add option to run docker without binding to any port

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -147,6 +147,8 @@ substitutions:
   [#878](https://github.com/pyodide/pyodide/pull/878).
 - {{ Enhancement }} Reduce the size of the core Pyodide package
   [#987](https://github.com/pyodide/pyodide/pull/987).
+- {{ Enhancement }} Optionally to disable docker port binding
+  [#1423](https://github.com/pyodide/pyodide/pull/1423).
 
 ### REPL
 

--- a/run_docker
+++ b/run_docker
@@ -14,6 +14,8 @@ Usage:
                                 This is ignored if the env var PYODIDE_DOCKER_IMAGE is set
     -p, --port <port>           System port to which to forward.
                                 This is ignored if the env var PYODIDE_SYSTEM_PORT is set
+                                If set to 'none', docker instance will not bind to any port
+                                (Useful for running the docker in multi-user environment)
 
   Prerequisites:
     Docker has to be set up on your system
@@ -69,8 +71,22 @@ PYODIDE_DOCKER_PORT=${PYODIDE_DOCKER_PORT:-"8000"}
 PYODIDE_SYSTEM_PORT=${PYODIDE_SYSTEM_PORT:-${DEFAULT_PYODIDE_SYSTEM_PORT}}
 PYODIDE_DOCKER_IMAGE=${PYODIDE_DOCKER_IMAGE:-${DEFAULT_PYODIDE_DOCKER_IMAGE}}
 
+# in case the port is not a number, do not bind the port
+case $DEFAULT_PYODIDE_SYSTEM_PORT in
+  none)
+  PORT_CONFIGURATION_LINE=""
+  ;;
+  ''|*[!0-9]*) # contains a non-digit character, therefore it is not a number
+  echo "WARNING: Invalid port argument '$DEFAULT_PYODIDE_SYSTEM_PORT'. Port binding disabled."
+  PORT_CONFIGURATION_LINE=""
+  ;;
+  *)
+  PORT_CONFIGURATION_LINE="-p $PYODIDE_SYSTEM_PORT:$PYODIDE_DOCKER_PORT"
+  ;;
+esac
+
 exec docker run \
-    -p "$PYODIDE_SYSTEM_PORT":"$PYODIDE_DOCKER_PORT" \
+    $PORT_CONFIGURATION_LINE \
     -it --rm \
     -v $PWD:/src \
     --user root -e NB_UID=$UID -e NB_GID=$GID \


### PR DESCRIPTION
Useful for building in multi-user environment.

Context:
`./run_docker` bash script configures docker to bind to a TCP/IP port (8000 by default). This feature was added in PR https://github.com/pyodide/pyodide/pull/263 and is used for accessing a server launched arbitrarily within the docker image. This feature is not needed for the actual `pyodide` build.

Binding to a fixed port causes a problem on multi-user systems, as ports are a shared resource, and users experience port collisions. Users could reconfigure the ports themselves (with the `--port` option), but this is not a systematic solution.

We propose to add an `--no-port` option that will disable the port binding feature.

As an alternative, we propose no to bind to any port unless the `--port` parameter is specified. This change, however, would break backward compatibility. Therefore, our PR addresses this issue in a backward-compatible manner, yet less systematic from design perspective.
