### PR TITLE
run_docker: Allow to run arbitrary command in docker

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -149,6 +149,8 @@ substitutions:
   [#987](https://github.com/pyodide/pyodide/pull/987).
 - {{ Enhancement }} Optionally to disable docker port binding
   [#1423](https://github.com/pyodide/pyodide/pull/1423).
+- {{ Enhancement }} Run arbitrary command in docker
+  [#1424](https://github.com/pyodide/pyodide/pull/1424)
 
 ### REPL
 

--- a/run_docker
+++ b/run_docker
@@ -5,20 +5,21 @@ set -eo pipefail
 
 function usage() {
   cat > /dev/stdout <<EOF
-Usage:
-  run_docker [OPTIONS] [COMMAND] [ARG...]
+Usage: run_docker [OPTIONS] [COMMAND] [ARG...]
 
-  Optional flags:
-    -h, --help                  Show this information and exit
-    --pre-built                 Use the prebuilt pyodide image.
-                                This is ignored if the env var PYODIDE_DOCKER_IMAGE is set
-    -p, --port <port>           System port to which to forward.
-                                This is ignored if the env var PYODIDE_SYSTEM_PORT is set
-                                If set to 'none', docker instance will not bind to any port
-                                (Useful for running the docker in multi-user environment)
+Runs COMMAND in a new Pyodide docker container. If no COMMAND is provided, starts a bash
+shell in the container.
 
-  Prerequisites:
-    Docker has to be set up on your system
+Options:
+  -h, --help                  Show this information and exit.
+  --pre-built                 Use the prebuilt Pyodide image.
+                              This is ignored if the env var PYODIDE_DOCKER_IMAGE is set.
+  -p, --port <port>           System port to which to forward.
+                              This is ignored if the env var PYODIDE_SYSTEM_PORT is set.
+                              If set to 'none', docker instance will not bind to any port.
+
+Prerequisites:
+  Docker has to be set up on your system.
 EOF
 }
 

--- a/run_docker
+++ b/run_docker
@@ -6,7 +6,7 @@ set -eo pipefail
 function usage() {
   cat > /dev/stdout <<EOF
 Usage:
-  run_docker [OPTIONS]
+  run_docker [OPTIONS] [COMMAND] [ARG...]
 
   Optional flags:
     -h, --help                  Show this information and exit
@@ -32,6 +32,7 @@ PYODIDE_IMAGE_TAG="12"
 PYODIDE_PREBUILT_IMAGE_TAG="0.17.0a2"
 DEFAULT_PYODIDE_DOCKER_IMAGE="iodide/pyodide-env:${PYODIDE_IMAGE_TAG}"
 DEFAULT_PYODIDE_SYSTEM_PORT="8000"
+DOCKER_COMMAND="/bin/bash"
 
 while [[ $# -gt 0 ]]
 do
@@ -60,9 +61,13 @@ do
         DEFAULT_PYODIDE_SYSTEM_PORT=$2
         shift 2
       ;;
-      *)
+      -*)
         >&2 echo "Unknown option $1"
         error
+      ;;
+      *)
+        DOCKER_COMMAND="$@"
+        break
       ;;
   esac
 done
@@ -92,4 +97,4 @@ exec docker run \
     --user root -e NB_UID=$UID -e NB_GID=$GID \
     --shm-size 2g \
     "${PYODIDE_DOCKER_IMAGE}" \
-    /bin/bash
+    $DOCKER_COMMAND


### PR DESCRIPTION
Useful for unattended builds.

The `./run_docker` bash script configures the docker image for pyodide build and launches interactive `bash` session within.

This PR allows to specify an arbitrary command that should be launched within the docker image. This allows for unattended builds, such as:
```
./run_docker --command "make \
EMSDK_NUM_CORES=16 \
EMCC_CORES=16 \
PYODIDE_JOBS=16 \
PYODIDE_PACKAGES=\"jedi\""
```

Another possible interface would be:
```
run_docker [OPTIONS] [COMMAND] [ARG...]
```
which would be used as follows:
```
./run_docker --port 8001 make PYODIDE_PACKAGES="jedi"
```
The benefit of the second proposed interface is less escaping and compatibility with the way how `docker run` accepts commands. This, however, would need redesign of the arguments parsing in `run_docker`. Now, the argument parsing throws an error for non-recognized arguments. Therefore, we decided for the `--command` approach, that is less intrusive to the existing code and interface.