### PR TITLE
Pin docutils to v0.16

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -5,3 +5,4 @@ sphinxcontrib-napoleon
 distlib   # required by micropip
 sphinx-js==3.1
 autodocsumm
+docutils==0.16


### PR DESCRIPTION
The update to docutils v0.17 broke the docs build.