### PR TITLE
Add run_in_executor shim to webloop

### DIFF
--- a/src/pyodide-py/pyodide/webloop.py
+++ b/src/pyodide-py/pyodide/webloop.py
@@ -156,6 +156,20 @@ class WebLoop(asyncio.AbstractEventLoop):
         delay = when - cur_time
         return self.call_later(delay, callback, *args, context=context)
 
+    def run_in_executor(self, executor, func, *args):
+        """This is normally supposed to run func(args) in a separate thread and
+        signal back to our event loop when it is done. It's possible to make the
+        executor, but if we actually try to submit any functions to it, it will
+        try to create a thread and throw an error. Best we can do is to run
+        func(args) in this thread and stick the result into a future.
+        """
+        fut = self.create_future()
+        try:
+            fut.set_result(func(*args))
+        except BaseException as e:
+            fut.set_exception(e)
+        return fut
+
     #
     # The remaining methods are copied directly from BaseEventLoop
     #

--- a/src/pyodide-py/pyodide/webloop.py
+++ b/src/pyodide-py/pyodide/webloop.py
@@ -157,11 +157,13 @@ class WebLoop(asyncio.AbstractEventLoop):
         return self.call_later(delay, callback, *args, context=context)
 
     def run_in_executor(self, executor, func, *args):
-        """This is normally supposed to run func(args) in a separate thread and
-        signal back to our event loop when it is done. It's possible to make the
-        executor, but if we actually try to submit any functions to it, it will
-        try to create a thread and throw an error. Best we can do is to run
-        func(args) in this thread and stick the result into a future.
+        """Arrange for func to be called in the specified executor.
+
+        This is normally supposed to run func(*args) in a separate process or
+        thread and signal back to our event loop when it is done. It's possible
+        to make the executor, but if we actually try to submit any functions to
+        it, it will try to create a thread and throw an error. Best we can do is
+        to run func(args) in this thread and stick the result into a future.
         """
         fut = self.create_future()
         try:

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -37,7 +37,7 @@ def test_return_result(selenium):
         from js import resolve
         async def foo(arg):
             return arg
-        
+
         def check_result(fut):
             result = fut.result()
             if result == 998:
@@ -62,14 +62,14 @@ def test_capture_exception(selenium):
             pass
         async def foo(arg):
             raise MyException('oops')
-        
+
         def capture_exception(fut):
             with raises(MyException):
                 fut.result()
             resolve()
         import asyncio
         fut = asyncio.ensure_future(foo(998))
-        fut.add_done_callback(capture_exception)                
+        fut.add_done_callback(capture_exception)
         """,
     )
 
@@ -142,4 +142,21 @@ def test_asyncio_exception(selenium):
         import asyncio
         asyncio.ensure_future(capture_exception())
         """,
+    )
+
+
+def test_run_in_executor(selenium):
+    # If run_in_executor tries to actually use ThreadPoolExecutor, it will throw
+    # an error since we can't start threads
+    selenium.run_js(
+        """
+        pyodide.runPythonAsync(`
+            from concurrent.futures import ThreadPoolExecutor
+            import asyncio
+            def f():
+                return 5
+            result = await asyncio.get_event_loop().run_in_executor(ThreadPoolExecutor(), f)
+            assert result == 5
+        `);
+        """
     )


### PR DESCRIPTION
This provides a webloop implementation of `run_in_executor`. The point of `run_in_executor` is for threading, so without threads around it is pretty pointless. We just run the code in this thread and then wrap the result in a future, ignoring the executor. Looking at the executor funny might cause it to try to start a thread and throw an error.

This should make some code that tries to mix asyncio with threading work by skipping the threading.