### PR TITLE
Actually add object_keys and object_values to JsProxy

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1311,6 +1311,8 @@ JsProxy_create_subtype(int flags)
   methods[cur_method++] = JsProxy_Dir_MethodDef;
   methods[cur_method++] = JsProxy_toPy_MethodDef;
   methods[cur_method++] = JsProxy_object_entries_MethodDef;
+  methods[cur_method++] = JsProxy_object_keys_MethodDef;
+  methods[cur_method++] = JsProxy_object_values_MethodDef;
 
   PyTypeObject* base = &JsProxyType;
   int tp_flags = Py_TPFLAGS_DEFAULT;

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -483,8 +483,8 @@ def test_object_entries_keys_values(selenium):
         pyodide.runPython(`
             from js import x
             assert x.object_entries().to_py() == [["a", 2], ["b", 3], ["c", 4]]
-            assert x.object_keys().to_py() == [2, 3, 4]
-            assert x.object_values().to_py() == ["a", "b", "c"]
+            assert x.object_keys().to_py() == ["a", "b", "c"]
+            assert x.object_values().to_py() == [2, 3, 4]
         `);
         """
     )

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -476,6 +476,20 @@ def test_register_jsmodule_docs_example(selenium_standalone):
     )
 
 
+def test_object_entries_keys_values(selenium):
+    selenium.run_js(
+        """
+        window.x = { a : 2, b : 3, c : 4 };
+        pyodide.runPython(`
+            from js import x
+            assert x.object_entries().to_py() == [["a", 2], ["b", 3], ["c", 4]]
+            assert x.object_keys().to_py() == [2, 3, 4]
+            assert x.object_values().to_py() == ["a", "b", "c"]
+        `);
+        """
+    )
+
+
 def test_mixins_feature_presence(selenium):
     result = selenium.run_js(
         """


### PR DESCRIPTION
I added `JsProxy_object_keys` and `JsProxy_object_values` a while back but forgot to actually expose them. Clearly they need a couple of tests...