### PR TITLE
MAINT/CI increase build timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
 
       - run:
           name: build packages
-          no_output_timeout: 1200
+          no_output_timeout: 1800
           command: |
             ccache -z
             make


### PR DESCRIPTION
Occasionally when building packages without ccache, the CI would timeout because there is no output for 20 min. For instance it happened in https://github.com/pyodide/pyodide/pull/1400 This increases the `no_output_timeout` for packages to avoid this issue.