### PR TITLE
MAINT/CI Fix compatibility between run_in_pyodide and driver_timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,6 @@ workflows:
             - test-python
             - test-core-firefox
             - test-packages-firefox
-            - test-core-chrome
             - test-emsdk
           filters:
             branches:
@@ -334,7 +333,6 @@ workflows:
             - test-python
             - test-core-firefox
             - test-packages-firefox
-            - test-core-chrome
             - test-emsdk
           filters:
             branches:

--- a/packages/pywavelets/test_pywt.py
+++ b/packages/pywavelets/test_pywt.py
@@ -1,10 +1,7 @@
-import pytest
-
 from pyodide_build.testing import run_in_pyodide
 
 
-@pytest.mark.driver_timeout(30)
-@run_in_pyodide(packages=["pywavelets"])
+@run_in_pyodide(packages=["pywavelets"], driver_timeout=30)
 def test_pywt():
     import pywt
     import numpy as np

--- a/packages/scikit-image/test_skimage.py
+++ b/packages/scikit-image/test_skimage.py
@@ -1,10 +1,7 @@
-import pytest
-
 from pyodide_build.testing import run_in_pyodide
 
 
-@pytest.mark.driver_timeout(40)
-@run_in_pyodide(packages=["scikit-image"])
+@run_in_pyodide(packages=["scikit-image"], driver_timeout=40)
 def test_skimage():
     import numpy as np
 

--- a/pyodide_build/testing.py
+++ b/pyodide_build/testing.py
@@ -8,6 +8,7 @@ def run_in_pyodide(
     _function: Optional[Callable] = None,
     standalone: bool = False,
     packages: List[str] = [],
+    driver_timeout: Optional[Union[str, int]] = None,
 ) -> Callable:
     """
     This decorator can be called in two ways --- with arguments and without
@@ -23,6 +24,8 @@ def run_in_pyodide(
         Whether to use a standalone selenium instance to run the test or not
     packages : List[str]
         List of packages to load before running the test
+    driver_timeout : Optional[Union[str, int]]
+        selenium driver timeout (in seconds)
     """
 
     def decorator(f):
@@ -35,29 +38,30 @@ def run_in_pyodide(
             source = "".join(lines)
 
             err = None
-            try:
-                # When writing the function, we set the filename to the file
-                # containing the source. This results in a more helpful
-                # traceback
-                selenium.run_js(
-                    """pyodide._module.pyodide_py.eval_code({!r}, // code
-                            pyodide._module.globals, // globals
-                            pyodide._module.globals, // locals
-                            "last_expr", // return_mode
-                            true, // quiet_trailing_semicolon
-                            {!r} // filename
-                        )""".format(
-                        source, inspect.getsourcefile(f)
+            with set_webdriver_script_timeout(selenium, driver_timeout):
+                try:
+                    # When writing the function, we set the filename to the file
+                    # containing the source. This results in a more helpful
+                    # traceback
+                    selenium.run_js(
+                        """pyodide._module.pyodide_py.eval_code({!r}, // code
+                                pyodide._module.globals, // globals
+                                pyodide._module.globals, // locals
+                                "last_expr", // return_mode
+                                true, // quiet_trailing_semicolon
+                                {!r} // filename
+                            )""".format(
+                            source, inspect.getsourcefile(f)
+                        )
                     )
-                )
-                # When invoking the function, use the default filename <eval>
-                selenium.run_js(
-                    """pyodide._module.pyodide_py.eval_code("{}()", pyodide._module.globals)""".format(
-                        f.__name__
+                    # When invoking the function, use the default filename <eval>
+                    selenium.run_js(
+                        """pyodide._module.pyodide_py.eval_code("{}()", pyodide._module.globals)""".format(
+                            f.__name__
+                        )
                     )
-                )
-            except selenium.JavascriptException as e:
-                err = e
+                except selenium.JavascriptException as e:
+                    err = e
 
             if err is not None:
                 pytest.fail(


### PR DESCRIPTION
It looks like there is an incompatibility between `run_in_pyodide` and `pytest.mark.driver_timeout` decorators that I missed in https://github.com/pyodide/pyodide/pull/1442

This should hopefully fix the last two failing tests in Firefox packages.

I also changed the CI to deploy the dev version if test-packages-firefox passed, independently of the Chrome CI.