### PR TITLE
Fix getBuffer on empty buffers

### DIFF
--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -761,16 +761,21 @@ JS_FILE(pyproxy_init_js, () => {0,0; /* Magic, see include_js_file.h */
               "Alternatively, toJs will automatically convert the buffer " +
               "to little endian.");
         }
-        if (startByteOffset % alignment !== 0 ||
-            minByteOffset % alignment !== 0 ||
-            maxByteOffset % alignment !== 0) {
+        let numBytes = maxByteOffset - minByteOffset;
+        if (numBytes !== 0 && (startByteOffset % alignment !== 0 ||
+                               minByteOffset % alignment !== 0 ||
+                               maxByteOffset % alignment !== 0)) {
           throw new Error(
               `Buffer does not have valid alignment for a ${ArrayType.name}`);
         }
-        let numBytes = maxByteOffset - minByteOffset;
         let numEntries = numBytes / alignment;
         let offset = (startByteOffset - minByteOffset) / alignment;
-        let data = new ArrayType(HEAP8.buffer, minByteOffset, numEntries);
+        let data;
+        if (numBytes === 0) {
+          data = new ArrayType();
+        } else {
+          data = new ArrayType(HEAP8.buffer, minByteOffset, numEntries);
+        }
         for (let i of strides.keys()) {
           strides[i] /= alignment;
         }

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -232,6 +232,25 @@ def test_pyproxy_get_buffer(selenium):
     )
 
 
+def test_get_empty_buffer(selenium):
+    """Previously empty buffers would raise alignment errors
+
+    This is because when Python makes an empty buffer, apparently the pointer
+    field is allowed to contain random garbage, which in particular won't be aligned.
+    """
+    selenium.run_js(
+        """
+        let a = pyodide.runPython(`
+            from array import array
+            array("Q")
+        `);
+        let b = a.getBuffer();
+        b.release();
+        a.destroy();
+        """
+    )
+
+
 @pytest.mark.parametrize(
     "array_type",
     [


### PR DESCRIPTION
Apparently when a buffer has length 0, the Python buffer API permits the pointer to be some random unaligned number. I thought that for an empty buffer it would be either NULL or at least have valid alignment. This adds a special case to make sure we don't throw an error on empty buffers.