### PR TITLE
Correct PYODIDE_BASE_URL for  console.html in CircleCI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
             - ./build
       - run:
           name: Prepare CircleCI artifacts
-          command: PYODIDE_BASE_URL="$CIRCLE_BUILD_URL/artifacts/0/root/repo/build/" make build/console.html
+          command: PYODIDE_BASE_URL="./" make build/console.html
 
       - store_artifacts:
           path: /root/repo/build/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,9 @@ jobs:
           paths:
             - ./packages/.artifacts
             - ./build
+      - run:
+          name: Prepare CircleCI artifacts
+          command: PYODIDE_BASE_URL="$CIRCLE_BUILD_URL/artifacts/0/root/repo/build/" make build/console.html
 
       - store_artifacts:
           path: /root/repo/build/

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ build/console.html: src/templates/console.html
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
 
+docs/_build/html/console.html: src/templates/console.html
+	cp $< $@
+	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
+
+
 build/webworker.js: src/webworker.js
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ env:
 	env
 
 
+.PHONY: build/pyodide.js
 build/pyodide.js: src/pyodide.js
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
@@ -69,23 +70,22 @@ build/test.html: src/templates/test.html
 	cp $< $@
 
 
+.PHONY: build/console.html
 build/console.html: src/templates/console.html
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
-
-docs/_build/html/console.html: src/templates/console.html
-	cp $< $@
-	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
-
-
+.PHONY: build/webworker.js
 build/webworker.js: src/webworker.js
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
+
+.PHONY: build/webworker_dev.js
 build/webworker_dev.js: src/webworker.js
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#./#g' $@
+
 
 test: all
 	pytest src emsdk/tests packages/*/test* pyodide_build -v

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,9 +3,11 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import os
 import sys
 from typing import Dict, Any
 import pathlib
+import subprocess
 
 base_dir = pathlib.Path(__file__).resolve().parent.parent
 path_dirs = [
@@ -102,3 +104,14 @@ htmlhelp_basename = "Pyodidedoc"
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ["search.html"]
+
+if "READTHEDOCS" in os.environ:
+    env = {"PYODIDE_BASE_URL": "https://cdn.jsdelivr.net/pyodide/dev/full/"}
+    os.makedirs("_build/html", exist_ok=True)
+    res = subprocess.check_output(
+        ["make", "-C", "..", "docs/_build/html/console.html"],
+        env=env,
+        stderr=subprocess.STDOUT,
+        encoding="utf-8",
+    )
+    print(res)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,11 +3,9 @@
 
 # -- Path setup --------------------------------------------------------------
 
-import os
 import sys
 from typing import Dict, Any
 import pathlib
-import subprocess
 
 base_dir = pathlib.Path(__file__).resolve().parent.parent
 path_dirs = [
@@ -104,14 +102,3 @@ htmlhelp_basename = "Pyodidedoc"
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ["search.html"]
-
-if "READTHEDOCS" in os.environ:
-    env = {"PYODIDE_BASE_URL": "https://cdn.jsdelivr.net/pyodide/dev/full/"}
-    os.makedirs("_build/html", exist_ok=True)
-    res = subprocess.check_output(
-        ["make", "-C", "..", "docs/_build/html/console.html"],
-        env=env,
-        stderr=subprocess.STDOUT,
-        encoding="utf-8",
-    )
-    print(res)


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide/issues/648

By adjusting PYODIDE_BASE_URL before artifacts are stored in CircleCI but after the workspace has been saved (which is used for S3 deployment), I think we should be able to use console.html from CircleCI artifacts without using local overrides in Chrome https://github.com/pyodide/pyodide/issues/1384#issuecomment-817411787