### PR TITLE
FIX Tell loadPackage about packages installed with micropip

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -55,16 +55,16 @@ substitutions:
   `pyodide.globals.get('key')`. [#1367](https://github.com/pyodide/pyodide/pull/1367)
 - {{ API }} Added `PyProxy.getBuffer` API to allow direct access to Python
   buffers as Javascript TypedArrays.
-  [1215](https://github.com/pyodide/pyodide/pull/1215)
+  [#1215](https://github.com/pyodide/pyodide/pull/1215)
 - {{ API }} The innermost level of a buffer converted to Javascript used to be a
   TypedArray if the buffer was contiguous and otherwise an Array. Now the
   innermost level will be a TypedArray unless the buffer format code is a '?' in
   which case it will be an Array of booleans, or if the format code is a "s" in
   which case the innermost level will be converted to a string.
-  [1376](https://github.com/pyodide/pyodide/pull/1376)
+  [#1376](https://github.com/pyodide/pyodide/pull/1376)
 - {{ Enhancement }} Javascript `BigInt`s are converted into Python `int` and
   Python `int`s larger than 2^53 are converted into `BigInt`.
-  [1407](https://github.com/pyodide/pyodide/pull/1407)
+  [#1407](https://github.com/pyodide/pyodide/pull/1407)
 
 ### Fixed
 - {{ Fix }} getattr and dir on JsProxy now report consistent results and include all
@@ -132,13 +132,16 @@ substitutions:
 - Changed the loading method: added an async function `loadPyodide` to load
   Pyodide to use instead of `languagePluginURL` and `languagePluginLoader`. The
   change is currently backwards compatible, but the old approach is deprecated.
-  [1363](https://github.com/pyodide/pyodide/pull/1363)
+  [#1363](https://github.com/pyodide/pyodide/pull/1363)
 
 ### micropip
 
 - {{ Feature }} `micropip` now supports installing wheels from relative URLs.
   [#872](https://github.com/pyodide/pyodide/pull/872)
 - {{ API }} `micropip.install` now returns a Python `Future` instead of a Javascript `Promise`.
+  [#1324](https://github.com/pyodide/pyodide/pull/1324/)
+- {{ FIX }} {any}`micropip.install` now interacts correctly with {any}`pyodide.loadPackage`.
+  [#1457](https://github.com/pyodide/pyodide/pull/1457/)
 
 ### Build system
 

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -57,6 +57,14 @@ else:
         return result
 
 
+if IN_BROWSER:
+    from pyodide_js import loadedPackages
+else:
+
+    class loadedPackages:  # type: ignore
+        pass
+
+
 async def _get_pypi_json(pkgname):
     url = f"https://pypi.org/pypi/{pkgname}/json"
     fd = await _get_url(url)
@@ -112,6 +120,7 @@ async def _install_wheel(name, fileinfo):
     wheel = await _get_url(url)
     _validate_wheel(wheel, fileinfo)
     _extract_wheel(wheel)
+    setattr(loadedPackages, name, url)
 
 
 class _PackageManager:

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -170,3 +170,25 @@ def test_last_version_from_pypi():
     wheel, ver = micropip.PACKAGE_MANAGER.find_wheel(metadata, requirement)
 
     assert ver == "0.15.5"
+
+
+def test_install_different_version(selenium_standalone_micropip):
+    selenium = selenium_standalone_micropip
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
+            import micropip
+            await micropip.install(
+                "https://files.pythonhosted.org/packages/89/06/2c2d3034b4d6bf22f2a4ae546d16925898658a33b4400cfb7e2c1e2871a3/pytz-2020.5-py2.py3-none-any.whl"
+            );
+        `);
+        """
+    )
+    selenium.run_js(
+        """
+        pyodide.runPython(`
+            import pytz
+            assert pytz.__version__ == "2020.5"
+        `);
+        """
+    )


### PR DESCRIPTION
This resolves #725. However, there are still some issues. The following code fails with an IO error
```js
await pyodide.runPythonAsync(`
import micropip
await micropip.install("https://files.pythonhosted.org/packages/70/94/784178ca5dd892a98f113cdd923372024dc04b8d40abe77ca76b5fb90ca6/pytz-2021.1-py2.py3-none-any.whl")
import pytz
`)
```
because both `loadPackagesFromImports` and `micropip.install` try to install `pytz`.

The situation would be solved if we removed the `loadPackagesFromImports` call from `runPythonAsync`. 
@rth What do you think about this?