### PR TITLE
Store artifacts in build-core CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,13 @@ jobs:
           paths:
             - .
 
+      - run:
+          name: Prepare CircleCI artifacts
+          command: PYODIDE_BASE_URL="./" make build/console.html
+
+      - store_artifacts:
+          path: /root/repo/build/
+
   build-packages:
     <<: *defaults
     steps:


### PR DESCRIPTION
Following #1453 also store artifacts from the core CI job so we can test a PR in a REPL without waiting for all packages to build.