### PR TITLE
FIX Only use Pyodide package if version constraint is satisfied

### DIFF
--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -125,7 +125,22 @@ async def _install_wheel(name, fileinfo):
 
 
 class _PackageManager:
-    version_scheme = version.get_scheme("normalized")
+    # PEP 386 version scheme
+    # https://www.python.org/dev/peps/pep-0386/#setuptools
+    #
+    # PEP 386 is "perhaps the most widely used Python version scheme, but since
+    # it tries to be very flexible and work with a wide range of conventions, it
+    # ends up allowing a very chaotic mess of version conventions"
+    #
+    # 'adaptive' is the distlib default version scheme. It "is based on the PEP
+    # 386 scheme, but when handed a non-conforming version, automatically tries
+    # to convert it to a normalized version"
+    #
+    # According to distlib docs, 'adaptive' successfully parses the versions of
+    # 96% of pypi packages tested (23685/24891)
+    #
+    # https://distlib.readthedocs.io/en/stable/internals.html#the-version-api
+    version_scheme = version.get_scheme("adaptive")
 
     def __init__(self):
         if IN_BROWSER:

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -125,22 +125,17 @@ async def _install_wheel(name, fileinfo):
 
 
 class _PackageManager:
-    # PEP 386 version scheme
-    # https://www.python.org/dev/peps/pep-0386/#setuptools
+    # 'normalized' is the distlib default version scheme, it is based on PEP 386.
     #
     # PEP 386 is "perhaps the most widely used Python version scheme, but since
     # it tries to be very flexible and work with a wide range of conventions, it
     # ends up allowing a very chaotic mess of version conventions"
     #
-    # 'adaptive' is the distlib default version scheme. It "is based on the PEP
-    # 386 scheme, but when handed a non-conforming version, automatically tries
-    # to convert it to a normalized version"
-    #
-    # According to distlib docs, 'adaptive' successfully parses the versions of
-    # 96% of pypi packages tested (23685/24891)
+    # PEP 386 version scheme
+    # https://www.python.org/dev/peps/pep-0386/#setuptools
     #
     # https://distlib.readthedocs.io/en/stable/internals.html#the-version-api
-    version_scheme = version.get_scheme("adaptive")
+    version_scheme = version.get_scheme("normalized")
 
     def __init__(self):
         if IN_BROWSER:

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -186,7 +186,29 @@ def test_install_different_version(selenium_standalone_micropip):
     )
     selenium.run_js(
         """
-        pyodide.runPython(`
+        await pyodide.runPythonAsync(`
+            import pytz
+            assert pytz.__version__ == "2020.5"
+        `);
+        """
+    )
+
+
+def test_install_different_version2(selenium_standalone_micropip):
+    selenium = selenium_standalone_micropip
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
+            import micropip
+            await micropip.install(
+                "pytz == 2020.5"
+            );
+        `);
+        """
+    )
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
             import pytz
             assert pytz.__version__ == "2020.5"
         `);

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -31,6 +31,7 @@ class Package:
 
         self.meta: dict = parse_package_config(pkgpath)
         self.name: str = self.meta["package"]["name"]
+        self.version: str = self.meta["package"]["version"]
         self.library: bool = self.meta.get("build", {}).get("library", False)
         self.shared_library: bool = self.meta.get("build", {}).get(
             "sharedlibrary", False
@@ -219,6 +220,7 @@ def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
         "dependencies": {"test": []},
         "import_name_to_package_name": {},
         "shared_library": {},
+        "versions": {},
     }
 
     libraries = [pkg.name for pkg in pkg_map.values() if pkg.library]
@@ -231,6 +233,7 @@ def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
         package_data["dependencies"][name] = [
             x for x in pkg.dependencies if x not in libraries
         ]
+        package_data["versions"][name] = pkg.version
         for imp in pkg.meta.get("test", {}).get("imports", [name]):
             package_data["import_name_to_package_name"][imp] = name
 


### PR DESCRIPTION
This fixes the other bug listed in #725. I added the version info to packages.json, then check whether a Pyodide package matches the version constraint before using it. When we decide to use it, store the version info into `installed_packages` so that later packages can check whether previously installed version matches their version constraints.

This should reduce the frequency with which there are unexpected version clashes that crash at import time or run time.

I also added extra comments and cleaned up the code a little bit.