### PR TITLE
Use packaging instead of distlib in micropip

### DIFF
--- a/packages/micropip/meta.yaml
+++ b/packages/micropip/meta.yaml
@@ -3,7 +3,8 @@ package:
   version: "0.1"
 requirements:
   run:
-    - distlib
+    - pyparsing
+    - packaging
 source:
   path: micropip
 test:

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -6,13 +6,13 @@ import json
 from pathlib import Path
 import zipfile
 from typing import Dict, Any, Union, List, Tuple
-from pyodide import to_js
 
-from distlib import markers, util, version
+from packaging.requirements import Requirement
 
 # Provide stubs for testing in native python
 try:
     import pyodide_js
+    from pyodide import to_js
 
     IN_BROWSER = True
 except ImportError:
@@ -125,18 +125,6 @@ async def _install_wheel(name, fileinfo):
 
 
 class _PackageManager:
-    # 'normalized' is the distlib default version scheme, it is based on PEP 386.
-    #
-    # PEP 386 is "perhaps the most widely used Python version scheme, but since
-    # it tries to be very flexible and work with a wide range of conventions, it
-    # ends up allowing a very chaotic mess of version conventions"
-    #
-    # PEP 386 version scheme
-    # https://www.python.org/dev/peps/pep-0386/#setuptools
-    #
-    # https://distlib.readthedocs.io/en/stable/internals.html#the-version-api
-    version_scheme = version.get_scheme("normalized")
-
     def __init__(self):
         if IN_BROWSER:
             self.builtin_packages = pyodide_js._module.packages.versions.to_py()
@@ -145,12 +133,6 @@ class _PackageManager:
         self.installed_packages = {}
 
     async def install(self, requirements: Union[str, List[str]], ctx=None):
-        if ctx is None:
-            ctx = {"extra": None}
-
-        complete_ctx = dict(markers.DEFAULT_CONTEXT)
-        complete_ctx.update(ctx)
-
         if isinstance(requirements, str):
             requirements = [requirements]
 
@@ -162,7 +144,7 @@ class _PackageManager:
         requirement_promises = []
         for requirement in requirements:
             requirement_promises.append(
-                self.add_requirement(requirement, complete_ctx, transaction)
+                self.add_requirement(requirement, ctx, transaction)
             )
 
         await gather(*requirement_promises)
@@ -174,11 +156,13 @@ class _PackageManager:
         if len(pyodide_packages):
             # Note: branch never happens in out-of-browser testing because in
             # that case builtin_packages is empty.
-            self.installed_packages.update(
-                {name: ver for (name, ver) in pyodide_packages}
-            )
+            self.installed_packages.update(pyodide_packages)
             wheel_promises.append(
-                asyncio.ensure_future(pyodide_js.loadPackage(to_js(pyodide_packages)))
+                asyncio.ensure_future(
+                    pyodide_js.loadPackage(
+                        to_js([name for [name, _] in pyodide_packages])
+                    )
+                )
             )
 
         # Now install PyPI packages
@@ -199,29 +183,28 @@ class _PackageManager:
             transaction["wheels"].append((name, wheel, version))
             return
 
-        req = util.parse_requirement(requirement)
-
-        matcher = self.version_scheme.matcher(req.requirement)
+        req = Requirement(requirement)
 
         # If there's a Pyodide package that matches the version constraint, use
         # the Pyodide package instead of the one on PyPI
-        if req.name in self.builtin_packages and matcher.match(
-            self.builtin_packages[req.name]
+        if (
+            req.name in self.builtin_packages
+            and self.builtin_packages[req.name] in req.specifier
         ):
             version = self.builtin_packages[req.name]
             transaction["pyodide_packages"].append((req.name, version))
             return
 
         if req.marker:
-            # handle environment-markers
+            # handle environment markers
             # https://www.python.org/dev/peps/pep-0508/#environment-markers
-            if not markers.evaluator.evaluate(req.marker, ctx):
+            if not req.marker.evaluate(ctx):
                 return
 
         # Is some version of this package is already installed?
         if req.name in transaction["locked"]:
             ver = transaction["locked"][req.name]
-            if matcher.match(ver):
+            if ver in req.specifier:
                 # installed version matches, nothing to do
                 return
             else:
@@ -239,25 +222,19 @@ class _PackageManager:
 
         transaction["wheels"].append((req.name, wheel, ver))
 
-    def find_wheel(self, metadata, req):
-        releases = []
-        for ver, files in metadata.get("releases", {}).items():
-            ver = self.version_scheme.suggest(ver)
-            if ver is not None:
-                releases.append((ver, files))
+    def find_wheel(self, metadata, req: Requirement):
+        releases = metadata.get("releases", {})
+        candidate_versions = sorted(
+            (Version(v) for v in req.specifier.filter(releases)),  # type: ignore
+            reverse=True,
+        )
+        for ver in candidate_versions:
+            release = releases[str(ver)]
+            for fileinfo in release:
+                if fileinfo["filename"].endswith("py3-none-any.whl"):
+                    return fileinfo, ver
 
-        def version_number(release):
-            return version.NormalizedVersion(release[0])
-
-        releases = sorted(releases, key=version_number, reverse=True)
-        matcher = self.version_scheme.matcher(req.requirement)
-        for ver, meta in releases:
-            if matcher.match(ver):
-                for fileinfo in meta:
-                    if fileinfo["filename"].endswith("py3-none-any.whl"):
-                        return fileinfo, ver
-
-        raise ValueError(f"Couldn't find a pure Python 3 wheel for '{req.requirement}'")
+        raise ValueError(f"Couldn't find a pure Python 3 wheel for '{req}'")
 
 
 # Make PACKAGE_MANAGER singleton

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -125,7 +125,22 @@ async def _install_wheel(name, fileinfo):
 
 
 class _PackageManager:
-    version_scheme = version.get_scheme("normalized")
+    # PEP 386 version scheme
+    # https://www.python.org/dev/peps/pep-0386/#setuptools
+    #
+    # PEP 386 is "perhaps the most widely used Python version scheme, but since
+    # it tries to be very flexible and work with a wide range of conventions, it
+    # ends up allowing a very chaotic mess of version conventions"
+    #
+    # 'adaptive' is the distlib default version scheme. It "is based on the PEP
+    # 386 scheme, but when handed a non-conforming version, automatically tries
+    # to convert it to a normalized version"
+    #
+    # According to distlib docs, 'adaptive' successfully parses the versions of
+    # 96% of pypi packages tested (23685/24891)
+    #
+    # https://distlib.readthedocs.io/en/stable/internals.html#the-version-api
+    version_scheme = version.get_scheme("adaptive")
 
     def __init__(self):
         if IN_BROWSER:

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -125,22 +125,17 @@ async def _install_wheel(name, fileinfo):
 
 
 class _PackageManager:
-    # PEP 386 version scheme
-    # https://www.python.org/dev/peps/pep-0386/#setuptools
+    # 'normalized' is the distlib default version scheme, it is based on PEP 386.
     #
     # PEP 386 is "perhaps the most widely used Python version scheme, but since
     # it tries to be very flexible and work with a wide range of conventions, it
     # ends up allowing a very chaotic mess of version conventions"
     #
-    # 'adaptive' is the distlib default version scheme. It "is based on the PEP
-    # 386 scheme, but when handed a non-conforming version, automatically tries
-    # to convert it to a normalized version"
-    #
-    # According to distlib docs, 'adaptive' successfully parses the versions of
-    # 96% of pypi packages tested (23685/24891)
+    # PEP 386 version scheme
+    # https://www.python.org/dev/peps/pep-0386/#setuptools
     #
     # https://distlib.readthedocs.io/en/stable/internals.html#the-version-api
-    version_scheme = version.get_scheme("adaptive")
+    version_scheme = version.get_scheme("normalized")
 
     def __init__(self):
         if IN_BROWSER:

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -186,7 +186,29 @@ def test_install_different_version(selenium_standalone_micropip):
     )
     selenium.run_js(
         """
-        pyodide.runPython(`
+        await pyodide.runPythonAsync(`
+            import pytz
+            assert pytz.__version__ == "2020.5"
+        `);
+        """
+    )
+
+
+def test_install_different_version2(selenium_standalone_micropip):
+    selenium = selenium_standalone_micropip
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
+            import micropip
+            await micropip.install(
+                "pytz == 2020.5"
+            );
+        `);
+        """
+    )
+    selenium.run_js(
+        """
+        await pyodide.runPythonAsync(`
             import pytz
             assert pytz.__version__ == "2020.5"
         `);

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -140,20 +140,10 @@ def test_install_custom_relative_url(selenium_standalone_micropip):
 def test_last_version_from_pypi():
     pytest.importorskip("distlib")
     import micropip
-
-    class Namespace:
-        def __init__(self, **entries):
-            self.__dict__.update(entries)
+    from packaging.requirements import Requirement
 
     # requirement as returned by distlib.util.parse_requirement
-    requirement = Namespace(
-        constraints=None,
-        extras=None,
-        marker=None,
-        name="dummy_module",
-        requirement="dummy_module",
-        url=None,
-    )
+    requirement = Requirement("dummy_module")
 
     # available versions
     versions = ["0.0.1", "0.15.5", "0.9.1"]
@@ -169,7 +159,7 @@ def test_last_version_from_pypi():
     # get version number from find_wheel
     wheel, ver = micropip.PACKAGE_MANAGER.find_wheel(metadata, requirement)
 
-    assert ver == "0.15.5"
+    assert str(ver) == "0.15.5"
 
 
 def test_install_different_version(selenium_standalone_micropip):

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -31,6 +31,7 @@ class Package:
 
         self.meta: dict = parse_package_config(pkgpath)
         self.name: str = self.meta["package"]["name"]
+        self.version: str = self.meta["package"]["version"]
         self.library: bool = self.meta.get("build", {}).get("library", False)
         self.shared_library: bool = self.meta.get("build", {}).get(
             "sharedlibrary", False
@@ -219,6 +220,7 @@ def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
         "dependencies": {"test": []},
         "import_name_to_package_name": {},
         "shared_library": {},
+        "versions": {},
     }
 
     libraries = [pkg.name for pkg in pkg_map.values() if pkg.library]
@@ -231,6 +233,7 @@ def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
         package_data["dependencies"][name] = [
             x for x in pkg.dependencies if x not in libraries
         ]
+        package_data["versions"][name] = pkg.version
         for imp in pkg.meta.get("test", {}).get("imports", [name]):
             package_data["import_name_to_package_name"][imp] = name
 


### PR DESCRIPTION
This is on top of #1463. Over there we discussed switching to `packaging` which seems to be recommended over `distlib`. Since `packaging` together with it's dependency `pyparsing` are together smaller than `distlib`, even when we remove the executables from `distlib`, and the code using `packaging` is somewhat simpler this seems to be a bit helpful in several ways.