### PR TITLE
DOC Add pyodide_build CLI documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,8 @@ extensions = [
     "sphinx_js",
     "autodocsumm",
     "sphinx_pyodide",
+    #    "sphinxarg.ext",
+    "sphinx_argparse_cli",
 ]
 
 myst_enable_extensions = ["substitution"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ extensions = [
     "sphinx_js",
     "autodocsumm",
     "sphinx_pyodide",
-    #    "sphinxarg.ext",
     "sphinx_argparse_cli",
 ]
 

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -28,7 +28,7 @@ load a package's dependencies automatically.
 ## mkpkg
 
 If you wish to create a new package for Pyodide, the easiest place to start is
-with the {ref}`mkpkg tool <pyodide-build-cli>`. If your package is on PyPI, just run:
+with the {ref}`mkpkg tool <pyodide-mkpkg>`. If your package is on PyPI, just run:
 
 `bin/pyodide mkpkg $PACKAGE_NAME`
 

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -28,7 +28,7 @@ load a package's dependencies automatically.
 ## mkpkg
 
 If you wish to create a new package for Pyodide, the easiest place to start is
-with the `mkpkg` tool. If your package is on PyPI, just run:
+with the {ref}`mkpkg tool <pyodide-build-cli>`. If your package is on PyPI, just run:
 
 `bin/pyodide mkpkg $PACKAGE_NAME`
 

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -6,3 +6,4 @@ distlib   # required by micropip
 sphinx-js==3.1
 autodocsumm
 docutils==0.16
+sphinx-argparse-cli~=1.5.1

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -6,4 +6,4 @@ distlib   # required by micropip
 sphinx-js==3.1
 autodocsumm
 docutils==0.16
-sphinx-argparse-cli~=1.5.1
+sphinx-argparse-cli~=1.6.0

--- a/docs/usage/api-reference.md
+++ b/docs/usage/api-reference.md
@@ -7,4 +7,5 @@
    api/js-api.md
    api/python-api.md
    api/micropip-api.md
+   api/pyodide-build-cli.md
 ```

--- a/docs/usage/api/pyodide-build-cli.md
+++ b/docs/usage/api/pyodide-build-cli.md
@@ -1,0 +1,10 @@
+(pyodide-build-cli)=
+# pyodide_build CLI
+
+```{eval-rst}
+.. sphinx_argparse_cli::
+   :module: pyodide_build.__main__
+   :func: make_parser
+   :prog: bin/pyodide
+   :title:
+```

--- a/pyodide_build/__main__.py
+++ b/pyodide_build/__main__.py
@@ -8,8 +8,11 @@ from . import serve
 from . import mkpkg
 
 
-def main():
+def make_parser() -> argparse.ArgumentParser:
+    """Create an argument parser with argparse"""
+
     main_parser = argparse.ArgumentParser(prog="pyodide")
+    main_parser.description = "A command line interface (CLI) for pyodide_build"
     subparsers = main_parser.add_subparsers(help="action")
 
     for command_name, module in (
@@ -19,8 +22,13 @@ def main():
         ("serve", serve),
         ("mkpkg", mkpkg),
     ):
-        parser = module.make_parser(subparsers.add_parser(command_name))
-        parser.set_defaults(func=module.main)
+        parser = module.make_parser(subparsers.add_parser(command_name))  # type: ignore
+        parser.set_defaults(func=module.main)  # type: ignore
+    return main_parser
+
+
+def main():
+    main_parser = make_parser()
 
     args = main_parser.parse_args()
     if hasattr(args, "func"):

--- a/pyodide_build/__main__.py
+++ b/pyodide_build/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import sys
 
 from . import buildall
 from . import buildpkg
@@ -22,6 +23,13 @@ def make_parser() -> argparse.ArgumentParser:
         ("serve", serve),
         ("mkpkg", mkpkg),
     ):
+        if "sphinx" in sys.modules and command_name in [
+            "buildpkg",
+            "buildall",
+            "pywasmcross",
+        ]:
+            # Likely building documentation, skip private API
+            continue
         parser = module.make_parser(subparsers.add_parser(command_name))  # type: ignore
         parser.set_defaults(func=module.main)  # type: ignore
     return main_parser

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -244,7 +244,9 @@ def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
 def make_parser(parser):
     parser.description = (
         "Build all of the packages in a given directory\n\n"
-        "Unless the --only option is provided"
+        "Unless the --only option is provided\n\n"
+        "Note: this is a private endpoint that should not be used "
+        "outside of the pyodide Makefile."
     )
     parser.add_argument(
         "dir",

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -297,7 +297,11 @@ def build_package(path: Path, args):
 
 
 def make_parser(parser: argparse.ArgumentParser):
-    parser.description = "Build a pyodide package."
+    parser.description = (
+        "Build a pyodide package.\n\n"
+        "Note: this is a private endpoint that should not be used "
+        "outside of the Pyodide Makefile."
+    )
     parser.add_argument(
         "package", type=str, nargs=1, help="Path to meta.yaml package description"
     )

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -435,7 +435,9 @@ def make_parser(parser):
     else:
         parser.description = (
             "Cross compile a Python distutils package. "
-            "Run from the root directory of the package's source"
+            "Run from the root directory of the package's source.\n\n"
+            "Note: this is a private endpoint that should not be used "
+            "outside of the Pyodide Makefile."
         )
         parser.add_argument(
             "--cflags",


### PR DESCRIPTION
Adds CLI documentation for pyodide_build.  Closes https://github.com/pyodide/pyodide/issues/854

Typically it would be called as `bin/pyodide <subcommand>`. The other, maybe clearer alternative, is `python -m pyodide_build <subcommand>` but because pyodide_build is not yet an installable package (doesn't have a `setup.py`) that only works from the root dir which is confusing.  

Done with https://github.com/gaborbernat/sphinx-argparse-cli, the other alternative was https://github.com/alex-rudakov/sphinx-argparse but it's not longer maintained and the rendering looks better with sphinx-argparse-cli.

- still haven't figured out how to cross-reference sub-commands https://github.com/gaborbernat/sphinx-argparse-cli/issues/7
- the description of sub-commands doesn't seem to be taken into account, will open an issue about it

Rendered docs: https://pyodide--1471.org.readthedocs.build/en/1471/usage/api/pyodide-build-cli.html