### PR TITLE
MAINT Improved Module.fatal_error

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -120,6 +120,38 @@ class SeleniumWrapper:
                     throw new Error(`Assertion failed: ${cb.toString().slice(6)}${message}`);
                 }
             };
+            window.assertThrows = function assert(cb, errname, pattern){
+                let pat_str = typeof pattern === "string" ? `"${pattern}"` : `${pattern}`;
+                let thiscallstr = `assertThrows(${cb.toString()}, "${errname}", ${pat_str})`;
+                if(typeof pattern === "string"){
+                    pattern = new RegExp(pattern);
+                }
+                let err = undefined;
+                try {
+                    cb();
+                } catch(e) {
+                    err = e;
+                }
+                console.log(err ? err.message : "no error");
+                if(!err){
+                    console.log("hi?");
+                    throw new Error(`${thiscallstr} failed, no error thrown`);
+                }
+                if(err.constructor.name !== errname){
+                    console.log(err.toString());
+                    throw new Error(
+                        `${thiscallstr} failed, expected error ` +
+                        `of type '${errname}' got type '${err.constructor.name}'`
+                    );
+                }
+                if(!pattern.test(err.message)){
+                    console.log(err.toString());
+                    throw new Error(
+                        `${thiscallstr} failed, expected error ` +
+                        `message to match pattern ${pat_str} got:\n${err.message}`
+                    );
+                }
+            };
             """,
             pyodide_checks=False,
         )

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -477,7 +477,7 @@ def test_fatal_error(selenium_standalone):
         == dedent(
             """
             Python initialization complete
-            Pyodide has suffered a fatal error, refresh the page. Please report this to the Pyodide maintainers.
+            Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.
             The cause of the fatal error was:
             {}
             Stack (most recent call first):
@@ -489,4 +489,11 @@ def test_fatal_error(selenium_standalone):
               File "/lib/python3.8/site-packages/pyodide/_base.py", line 344 in eval_code
             """
         ).strip()
+    )
+    selenium_standalone.run_js(
+        """
+        assertThrows(() => pyodide.runPython, "Error", "Pyodide already fatally failed and can no longer be used.")
+        assertThrows(() => pyodide.globals, "Error", "Pyodide already fatally failed and can no longer be used.")
+        assert(() => pyodide._module.runPython("1+1") === 2);
+        """
     )

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -127,7 +127,7 @@ def test_pyproxy_destroy(selenium):
         selenium.run_js(
             """
             let f = pyodide.globals.get('f');
-            console.assert(f.get_value(1) === 64);
+            assert(()=> f.get_value(1) === 64);
             f.destroy();
             f.get_value();
             """
@@ -370,37 +370,6 @@ def test_pyproxy_mixins(selenium):
 def test_pyproxy_mixins2(selenium):
     selenium.run_js(
         """
-        window.assert = function assert(cb){
-            if(cb() !== true){
-                throw new Error(`Assertion failed: ${cb.toString().slice(6)}`);
-            }
-        };
-        window.assertThrows = function assert(cb, errname, pattern){
-          let err = undefined;
-          try {
-            cb();
-          } catch(e) {
-            err = e;
-          } finally {
-            if(!err){
-              throw new Error(`assertThrows(${cb.toString()}) failed, no error thrown`);
-            }
-            if(err.constructor.name !== errname){
-              console.log(err.toString());
-              throw new Error(
-                `assertThrows(${cb.toString()}) failed, expected error` +
-                `of type '${errname}' got type '${err.constructor.name}'`
-              );
-            }
-            if(!pattern.test(err.message)){
-              console.log(err.toString());
-              throw new Error(
-                `assertThrows(${cb.toString()}) failed, expected error` +
-                `message to match pattern '${pattern}' got:\n${err.message}`
-              );
-            }
-          }
-        };
         assert(() => !("prototype" in pyodide.globals));
         assert(() => !("caller" in pyodide.globals));
         assert(() => !("name" in pyodide.globals));

--- a/src/tests/test_testing.py
+++ b/src/tests/test_testing.py
@@ -11,3 +11,73 @@ def test_web_server_secondary(selenium, web_server_secondary):
 @run_in_pyodide
 def test_run_in_pyodide():
     pass
+
+
+def test_assert(selenium):
+    selenium.run_js(
+        r"""
+        let shouldPass;
+        shouldPass = true;
+        assert(() => shouldPass, "blah");
+        shouldPass = false;
+        let threw = false;
+        try {
+            assert(() => shouldPass, "blah");
+        } catch(e){
+            threw = true;
+            if(e.message !== `Assertion failed: shouldPass\nblah`){
+                throw new Error(`Unexpected message:\n${e.message}`);
+            }
+        }
+        if(!threw){
+            throw new Error("Didn't throw!");
+        }
+        """
+    )
+
+    selenium.run_js(
+        r"""
+        let shouldPass;
+        let threw;
+        assertThrows(() => { throw new TypeError("aaabbbccc") }, "TypeError", "bbc");
+        assertThrows(() => { throw new TypeError("aaabbbccc") }, "TypeError", /.{3}.{3}.{3}/);
+
+        threw = false;
+        try {
+            assertThrows(() => 0, "TypeError", /.*/);
+        } catch(e) {
+            threw = true;
+            assert(() => e.message == `assertThrows(() => 0, "TypeError", /.*/) failed, no error thrown`, e.message);
+        }
+        assert(() => threw);
+
+        threw = false;
+        try {
+            assertThrows(() => { throw new ReferenceError("blah"); }, "TypeError", /.*/);
+        } catch(e) {
+            threw = true;
+            assert(() => e.message.endsWith("expected error of type 'TypeError' got type 'ReferenceError'"));
+        }
+        assert(() => threw);
+
+        threw = false;
+        try {
+            assertThrows(() => { throw new TypeError("blah"); }, "TypeError", "abcd");
+        } catch(e) {
+            threw = true;
+            console.log(`!!${e.message}!!`);
+            assert(() => e.message.endsWith(`expected error message to match pattern "abcd" got:\nblah`));
+        }
+        assert(() => threw);
+
+        threw = false;
+        try {
+            assertThrows(() => { throw new TypeError("blah"); }, "TypeError", /a..d/);
+        } catch(e) {
+            threw = true;
+            console.log(`!!${e.message}!!`);
+            assert(() => e.message.endsWith(`expected error message to match pattern /a..d/ got:\nblah`));
+        }
+        assert(() => threw);
+        """
+    )

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -78,15 +78,6 @@ def test_nan_conversions(selenium):
 def test_bigint_conversions(selenium_module_scope, n):
     with selenium_context_manager(selenium_module_scope) as selenium:
         h = hex(n)
-        selenium.run_js(
-            """
-            window.assert = function assert(cb){
-                if(cb() !== true){
-                    throw new Error(`Assertion failed: ${cb.toString().slice(6)}`);
-                }
-            };
-            """
-        )
         selenium.run_js(f"window.h = {h!r};")
         selenium.run_js(
             """
@@ -659,25 +650,15 @@ def test_python2js_with_depth(selenium):
 
     selenium.run_js(
         """
-        window.assert = function assert(x, msg){
-            if(x !== true){
-                throw new Error(`Assertion failed: ${msg}`);
-            }
-        }
-        """
-    )
-
-    selenium.run_js(
-        """
         pyodide.runPython("a = [1,[2,[3,[4,[5,[6,[7]]]]]]]")
         let a = pyodide.globals.get("a");
         for(let i=0; i < 7; i++){
             let x = a.toJs(i);
             for(let j=0; j < i; j++){
-                assert(Array.isArray(x), `i: ${i}, j: ${j}`);
+                assert(() => Array.isArray(x), `i: ${i}, j: ${j}`);
                 x = x[1];
             }
-            assert(pyodide.isPyProxy(x), `i: ${i}, j: ${i}`);
+            assert(() => pyodide.isPyProxy(x), `i: ${i}, j: ${i}`);
         }
         """
     )
@@ -685,19 +666,14 @@ def test_python2js_with_depth(selenium):
     selenium.run_js(
         """
         pyodide.runPython("a = [1, (2, (3, [4, (5, (6, [7]))]))]")
-        function assert(x, msg){
-            if(x !== true){
-                throw new Error(`Assertion failed: ${msg}`);
-            }
-        }
         let a = pyodide.globals.get("a");
         for(let i=0; i < 7; i++){
             let x = a.toJs(i);
             for(let j=0; j < i; j++){
-                assert(Array.isArray(x), `i: ${i}, j: ${j}`);
+                assert(() => Array.isArray(x), `i: ${i}, j: ${j}`);
                 x = x[1];
             }
-            assert(pyodide.isPyProxy(x), `i: ${i}, j: ${i}`);
+            assert(() => pyodide.isPyProxy(x), `i: ${i}, j: ${i}`);
         }
         """
     )
@@ -712,10 +688,10 @@ def test_python2js_with_depth(selenium):
         let total_refs = pyodide._module.hiwire.num_keys();
         let res = pyodide.globals.get("c").toJs();
         let new_total_refs = pyodide._module.hiwire.num_keys();
-        assert(total_refs === new_total_refs);
-        assert(res[0] === res[1]);
-        assert(res[0][0] === res[1][1]);
-        assert(res[4][0] === res[1][4]);
+        assert(() => total_refs === new_total_refs);
+        assert(() => res[0] === res[1]);
+        assert(() => res[0][0] === res[1][1]);
+        assert(() => res[4][0] === res[1][4]);
         """
     )
 
@@ -730,11 +706,11 @@ def test_python2js_with_depth(selenium):
         let total_refs = pyodide._module.hiwire.num_keys();
         let res = pyodide.globals.get("a").toJs();
         let new_total_refs = pyodide._module.hiwire.num_keys();
-        assert(total_refs === new_total_refs);
-        assert(res[0][0] === "b");
-        assert(res[1][2] === 3);
-        assert(res[1][3] === res[0]);
-        assert(res[0][1] === res[1]);
+        assert(() => total_refs === new_total_refs);
+        assert(() => res[0][0] === "b");
+        assert(() => res[1][2] === 3);
+        assert(() => res[1][3] === res[0]);
+        assert(() => res[0][1] === res[1]);
         """
     )
     msg = "pyodide.ConversionError"


### PR DESCRIPTION
The current `Module.fatal_error` has a few drawbacks:
1. `pyodide._module.runPython` won't work anymore
2. After it fails some actions cause `Error: Object already destroyed` which is unhelpful in the CI.

I also added `assertThrows` to `conftest.py` and added `test_testing` tests which test `assertThrows` and `assert`.