### PR TITLE
DOC Make dev documentation consistent + version warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 [![Build Status](https://circleci.com/gh/pyodide/pyodide.png)](https://circleci.com/gh/pyodide/pyodide)
-[![Documentation Status](https://readthedocs.org/projects/pyodide/badge/?version=latest)](https://pyodide.readthedocs.io/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/pyodide/badge/?version=v0.17.0a2)](https://pyodide.readthedocs.io/?badge=v0.17.0a2)
 
 Python with the scientific stack, compiled to WebAssembly.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ import pyodide
 import micropip  # noqa
 
 # The full version, including alpha/beta/rc tags.
-release = version = "0.15.0"  # pyodide.__version__
+release = version = pyodide.__version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,8 +57,8 @@ versionwarning_messages = {
     "latest": (
         "This is the development version of the documentation. ",
         'See <a href="https://pyodide.org/">here</a> for latest stable '
-        "documentation. In particular, do not use Pyodide with non "
-        "versionned (`dev`) URLs from the CDN for deployed applications.",
+        "documentation. Please do not use Pyodide with non "
+        "versioned (`dev`) URLs from the CDN for deployed applications!",
     )
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ import pyodide
 import micropip  # noqa
 
 # The full version, including alpha/beta/rc tags.
-release = version = pyodide.__version__
+release = version = "0.15.0"  # pyodide.__version__
 
 
 # -- General configuration ---------------------------------------------------
@@ -46,11 +46,21 @@ extensions = [
     "autodocsumm",
     "sphinx_pyodide",
     "sphinx_argparse_cli",
+    "versionwarning.extension",
 ]
 
 myst_enable_extensions = ["substitution"]
 js_source_path = ["../src/", "../src/core"]
 root_for_relative_js_paths = "../src/"
+
+versionwarning_messages = {
+    "latest": (
+        "This is the development version of the documentation. ",
+        'See <a href="https://pyodide.org/">here</a> for latest stable '
+        "documentation. In particular, do not use Pyodide with non "
+        "versionned (`dev`) URLs from the CDN for deployed applications.",
+    )
+}
 
 autosummary_generate = True
 autodoc_default_flags = ["members", "inherited-members"]

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -7,3 +7,4 @@ sphinx-js==3.1
 autodocsumm
 docutils==0.16
 sphinx-argparse-cli~=1.6.0
+sphinx-version-warning~=1.1.2

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -118,10 +118,10 @@ installs from PyPi.
   <meta charset="utf-8">
 </head>
 <body>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/pyodide.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
   <script type="text/javascript">
     async function main(){
-      await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/' });
+      await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/dev/full/' });
       await pyodide.runPythonAsync(`
         import micropip # runPythonAsync will load micropip automatically
         await micropip.install('snowballstemmer')

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -6,7 +6,7 @@
 
 To include Pyodide in your project you can use the following CDN URL:
 ```{eval-rst}
-  https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/pyodide.js
+  https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js
 ```
 
 You can also download a release from [Github
@@ -20,7 +20,7 @@ namespace called {js:mod}`pyodide`.
 
 ```pyodide
 async function main() {
-  await loadPyodide({ indexURL : "https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/" });
+  await loadPyodide({ indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/" });
   // Pyodide is now ready to use...
   console.log(pyodide.runPython(`
     import sys
@@ -54,7 +54,7 @@ Create and save a test `index.html` page with the following contents:
 <!DOCTYPE html>
 <html>
   <head>
-      <script src="https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/pyodide.js"></script>
+      <script src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
   </head>
   <body>
     Pyodide test page <br>
@@ -62,7 +62,7 @@ Create and save a test `index.html` page with the following contents:
     <script type="text/javascript">
       async function main(){
         await loadPyodide({
-          indexURL : "https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/"
+          indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/"
         });
         console.log(pyodide.runPython(`
             import sys
@@ -83,7 +83,7 @@ Create and save a test `index.html` page with the following contents:
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
 </head>
 
 <body>
@@ -108,7 +108,7 @@ Create and save a test `index.html` page with the following contents:
     output.value = 'Initializing...\n';
     // init Pyodide
     async function main(){
-      await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/' });
+      await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/dev/full/' });
       output.value += 'Ready!\n';
     }
     let pyodideReadyPromise = main();

--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -103,10 +103,10 @@ lines `pythonLoading = self.pyodide.loadPackage(['numpy', 'pytz'])` and
 // Setup your project to serve `py-worker.js`. You should also serve
 // `pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`,
 // and `.wasm` files as well:
-importScripts('https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/pyodide.js');
+importScripts('https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js');
 
 async function loadPyodideAndPackages(){
-    await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/' });
+    await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/dev/full/' });
     await self.pyodide.loadPackage(['numpy', 'pytz']);
 }
 let pyodideReadyPromise = loadPyodideAndPackages();


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide/issues/1416

This aims to make the documentation versions more consistent,
 
- **stable version**. Currently "v0.17.0a2"  https://pyodide.org/en/0.17.0a2/. Will be https://pyodide.org/en/stable/ for next release. Should already be consistent
- Unversionned path: https://pyodide.org now redirects to "v0.17.0a2" in the future will redirect to "stable"  (this can be changed as "Default version" in https://readthedocs.org/dashboard/pyodide/advanced/)
- **dev/latest version**. Uses dev URLs from the CDN, and now includes a banner about it being a development version.
- **older versions**. In the future, will show a banner about them being an outdated version thanks to https://github.com/humitos/sphinx-version-warning

Fixed README to only point to the "v0.17.0a2" (previously there was 1 link to dev out there)