### PR TITLE
CI/DOC fixes following rename of master branch to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ workflows:
             - test-emsdk
           filters:
             branches:
-              ignore: /.*/
+              only: main
             tags:
               only: /^\d+\.\d+\.\w+$/
       - deploy-s3:
@@ -345,4 +345,4 @@ workflows:
             - test-emsdk
           filters:
             branches:
-              only: master
+              only: main

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -28,9 +28,9 @@ Work on Pyodide happens on Github. Core members and contributors can make Pull
 Requests to fix issues and add features, which all go through the same review
 process. We’ll detail how you can start making PRs below.
 
-We’ll do our best to keep `master` in a non-breaking state, ideally with tests
+We’ll do our best to keep `main` in a non-breaking state, ideally with tests
 always passing. The unfortunate reality of software development is sometimes
-things break. As such, `master` cannot be expected to remain reliable at all
+things break. As such, `main` cannot be expected to remain reliable at all
 times. We recommend using the latest stable version of Pyodide.
 
 Pyodide follows semantic versioning (http://semver.org/) - major versions for
@@ -71,7 +71,7 @@ on using the Pull Request feature. We use the "fork and pull" model
 where contributors push changes to their personal fork and create pull requests
 to bring those changes into the source repository.
 
-Please make pull requests against the `master` branch.
+Please make pull requests against the `main` branch.
 
 If you’re looking for a way to jump in and contribute, our list of
 [good first issues](https://github.com/pyodide/pyodide/labels/good%20first%20issue)

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -146,11 +146,11 @@ Extra arguments to pass to the linker when building for WebAssembly.
 
 #### `build/library`
 
-Should be set to true for library packages. Library packages are packages that are needed for other packages but are not Python packages themselves. For library packages, the script specified in the `build/script` section is run to compile the library. See the [zlib meta.yaml](https://github.com/pyodide/pyodide/blob/master/packages/zlib/meta.yaml) for an example of a library package specification.
+Should be set to true for library packages. Library packages are packages that are needed for other packages but are not Python packages themselves. For library packages, the script specified in the `build/script` section is run to compile the library. See the [zlib meta.yaml](https://github.com/pyodide/pyodide/blob/main/packages/zlib/meta.yaml) for an example of a library package specification.
 
 #### `build/sharedlibrary`
 
-Should be set to true for shared library packages. Shared library packages are packages that are needed for other packages, but are loaded dynamically when Pyodide is run. For shared library packages, the script specified in the `build/script` section is run to compile the library. The script should build the shared library and copy into into a subfolder of the source folder called `install`. Files or folders in this install folder will be packaged to make the Pyodide package. See the [CLAPACK meta.yaml](https://github.com/pyodide/pyodide/blob/master/packages/CLAPACK/meta.yaml) for an example of a shared library specification.
+Should be set to true for shared library packages. Shared library packages are packages that are needed for other packages, but are loaded dynamically when Pyodide is run. For shared library packages, the script specified in the `build/script` section is run to compile the library. The script should build the shared library and copy into into a subfolder of the source folder called `install`. Files or folders in this install folder will be packaged to make the Pyodide package. See the [CLAPACK meta.yaml](https://github.com/pyodide/pyodide/blob/main/packages/CLAPACK/meta.yaml) for an example of a shared library specification.
 
 #### `build/script`
 

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -8,7 +8,7 @@ browser.
 Pyodide brings the Python 3.8 runtime to the browser via WebAssembly, along with
 the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and
 scikit-learn. The [packages
-directory](https://github.com/pyodide/pyodide/tree/master/packages) lists over
+directory](https://github.com/pyodide/pyodide/tree/main/packages) lists over
 75 packages which are currently available. In addition it's possible to install
 pure Python wheels from PyPi.
 


### PR DESCRIPTION
I forgot to replace master with main in the CI code and documentation following https://github.com/pyodide/pyodide/issues/1455  

Which explains why the dev version hasn't been deployed for a few last commits on `main`