### PR TITLE
CI Fix release deployment branch filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ workflows:
             - test-emsdk
           filters:
             branches:
-              only: main
+              ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\w+$/
       - deploy-s3:


### PR DESCRIPTION
Fixes an issue with branch filter for release deployment introduced in https://github.com/pyodide/pyodide/pull/1488 . Looks like I misunderstood how this filtering works.