### PR TITLE
Add "Try it online" section to the docs

### DIFF
--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -2,6 +2,10 @@
 
 # Getting started
 
+## Try it online
+
+Try Pyodide in a [REPL](https://pyodide.org/en/latest/console.html) directly in your browser (no installation needed).
+
 ## Setup
 
 To include Pyodide in your project you can use the following CDN URL:


### PR DESCRIPTION
There is already a link to the interactive console in the README.md to try Pyodide in the browser without installing anything:

https://github.com/pyodide/pyodide#try-pyodide-no-installation-needed

It would be nice to also have one in the docs, for folks landing on https://pyodide.org directly.

And with the latest docs, the console seems to be reachable with: https://pyodide.org/en/latest/console.html