### PR TITLE
DOC Disable sphinx versionwarning extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,8 @@ extensions = [
     "autodocsumm",
     "sphinx_pyodide",
     "sphinx_argparse_cli",
-    "versionwarning.extension",
+    #  TODO: Temporary disabling for the 0.17.0 release, needs more investigation
+    #     "versionwarning.extension",
     "sphinx_issues",
 ]
 


### PR DESCRIPTION
Temporarily disables sphinx versionwarning introduced in https://github.com/pyodide/pyodide/pull/1479

It should have shown a banner on the latest version but it didn't. Similarly I would like to make sure it doesn't mark 0.17.0 as outdated with respect to latest. Since it's not very straightforward to test locally and I didn't get an answer in https://github.com/humitos/sphinx-version-warning/issues/33 , better to exclude it from the release.