### PR TITLE
CI Disable multiprocessing for test-packages-firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       - run:
           name: test
           command: |
-            tools/pytest_wrapper.py packages/test* packages/*/test* -v -k firefox -n 2
+            tools/pytest_wrapper.py packages/test* packages/*/test* -v -k firefox
 
   test-packages-chrome:
     <<: *defaults

--- a/packages/pillow/test_pillow.py
+++ b/packages/pillow/test_pillow.py
@@ -1,9 +1,9 @@
-import pytest
 from pyodide_build.testing import run_in_pyodide
 
 
-@pytest.mark.xfail
-@run_in_pyodide(packages=["pillow"])
+@run_in_pyodide(
+    packages=["pillow"], xfail_browsers={"firefox": "timeout", "chrome": ""}
+)
 def test_pillow():
     from PIL import Image, ImageDraw, ImageOps
     import io


### PR DESCRIPTION
In 3 last CI runs on main, `test-packages-firefox failed with a timeout. Trying to work around it by disabling parallelism.