### PR TITLE
MAINT Make InteractiveConsole private

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -107,9 +107,6 @@ See the {ref}`0-17-0-release-notes` for more information.
 
 ### pyodide-py package
 
-- {{ Feature }} Added an `InteractiveConsole` class with completion support to
-  ease the integration of Pyodide REPL in webpages (used in console.html)
-  {pr}`1125` and {pr}`1155`
 - {{ Feature }} Added a Python event loop to support asyncio by scheduling
   coroutines to run as jobs on the browser event loop. This event loop is
   available by default and automatically enabled by any relevant asyncio API,

--- a/src/pyodide-py/pyodide/console.py
+++ b/src/pyodide-py/pyodide/console.py
@@ -34,12 +34,12 @@ except ImportError:
         pass
 
 
-__all__ = ["InteractiveConsole", "repr_shorten"]
+__all__ = ["repr_shorten"]
 
 
 class _StdStream(io.TextIOWrapper):
     """
-    Custom std stream to retdirect sys.stdout/stderr in InteractiveConsole.
+    Custom std stream to retdirect sys.stdout/stderr in _InteractiveConsole.
 
     Parmeters
     ---------
@@ -87,12 +87,12 @@ class _CallbackBuffer(io.RawIOBase):
         return len(data)
 
 
-class InteractiveConsole(code.InteractiveConsole):
+class _InteractiveConsole(code.InteractiveConsole):
     """Interactive Pyodide console
 
     Base implementation for an interactive console that manages
     stdout/stderr redirection. Since packages are loaded before running
-    code, :any:`InteractiveConsole.runcode` returns a JS promise.
+    code, :any:`_InteractiveConsole.runcode` returns a JS promise.
 
     ``self.stdout_callback`` and ``self.stderr_callback`` can be overloaded.
 
@@ -201,8 +201,8 @@ class InteractiveConsole(code.InteractiveConsole):
     def runsource(self, *args, **kwargs):
         """Force streams redirection.
 
-        Syntax errors are not thrown by :any:`InteractiveConsole.runcode` but
-        here in :any:`InteractiveConsole.runsource`. This is why we force
+        Syntax errors are not thrown by :any:`_InteractiveConsole.runcode` but
+        here in :any:`_InteractiveConsole.runsource`. This is why we force
         redirection here since doing twice is not an issue.
         """
 
@@ -291,7 +291,7 @@ class InteractiveConsole(code.InteractiveConsole):
 
         Examples
         --------
-        >>> shell = InteractiveConsole()
+        >>> shell = _InteractiveConsole()
         >>> shell.complete("str.isa")
         (['str.isalnum(', 'str.isalpha(', 'str.isascii('], 0)
         >>> shell.complete("a = 5 ; str.isa")

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -276,11 +276,13 @@ globalThis.loadPyodide = async function(config = {}) {
    * Load a package or a list of packages over the network. This installs the
    * package in the virtual filesystem. The package needs to be imported from
    * Python before it can be used.
-   * @param {String | Array | PyProxy} names Either a single package name or URL or a list
-   * of them. URLs can be absolute or relative. The URLs must have file name
+   * @param {String | Array | PyProxy} names Either a single package name or URL
+   * or a list of them. URLs can be absolute or relative. The URLs must have
+   * file name
    * ``<package-name>.js`` and there must be a file called
-   * ``<package-name>.data`` in the same directory. The argument can be a ``PyProxy`` of a list, 
-   * in which case the list will be converted to Javascript and the ``PyProxy`` will be destroyed.
+   * ``<package-name>.data`` in the same directory. The argument can be a
+   * ``PyProxy`` of a list, in which case the list will be converted to
+   * Javascript and the ``PyProxy`` will be destroyed.
    * @param {function} messageCallback A callback, called with progress messages
    *    (optional)
    * @param {function} errorCallback A callback, called with error/warning

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -24,7 +24,7 @@
             from pyodide import console
             import __main__
 
-            class PyConsole(console.InteractiveConsole):
+            class PyConsole(console._InteractiveConsole):
                 def __init__(self):
                     super().__init__(
                         __main__.__dict__,

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -49,7 +49,7 @@ def test_interactive_console_streams(safe_sys_redirections):
     ##########################
     # Persistent redirection #
     ##########################
-    shell = console.InteractiveConsole(
+    shell = console._InteractiveConsole(
         stdout_callback=stdout_callback,
         stderr_callback=stderr_callback,
         persistent_stream_redirection=True,
@@ -101,7 +101,7 @@ def test_interactive_console_streams(safe_sys_redirections):
     ##############################
     # Non persistent redirection #
     ##############################
-    shell = console.InteractiveConsole(
+    shell = console._InteractiveConsole(
         stdout_callback=stdout_callback,
         stderr_callback=stderr_callback,
         persistent_stream_redirection=False,
@@ -157,7 +157,7 @@ def test_interactive_console(selenium, safe_selenium_sys_redirections):
     selenium.run(
         """
         import sys
-        from pyodide.console import InteractiveConsole
+        from pyodide.console import _InteractiveConsole
 
         result = None
 
@@ -165,7 +165,7 @@ def test_interactive_console(selenium, safe_selenium_sys_redirections):
             global result
             result = value
 
-        shell = InteractiveConsole()
+        shell = _InteractiveConsole()
         shell.display = display
         """
     )
@@ -209,7 +209,7 @@ def test_completion(selenium, safe_selenium_sys_redirections):
         """
         from pyodide import console
 
-        shell = console.InteractiveConsole()
+        shell = console._InteractiveConsole()
         """
     )
 
@@ -252,7 +252,7 @@ def test_interactive_console_top_level_await(selenium, safe_selenium_sys_redirec
     selenium.run(
         """
         import sys
-        from pyodide.console import InteractiveConsole
+        from pyodide.console import _InteractiveConsole
 
         result = None
 
@@ -260,7 +260,7 @@ def test_interactive_console_top_level_await(selenium, safe_selenium_sys_redirec
             global result
             result = value
 
-        shell = InteractiveConsole()
+        shell = _InteractiveConsole()
         shell.display = display
         """
     )


### PR DESCRIPTION
Due to concerns about some aspects of the API of `InteractiveConsole` in https://github.com/pyodide/pyodide/issues/1516 and https://github.com/pyodide/pyodide/pull/1519 we are making it private for this release. I will likely get stabilized in 0.18.

(`CodeRunner` is already in a private module)