### PR TITLE
Bump main to 0.18.0dev0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,8 +51,7 @@ extensions = [
     "autodocsumm",
     "sphinx_pyodide",
     "sphinx_argparse_cli",
-    #  TODO: Temporary disabling for the 0.17.0 release, needs more investigation
-    #     "versionwarning.extension",
+    "versionwarning.extension",
     "sphinx_issues",
 ]
 
@@ -125,7 +124,7 @@ htmlhelp_basename = "Pyodidedoc"
 epub_exclude_files = ["search.html"]
 
 if "READTHEDOCS" in os.environ:
-    env = {"PYODIDE_BASE_URL": "https://cdn.jsdelivr.net/pyodide/v0.17.0/full/"}
+    env = {"PYODIDE_BASE_URL": "https://cdn.jsdelivr.net/pyodide/dev/full/"}
     os.makedirs("_build/html", exist_ok=True)
     res = subprocess.check_output(
         ["make", "-C", "..", "docs/_build/html/console.html"],

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -10,6 +10,8 @@ substitutions:
 (changelog)=
 # Change Log
 
+## [Unreleased]
+
 ## Version 0.17.0
 *April 21, 2020*
 

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -118,10 +118,10 @@ installs from PyPi.
   <meta charset="utf-8">
 </head>
 <body>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/pyodide/v0.17.0/full/pyodide.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
   <script type="text/javascript">
     async function main(){
-      await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/v0.17.0/full/' });
+      await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/dev/full/' });
       await pyodide.runPythonAsync(`
         import micropip # runPythonAsync will load micropip automatically
         await micropip.install('snowballstemmer')

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -10,7 +10,7 @@ Try Pyodide in a [REPL](https://pyodide.org/en/latest/console.html) directly in 
 
 To include Pyodide in your project you can use the following CDN URL:
 ```{eval-rst}
-  https://cdn.jsdelivr.net/pyodide/v0.17.0/full/pyodide.js
+  https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js
 ```
 
 You can also download a release from [Github
@@ -24,7 +24,7 @@ namespace called {js:mod}`pyodide`.
 
 ```pyodide
 async function main() {
-  await loadPyodide({ indexURL : "https://cdn.jsdelivr.net/pyodide/v0.17.0/full/" });
+  await loadPyodide({ indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/" });
   // Pyodide is now ready to use...
   console.log(pyodide.runPython(`
     import sys
@@ -58,7 +58,7 @@ Create and save a test `index.html` page with the following contents:
 <!DOCTYPE html>
 <html>
   <head>
-      <script src="https://cdn.jsdelivr.net/pyodide/v0.17.0/full/pyodide.js"></script>
+      <script src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
   </head>
   <body>
     Pyodide test page <br>
@@ -66,7 +66,7 @@ Create and save a test `index.html` page with the following contents:
     <script type="text/javascript">
       async function main(){
         await loadPyodide({
-          indexURL : "https://cdn.jsdelivr.net/pyodide/v0.17.0/full/"
+          indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/"
         });
         console.log(pyodide.runPython(`
             import sys
@@ -87,7 +87,7 @@ Create and save a test `index.html` page with the following contents:
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.17.0/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
 </head>
 
 <body>
@@ -112,7 +112,7 @@ Create and save a test `index.html` page with the following contents:
     output.value = 'Initializing...\n';
     // init Pyodide
     async function main(){
-      await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/v0.17.0/full/' });
+      await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/dev/full/' });
       output.value += 'Ready!\n';
     }
     let pyodideReadyPromise = main();

--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -103,10 +103,10 @@ lines `pythonLoading = self.pyodide.loadPackage(['numpy', 'pytz'])` and
 // Setup your project to serve `py-worker.js`. You should also serve
 // `pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`,
 // and `.wasm` files as well:
-importScripts('https://cdn.jsdelivr.net/pyodide/v0.17.0/full/pyodide.js');
+importScripts('https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js');
 
 async function loadPyodideAndPackages(){
-    await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/v0.17.0/full/' });
+    await loadPyodide({ indexURL : 'https://cdn.jsdelivr.net/pyodide/dev/full/' });
     await self.pyodide.loadPackage(['numpy', 'pytz']);
 }
 let pyodideReadyPromise = loadPyodideAndPackages();

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -15,7 +15,7 @@ if platform.system() == "Emscripten":
     asyncio.set_event_loop_policy(WebLoopPolicy())
 
 
-__version__ = "0.17.0"
+__version__ = "0.18.0dev0"
 
 __all__ = [
     "open_url",


### PR DESCRIPTION
We really should automate some of these replacements in the docs. The issue last time I tried was that sphinx replacements didn't work inside code blocks.