### PR TITLE
CI Fix release deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
       - run:
           name: Install requirements
           command: |
-            apk add --no-cache --update python3
+            apk add --no-cache --update python3 make
             python3 -m pip install awscli
       - run:
           name: Deploy Github Releases


### PR DESCRIPTION
This small omission almost made the release process fail.

Release CI failed https://app.circleci.com/pipelines/github/pyodide/pyodide/2715/workflows/9d6911d2-fa14-43bb-a70f-f2e26b29d792/jobs/28139 due to missing `make` before uploading to S3 but after making the GH release. I had to SSH into that CI Job to upload manually. 

Then after checking the https://pyodide.org/en/stable/console.html I realized that `PYODIDE_BASE_URL` was not set. Re-uploaded `pyodide.js` and `webworker.js` however,
 - [pyodide.js](https://cdn.jsdelivr.net/pyodide/v0.17.0/full/pyodide.js) was already cached by JsDelivr, so it serves the incorrect version meaning that `loadPyodide` without an explicit `indexURL` will not work. Though since we never mention in the docs that it's a possibility, I think it's fine.
 - [webworker.js](https://cdn.jsdelivr.net/pyodide/v0.17.0/full/webworker.js) was luckily not yet cached so it serves the correct version.

So I think it should be OK after all.