### PR TITLE
Convert eval_code helper methods to pure functions

### DIFF
--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -165,8 +165,7 @@ def should_quiet(source: str) -> bool:
     """
     Should we suppress output?
 
-    Returns ``True`` if ``quiet_trailing_semicolon`` is set to ``True`` and
-    the last nonwhitespace character of ``code`` is a semicolon.
+    Returns ``True`` if the last nonwhitespace character of ``code`` is a semicolon.
 
     Examples
     --------

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -33,6 +33,263 @@ def open_url(url: str) -> StringIO:
     req.send(None)
     return StringIO(req.response)
 
+def should_quiet(source: str) -> bool:
+    """Should we suppress output?
+
+    Returns ``True`` if the last nonwhitespace character of ``source`` is a
+    semicolon.
+    Examples
+    --------
+    >>> CodeRunner().quiet('1 + 1') False CodeRunner().quiet('1 + 1 ;') 
+    True
+    >>> CodeRunner().quiet('1 + 1 # comment ;') 
+    False
+    >>> CodeRunner(quiet_trailing_semicolon=False).quiet('1 + 1 ;') 
+    False
+    """
+    # We need to wrap tokens in a buffer because:
+    # "Tokenize requires one argument, readline, which must be
+    # a callable object which provides the same interface as the
+    # io.IOBase.readline() method of file objects"
+    source_io = StringIO(source)
+    tokens = list(tokenize.generate_tokens(source_io.readline))
+
+    for token in reversed(tokens):
+        if token.type in (
+            tokenize.ENDMARKER,
+            tokenize.NL,  # ignoring empty lines (\n\n)
+            tokenize.NEWLINE,
+            tokenize.COMMENT,
+        ):
+            continue
+        return (token.type == tokenize.OP) and (token.string == ";")
+    return False
+
+
+def _last_assign_to_expr(mod: ast.Module):
+    """
+    Implementation of 'last_expr_or_assign' return_mode.
+    It modify the supplyied AST module so that the last
+    statement's value can be returned in 'last_expr' return_mode.
+    """
+    # Largely inspired from IPython:
+    # https://github.com/ipython/ipython/blob/3587f5bb6c8570e7bbb06cf5f7e3bc9b9467355a/IPython/core/interactiveshell.py#L3229
+
+    last_node = mod.body[-1]
+
+    if isinstance(last_node, ast.Assign):
+        # In this case there can be multiple targets as in `a = b = 1`.
+        # We just take the first one.
+        target = last_node.targets[0]
+    elif isinstance(last_node, (ast.AugAssign, ast.AnnAssign)):
+        target = last_node.target
+    else:
+        return
+    if isinstance(target, ast.Name):
+        last_node = ast.Expr(ast.Name(target.id, ast.Load()))
+        mod.body.append(last_node)
+        # Update the line numbers shown in error messages.
+        ast.fix_missing_locations(mod)
+
+def _split_and_compile(code: str, *, return_mode, filename, flags: int = 0x0) -> Tuple[Any, Any]:
+    """
+    Split ``code`` in two parts, everything but last expression and
+    last expresion then compile each part.
+
+    Returns:
+    --------
+    code object
+        first part's code object (or None)
+    code object
+        last expression's code object (or None)
+    """
+    # handle mis-indented input from multi-line strings
+    code = dedent(code)
+
+    mod = ast.parse(code, filename=filename)
+    if not mod.body:
+        return None, None
+
+    if return_mode == "last_expr_or_assign":
+        # If the last statement is a named assignment, add an extra
+        # expression to the end with just the L-value so that we can
+        # handle it with the last_expr code.
+        _last_assign_to_expr(mod)
+
+    # we extract last expression
+    if (
+        return_mode.startswith("last_expr")  # last_expr or last_expr_or_assign
+        and isinstance(mod.body[-1], (ast.Expr, ast.Await))
+    ):
+        last_expr = ast.Expression(mod.body.pop().value)  # type: ignore
+    else:
+        last_expr = None  # type: ignore
+
+    # we compile
+    mod = compile(mod, filename, "exec", flags=flags)  # type: ignore
+    if last_expr is not None:
+        last_expr = compile(last_expr, filename, "eval", flags=flags)  # type: ignore
+
+    return mod, last_expr
+
+def eval_code(
+    code: str,
+    globals: Optional[Dict[str, Any]] = None,
+    locals: Optional[Dict[str, Any]] = None,
+    return_mode: str = "last_expr",
+    quiet_trailing_semicolon: bool = True,
+    filename: str = "<exec>",
+) -> Any:
+    """Runs a code string.
+
+    Parameters
+    ----------
+    code : ``str``
+
+       The Python code to run.
+
+    globals : ``dict``
+
+        The global scope in which to execute code. This is used as the ``globals``
+        parameter for ``exec``. See
+        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
+        for more info. If the ``globals`` is absent, it is set equal to a new empty
+        dictionary.
+
+    locals : ``dict``
+
+        The local scope in which to execute code. This is used as the ``locals``
+        parameter for ``exec``. As with ``exec``, if ``locals`` is absent, it is set equal
+        to ``globals``. See
+        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
+        for more info.
+
+    return_mode : ``str``
+
+        Specifies what should be returned, must be one of ``'last_expr'``,
+        ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
+        raised.
+
+        * ``'last_expr'`` -- return the last expression
+        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
+        * ``'none'`` -- always return ``None``.
+
+    quiet_trailing_semicolon : ``bool``
+
+        Whether a trailing semicolon should 'quiet' the
+        result or not. Setting this to ``True`` (default) mimic the CPython's
+        interpreter behavior ; whereas setting it to ``False`` mimic the IPython's
+        interpreter behavior.
+
+    filename : ``str``
+
+        The file name to use in error messages and stack traces
+
+    Returns
+    -------
+    ``Any``
+
+        If the last nonwhitespace character of ``code`` is a semicolon return ``None``.
+        If the last statement is an expression, return the result of the expression.
+        (Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters to
+        modify this default behavior.)
+    """
+    if quiet_trailing_semicolon and should_quiet(code):
+        return_mode = "none"
+    mod, last_expr = _split_and_compile(code, return_mode=return_mode, filename=filename)
+
+    # running first part
+    if mod is not None:
+        exec(mod, globals, locals)
+
+    # evaluating last expression
+    if last_expr is not None:
+        return eval(last_expr, globals, locals)
+
+async def eval_code_async(
+    code: str,
+    globals: Optional[Dict[str, Any]] = None,
+    locals: Optional[Dict[str, Any]] = None,
+    return_mode: str = "last_expr",
+    quiet_trailing_semicolon: bool = True,
+    filename: str = "<exec>",
+) -> Any:
+    """Runs a code string asynchronously.
+
+    Uses
+    `PyCF_ALLOW_TOP_LEVEL_AWAIT <https://docs.python.org/3/library/ast.html#ast.PyCF_ALLOW_TOP_LEVEL_AWAIT>`_
+    to compile to code.
+
+    Parameters
+    ----------
+    code : ``str``
+
+       The Python code to run.
+
+    globals : ``dict``
+
+        The global scope in which to execute code. This is used as the ``globals``
+        parameter for ``exec``. See
+        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
+        for more info. If the ``globals`` is absent, it is set equal to a new empty
+        dictionary.
+
+    locals : ``dict``
+
+        The local scope in which to execute code. This is used as the ``locals``
+        parameter for ``exec``. As with ``exec``, if ``locals`` is absent, it is set equal
+        to ``globals``. See
+        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
+        for more info.
+
+    return_mode : ``str``
+
+        Specifies what should be returned, must be one of ``'last_expr'``,
+        ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
+        raised.
+
+        * ``'last_expr'`` -- return the last expression
+        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
+        * ``'none'`` -- always return ``None``.
+
+    quiet_trailing_semicolon : ``bool``
+
+        Whether a trailing semicolon should 'quiet' the
+        result or not. Setting this to ``True`` (default) mimic the CPython's
+        interpreter behavior ; whereas setting it to ``False`` mimic the IPython's
+        interpreter behavior.
+
+    filename : ``str``
+
+        The file name to use in error messages and stack traces
+
+    Returns
+    -------
+    ``Any``
+
+        If the last nonwhitespace character of ``code`` is a semicolon return ``None``.
+        If the last statement is an expression, return the result of the expression.
+        (Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters to
+        modify this default behavior.)
+    """
+    if quiet_trailing_semicolon and should_quiet(code):
+        return_mode = "none"
+    mod, last_expr = _split_and_compile(code, return_mode=return_mode, filename=filename)
+
+    # running first part
+    coroutine = None
+    if mod is not None:
+        coroutine = exec(mod, globals, locals)
+    if coroutine is not None:
+        await coroutine
+
+    # evaluating last expression
+    result = None
+    if last_expr is not None:
+        result = eval(last_expr, globals, locals)
+    if iscoroutine(result):
+        result = await result
+    return result
 
 class CodeRunner:
     """
@@ -104,116 +361,6 @@ class CodeRunner:
             raise ValueError(f"Unrecognized return_mode {return_mode!r}")
         self.return_mode = return_mode
 
-    def quiet(self, code: str) -> bool:
-        """
-        Should we suppress output?
-
-        Returns ``True`` if ``quiet_trailing_semicolon`` is set to ``True`` and
-        the last nonwhitespace character of ``code`` is a semicolon.
-
-        Examples
-        --------
-        >>> CodeRunner().quiet('1 + 1')
-        False
-        >>> CodeRunner().quiet('1 + 1 ;')
-        True
-        >>> CodeRunner().quiet('1 + 1 # comment ;')
-        False
-        >>> CodeRunner(quiet_trailing_semicolon=False).quiet('1 + 1 ;')
-        False
-        """
-        # largely inspired from IPython:
-        # https://github.com/ipython/ipython/blob/86d24741188b0cedd78ab080d498e775ed0e5272/IPython/core/displayhook.py#L84
-
-        if not self.quiet_trailing_semicolon:
-            return False
-
-        # We need to wrap tokens in a buffer because:
-        # "Tokenize requires one argument, readline, which must be
-        # a callable object which provides the same interface as the
-        # io.IOBase.readline() method of file objects"
-        codeio = StringIO(code)
-        tokens = list(tokenize.generate_tokens(codeio.readline))
-
-        for token in reversed(tokens):
-            if token.type in (
-                tokenize.ENDMARKER,
-                tokenize.NL,  # ignoring empty lines (\n\n)
-                tokenize.NEWLINE,
-                tokenize.COMMENT,
-            ):
-                continue
-            return (token.type == tokenize.OP) and (token.string == ";")
-
-        return False
-
-    def _last_assign_to_expr(self, mod: ast.Module):
-        """
-        Implementation of 'last_expr_or_assign' return_mode.
-        It modify the supplyied AST module so that the last
-        statement's value can be returned in 'last_expr' return_mode.
-        """
-        # Largely inspired from IPython:
-        # https://github.com/ipython/ipython/blob/3587f5bb6c8570e7bbb06cf5f7e3bc9b9467355a/IPython/core/interactiveshell.py#L3229
-
-        last_node = mod.body[-1]
-
-        if isinstance(last_node, ast.Assign):
-            # In this case there can be multiple targets as in `a = b = 1`.
-            # We just take the first one.
-            target = last_node.targets[0]
-        elif isinstance(last_node, (ast.AugAssign, ast.AnnAssign)):
-            target = last_node.target
-        else:
-            return
-        if isinstance(target, ast.Name):
-            last_node = ast.Expr(ast.Name(target.id, ast.Load()))
-            mod.body.append(last_node)
-            # Update the line numbers shown in error messages.
-            ast.fix_missing_locations(mod)
-
-    def _split_and_compile(self, code: str, flags: int = 0x0) -> Tuple[Any, Any]:
-        """
-        Split ``code`` in two parts, everything but last expression and
-        last expresion then compile each part.
-
-        Returns:
-        --------
-        code object
-            first part's code object (or None)
-        code object
-            last expression's code object (or None)
-        """
-        # handle mis-indented input from multi-line strings
-        code = dedent(code)
-
-        mod = ast.parse(code, filename=self.filename)
-        if not mod.body:
-            return None, None
-
-        if self.return_mode == "last_expr_or_assign":
-            # If the last statement is a named assignment, add an extra
-            # expression to the end with just the L-value so that we can
-            # handle it with the last_expr code.
-            self._last_assign_to_expr(mod)
-
-        # we extract last expression
-        if (
-            self.return_mode.startswith("last_expr")  # last_expr or last_expr_or_assign
-            and isinstance(mod.body[-1], (ast.Expr, ast.Await))
-            and not self.quiet(code)
-        ):
-            last_expr = ast.Expression(mod.body.pop().value)  # type: ignore
-        else:
-            last_expr = None  # type: ignore
-
-        # we compile
-        mod = compile(mod, self.filename, "exec", flags=flags)  # type: ignore
-        if last_expr is not None:
-            last_expr = compile(last_expr, self.filename, "eval", flags=flags)  # type: ignore
-
-        return mod, last_expr
-
     def run(self, code: str) -> Any:
         """Runs a code string.
 
@@ -231,15 +378,14 @@ class CodeRunner:
         Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters in the
         constructor to modify this default behavior.
         """
-        mod, last_expr = self._split_and_compile(code)
-
-        # running first part
-        if mod is not None:
-            exec(mod, self.globals, self.locals)
-
-        # evaluating last expression
-        if last_expr is not None:
-            return eval(last_expr, self.globals, self.locals)
+        return eval_code(
+            code, 
+            globals=self.globals, 
+            locals=self.locals, 
+            return_mode=self.return_mode, 
+            quiet_trailing_semicolon=self.quiet_trailing_semicolon, 
+            filename=self.filename
+        )
 
     async def run_async(self, code: str) -> Any:
         """Runs a code string asynchronously.
@@ -262,167 +408,14 @@ class CodeRunner:
         Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters in the
         constructor to modify this default behavior.
         """
-        mod, last_expr = self._split_and_compile(
-            code, flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT  # type: ignore
+        return eval_code_async(
+            code, 
+            globals=self.globals, 
+            locals=self.locals, 
+            return_mode=self.return_mode, 
+            quiet_trailing_semicolon=self.quiet_trailing_semicolon, 
+            filename=self.filename
         )
-        # running first part
-        if mod is not None:
-            coro = eval(mod, self.globals, self.locals)
-            if iscoroutine(coro):
-                await coro
-
-        # evaluating last expression
-        if last_expr is not None:
-            res = eval(last_expr, self.globals, self.locals)
-            if iscoroutine(res):
-                res = await res
-            return res
-
-
-def eval_code(
-    code: str,
-    globals: Optional[Dict[str, Any]] = None,
-    locals: Optional[Dict[str, Any]] = None,
-    return_mode: str = "last_expr",
-    quiet_trailing_semicolon: bool = True,
-    filename: str = "<exec>",
-) -> Any:
-    """Runs a code string.
-
-    Parameters
-    ----------
-    code : ``str``
-
-       The Python code to run.
-
-    globals : ``dict``
-
-        The global scope in which to execute code. This is used as the ``globals``
-        parameter for ``exec``. See
-        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
-        for more info. If the ``globals`` is absent, it is set equal to a new empty
-        dictionary.
-
-    locals : ``dict``
-
-        The local scope in which to execute code. This is used as the ``locals``
-        parameter for ``exec``. As with ``exec``, if ``locals`` is absent, it is set equal
-        to ``globals``. See
-        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
-        for more info.
-
-    return_mode : ``str``
-
-        Specifies what should be returned, must be one of ``'last_expr'``,
-        ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
-        raised.
-
-        * ``'last_expr'`` -- return the last expression
-        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
-        * ``'none'`` -- always return ``None``.
-
-    quiet_trailing_semicolon : ``bool``
-
-        Whether a trailing semicolon should 'quiet' the
-        result or not. Setting this to ``True`` (default) mimic the CPython's
-        interpreter behavior ; whereas setting it to ``False`` mimic the IPython's
-        interpreter behavior.
-
-    filename : ``str``
-
-        The file name to use in error messages and stack traces
-
-    Returns
-    -------
-    ``Any``
-
-        If the last nonwhitespace character of ``code`` is a semicolon return ``None``.
-        If the last statement is an expression, return the result of the expression.
-        (Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters to
-        modify this default behavior.)
-    """
-    return CodeRunner(
-        globals=globals,
-        locals=locals,
-        return_mode=return_mode,
-        quiet_trailing_semicolon=quiet_trailing_semicolon,
-        filename=filename,
-    ).run(code)
-
-
-async def eval_code_async(
-    code: str,
-    globals: Optional[Dict[str, Any]] = None,
-    locals: Optional[Dict[str, Any]] = None,
-    return_mode: str = "last_expr",
-    quiet_trailing_semicolon: bool = True,
-    filename: str = "<exec>",
-) -> Any:
-    """Runs a code string asynchronously.
-
-    Uses
-    `PyCF_ALLOW_TOP_LEVEL_AWAIT <https://docs.python.org/3/library/ast.html#ast.PyCF_ALLOW_TOP_LEVEL_AWAIT>`_
-    to compile to code.
-
-    Parameters
-    ----------
-    code : ``str``
-
-       The Python code to run.
-
-    globals : ``dict``
-
-        The global scope in which to execute code. This is used as the ``globals``
-        parameter for ``exec``. See
-        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
-        for more info. If the ``globals`` is absent, it is set equal to a new empty
-        dictionary.
-
-    locals : ``dict``
-
-        The local scope in which to execute code. This is used as the ``locals``
-        parameter for ``exec``. As with ``exec``, if ``locals`` is absent, it is set equal
-        to ``globals``. See
-        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
-        for more info.
-
-    return_mode : ``str``
-
-        Specifies what should be returned, must be one of ``'last_expr'``,
-        ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
-        raised.
-
-        * ``'last_expr'`` -- return the last expression
-        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
-        * ``'none'`` -- always return ``None``.
-
-    quiet_trailing_semicolon : ``bool``
-
-        Whether a trailing semicolon should 'quiet' the
-        result or not. Setting this to ``True`` (default) mimic the CPython's
-        interpreter behavior ; whereas setting it to ``False`` mimic the IPython's
-        interpreter behavior.
-
-    filename : ``str``
-
-        The file name to use in error messages and stack traces
-
-    Returns
-    -------
-    ``Any``
-
-        If the last nonwhitespace character of ``code`` is a semicolon return ``None``.
-        If the last statement is an expression, return the result of the expression.
-        (Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters to
-        modify this default behavior.)
-    """
-    return await CodeRunner(
-        globals=globals,
-        locals=locals,
-        return_mode=return_mode,
-        quiet_trailing_semicolon=quiet_trailing_semicolon,
-        filename=filename,
-    ).run_async(code)
 
 
 def find_imports(code: str) -> List[str]:

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -183,7 +183,7 @@ if True:
         """
         # largely inspired from IPython:
         # https://github.com/ipython/ipython/blob/86d24741188b0cedd78ab080d498e775ed0e5272/IPython/core/displayhook.py#L84
-        
+
         # We need to wrap tokens in a buffer because:
         # "Tokenize requires one argument, readline, which must be
         # a callable object which provides the same interface as the
@@ -418,7 +418,7 @@ async def eval_code_async(
     if quiet_trailing_semicolon and should_quiet(code):
         return_mode = "none"
     mod, last_expr = _split_and_compile(
-        code, return_mode=return_mode, filename=filename
+        code, return_mode=return_mode, filename=filename, flags=flags | ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
     )
 
     # running first part

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -418,7 +418,7 @@ async def eval_code_async(
     if quiet_trailing_semicolon and should_quiet(code):
         return_mode = "none"
     mod, last_expr = _split_and_compile(
-        code, return_mode=return_mode, filename=filename, flags=flags | ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+        code, return_mode=return_mode, filename=filename, flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
     )
 
     # running first part

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -172,13 +172,11 @@ if True:
 
         Examples
         --------
-        >>> CodeRunner().quiet('1 + 1')
+        >>> should_quiet('1 + 1')
         False
-        >>> CodeRunner().quiet('1 + 1 ;')
+        >>> should_quiet('1 + 1 ;')
         True
-        >>> CodeRunner().quiet('1 + 1 # comment ;')
-        False
-        >>> CodeRunner(quiet_trailing_semicolon=False).quiet('1 + 1 ;')
+        >>> should_quiet('1 + 1 # comment ;')
         False
         """
         # largely inspired from IPython:

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -33,264 +33,6 @@ def open_url(url: str) -> StringIO:
     req.send(None)
     return StringIO(req.response)
 
-if True:
-    def should_quiet(source: str) -> bool:
-        """Should we suppress output?
-
-        Returns ``True`` if the last nonwhitespace character of ``source`` is a
-        semicolon.
-        Examples
-        --------
-        >>> CodeRunner().quiet('1 + 1') False CodeRunner().quiet('1 + 1 ;') 
-        True
-        >>> CodeRunner().quiet('1 + 1 # comment ;') 
-        False
-        >>> CodeRunner(quiet_trailing_semicolon=False).quiet('1 + 1 ;') 
-        False
-        """
-        # We need to wrap tokens in a buffer because:
-        # "Tokenize requires one argument, readline, which must be
-        # a callable object which provides the same interface as the
-        # io.IOBase.readline() method of file objects"
-        source_io = StringIO(source)
-        tokens = list(tokenize.generate_tokens(source_io.readline))
-
-        for token in reversed(tokens):
-            if token.type in (
-                tokenize.ENDMARKER,
-                tokenize.NL,  # ignoring empty lines (\n\n)
-                tokenize.NEWLINE,
-                tokenize.COMMENT,
-            ):
-                continue
-            return (token.type == tokenize.OP) and (token.string == ";")
-        return False
-
-
-    def _last_assign_to_expr(mod: ast.Module):
-        """
-        Implementation of 'last_expr_or_assign' return_mode.
-        It modify the supplyied AST module so that the last
-        statement's value can be returned in 'last_expr' return_mode.
-        """
-        # Largely inspired from IPython:
-        # https://github.com/ipython/ipython/blob/3587f5bb6c8570e7bbb06cf5f7e3bc9b9467355a/IPython/core/interactiveshell.py#L3229
-
-        last_node = mod.body[-1]
-
-        if isinstance(last_node, ast.Assign):
-            # In this case there can be multiple targets as in `a = b = 1`.
-            # We just take the first one.
-            target = last_node.targets[0]
-        elif isinstance(last_node, (ast.AugAssign, ast.AnnAssign)):
-            target = last_node.target
-        else:
-            return
-        if isinstance(target, ast.Name):
-            last_node = ast.Expr(ast.Name(target.id, ast.Load()))
-            mod.body.append(last_node)
-            # Update the line numbers shown in error messages.
-            ast.fix_missing_locations(mod)
-
-    def _split_and_compile(code: str, *, return_mode, filename, flags: int = 0x0) -> Tuple[Any, Any]:
-        """
-        Split ``code`` in two parts, everything but last expression and
-        last expresion then compile each part.
-
-        Returns:
-        --------
-        code object
-            first part's code object (or None)
-        code object
-            last expression's code object (or None)
-        """
-        # handle mis-indented input from multi-line strings
-        code = dedent(code)
-
-        mod = ast.parse(code, filename=filename)
-        if not mod.body:
-            return None, None
-
-        if return_mode == "last_expr_or_assign":
-            # If the last statement is a named assignment, add an extra
-            # expression to the end with just the L-value so that we can
-            # handle it with the last_expr code.
-            _last_assign_to_expr(mod)
-
-        # we extract last expression
-        if (
-            return_mode.startswith("last_expr")  # last_expr or last_expr_or_assign
-            and isinstance(mod.body[-1], (ast.Expr, ast.Await))
-        ):
-            last_expr = ast.Expression(mod.body.pop().value)  # type: ignore
-        else:
-            last_expr = None  # type: ignore
-
-        # we compile
-        mod = compile(mod, filename, "exec", flags=flags)  # type: ignore
-        if last_expr is not None:
-            last_expr = compile(last_expr, filename, "eval", flags=flags)  # type: ignore
-
-        return mod, last_expr
-
-    def eval_code(
-        code: str,
-        globals: Optional[Dict[str, Any]] = None,
-        locals: Optional[Dict[str, Any]] = None,
-        return_mode: str = "last_expr",
-        quiet_trailing_semicolon: bool = True,
-        filename: str = "<exec>",
-    ) -> Any:
-        """Runs a code string.
-
-        Parameters
-        ----------
-        code : ``str``
-
-        The Python code to run.
-
-        globals : ``dict``
-
-            The global scope in which to execute code. This is used as the ``globals``
-            parameter for ``exec``. See
-            `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
-            for more info. If the ``globals`` is absent, it is set equal to a new empty
-            dictionary.
-
-        locals : ``dict``
-
-            The local scope in which to execute code. This is used as the ``locals``
-            parameter for ``exec``. As with ``exec``, if ``locals`` is absent, it is set equal
-            to ``globals``. See
-            `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
-            for more info.
-
-        return_mode : ``str``
-
-            Specifies what should be returned, must be one of ``'last_expr'``,
-            ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
-            raised.
-
-            * ``'last_expr'`` -- return the last expression
-            * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
-            * ``'none'`` -- always return ``None``.
-
-        quiet_trailing_semicolon : ``bool``
-
-            Whether a trailing semicolon should 'quiet' the
-            result or not. Setting this to ``True`` (default) mimic the CPython's
-            interpreter behavior ; whereas setting it to ``False`` mimic the IPython's
-            interpreter behavior.
-
-        filename : ``str``
-
-            The file name to use in error messages and stack traces
-
-        Returns
-        -------
-        ``Any``
-
-            If the last nonwhitespace character of ``code`` is a semicolon return ``None``.
-            If the last statement is an expression, return the result of the expression.
-            (Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters to
-            modify this default behavior.)
-        """
-        if quiet_trailing_semicolon and should_quiet(code):
-            return_mode = "none"
-        mod, last_expr = _split_and_compile(code, return_mode=return_mode, filename=filename)
-
-        # running first part
-        if mod is not None:
-            exec(mod, globals, locals)
-
-        # evaluating last expression
-        if last_expr is not None:
-            return eval(last_expr, globals, locals)
-
-    async def eval_code_async(
-        code: str,
-        globals: Optional[Dict[str, Any]] = None,
-        locals: Optional[Dict[str, Any]] = None,
-        return_mode: str = "last_expr",
-        quiet_trailing_semicolon: bool = True,
-        filename: str = "<exec>",
-    ) -> Any:
-        """Runs a code string asynchronously.
-
-        Uses
-        `PyCF_ALLOW_TOP_LEVEL_AWAIT <https://docs.python.org/3/library/ast.html#ast.PyCF_ALLOW_TOP_LEVEL_AWAIT>`_
-        to compile to code.
-
-        Parameters
-        ----------
-        code : ``str``
-
-        The Python code to run.
-
-        globals : ``dict``
-
-            The global scope in which to execute code. This is used as the ``globals``
-            parameter for ``exec``. See
-            `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
-            for more info. If the ``globals`` is absent, it is set equal to a new empty
-            dictionary.
-
-        locals : ``dict``
-
-            The local scope in which to execute code. This is used as the ``locals``
-            parameter for ``exec``. As with ``exec``, if ``locals`` is absent, it is set equal
-            to ``globals``. See
-            `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
-            for more info.
-
-        return_mode : ``str``
-
-            Specifies what should be returned, must be one of ``'last_expr'``,
-            ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
-            raised.
-
-            * ``'last_expr'`` -- return the last expression
-            * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
-            * ``'none'`` -- always return ``None``.
-
-        quiet_trailing_semicolon : ``bool``
-
-            Whether a trailing semicolon should 'quiet' the
-            result or not. Setting this to ``True`` (default) mimic the CPython's
-            interpreter behavior ; whereas setting it to ``False`` mimic the IPython's
-            interpreter behavior.
-
-        filename : ``str``
-
-            The file name to use in error messages and stack traces
-
-        Returns
-        -------
-        ``Any``
-
-            If the last nonwhitespace character of ``code`` is a semicolon return ``None``.
-            If the last statement is an expression, return the result of the expression.
-            (Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters to
-            modify this default behavior.)
-        """
-        if quiet_trailing_semicolon and should_quiet(code):
-            return_mode = "none"
-        mod, last_expr = _split_and_compile(code, return_mode=return_mode, filename=filename)
-
-        # running first part
-        coroutine = None
-        if mod is not None:
-            coroutine = exec(mod, globals, locals)
-        if coroutine is not None:
-            await coroutine
-
-        # evaluating last expression
-        result = None
-        if last_expr is not None:
-            result = eval(last_expr, globals, locals)
-        if iscoroutine(result):
-            result = await result
-        return result
 
 class CodeRunner:
     """
@@ -380,12 +122,12 @@ class CodeRunner:
         constructor to modify this default behavior.
         """
         return eval_code(
-            code, 
-            globals=self.globals, 
-            locals=self.locals, 
-            return_mode=self.return_mode, 
-            quiet_trailing_semicolon=self.quiet_trailing_semicolon, 
-            filename=self.filename
+            code,
+            globals=self.globals,
+            locals=self.locals,
+            return_mode=self.return_mode,
+            quiet_trailing_semicolon=self.quiet_trailing_semicolon,
+            filename=self.filename,
         )
 
     async def run_async(self, code: str) -> Any:
@@ -410,13 +152,289 @@ class CodeRunner:
         constructor to modify this default behavior.
         """
         return eval_code_async(
-            code, 
-            globals=self.globals, 
-            locals=self.locals, 
-            return_mode=self.return_mode, 
-            quiet_trailing_semicolon=self.quiet_trailing_semicolon, 
-            filename=self.filename
+            code,
+            globals=self.globals,
+            locals=self.locals,
+            return_mode=self.return_mode,
+            quiet_trailing_semicolon=self.quiet_trailing_semicolon,
+            filename=self.filename,
         )
+
+
+if True:
+
+    def should_quiet(source: str) -> bool:
+        """
+        Should we suppress output?
+
+        Returns ``True`` if ``quiet_trailing_semicolon`` is set to ``True`` and
+        the last nonwhitespace character of ``code`` is a semicolon.
+
+        Examples
+        --------
+        >>> CodeRunner().quiet('1 + 1')
+        False
+        >>> CodeRunner().quiet('1 + 1 ;')
+        True
+        >>> CodeRunner().quiet('1 + 1 # comment ;')
+        False
+        >>> CodeRunner(quiet_trailing_semicolon=False).quiet('1 + 1 ;')
+        False
+        """
+        # largely inspired from IPython:
+        # https://github.com/ipython/ipython/blob/86d24741188b0cedd78ab080d498e775ed0e5272/IPython/core/displayhook.py#L84
+        
+        # We need to wrap tokens in a buffer because:
+        # "Tokenize requires one argument, readline, which must be
+        # a callable object which provides the same interface as the
+        # io.IOBase.readline() method of file objects"
+        source_io = StringIO(source)
+        tokens = list(tokenize.generate_tokens(source_io.readline))
+
+        for token in reversed(tokens):
+            if token.type in (
+                tokenize.ENDMARKER,
+                tokenize.NL,  # ignoring empty lines (\n\n)
+                tokenize.NEWLINE,
+                tokenize.COMMENT,
+            ):
+                continue
+            return (token.type == tokenize.OP) and (token.string == ";")
+        return False
+
+    def _last_assign_to_expr(mod: ast.Module):
+        """
+        Implementation of 'last_expr_or_assign' return_mode.
+        It modify the supplyied AST module so that the last
+        statement's value can be returned in 'last_expr' return_mode.
+        """
+        # Largely inspired from IPython:
+        # https://github.com/ipython/ipython/blob/3587f5bb6c8570e7bbb06cf5f7e3bc9b9467355a/IPython/core/interactiveshell.py#L3229
+
+        last_node = mod.body[-1]
+
+        if isinstance(last_node, ast.Assign):
+            # In this case there can be multiple targets as in `a = b = 1`.
+            # We just take the first one.
+            target = last_node.targets[0]
+        elif isinstance(last_node, (ast.AugAssign, ast.AnnAssign)):
+            target = last_node.target
+        else:
+            return
+        if isinstance(target, ast.Name):
+            last_node = ast.Expr(ast.Name(target.id, ast.Load()))
+            mod.body.append(last_node)
+            # Update the line numbers shown in error messages.
+            ast.fix_missing_locations(mod)
+
+    def _split_and_compile(
+        code: str, *, return_mode, filename, flags: int = 0x0
+    ) -> Tuple[Any, Any]:
+        """
+        Split ``code`` in two parts, everything but last expression and
+        last expresion then compile each part.
+
+        Returns:
+        --------
+        code object
+            first part's code object (or None)
+        code object
+            last expression's code object (or None)
+        """
+        # handle mis-indented input from multi-line strings
+        code = dedent(code)
+
+        mod = ast.parse(code, filename=filename)
+        if not mod.body:
+            return None, None
+
+        if return_mode == "last_expr_or_assign":
+            # If the last statement is a named assignment, add an extra
+            # expression to the end with just the L-value so that we can
+            # handle it with the last_expr code.
+            _last_assign_to_expr(mod)
+
+        # we extract last expression
+        if return_mode.startswith(
+            "last_expr"
+        ) and isinstance(  # last_expr or last_expr_or_assign
+            mod.body[-1], (ast.Expr, ast.Await)
+        ):
+            last_expr = ast.Expression(mod.body.pop().value)  # type: ignore
+        else:
+            last_expr = None  # type: ignore
+
+        # we compile
+        mod = compile(mod, filename, "exec", flags=flags)  # type: ignore
+        if last_expr is not None:
+            last_expr = compile(last_expr, filename, "eval", flags=flags)  # type: ignore
+
+        return mod, last_expr
+
+
+def eval_code(
+    code: str,
+    globals: Optional[Dict[str, Any]] = None,
+    locals: Optional[Dict[str, Any]] = None,
+    return_mode: str = "last_expr",
+    quiet_trailing_semicolon: bool = True,
+    filename: str = "<exec>",
+) -> Any:
+    """Runs a code string.
+
+    Parameters
+    ----------
+    code : ``str``
+
+       The Python code to run.
+
+    globals : ``dict``
+
+        The global scope in which to execute code. This is used as the ``globals``
+        parameter for ``exec``. See
+        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
+        for more info. If the ``globals`` is absent, it is set equal to a new empty
+        dictionary.
+
+    locals : ``dict``
+
+        The local scope in which to execute code. This is used as the ``locals``
+        parameter for ``exec``. As with ``exec``, if ``locals`` is absent, it is set equal
+        to ``globals``. See
+        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
+        for more info.
+
+    return_mode : ``str``
+
+        Specifies what should be returned, must be one of ``'last_expr'``,
+        ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
+        raised.
+
+        * ``'last_expr'`` -- return the last expression
+        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
+        * ``'none'`` -- always return ``None``.
+
+    quiet_trailing_semicolon : ``bool``
+
+        Whether a trailing semicolon should 'quiet' the
+        result or not. Setting this to ``True`` (default) mimic the CPython's
+        interpreter behavior ; whereas setting it to ``False`` mimic the IPython's
+        interpreter behavior.
+
+    filename : ``str``
+
+        The file name to use in error messages and stack traces
+
+    Returns
+    -------
+    ``Any``
+
+        If the last nonwhitespace character of ``code`` is a semicolon return ``None``.
+        If the last statement is an expression, return the result of the expression.
+        (Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters to
+        modify this default behavior.)
+    """
+    if quiet_trailing_semicolon and should_quiet(code):
+        return_mode = "none"
+    mod, last_expr = _split_and_compile(
+        code, return_mode=return_mode, filename=filename
+    )
+
+    # running first part
+    if mod is not None:
+        exec(mod, globals, locals)
+
+    # evaluating last expression
+    if last_expr is not None:
+        return eval(last_expr, globals, locals)
+
+
+async def eval_code_async(
+    code: str,
+    globals: Optional[Dict[str, Any]] = None,
+    locals: Optional[Dict[str, Any]] = None,
+    return_mode: str = "last_expr",
+    quiet_trailing_semicolon: bool = True,
+    filename: str = "<exec>",
+) -> Any:
+    """Runs a code string asynchronously.
+
+    Uses
+    `PyCF_ALLOW_TOP_LEVEL_AWAIT <https://docs.python.org/3/library/ast.html#ast.PyCF_ALLOW_TOP_LEVEL_AWAIT>`_
+    to compile to code.
+
+    Parameters
+    ----------
+    code : ``str``
+
+       The Python code to run.
+
+    globals : ``dict``
+
+        The global scope in which to execute code. This is used as the ``globals``
+        parameter for ``exec``. See
+        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
+        for more info. If the ``globals`` is absent, it is set equal to a new empty
+        dictionary.
+
+    locals : ``dict``
+
+        The local scope in which to execute code. This is used as the ``locals``
+        parameter for ``exec``. As with ``exec``, if ``locals`` is absent, it is set equal
+        to ``globals``. See
+        `the exec documentation <https://docs.python.org/3/library/functions.html#exec>`_
+        for more info.
+
+    return_mode : ``str``
+
+        Specifies what should be returned, must be one of ``'last_expr'``,
+        ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
+        raised.
+
+        * ``'last_expr'`` -- return the last expression
+        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
+        * ``'none'`` -- always return ``None``.
+
+    quiet_trailing_semicolon : ``bool``
+
+        Whether a trailing semicolon should 'quiet' the
+        result or not. Setting this to ``True`` (default) mimic the CPython's
+        interpreter behavior ; whereas setting it to ``False`` mimic the IPython's
+        interpreter behavior.
+
+    filename : ``str``
+
+        The file name to use in error messages and stack traces
+
+    Returns
+    -------
+    ``Any``
+
+        If the last nonwhitespace character of ``code`` is a semicolon return ``None``.
+        If the last statement is an expression, return the result of the expression.
+        (Use the ``return_mode`` and ``quiet_trailing_semicolon`` parameters to
+        modify this default behavior.)
+    """
+    if quiet_trailing_semicolon and should_quiet(code):
+        return_mode = "none"
+    mod, last_expr = _split_and_compile(
+        code, return_mode=return_mode, filename=filename
+    )
+
+    # running first part
+    coroutine = None
+    if mod is not None:
+        coroutine = exec(mod, globals, locals)
+    if coroutine is not None:
+        await coroutine
+
+    # evaluating last expression
+    result = None
+    if last_expr is not None:
+        result = eval(last_expr, globals, locals)
+    if iscoroutine(result):
+        result = await result
+    return result
 
 
 def find_imports(code: str) -> List[str]:

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -422,7 +422,7 @@ async def eval_code_async(
     # running first part
     coroutine = None
     if mod is not None:
-        coroutine = exec(mod, globals, locals)
+        coroutine = eval(mod, globals, locals)
     if coroutine is not None:
         await coroutine
 

--- a/src/templates/test.html
+++ b/src/templates/test.html
@@ -3,6 +3,9 @@
   <head>
   <meta charset="utf-8"/>
   <script type="text/javascript">
+    function sleep(s){
+      return new Promise(resolve => setTimeout(resolve, s));
+    }
     window.logs = [];
     console.log = function(message) {
       window.logs.push(message);

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 sys.path.append(str(Path(__file__).parents[2] / "src" / "pyodide-py"))
 
 from pyodide import find_imports, eval_code  # noqa: E402
-from pyodide._base import CodeRunner  # noqa: E402
+from pyodide._base import CodeRunner, should_quiet  # noqa: E402
 
 
 def test_find_imports():
@@ -25,9 +25,9 @@ def test_find_imports():
 
 def test_code_runner():
     runner = CodeRunner()
-    assert runner.quiet("1+1;")
-    assert not runner.quiet("1+1#;")
-    assert not runner.quiet("5-2  # comment with trailing semicolon ;")
+    assert should_quiet("1+1;")
+    assert not should_quiet("1+1#;")
+    assert not should_quiet("5-2  # comment with trailing semicolon ;")
     assert runner.run("4//2\n") == 2
     assert runner.run("4//2;") is None
     assert runner.run("x = 2\nx") == 2
@@ -42,9 +42,6 @@ def test_code_runner():
 
     # with 'quiet_trailing_semicolon' set to False
     runner = CodeRunner(quiet_trailing_semicolon=False)
-    assert not runner.quiet("1+1;")
-    assert not runner.quiet("1+1#;")
-    assert not runner.quiet("5-2  # comment with trailing semicolon ;")
     assert runner.run("4//2\n") == 2
     assert runner.run("4//2;") == 2
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -469,10 +469,14 @@ def test_fatal_error(selenium_standalone):
         }
         """
     )
+    import re
+
+    strip_stack_trace = lambda x: re.sub("\n.*site-packages.*", "", x)
     assert (
-        selenium_standalone.logs
+        strip_stack_trace(selenium_standalone.logs)
         == dedent(
-            """
+            strip_stack_trace(
+                """
             Python initialization complete
             Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.
             The cause of the fatal error was:
@@ -485,6 +489,7 @@ def test_fatal_error(selenium_standalone):
               File "/lib/python3.8/site-packages/pyodide/_base.py", line 242 in run
               File "/lib/python3.8/site-packages/pyodide/_base.py", line 344 in eval_code
             """
+            )
         ).strip()
     )
     selenium_standalone.run_js(

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -174,20 +174,26 @@ def test_webloop_exception_handler(selenium):
     )
     assert "Task exception was never retrieved" in selenium.logs
     try:
-        selenium.run(
+        selenium.run_js(
             """
-            import asyncio
-            loop = asyncio.get_event_loop()
-            def exception_handler(loop, context):
-                global exc
-                exc = context
-            loop.set_exception_handler(exception_handler)
+            pyodide.runPython(`
+                import asyncio
+                loop = asyncio.get_event_loop()
+                exc = []
+                def exception_handler(loop, context):
+                    exc.append(context)
+                loop.set_exception_handler(exception_handler)
 
-            async def test():
-                raise Exception("blah")
-            asyncio.ensure_future(test());
+                async def test():
+                    raise Exception("blah")
+                asyncio.ensure_future(test());
+                1
+            `);
+            await sleep(100)
+            pyodide.runPython(`
+                assert exc[0]["exception"].args[0] == "blah"
+            `)
             """
         )
-        assert selenium.run('exc["exception"].args[0] == "blah"')
     finally:
         selenium.run("loop.set_exception_handler(None)")


### PR DESCRIPTION
This is a first step towards doing the stuff in #1519.

I tried to change as little as possible, the main changes are converting `self.some_field` accesses to function arguments. I also lightly refactored to reduce the number of fields that `should_quiet` and `_split_and_compile` need access to.

Most of the diff comes from reordering the run and run_async methods.