### PR TITLE
Use same image when deploying dev as when deploying release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\w+$/
-      - deploy-s3:
+      - deploy-dev:
           requires:
             - lint
             - test-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,8 +265,7 @@ jobs:
       - run:
           name: Install requirements
           command: |
-            sudo apt-get update
-            sudo apt-get install -y groff
+            apk add --no-cache --update python3 make
             python3 -m pip install awscli
       - run:
           name: Deploy to pyodide-cdn2.iodide.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,11 +211,11 @@ jobs:
           path: /root/repo/build/benchmarks.json
 
   deploy-release:
+    # To reduce chance of deployment issues, try to keep the steps here as
+    # similar as possible to the steps in deploy-release!
     resource_class: small
 
     docker:
-      # To reduce chance of deployment issues, make sure to use same image for
-      # deploy-dev and deploy-release
       - image: cibuilds/github:0.13
 
     steps:
@@ -248,11 +248,11 @@ jobs:
             aws s3api put-bucket-website --cli-input-json file://.circleci/s3-website-config.json
 
   deploy-dev:
+    # To reduce chance of deployment issues, try to keep the steps here as
+    # similar as possible to the steps in deploy-release!
     resource_class: small
 
     docker:
-      # To reduce chance of deployment issues, make sure to use same image for
-      # deploy-dev and deploy-release
       - image: cibuilds/github:0.13 
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,8 @@ jobs:
     resource_class: small
 
     docker:
+      # To reduce chance of deployment issues, make sure to use same image for
+      # deploy-dev and deploy-release
       - image: cibuilds/github:0.13
 
     steps:
@@ -245,11 +247,13 @@ jobs:
             # update 301 redirect for the /latest/* route.
             aws s3api put-bucket-website --cli-input-json file://.circleci/s3-website-config.json
 
-  deploy-s3:
+  deploy-dev:
     resource_class: small
 
     docker:
-      - image: circleci/python:3.7.7
+      # To reduce chance of deployment issues, make sure to use same image for
+      # deploy-dev and deploy-release
+      - image: cibuilds/github:0.13 
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,13 +260,21 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Set PYODIDE_BASE_URL
-          command: PYODIDE_BASE_URL="https://cdn.jsdelivr.net/pyodide/dev/full/" make update_base_url
-      - run:
           name: Install requirements
           command: |
             apk add --no-cache --update python3 make
             python3 -m pip install awscli
+      - run:
+          name: Deploy Draft Github Release
+          command: |
+            cp -r build /tmp/pyodide
+            cd /tmp/
+            export CIRCLE_TAG="dev"
+            tar cjf pyodide-build-${CIRCLE_TAG}.tar.bz2  pyodide/
+            ghr -draft -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
+      - run:
+          name: Set PYODIDE_BASE_URL
+          command: PYODIDE_BASE_URL="https://cdn.jsdelivr.net/pyodide/dev/full/" make update_base_url
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
 
   deploy-release:
     # To reduce chance of deployment issues, try to keep the steps here as
-    # similar as possible to the steps in deploy-release!
+    # similar as possible to the steps in deploy-dev!
     resource_class: small
 
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,14 +265,6 @@ jobs:
             apk add --no-cache --update python3 make
             python3 -m pip install awscli
       - run:
-          name: Deploy Draft Github Release
-          command: |
-            cp -r build /tmp/pyodide
-            cd /tmp/
-            export CIRCLE_TAG="dev"
-            tar cjf pyodide-build-${CIRCLE_TAG}.tar.bz2  pyodide/
-            ghr -draft -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
-      - run:
           name: Set PYODIDE_BASE_URL
           command: PYODIDE_BASE_URL="https://cdn.jsdelivr.net/pyodide/dev/full/" make update_base_url
       - run:


### PR DESCRIPTION
For both v0.16.0 and v0.17.0 we had issues with the deploy-release recipe. Problem is that we don't run it very often, so we don't know if it works except when we really care whether it works.

In lieu of getting better test coverage for the deploy-release recipe, we can just make the deploy-dev recipe really similar. So we should use the same docker images, install the same requirements, and as far as practically possible execute the same commands.

I added a `ghr -draft` to the deploy-dev recipe. I have no idea if this is actually a good idea, but it seemed like it would be appropriate for the use case of making sure that the rest of the command would succeed.

https://github.com/tcnksm/ghr/#github-api-token
https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository