### PR TITLE
Add PyProxy.clone

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,8 @@ substitutions:
 - {{ Enhancement }} Added the {any}`PyProxy.callKwargs` method to allow using
   Python functions with keyword arguments from Javascript.
   {pr}`1539`
+- {{ Enhancement }} Added the {any}`PyProxy.clone` method.
+  {pr}`1549`
 
 ## Version 0.17.0
 *April 21, 2020*

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -249,7 +249,7 @@ JS_FILE(pyproxy_init_js, () => {0,0; /* Magic, see include_js_file.h */
     }
     /**
      * Make a new PyProxy pointing to the same Python object.
-     * Useful if someone else is destroying your PyProxy.
+     * Useful if the PyProxy is destroyed somewhere else.
      */
     clone() {
       let ptrobj = _getPtr(this);

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -228,6 +228,10 @@ JS_FILE(pyproxy_init_js, () => {0,0; /* Magic, see include_js_file.h */
      * Pyodide will automatically destroy the ``PyProxy`` when it is garbage
      * collected, however there is no guarantee that the finalizer will be run
      * in a timely manner so it is better to ``destory`` the proxy explicitly.
+     *
+     * @param {string} [destroyed_msg] The error message to print if use is
+     *        attempted after destroying. Defaults to "Object has already been
+     *        destroyed".
      */
     destroy(destroyed_msg) {
       let ptrobj = _getPtr(this);

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -60,6 +60,18 @@ def test_pyproxy(selenium):
     )
 
 
+def test_pyproxy_clone(selenium):
+    selenium.run_js(
+        """
+        let d = pyodide.runPython("list(range(10))")
+        e = d.clone();
+        d.destroy();
+        assert(() => e.length === 10);
+        e.destroy();
+        """
+    )
+
+
 def test_pyproxy_refcount(selenium):
     result = selenium.run_js(
         """


### PR DESCRIPTION
Allows easier control over Python references from Javascript. Prerequisite for "borrowed PyProxies" plan.