### PR TITLE
MAINT Refactor package lock

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -266,7 +266,7 @@ globalThis.loadPyodide = async function(config = {}) {
    * @returns A zero argument function that releases the lock.
    * @private
    */
-  async function acquirePackageLock(){
+  async function acquirePackageLock() {
     let old_lock = _package_lock;
     let releaseLock;
     _package_lock = new Promise(resolve => releaseLock = resolve);
@@ -366,10 +366,10 @@ globalThis.loadPyodide = async function(config = {}) {
     let releaseLock = await acquirePackageLock();
     try {
       await _loadPackage(sharedLibraryNames, messageCallback || console.log,
-                             errorCallback || console.error);
+                         errorCallback || console.error);
       Module.preloadPlugins.shift(loadPluginOverride);
       await _loadPackage(names, messageCallback || console.log,
-                             errorCallback || console.error);
+                         errorCallback || console.error);
     } finally {
       releaseLock();
     }


### PR DESCRIPTION
Hide the promise-chain hijinks in a named function to clean up application logic.

This changes the logic slightly by not releasing the lock between the two calls to `_loadPackage`. I think that the old version was wrong, but because the first `_loadPackage` call is currently only ever used to load LAPACK, we didn't ever notice.