### PR TITLE
MAINT Rename some hiwire array/object methods

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -316,9 +316,9 @@ EM_JS_NUM(errcode, JsArray_Push, (JsRef idarr, JsRef idval), {
   Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
 });
 
-EM_JS_REF(JsRef, hiwire_object, (), { return Module.hiwire.new_value({}); });
+EM_JS_REF(JsRef, JsObject_New, (), { return Module.hiwire.new_value({}); });
 
-EM_JS_REF(JsRef, hiwire_get_member_string, (JsRef idobj, const char* ptrkey), {
+EM_JS_REF(JsRef, JsObject_GetString, (JsRef idobj, const char* ptrkey), {
   let jsobj = Module.hiwire.get_value(idobj);
   let jskey = UTF8ToString(ptrkey);
   let result = jsobj[jskey];
@@ -333,7 +333,7 @@ EM_JS_REF(JsRef, hiwire_get_member_string, (JsRef idobj, const char* ptrkey), {
 // clang-format off
 EM_JS_NUM(
 errcode,
-hiwire_set_member_string,
+JsObject_SetString,
 (JsRef idobj, const char* ptrkey, JsRef idval),
 {
   let jsobj = Module.hiwire.get_value(idobj);
@@ -344,7 +344,7 @@ hiwire_set_member_string,
 
 EM_JS_NUM(
 errcode,
-hiwire_delete_member_string,
+JsObject_DeleteString,
 (JsRef idobj, const char* ptrkey),
 {
   let jsobj = Module.hiwire.get_value(idobj);
@@ -353,7 +353,7 @@ hiwire_delete_member_string,
 });
 // clang-format on
 
-EM_JS_REF(JsRef, hiwire_get_member_int, (JsRef idobj, int idx), {
+EM_JS_REF(JsRef, JsArray_Get, (JsRef idobj, int idx), {
   let obj = Module.hiwire.get_value(idobj);
   let result = obj[idx];
   // clang-format off
@@ -364,11 +364,11 @@ EM_JS_REF(JsRef, hiwire_get_member_int, (JsRef idobj, int idx), {
   return Module.hiwire.new_value(result);
 });
 
-EM_JS_NUM(errcode, hiwire_set_member_int, (JsRef idobj, int idx, JsRef idval), {
+EM_JS_NUM(errcode, JsArray_Set, (JsRef idobj, int idx, JsRef idval), {
   Module.hiwire.get_value(idobj)[idx] = Module.hiwire.get_value(idval);
 });
 
-EM_JS_NUM(errcode, hiwire_delete_member_int, (JsRef idobj, int idx), {
+EM_JS_NUM(errcode, JsArray_Delete, (JsRef idobj, int idx), {
   let obj = Module.hiwire.get_value(idobj);
   // Weird edge case: allow deleting an empty entry, but we raise a key error if
   // access is attempted.
@@ -378,7 +378,7 @@ EM_JS_NUM(errcode, hiwire_delete_member_int, (JsRef idobj, int idx), {
   obj.splice(idx, 1);
 });
 
-EM_JS_REF(JsRef, hiwire_dir, (JsRef idobj), {
+EM_JS_REF(JsRef, JsObject_Dir, (JsRef idobj), {
   let jsobj = Module.hiwire.get_value(idobj);
   let result = [];
   do {
@@ -672,17 +672,17 @@ EM_JS_REF(JsRef, hiwire_get_iterator, (JsRef idobj), {
   return Module.hiwire.new_value(jsobj[Symbol.iterator]());
 })
 
-EM_JS_REF(JsRef, hiwire_object_entries, (JsRef idobj), {
+EM_JS_REF(JsRef, JsObject_Entries, (JsRef idobj), {
   let jsobj = Module.hiwire.get_value(idobj);
   return Module.hiwire.new_value(Object.entries(jsobj));
 });
 
-EM_JS_REF(JsRef, hiwire_object_keys, (JsRef idobj), {
+EM_JS_REF(JsRef, JsObject_Keys, (JsRef idobj), {
   let jsobj = Module.hiwire.get_value(idobj);
   return Module.hiwire.new_value(Object.keys(jsobj));
 });
 
-EM_JS_REF(JsRef, hiwire_object_values, (JsRef idobj), {
+EM_JS_REF(JsRef, JsObject_Values, (JsRef idobj), {
   let jsobj = Module.hiwire.get_value(idobj);
   return Module.hiwire.new_value(Object.values(jsobj));
 });

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -289,7 +289,7 @@ EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
   throw Module.hiwire.pop_value(iderr);
 });
 
-EM_JS_NUM(bool, hiwire_is_array, (JsRef idobj), {
+EM_JS_NUM(bool, JsArray_Check, (JsRef idobj), {
   let obj = Module.hiwire.get_value(idobj);
   if (Array.isArray(obj)) {
     return true;

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -310,9 +310,9 @@ EM_JS_NUM(bool, hiwire_is_array, (JsRef idobj), {
   return false;
 });
 
-EM_JS_REF(JsRef, hiwire_array, (), { return Module.hiwire.new_value([]); });
+EM_JS_REF(JsRef, JsArray_New, (), { return Module.hiwire.new_value([]); });
 
-EM_JS_NUM(errcode, hiwire_push_array, (JsRef idarr, JsRef idval), {
+EM_JS_NUM(errcode, JsArray_Push, (JsRef idarr, JsRef idval), {
   Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
 });
 
@@ -397,13 +397,13 @@ EM_JS_REF(JsRef, hiwire_dir, (JsRef idobj), {
 static JsRef
 convert_va_args(va_list args)
 {
-  JsRef idargs = hiwire_array();
+  JsRef idargs = JsArray_New();
   while (true) {
     JsRef idarg = va_arg(args, JsRef);
     if (idarg == NULL) {
       break;
     }
-    hiwire_push_array(idargs, idarg);
+    JsArray_Push(idargs, idarg);
   }
   va_end(args);
   return idargs;

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -175,7 +175,7 @@ JsArray_Push(JsRef idobj, JsRef idval);
  * Returns: New reference
  */
 JsRef
-hiwire_object();
+JsObject_New();
 
 /**
  * Throw a javascript Error object.
@@ -191,19 +191,19 @@ hiwire_throw_error(JsRef iderr);
  * Returns: New reference
  */
 JsRef
-hiwire_get_member_string(JsRef idobj, const char* ptrname);
+JsObject_GetString(JsRef idobj, const char* ptrname);
 
 /**
  * Set an object member by string.
  */
 errcode
-hiwire_set_member_string(JsRef idobj, const char* ptrname, JsRef idval);
+JsObject_SetString(JsRef idobj, const char* ptrname, JsRef idval);
 
 /**
  * Delete an object member by string.
  */
 errcode
-hiwire_delete_member_string(JsRef idobj, const char* ptrname);
+JsObject_DeleteString(JsRef idobj, const char* ptrname);
 
 /**
  * Get an object member by integer.
@@ -211,23 +211,23 @@ hiwire_delete_member_string(JsRef idobj, const char* ptrname);
  * Returns: New reference
  */
 JsRef
-hiwire_get_member_int(JsRef idobj, int idx);
+JsArray_Get(JsRef idobj, int idx);
 
 /**
  * Set an object member by integer.
  */
 errcode
-hiwire_set_member_int(JsRef idobj, int idx, JsRef idval);
+JsArray_Set(JsRef idobj, int idx, JsRef idval);
 
 errcode
-hiwire_delete_member_int(JsRef idobj, int idx);
+JsArray_Delete(JsRef idobj, int idx);
 
 /**
  * Get the methods on an object, both on itself and what it inherits.
  *
  */
 JsRef
-hiwire_dir(JsRef idobj);
+JsObject_Dir(JsRef idobj);
 
 /**
  * Call a function
@@ -492,19 +492,19 @@ hiwire_get_iterator(JsRef idobj);
  * Returns `Object.entries(obj)`
  */
 JsRef
-hiwire_object_entries(JsRef idobj);
+JsObject_Entries(JsRef idobj);
 
 /**
  * Returns `Object.keys(obj)`
  */
 JsRef
-hiwire_object_keys(JsRef idobj);
+JsObject_Keys(JsRef idobj);
 
 /**
  * Returns `Object.values(obj)`
  */
 JsRef
-hiwire_object_values(JsRef idobj);
+JsObject_Values(JsRef idobj);
 
 /**
  * Returns 1 if the value is a typedarray.

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -153,7 +153,7 @@ JsRef
 hiwire_bool(bool boolean);
 
 bool
-hiwire_is_array(JsRef idobj);
+JsArray_Check(JsRef idobj);
 
 /**
  * Create a new Javascript Array.
@@ -161,16 +161,13 @@ hiwire_is_array(JsRef idobj);
  * Returns: New reference
  */
 JsRef
-hiwire_array();
+JsArray_New();
 
 /**
  * Push a value to the end of a Javascript array.
- *
- * If the user no longer needs the value outside of the array, it is the user's
- * responsibility to decref it.
  */
 errcode
-hiwire_push_array(JsRef idobj, JsRef idval);
+JsArray_Push(JsRef idobj, JsRef idval);
 
 /**
  * Create a new Javascript object.

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -146,7 +146,7 @@ JsProxy_GetAttr(PyObject* self, PyObject* attr)
 
   const char* key = PyUnicode_AsUTF8(attr);
   FAIL_IF_NULL(key);
-  if (strcmp(key, "keys") == 0 && hiwire_is_array(JsProxy_REF(self))) {
+  if (strcmp(key, "keys") == 0 && JsArray_Check(JsProxy_REF(self))) {
     // Sometimes Python APIs test for the existence of a "keys" function
     // to decide whether something should be treated like a dict.
     // This mixes badly with the javascript Array.keys API, so pretend that it
@@ -616,7 +616,7 @@ JsProxy_Dir(PyObject* self, PyObject* _args)
   FAIL_IF_NULL(pydir);
   // Merge and sort
   FAIL_IF_MINUS_ONE(_PySet_Update(result_set, pydir));
-  if (hiwire_is_array(GET_JSREF(self))) {
+  if (JsArray_Check(GET_JSREF(self))) {
     // See comment about Array.keys in GetAttr
     keys_str = PyUnicode_FromString("keys");
     FAIL_IF_NULL(keys_str);
@@ -1036,12 +1036,12 @@ JsMethod_ConvertArgs(PyObject* const* args, Py_ssize_t nargs, PyObject* kwnames)
   JsRef idarg = NULL;
   JsRef idkwargs = NULL;
 
-  idargs = hiwire_array();
+  idargs = JsArray_New();
   FAIL_IF_NULL(idargs);
   for (Py_ssize_t i = 0; i < nargs; ++i) {
     idarg = python2js(args[i]);
     FAIL_IF_NULL(idarg);
-    FAIL_IF_MINUS_ONE(hiwire_push_array(idargs, idarg));
+    FAIL_IF_MINUS_ONE(JsArray_Push(idargs, idarg));
     hiwire_CLEAR(idarg);
   }
 
@@ -1071,7 +1071,7 @@ JsMethod_ConvertArgs(PyObject* const* args, Py_ssize_t nargs, PyObject* kwnames)
     FAIL_IF_MINUS_ONE(hiwire_set_member_string(idkwargs, name_utf8, idarg));
     hiwire_CLEAR(idarg);
   }
-  FAIL_IF_MINUS_ONE(hiwire_push_array(idargs, idkwargs));
+  FAIL_IF_MINUS_ONE(JsArray_Push(idargs, idkwargs));
 
 success:
   success = true;
@@ -1674,7 +1674,7 @@ JsProxy_create_with_this(JsRef object, JsRef this)
   if (hiwire_is_promise(object)) {
     type_flags |= IS_AWAITABLE;
   }
-  if (hiwire_is_array(object)) {
+  if (JsArray_Check(object)) {
     type_flags |= IS_ARRAY;
   }
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -346,7 +346,7 @@ _pyproxy_ownKeys(PyObject* pyobj)
   pydir = PyObject_Dir(pyobj);
   FAIL_IF_NULL(pydir);
 
-  iddir = hiwire_array();
+  iddir = JsArray_New();
   FAIL_IF_NULL(iddir);
   Py_ssize_t n = PyList_Size(pydir);
   FAIL_IF_MINUS_ONE(n);
@@ -354,7 +354,7 @@ _pyproxy_ownKeys(PyObject* pyobj)
     PyObject* pyentry = PyList_GetItem(pydir, i); /* borrowed */
     identry = python2js(pyentry);
     FAIL_IF_NULL(identry);
-    FAIL_IF_MINUS_ONE(hiwire_push_array(iddir, identry));
+    FAIL_IF_MINUS_ONE(JsArray_Push(iddir, identry));
     hiwire_CLEAR(identry);
   }
 
@@ -775,8 +775,8 @@ _pyproxy_get_buffer(PyObject* ptrobj)
     // case, shape, strides and suboffsets MUST be NULL."
     // https://docs.python.org/3/c-api/buffer.html#c.Py_buffer.ndim
     result.largest_ptr += view.itemsize;
-    result.shape = hiwire_array();
-    result.strides = hiwire_array();
+    result.shape = JsArray_New();
+    result.strides = JsArray_New();
     result.c_contiguous = true;
     result.f_contiguous = true;
     goto success;

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -416,7 +416,7 @@ _pyproxy_apply(PyObject* callable,
 
   // Put both arguments and keyword arguments into pyargs
   for (Py_ssize_t i = 0; i < total_args; ++i) {
-    jsitem = hiwire_get_member_int(jsargs, i);
+    jsitem = JsArray_Get(jsargs, i);
     // pyitem is moved into pyargs so we don't need to clear it later.
     PyObject* pyitem = js2python(jsitem);
     if (pyitem == NULL) {
@@ -430,7 +430,7 @@ _pyproxy_apply(PyObject* callable,
     // Put names of keyword arguments into a tuple
     pykwnames = PyTuple_New(numkwargs);
     for (Py_ssize_t i = 0; i < numkwargs; i++) {
-      jsitem = hiwire_get_member_int(jskwnames, i);
+      jsitem = JsArray_Get(jskwnames, i);
       // pyitem is moved into pykwargs so we don't need to clear it later.
       PyObject* pyitem = js2python(jsitem);
       PyTuple_SET_ITEM(pykwnames, i, pyitem);

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -98,8 +98,9 @@ JS_FILE(pyproxy_init_js, () => {
   function _getPtr(jsobj) {
     let ptr = jsobj.$$.ptr;
     if (ptr === null) {
-      throw new Error(jsobj.$$.destroyed_msg ||
-                      "Object has already been destroyed");
+      throw new Error(
+        jsobj.$$.destroyed_msg || "Object has already been destroyed"
+      );
     }
     return ptr;
   }

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -110,7 +110,7 @@ _python2js_sequence(PyObject* x, PyObject* cache, int depth)
   // result:
   JsRef jsarray = NULL;
 
-  jsarray = hiwire_array();
+  jsarray = JsArray_New();
   FAIL_IF_MINUS_ONE(_python2js_add_to_cache(cache, x, jsarray));
   Py_ssize_t length = PySequence_Size(x);
   FAIL_IF_MINUS_ONE(length);
@@ -119,7 +119,7 @@ _python2js_sequence(PyObject* x, PyObject* cache, int depth)
     FAIL_IF_NULL(pyitem);
     jsitem = _python2js(pyitem, cache, depth);
     FAIL_IF_NULL(jsitem);
-    hiwire_push_array(jsarray, jsitem);
+    JsArray_Push(jsarray, jsitem);
     Py_CLEAR(pyitem);
     hiwire_CLEAR(jsitem);
   }


### PR DESCRIPTION
E.g., `JsArray_New` and `JsObject_New` are easier to understand and to remember than `hiwire_array` and `hiwire_object`.