### PR TITLE
DOC Disable sphinx.versionwarning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ extensions = [
     "autodocsumm",
     "sphinx_pyodide",
     "sphinx_argparse_cli",
-    "versionwarning.extension",
+    #    "versionwarning.extension",
     "sphinx_issues",
 ]
 


### PR DESCRIPTION
Currently it fails on main (but not in PRs) with,
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/latest/lib/python3.8/site-packages/sphinx/events.py", line 111, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/latest/lib/python3.8/site-packages/versionwarning/signals.py", line 40, in generate_versionwarning_data_json
    message=message.format(
AttributeError: 'tuple' object has no attribute 'format'
```
Upstream report https://github.com/humitos/sphinx-version-warning/issues/34

Would need to investigate more, but for now disabling this extension to be able to deploy documentation on main.