### PR TITLE
DOCS Fix the code snippet to fetch Python code as runPython's parameter

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -9,7 +9,7 @@ The two possible solutions are,
   {ref}`load it with micropip <micropip-installing-from-arbitrary-urls>`.
 - fetch the Python code as a string and evaluate it in Python,
   ```js
-  pyodide.runPython(await fetch('https://some_url/...'))
+  pyodide.runPython(await (await fetch('https://some_url/...')).text());
   ```
 
 In both cases, files need to be served with a web server and cannot be loaded from local file system.


### PR DESCRIPTION
Previous:
```
  pyodide.runPython(await fetch('https://some_url/...'))
```

After:

```
  pyodide.runPython(await (await fetch('https://some_url/...')).text());
```