### PR TITLE
Reduce recursion limit

### DIFF
--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -71,7 +71,7 @@ globalThis.loadPyodide = async function (config = {}) {
       recurse();
     } catch (err) {}
 
-    let recursionLimit = depth / 50;
+    let recursionLimit = depth / 60;
     if (recursionLimit > 1000) {
       recursionLimit = 1000;
     }


### PR DESCRIPTION
cpython_core[test_json.test_recursion-firefox] is failing due because recursion limit is too high. Probably reducing it should help.