### PR TITLE
MAINT Update Makefile to repeat pip install pyodide_build and npm install less

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,12 @@ env:
 	env
 
 
-.PHONY: build/pyodide.js
-build/pyodide.js: src/js/*.js
+src/js/node_modules/.installed : src/js/package.json
 	cd src/js && npm install --save-dev
+	touch src/js/node_modules/.installed
+
+.PHONY: build/pyodide.js
+build/pyodide.js: src/js/*.js src/js/node_modules/.installed
 	npx typescript src/js/pyodide.js --lib ES2018 --declaration --allowJs --emitDeclarationOnly --outDir build
 	npx rollup -c src/js/rollup.config.js
 

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -7,12 +7,13 @@ else
 	ONLY_PACKAGES=--only "$(PYODIDE_PACKAGES)"
 endif
 
-all:
-	mkdir -p $(PYODIDE_LIBRARIES)
-	python3 -m pip install -e ../pyodide-build --no-deps --prefix $(PYODIDE_LIBRARIES)
+all: .artifacts/bin/pyodide-build
 	PYTHONPATH="$(PYODIDE_LIBRARIES)/lib/python:$(PYODIDE_ROOT)/pyodide-build/" pyodide-build buildall . ../build \
 		--target=$(TARGETPYTHONROOT) $(ONLY_PACKAGES) --install-dir $(PYODIDE_LIBRARIES) --n-jobs $${PYODIDE_JOBS:-4}
 
+.artifacts/bin/pyodide-build: ../pyodide-build/pyodide_build/**
+	mkdir -p $(PYODIDE_LIBRARIES)
+	python3 -m pip install -e ../pyodide-build --no-deps --prefix $(PYODIDE_LIBRARIES)
 
 update-all:
 	for pkg in $$(find . -maxdepth 1 -type d -exec basename {} \; | tail -n +2); do \


### PR DESCRIPTION
I pulled out the `pip install -e ../pyodide-build` and `npm install` into separate build rules so that they don't have to be repeated every time we partially rebuild pyodide.

In the case of `pyodide-build`, it creates a file in `packages/.artifacts/bin/pyodide-build` which is suitable as a makefile dependency. In the case of `npm install`, I explicitly touch `src/js/node_module/.installed` to keep track. 