### PR TITLE
ENH Use leading $ to distinguish shadowed PyProxy methods

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -109,7 +109,7 @@ class SeleniumWrapper:
         self.run_js("Error.stackTraceLimit = Infinity;", pyodide_checks=False)
         self.run_js(
             """
-            window.assert = function assert(cb, message=""){
+            window.assert = function(cb, message=""){
                 if(message !== ""){
                     message = "\\n" + message;
                 }
@@ -117,37 +117,55 @@ class SeleniumWrapper:
                     throw new Error(`Assertion failed: ${cb.toString().slice(6)}${message}`);
                 }
             };
-            window.assertThrows = function assert(cb, errname, pattern){
-                let pat_str = typeof pattern === "string" ? `"${pattern}"` : `${pattern}`;
-                let thiscallstr = `assertThrows(${cb.toString()}, "${errname}", ${pat_str})`;
+            window.assertAsync = async function(cb, message=""){
+                if(message !== ""){
+                    message = "\\n" + message;
+                }
+                if(await cb() !== true){
+                    throw new Error(`Assertion failed: ${cb.toString().slice(12)}${message}`);
+                }
+            };
+            function checkError(err, errname, pattern, pat_str, thiscallstr){
                 if(typeof pattern === "string"){
                     pattern = new RegExp(pattern);
                 }
-                let err = undefined;
-                try {
-                    cb();
-                } catch(e) {
-                    err = e;
-                }
-                console.log(err ? err.message : "no error");
                 if(!err){
-                    console.log("hi?");
                     throw new Error(`${thiscallstr} failed, no error thrown`);
                 }
                 if(err.constructor.name !== errname){
-                    console.log(err.toString());
                     throw new Error(
                         `${thiscallstr} failed, expected error ` +
                         `of type '${errname}' got type '${err.constructor.name}'`
                     );
                 }
                 if(!pattern.test(err.message)){
-                    console.log(err.toString());
                     throw new Error(
                         `${thiscallstr} failed, expected error ` +
                         `message to match pattern ${pat_str} got:\n${err.message}`
                     );
                 }
+            }
+            window.assertThrows = function(cb, errname, pattern){
+                let pat_str = typeof pattern === "string" ? `"${pattern}"` : `${pattern}`;
+                let thiscallstr = `assertThrows(${cb.toString()}, "${errname}", ${pat_str})`;
+                let err = undefined;
+                try {
+                    cb();
+                } catch(e) {
+                    err = e;
+                }
+                checkError(err, errname, pattern, pat_str, thiscallstr);
+            };
+            window.assertThrowsAsync = async function(cb, errname, pattern){
+                let pat_str = typeof pattern === "string" ? `"${pattern}"` : `${pattern}`;
+                let thiscallstr = `assertThrowsAsync(${cb.toString()}, "${errname}", ${pat_str})`;
+                let err = undefined;
+                try {
+                    await cb();
+                } catch(e) {
+                    err = e;
+                }
+                checkError(err, errname, pattern, pat_str, thiscallstr);
             };
             """,
             pyodide_checks=False,

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -36,6 +36,14 @@ substitutions:
   {pr}`1539`
 - {{ Enhancement }} Added the {any}`PyProxy.clone` method.
   {pr}`1549`
+- {{ API }} Updated the method resolution order on `PyProxy`. Performing a
+  lookup on a `PyProxy` will prefer to pick a method from the `PyProxy` api, if
+  no such method is found, it will use `getattr` on the proxied object.
+  Prefixing a name with `$` forces `getattr`. For instance, `PyProxy.destroy`
+  now always refers to the method that destroys the proxy, whereas
+  `PyProxy.$destroy` refers to an attribute or method called `destroy` on the
+  proxied object.
+  {pr}`1604`
 
 ### pyodide-build
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -148,9 +148,17 @@ pyproxy_getflags(PyObject* pyobj)
 JsRef
 _pyproxy_repr(PyObject* pyobj)
 {
-  PyObject* repr_py = PyObject_Repr(pyobj);
-  const char* repr_utf8 = PyUnicode_AsUTF8(repr_py);
-  JsRef repr_js = hiwire_string_utf8(repr_utf8);
+  PyObject* repr_py = NULL;
+  const char* repr_utf8 = NULL;
+  JsRef repr_js = NULL;
+
+  repr_py = PyObject_Repr(pyobj);
+  FAIL_IF_NULL(repr_py);
+  repr_utf8 = PyUnicode_AsUTF8(repr_py);
+  FAIL_IF_NULL(repr_utf8);
+  repr_js = hiwire_string_utf8(repr_utf8);
+
+finally:
   Py_CLEAR(repr_py);
   return repr_js;
 }

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -678,27 +678,24 @@ Module.PyProxyHandlers = {
   },
   get: function (jsobj, jskey) {
     // Preference order:
-    // 1. things we have to return to avoid making Javascript angry
+    // 1. stuff from Javascript
     // 2. the result of Python getattr
-    // 3. stuff from the prototype chain
 
-    // 1. things we have to return to avoid making Javascript angry
-    // This conditional looks funky but it's the only thing I found that
-    // worked right in all cases.
-    if (jskey in jsobj && !(jskey in Object.getPrototypeOf(jsobj))) {
+    // Javascript lookup -- make sure not to let symbols through, passing them
+    // to python_getattr will crash.
+    if (jskey in jsobj || typeof jskey === "symbol") {
       return Reflect.get(jsobj, jskey);
     }
-    // python_getattr will crash when given a Symbol
-    if (typeof jskey === "symbol") {
-      return Reflect.get(jsobj, jskey);
+    // If keys start with $ remove the $. User can use initial $ to
+    // unambiguously ask for a key on the Python object
+    if (jskey.startsWith("$")) {
+      jskey = jskey.slice(1);
     }
     // 2. The result of getattr
     let idresult = python_getattr(jsobj, jskey);
     if (idresult !== 0) {
       return Module.hiwire.pop_value(idresult);
     }
-    // 3. stuff from the prototype chain.
-    return Reflect.get(jsobj, jskey);
   },
   set: function (jsobj, jskey, jsval) {
     // We're only willing to set properties on the python object, throw an

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -392,7 +392,8 @@ def test_pyproxy_mixins2(selenium):
         assert(() => !("length" in get_method));
         assert(() => !("name" in get_method));
 
-        assert(() => pyodide.globals.get.type === "builtin_function_or_method");
+        assert(() => pyodide.globals.$get.type === "builtin_function_or_method");
+        assert(() => pyodide.globals.get.type === undefined);
         assert(() => pyodide.globals.set.type === undefined);
 
         let [Test, t] = pyodide.runPython(`
@@ -666,66 +667,70 @@ def test_fatal_error(selenium_standalone):
     selenium_standalone.run_js(
         """
         let fatal_error = false;
+        let old_fatal_error = pyodide._module.fatal_error;
         pyodide._module.fatal_error = (e) => {
             fatal_error = true;
             throw e;
         }
-        function expect_fatal(func){
-            fatal_error = false;
-            try {
-                func();
-            } catch(e) {
-                // pass
-            } finally {
-                if(!fatal_error){
-                    throw new Error(`No fatal error occured: ${func.toString().slice(6)}`);
+        try {
+            function expect_fatal(func){
+                fatal_error = false;
+                try {
+                    func();
+                } catch(e) {
+                    // pass
+                } finally {
+                    if(!fatal_error){
+                        throw new Error(`No fatal error occured: ${func.toString().slice(6)}`);
+                    }
                 }
             }
+            let t = pyodide.runPython(`
+                from _pyodide_core import trigger_fatal_error
+                def tfe(*args, **kwargs):
+                    trigger_fatal_error()
+                class Temp:
+                    __getattr__ = tfe
+                    __setattr__ = tfe
+                    __delattr__ = tfe
+                    __dir__ = tfe
+                    __call__ = tfe
+                    __getitem__ = tfe
+                    __setitem__ = tfe
+                    __delitem__ = tfe
+                    __iter__ = tfe
+                    __len__ = tfe
+                    __contains__ = tfe
+                    __await__ = tfe
+                    __repr__ = tfe
+                    __del__ = tfe
+                Temp()
+            `);
+            expect_fatal(() => "x" in t);
+            expect_fatal(() => t.x);
+            expect_fatal(() => t.x = 2);
+            expect_fatal(() => delete t.x);
+            expect_fatal(() => Object.getOwnPropertyNames(t));
+            expect_fatal(() => t());
+            expect_fatal(() => t.get(1));
+            expect_fatal(() => t.set(1, 2));
+            expect_fatal(() => t.delete(1));
+            expect_fatal(() => t.has(1));
+            expect_fatal(() => t.length);
+            // expect_fatal(() => t.then(()=>{}));
+            expect_fatal(() => t.toString());
+            expect_fatal(() => Array.from(t));
+            t.destroy();
+            a = pyodide.runPython(`
+                from array import array
+                array("I", [1,2,3,4])
+            `);
+            b = a.getBuffer();
+            b._view_ptr = 1e10;
+            expect_fatal(() => b.release());
+        } finally {
+            pyodide._module.fatal_error = old_fatal_error;
         }
-        let t = pyodide.runPython(`
-            from _pyodide_core import trigger_fatal_error
-            def tfe(*args, **kwargs):
-                trigger_fatal_error()
-            class Temp:
-                __getattr__ = tfe
-                __setattr__ = tfe
-                __delattr__ = tfe
-                __dir__ = tfe
-                __call__ = tfe
-                __getitem__ = tfe
-                __setitem__ = tfe
-                __delitem__ = tfe
-                __iter__ = tfe
-                __len__ = tfe
-                __contains__ = tfe
-                __await__ = tfe
-                __repr__ = tfe
-                __del__ = tfe
-            Temp()
-        `);
-        expect_fatal(() => "x" in t);
-        expect_fatal(() => t.x);
-        expect_fatal(() => t.x = 2);
-        expect_fatal(() => delete t.x);
-        expect_fatal(() => Object.getOwnPropertyNames(t));
-        expect_fatal(() => t());
-        expect_fatal(() => t.get(1));
-        expect_fatal(() => t.set(1, 2));
-        expect_fatal(() => t.delete(1));
-        expect_fatal(() => t.has(1));
-        expect_fatal(() => t.length);
-        expect_fatal(() => t.then(()=>{}));
-        expect_fatal(() => t.toString());
-        expect_fatal(() => Array.from(t));
-        expect_fatal(() => t.destroy());
-        expect_fatal(() => t.destroy());
-        a = pyodide.runPython(`
-            from array import array
-            array("I", [1,2,3,4])
-        `);
-        b = a.getBuffer();
-        b._view_ptr = 1e10;
-        expect_fatal(() => b.release());
         """
     )
 

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -772,3 +772,23 @@ def test_pyproxy_call(selenium):
     msg = r"TypeError: f\(\) got multiple values for argument 'x'"
     with pytest.raises(selenium.JavascriptException, match=msg):
         selenium.run_js("f.callKwargs(76, {x : 6})")
+
+
+def test_pyproxy_name_clash(selenium):
+    selenium.run_js(
+        """
+        let d = pyodide.runPython("{'a' : 2}");
+        assert(() => d.get('a') === 2);
+        assert(() => d.$get('b', 3) === 3);
+
+        let t = pyodide.runPython(`
+            class Test:
+                def destroy(self):
+                    return 7
+            Test()
+        `);
+        assert(() => t.$destroy() === 7);
+        t.destroy();
+        assertThrows(() => t.$destroy, "Error", "Object has already been destroyed");
+        """
+    )

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -392,9 +392,11 @@ def test_pyproxy_mixins2(selenium):
         assert(() => !("length" in get_method));
         assert(() => !("name" in get_method));
 
-        assert(() => pyodide.globals.$get.type === "builtin_function_or_method");
-        assert(() => pyodide.globals.get.type === undefined);
-        assert(() => pyodide.globals.set.type === undefined);
+        let d = pyodide.runPython("{}");
+        assert(() => d.$get.type === "builtin_function_or_method");
+        assert(() => d.get.type === undefined);
+        assert(() => d.set.type === undefined);
+        d.destroy();
 
         let [Test, t] = pyodide.runPython(`
             class Test: pass
@@ -655,7 +657,6 @@ def test_errors(selenium):
         expect_error(() => t.delete(1));
         expect_error(() => t.has(1));
         expect_error(() => t.length);
-        expect_error(() => t.then(()=>{}));
         expect_error(() => t.toString());
         expect_error(() => Array.from(t));
         """


### PR DESCRIPTION
This resolves #1589. It updates the MRO for PyProxy: now `proxy.destroy` always refers to the method PyProxy class method that destroys the proxy, `proxy.$destroy` refers to an attribute or method on the proxied Python object. Similarly, `proxy.get` refers to the `PyProxy.get` method if `type(proxy)` has a `__getitem__` method. Otherwise, it refers to an attribute or method on the proxied object. To unambigiously look up `get` on the proxied object, use `proxy.$get`.

The docs should be updated to explain this.