### PR TITLE
Add support for pyproxy allocation tracing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ addopts = --doctest-modules
 markers =
     skip_refcount_check: Dont run refcount checks
     driver_timeout: Set script timeout in WebDriver
+    trace_pyproxies: Trace pyproxy allocations
 
 [bumpversion]
 current_version = 0.16.1

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -46,6 +46,25 @@ if (globalThis.FinalizationRegistry) {
   // Module.bufferFinalizationRegistry = finalizationRegistry;
 }
 
+let pyproxy_alloc_map = new Map();
+Module.pyproxy_alloc_map = pyproxy_alloc_map;
+let trace_pyproxy_alloc;
+let trace_pyproxy_dealloc;
+
+Module.enable_pyproxy_allocation_tracing = function(){
+  trace_pyproxy_alloc = function(proxy){
+    pyproxy_alloc_map.set(proxy, Error().stack);
+  }
+  trace_pyproxy_dealloc = function(proxy){
+    pyproxy_alloc_map.delete(proxy);
+  }
+}
+Module.disable_pyproxy_allocation_tracing = function(){
+  trace_pyproxy_alloc = function(proxy){};
+  trace_pyproxy_dealloc = function(proxy){};
+}
+Module.disable_pyproxy_allocation_tracing();
+
 /**
  * In the case that the Python object is callable, PyProxyClass inherits from
  * Function so that PyProxy objects can be callable.
@@ -93,6 +112,7 @@ Module.pyproxy_new = function (ptrobj) {
   });
   Module._Py_IncRef(ptrobj);
   let proxy = new Proxy(target, Module.PyProxyHandlers);
+  trace_pyproxy_alloc(proxy);
   Module.finalizationRegistry.register(proxy, ptrobj, proxy);
   return proxy;
 };
@@ -251,6 +271,7 @@ Module.PyProxyClass = class {
     this.$$.destroyed_msg = destroyed_msg;
     try {
       Module._Py_DecRef(ptrobj);
+      trace_pyproxy_dealloc(this);
     } catch (e) {
       Module.fatal_error(e);
     }

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -51,18 +51,18 @@ Module.pyproxy_alloc_map = pyproxy_alloc_map;
 let trace_pyproxy_alloc;
 let trace_pyproxy_dealloc;
 
-Module.enable_pyproxy_allocation_tracing = function(){
-  trace_pyproxy_alloc = function(proxy){
+Module.enable_pyproxy_allocation_tracing = function () {
+  trace_pyproxy_alloc = function (proxy) {
     pyproxy_alloc_map.set(proxy, Error().stack);
-  }
-  trace_pyproxy_dealloc = function(proxy){
+  };
+  trace_pyproxy_dealloc = function (proxy) {
     pyproxy_alloc_map.delete(proxy);
-  }
-}
-Module.disable_pyproxy_allocation_tracing = function(){
-  trace_pyproxy_alloc = function(proxy){};
-  trace_pyproxy_dealloc = function(proxy){};
-}
+  };
+};
+Module.disable_pyproxy_allocation_tracing = function () {
+  trace_pyproxy_alloc = function (proxy) {};
+  trace_pyproxy_dealloc = function (proxy) {};
+};
 Module.disable_pyproxy_allocation_tracing();
 
 /**

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -81,7 +81,12 @@ export let version = ""; // actually defined in runPythonSimple in loadPyodide (
  *          documentation for :any:`pyodide.eval_code` for more info.
  */
 export function runPython(code, globals = Module.globals) {
-  return Module.pyodide_py_eval_code(code, globals);
+  let eval_code = Module.pyodide_py.eval_code;
+  try {
+    return eval_code(code, globals);
+  } finally {
+    eval_code.destroy();
+  }
 }
 Module.runPython = runPython;
 
@@ -176,11 +181,13 @@ export function pyimport(name) {
  * @async
  */
 export async function runPythonAsync(code) {
-  let coroutine = Module.pyodide_py_eval_code_async(code, Module.globals);
+  let eval_code_async = Module.pyodide_py.eval_code_async;
+  let coroutine = eval_code_async(code, Module.globals);
   try {
     let result = await coroutine;
     return result;
   } finally {
+    eval_code_async.destroy();
     coroutine.destroy();
   }
 }

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -81,7 +81,7 @@ export let version = ""; // actually defined in runPythonSimple in loadPyodide (
  *          documentation for :any:`pyodide.eval_code` for more info.
  */
 export function runPython(code, globals = Module.globals) {
-  return Module.pyodide_py.eval_code(code, globals);
+  return Module.pyodide_py_eval_code(code, globals);
 }
 Module.runPython = runPython;
 
@@ -176,7 +176,7 @@ export function pyimport(name) {
  * @async
  */
 export async function runPythonAsync(code) {
-  let coroutine = Module.pyodide_py.eval_code_async(code, Module.globals);
+  let coroutine = Module.pyodide_py_eval_code_async(code, Module.globals);
   try {
     let result = await coroutine;
     return result;

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -238,6 +238,8 @@ def temp(Module):
   pyodide.globals = Module.globals;
   pyodide.pyodide_py = Module.pyodide_py;
   pyodide.version = Module.version;
+  Module.pyodide_py_eval_code = Module.pyodide_py.eval_code;
+  Module.pyodide_py_eval_code_async = Module.pyodide_py.eval_code_async;
 
   registerJsModule("js", globalThis);
   registerJsModule("pyodide_js", pyodide);

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -238,8 +238,6 @@ def temp(Module):
   pyodide.globals = Module.globals;
   pyodide.pyodide_py = Module.pyodide_py;
   pyodide.version = Module.version;
-  Module.pyodide_py_eval_code = Module.pyodide_py.eval_code;
-  Module.pyodide_py_eval_code_async = Module.pyodide_py.eval_code_async;
 
   registerJsModule("js", globalThis);
   registerJsModule("pyodide_js", pyodide);

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -237,6 +237,16 @@ def test_run_python_async_toplevel_await(selenium):
     )
 
 
+@pytest.mark.trace_pyproxies
+def test_run_python_proxy_leak(selenium):
+    selenium.run_js(
+        """
+        pyodide.runPython("")
+        await pyodide.runPythonAsync("")
+        """
+    )
+
+
 def test_run_python_last_exc(selenium):
     selenium.run_js(
         """


### PR DESCRIPTION
A while back we added tests to make sure we weren't leaking hiwire keys. As a special case of this, we also were testing that we weren't leaking JsProxies. In the future, I would like to add tests to show that we aren't leaking PyProxies either. Currently we leak quite a lot of them.

Before we actually add any tests to show that we aren't leaking proxies, I'd like to rework the model of the PyProxy lifetime. The planned changes should make it far easier to actually avoid these leaks while still using a reasonably natural coding style.

This change has no user-facing effect: the tracing is disabled by default and the API to enable it is private and always will be.