### PR TITLE
TST xfail test_zipfile on Chrome

### DIFF
--- a/src/tests/python_tests.txt
+++ b/src/tests/python_tests.txt
@@ -549,7 +549,7 @@ test_xmlrpc_net
 test_xxtestfuzz
 test_yield_from
 test_zipapp
-test_zipfile
+test_zipfile  crash-chrome
 test_zipfile64
 test_zipimport
 test_zipimport_support


### PR DESCRIPTION
This CPython test fails quite frequently with a timeout on Chrome (most recently on `main` in d814aee3dd8ff6aab61fcaa8c91df1cf04beb19f).

Skipping it for now, in order to try to reach green CI on `main`