### PR TITLE
Add md5sum to dependency-check script

### DIFF
--- a/tools/dependency-check.sh
+++ b/tools/dependency-check.sh
@@ -32,6 +32,10 @@ check_pkgconfig() {
   check_binary_present "pkg-config"
 }
 
+check_md5sum() {
+  check_binary_present "md5sum"
+}
+
 check_fortran_dependencies() {
   check_binary_present "gfortran"
   check_binary_present "f2c"

--- a/tools/dependency-check.sh
+++ b/tools/dependency-check.sh
@@ -54,3 +54,4 @@ check_pkgconfig
 #check_python_headers
 check_fortran_dependencies
 check_pyyaml
+check_md5sum


### PR DESCRIPTION
`md5sum` is required to run. As without it the build fails in macOS.

```
md5sum --quiet --check checksums || (rm /Users/syrus/Development/pyodide/cpython/downloads/Python-3.8.2.tgz; false)
/bin/bash: md5sum: command not found
make[1]: *** [/Users/syrus/Development/pyodide/cpython/downloads/Python-3.8.2.tgz] Error 1
make: *** [cpython/installs/python-3.8.2/lib/python3.8] Error 2
```