### PR TITLE
Include 'audioop' in standard library.

### DIFF
--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -7,6 +7,7 @@
 *static*
 
 array arraymodule.c	# array objects
+audioop audioop.c	# Operations on audio samples
 math mathmodule.c _math.c # -lm # math library functions, e.g. sin()
 cmath cmathmodule.c # complex math functions
 _contextvars _contextvarsmodule.c

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -40,7 +40,8 @@ substitutions:
   can be disabled with the `fullStdLib` parameter set to `false`.
   All optional stdlib modules can then be loaded as needed with
   {any}`pyodide.loadPackage`. {pr}`1543`
-- The standard library module `audioop` is now included, making the `wave`, `sndhdr`, `aifc`, and `sunau` modules usable.
+- The standard library module `audioop` is now included, making the `wave`,
+  `sndhdr`, `aifc`, and `sunau` modules usable. {pr}`1623`
 
 ### Python / JS type conversions
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -40,6 +40,7 @@ substitutions:
   can be disabled with the `fullStdLib` parameter set to `false`.
   All optional stdlib modules can then be loaded as needed with
   {any}`pyodide.loadPackage`. {pr}`1543`
+- The standard library module `audioop` is now included, making the `wave`, `sndhdr`, `aifc`, and `sunau` modules usable.
 
 ### Python / JS type conversions
 

--- a/src/tests/python_tests.txt
+++ b/src/tests/python_tests.txt
@@ -43,6 +43,7 @@ test__osx_support   platform-specific
 test__xxsubinterpreters
 test_abc
 test_abstract_numbers
+test_aifc
 test_argparse  crash-chrome
 test_array
 test_asdl_parser
@@ -74,6 +75,7 @@ test_asyncio.test_windows_events
 test_asyncio.test_windows_utils
 test_asyncore bad ioctl syscall async
 test_atexit
+test_audioop
 test_audit   subprocess
 test_augassign
 test_base64
@@ -426,6 +428,7 @@ test_slice
 test_smtpd
 test_smtplib  bad ioctl syscall 21537
 test_smtpnet
+test_sndhdr
 test_socket
 test_socketserver
 test_sort
@@ -447,6 +450,7 @@ test_structmembers
 test_structseq
 test_subclassinit
 test_subprocess
+test_sunau
 test_sundry
 test_super
 test_support  multiprocessing
@@ -526,6 +530,7 @@ test_uuid subprocess
 test_venv nonsense
 test_wait3  threading
 test_wait4  threading
+test_wave
 test_weakref  threading
 test_weakset
 test_webbrowser replaced

--- a/src/tests/python_tests.txt
+++ b/src/tests/python_tests.txt
@@ -12,7 +12,6 @@
 # - platform-specific: This is testing something about a particular platform
 #   that isn't relevant here
 # - async: relies on async
-# - audioop: Requires the audioop module
 # - floating point: Failures caused by floating-point differences
 # - threading: Failures due to lack of a threading implementation
 # - subprocess: Failures caused by no subprocess module. Some of these are
@@ -44,7 +43,6 @@ test__osx_support   platform-specific
 test__xxsubinterpreters
 test_abc
 test_abstract_numbers
-test_aifc   audioop
 test_argparse  crash-chrome
 test_array
 test_asdl_parser
@@ -76,7 +74,6 @@ test_asyncio.test_windows_events
 test_asyncio.test_windows_utils
 test_asyncore bad ioctl syscall async
 test_atexit
-test_audioop  audioop
 test_audit   subprocess
 test_augassign
 test_base64
@@ -429,7 +426,6 @@ test_slice
 test_smtpd
 test_smtplib  bad ioctl syscall 21537
 test_smtpnet
-test_sndhdr audioop
 test_socket
 test_socketserver
 test_sort
@@ -451,7 +447,6 @@ test_structmembers
 test_structseq
 test_subclassinit
 test_subprocess
-test_sunau  audioop
 test_sundry
 test_super
 test_support  multiprocessing
@@ -531,7 +526,6 @@ test_uuid subprocess
 test_venv nonsense
 test_wait3  threading
 test_wait4  threading
-test_wave   audioop
 test_weakref  threading
 test_weakset
 test_webbrowser replaced


### PR DESCRIPTION
Fixes #801.

Effect on build size:
- pyodide.asm.data: 4888450 (-985)
- pyodide.asm.js: 1841020 (+165)
- pyodide.asm.wasm: 11380901 (+30084)