### PR TITLE
Try new recursion limit formula

### DIFF
--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -147,10 +147,7 @@ function fixRecursionLimit() {
     recurse();
   } catch (err) {}
 
-  let recursionLimit = depth / 60;
-  if (recursionLimit > 1000) {
-    recursionLimit = 1000;
-  }
+  let recursionLimit = Math.min(depth / 50, 400);
   Module.runPythonSimple(
     `import sys; sys.setrecursionlimit(int(${recursionLimit}))`
   );


### PR DESCRIPTION
Recursion limit is too high on Facebook but too low (?) in chrome. See #1629. With this new rule, in firefox it will usually be set to 400.