### PR TITLE
Allow Comlink proxies to be imported

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,25 +20,25 @@ substitutions:
   {any}`eval_code` and {any}`eval_code_async`. Designed with
   the needs of REPL implementations in mind.
   {pr}`1563`
-- {{ Fixed }} {any}`eval_code_async` no longer automatically awaits a returned
+- {{ Fix }} {any}`eval_code_async` no longer automatically awaits a returned
   coroutine or attempts to await a returned generator object (which triggered an
   error).
   {pr}`1563`
-- {{ Fixed }} micropip now correctly handles packages that have mixed case names.
+- {{ Fix }} micropip now correctly handles packages that have mixed case names.
   (See {issue}`1614`).
   {pr}`1615`
 
-- {{ ENH }} Pyodide now ships with first party typescript types for the entire
+- {{ Enhancement }} Pyodide now ships with first party typescript types for the entire
   Javascript API (though no typings are available for `PyProxy` fields).
   {pr}`1601`
 
--{{ ENH }} If a Python error occurs in a reentrant `runPython` call, the error
+- {{ Enhancement }} If a Python error occurs in a reentrant `runPython` call, the error
   will be propagated into the outer `runPython` context as the original error
   type. This is particularly important if the error is a `KeyboardInterrupt`.
   {pr}`1447`
 
-- {{ ENH }} It is now possible to import `Comlink` objects into Pyodide after
-  using :any:`registerComlink`
+- {{ Enhancement }} It is now possible to import `Comlink` objects into Pyodide after
+  using {any}`pyodide.registerComlink`
   {pr}`1642`
 
 ## Standard library
@@ -214,10 +214,10 @@ See the {ref}`0-17-0-release-notes` for more information.
   {pr}`872`
 - {{ API }} `micropip.install` now returns a Python `Future` instead of a Javascript `Promise`.
   {pr}`1324`
-- {{ FIX }} {any}`micropip.install` now interacts correctly with
+- {{ Fix }} {any}`micropip.install` now interacts correctly with
   {any}`pyodide.loadPackage`.
   {pr}`1457`
-- {{ FIX }} {any}`micropip.install` now handles version constraints correctly
+- {{ Fix }} {any}`micropip.install` now handles version constraints correctly
   even if there is a version of the package available from the Pyodide `indexURL`.
 
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -37,6 +37,10 @@ substitutions:
   type. This is particularly important if the error is a `KeyboardInterrupt`.
   {pr}`1447`
 
+- {{ ENH }} It is now possible to import `Comlink` objects into Pyodide after
+  using :any:`registerComlink`
+  {pr}`1642`
+
 ## Standard library
 
 - The following standard library modules are now available as standalone packages

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -596,6 +596,11 @@ EM_JS_NUM(bool, hiwire_is_function, (JsRef idobj), {
   // clang-format on
 });
 
+EM_JS_NUM(bool, hiwire_is_comlink_proxy, (JsRef idobj), {
+  let value = Module.hiwire.get_value(idobj);
+  return !!(Module.Comlink && value[Module.Comlink.createEndpoint]);
+});
+
 EM_JS_NUM(bool, hiwire_is_error, (JsRef idobj), {
   // From https://stackoverflow.com/a/45496068
   let value = Module.hiwire.get_value(idobj);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -381,6 +381,12 @@ bool
 hiwire_is_function(JsRef idobj);
 
 /**
+ * Check if the object is a comlink proxy.
+ */
+bool
+hiwire_is_comlink_proxy(JsRef idobj);
+
+/**
  * Check if the object is an error.
  */
 bool

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1681,7 +1681,7 @@ JsProxy_create_with_this(JsRef object, JsRef this)
   if (hiwire_is_promise(object)) {
     type_flags |= IS_AWAITABLE;
   }
-  if (hiwire_is_array(object)) {
+  if (JsArray_Check(object)) {
     type_flags |= IS_ARRAY;
   }
 done_feature_detecting:

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1636,10 +1636,18 @@ finally:
 PyObject*
 JsProxy_create_with_this(JsRef object, JsRef this)
 {
+  int type_flags = 0;
+  bool success = false;
+  PyTypeObject* type = NULL;
+  PyObject* result = NULL;
+  if (hiwire_is_comlink_proxy(object)) {
+    // Comlink proxies are weird and break our feature detection pretty badly.
+    type_flags = IS_CALLABLE | IS_AWAITABLE | IS_ARRAY;
+    goto done_feature_detecting;
+  }
   if (hiwire_is_error(object)) {
     return JsProxy_new_error(object);
   }
-  int type_flags = 0;
   if (hiwire_is_function(object)) {
     type_flags |= IS_CALLABLE;
   }
@@ -1673,13 +1681,10 @@ JsProxy_create_with_this(JsRef object, JsRef this)
   if (hiwire_is_promise(object)) {
     type_flags |= IS_AWAITABLE;
   }
-  if (JsArray_Check(object)) {
+  if (hiwire_is_array(object)) {
     type_flags |= IS_ARRAY;
   }
-
-  bool success = false;
-  PyTypeObject* type = NULL;
-  PyObject* result = NULL;
+done_feature_detecting:
 
   type = JsProxy_get_subtype(type_flags);
   FAIL_IF_NULL(type);

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -231,9 +231,8 @@ export function registerJsModule(name, module) {
 }
 
 /**
- * Tell Pyodide about an available copy of Comlink.
+ * Tell Pyodide about Comlink.
  * Necessary to enable use of Comlink Proxies from Python.
- * @private
  */
 export function registerComlink(Comlink) {
   Module._Comlink = Comlink;

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -232,7 +232,7 @@ export function registerJsModule(name, module) {
 
 /**
  * Tell Pyodide about Comlink.
- * Necessary to enable use of Comlink Proxies from Python.
+ * Necessary to enable importing Comlink proxies into Python.
  */
 export function registerComlink(Comlink) {
   Module._Comlink = Comlink;

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -231,6 +231,15 @@ export function registerJsModule(name, module) {
 }
 
 /**
+ * Tell Pyodide about an available copy of Comlink.
+ * Necessary to enable use of Comlink Proxies from Python.
+ * @private
+ */
+export function registerComlink(Comlink) {
+  Module._Comlink = Comlink;
+}
+
+/**
  * Unregisters a Javascript module with given name that has been previously
  * registered with :js:func:`pyodide.registerJsModule` or
  * :func:`pyodide.register_js_module`. If a Javascript module with that name
@@ -326,6 +335,7 @@ export function makePublicAPI() {
     unregisterJsModule,
     setInterruptBuffer,
     toPy,
+    registerComlink,
     PythonError,
     PyBuffer,
   };


### PR DESCRIPTION
This patches the feature detection code to fix handling of Comlink proxies when the `Comlink` namespace has been registered with `pyodide` via `pyodide.registerComlink`. This issue came up recently in discussion with @aadereiko in gitter.