### PR TITLE
Store package build logs as circleci artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,9 @@ jobs:
       - store_artifacts:
           path: /root/repo/build/
 
+      - store_artifacts:
+          path: /root/repo/packages/build-logs
+
   test-core-firefox:
     <<: *defaults
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ geckodriver.log
 node_modules
 packages/.artifacts
 packages/*/build.log
+packages/build-logs
 dist/

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -8,8 +8,10 @@ else
 endif
 
 all: .artifacts/bin/pyodide-build
+	mkdir -p build-logs
 	PYTHONPATH="$(PYODIDE_LIBRARIES)/lib/python:$(PYODIDE_ROOT)/pyodide-build/" pyodide-build buildall . ../build \
-		--target=$(TARGETPYTHONROOT) $(ONLY_PACKAGES) --install-dir $(PYODIDE_LIBRARIES) --n-jobs $${PYODIDE_JOBS:-4}
+		--target=$(TARGETPYTHONROOT) $(ONLY_PACKAGES) --install-dir $(PYODIDE_LIBRARIES) --n-jobs $${PYODIDE_JOBS:-4} \
+		--log-dir=build-logs
 
 .artifacts/bin/pyodide-build: ../pyodide-build/pyodide_build/**
 	mkdir -p $(PYODIDE_LIBRARIES)

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -99,8 +99,6 @@ class Package(BasePackage):
                     args.target,
                     "--install-dir",
                     args.install_dir,
-                    "--log-dir",
-                    args.log_dir,
                 ],
                 check=False,
                 stdout=f,

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -99,10 +99,17 @@ class Package(BasePackage):
                     args.target,
                     "--install-dir",
                     args.install_dir,
+                    "--log-dir",
+                    args.log_dir,
                 ],
                 check=False,
                 stdout=f,
                 stderr=subprocess.STDOUT,
+            )
+
+        if args.log_dir:
+            shutil.copy(
+                self.pkgdir / "build.log", Path(args.log_dir) / f"{self.name}.log"
             )
 
         try:
@@ -336,6 +343,14 @@ def make_parser(parser):
             "default. Set to 'skip' to skip installation. Installation is "
             "needed if you want to build other packages that depend on this one."
         ),
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        dest="log_dir",
+        nargs="?",
+        default=None,
+        help=("Directory to place log files"),
     )
     parser.add_argument(
         "--only",

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -336,6 +336,14 @@ def make_parser(parser: argparse.ArgumentParser):
             "needed if you want to build other packages that depend on this one."
         ),
     )
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        dest="log_dir",
+        nargs="?",
+        default=None,
+        help=("Directory to place log files"),
+    )
     return parser
 
 

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -336,14 +336,6 @@ def make_parser(parser: argparse.ArgumentParser):
             "needed if you want to build other packages that depend on this one."
         ),
     )
-    parser.add_argument(
-        "--log-dir",
-        type=str,
-        dest="log_dir",
-        nargs="?",
-        default=None,
-        help=("Directory to place log files"),
-    )
     return parser
 
 


### PR DESCRIPTION
This makes it so we can view the build logs for succeeded package builds. Should make it easier to debug package builds.