### PR TITLE
Use new in 3.9 OneArg and NoArgs call methods instead of ObjArgs

### DIFF
--- a/src/core/docstring.c
+++ b/src/core/docstring.c
@@ -16,8 +16,8 @@ set_method_docstring(PyMethodDef* method, PyObject* parent)
   py_method = PyObject_GetAttrString(parent, method->ml_name);
   FAIL_IF_NULL(py_method);
 
-  py_result = _PyObject_CallMethodIdObjArgs(
-    py_docstring_mod, &PyId_get_cmeth_docstring, py_method, NULL);
+  py_result = _PyObject_CallMethodIdOneArg(
+    py_docstring_mod, &PyId_get_cmeth_docstring, py_method);
   FAIL_IF_NULL(py_result);
 
   Py_ssize_t size;

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -604,7 +604,7 @@ JsProxy_Dir(PyObject* self, PyObject* _args)
   object__dir__ =
     _PyObject_GetAttrId((PyObject*)&PyBaseObject_Type, &PyId___dir__);
   FAIL_IF_NULL(object__dir__);
-  keys = PyObject_CallFunctionObjArgs(object__dir__, self, NULL);
+  keys = PyObject_CallOneArg(object__dir__, self);
   FAIL_IF_NULL(keys);
   result_set = PySet_New(keys);
   FAIL_IF_NULL(result_set);
@@ -718,7 +718,7 @@ JsProxy_Await(JsProxy* self)
   JsRef promise_result = NULL;
   PyObject* result = NULL;
 
-  loop = _PyObject_CallNoArg(asyncio_get_event_loop);
+  loop = PyObject_CallNoArgs(asyncio_get_event_loop);
   FAIL_IF_NULL(loop);
 
   fut = _PyObject_CallMethodId(loop, &PyId_create_future, NULL);
@@ -1013,7 +1013,7 @@ JsProxy_new_error(JsRef idobj)
   proxy = JsProxyType.tp_alloc(&JsProxyType, 0);
   FAIL_IF_NULL(proxy);
   FAIL_IF_NONZERO(JsProxy_cinit(proxy, idobj));
-  result = PyObject_CallFunctionObjArgs(Exc_JsException, proxy, NULL);
+  result = PyObject_CallOneArg(Exc_JsException, proxy);
   FAIL_IF_NULL(result);
 finally:
   Py_CLEAR(proxy);
@@ -1753,7 +1753,7 @@ JsProxy_init(PyObject* core_module)
   FAIL_IF_NULL(_pyodide_core);
   _Py_IDENTIFIER(JsProxy);
   jsproxy_mock =
-    _PyObject_CallMethodIdObjArgs(_pyodide_core, &PyId_JsProxy, NULL);
+    _PyObject_CallMethodIdNoArgs(_pyodide_core_docs, &PyId_JsProxy);
   FAIL_IF_NULL(jsproxy_mock);
 
   // Load the docstrings for JsProxy methods from the corresponding stubs in

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -501,7 +501,7 @@ _pyproxyGen_Send(PyObject* receiver, JsRef jsval)
     retval = Py_TYPE(receiver)->tp_iternext(receiver);
   } else {
     _Py_IDENTIFIER(send);
-    retval = _PyObject_CallMethodIdObjArgs(receiver, &PyId_send, v, NULL);
+    retval = _PyObject_CallMethodIdOneArg(receiver, &PyId_send, v);
   }
   FAIL_IF_NULL(retval);
 
@@ -626,7 +626,7 @@ FutureDoneCallback_call(FutureDoneCallback* self,
   if (!PyArg_UnpackTuple(args, "future_done_callback", 1, 1, &fut)) {
     return NULL;
   }
-  PyObject* result = _PyObject_CallMethodIdObjArgs(fut, &PyId_result, NULL);
+  PyObject* result = _PyObject_CallMethodIdNoArgs(fut, &PyId_result);
   int errcode;
   if (result != NULL) {
     errcode = FutureDoneCallback_call_resolve(self, result);
@@ -683,12 +683,11 @@ _pyproxy_ensure_future(PyObject* pyobject,
   PyObject* future = NULL;
   PyObject* callback = NULL;
   PyObject* retval = NULL;
-  future =
-    _PyObject_CallMethodIdObjArgs(asyncio, &PyId_ensure_future, pyobject, NULL);
+  future = _PyObject_CallMethodIdOneArg(asyncio, &PyId_ensure_future, pyobject);
   FAIL_IF_NULL(future);
   callback = FutureDoneCallback_cnew(resolve_handle, reject_handle);
-  retval = _PyObject_CallMethodIdObjArgs(
-    future, &PyId_add_done_callback, callback, NULL);
+  retval =
+    _PyObject_CallMethodIdOneArg(future, &PyId_add_done_callback, callback);
   FAIL_IF_NULL(retval);
 
   success = true;


### PR DESCRIPTION
The `ObjArgs` methods have a `NULL` terminated argument list which can be a bit error prone. The new `OneArg` and `NoArgs` methods are a bit clearer and easier to use.