### PR TITLE
remove unnecessary 'else' after return

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -186,8 +186,7 @@ class SeleniumWrapper:
         logs = self.driver.execute_script("return window.logs;")
         if logs is not None:
             return "\n".join(str(x) for x in logs)
-        else:
-            return ""
+        return ""
 
     def clean_logs(self):
         self.driver.execute_script("window.logs = []")


### PR DESCRIPTION
removed unnecessary else after return
example 
```python
def test(x, y, z):
    if x:
        return y
    else:  # This is unnecessary here.
        return z
```
to
```python
def test(x, y, z):
    if x:
        return y
    return z
```