### PR TITLE
CI Disable pytest-xdist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
             mkdir test-results
             tools/pytest_wrapper.py \
               --junitxml=test-results/junit.xml \
-              --verbose --numprocesses 3 \
+              --verbose \
               << parameters.test-params >>
       - store_test_results:
           path: test-results


### PR DESCRIPTION
An attempt to improve CI stability by avoiding to run tests in parallel. 

I generally the issues we have have to do with CPU oversubscription as mentioned in https://github.com/pyodide/pyodide/issues/1389 . Even when only one test is run at a time, multiple threads are created by the browser. Also for each test failure we have a 30s penalty until the timeout it reached. So running tests serially might not be that much slower, and should, hopefully, be more reliable. 

Alternative to #1690 