### PR TITLE
Change converter depth arguments to be named arguments

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -96,6 +96,11 @@ substitutions:
   attached to the base `PyProxy`. This is intended to allow for more idiomatic
   usage.
   (See {issue}`1617`.) {pr}`1636`
+- {{ API }} The depth argument to `toJs` is now passed as an option, so
+  `toJs(n)` in v0.17 changed to `toJs({depth : n})`. Similarly, `pyodide.toPy`
+  now takes `depth` as a named argument. Also `to_js` and `to_py` only take
+  depth as a keyword argument.
+  {pr}``
 
 ### pyodide-build
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -100,7 +100,7 @@ substitutions:
   `toJs(n)` in v0.17 changed to `toJs({depth : n})`. Similarly, `pyodide.toPy`
   now takes `depth` as a named argument. Also `to_js` and `to_py` only take
   depth as a keyword argument.
-  {pr}``
+  {pr}`1721`
 
 ### pyodide-build
 

--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -226,7 +226,7 @@ destroy it, you will leak the Python object. See {ref}`avoiding-leaks`.
 ### Python to Javascript
 Explicit conversion of a {any}`PyProxy` into a native Javascript object is done with
 the {any}`PyProxy.toJs` method. By default, the `toJs` method does a recursive "deep"
-conversion, to do a shallow conversion use `proxy.toJs(1)`. The `toJs` method
+conversion, to do a shallow conversion use `proxy.toJs({depth : 1})`. The `toJs` method
 performs the following explicit conversions:
 
 | Python            | Javascript          |

--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -280,7 +280,7 @@ function destroyToJsResult(x){
 ### Javascript to Python
 Explicit conversion of a {any}`JsProxy` into a native Python object is done with the
 {any}`JsProxy.to_py` method. By default, the `to_py` method does a recursive "deep"
-conversion, to do a shallow conversion use `proxy.to_py(1)` The `to_py` method
+conversion, to do a shallow conversion use `proxy.to_py(depth=1)` The `to_py` method
 performs the following explicit conversions:
 
 | Javascript       | Python              |

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -658,8 +658,8 @@ JsProxy_toPy(PyObject* self,
   static const char* const _keywords[] = { "depth", 0 };
   static struct _PyArg_Parser _parser = { "|$i:toPy", _keywords, 0 };
   int depth = -1;
-  if (kwnames != NULL && !_PyArg_ParseStackAndKeywords(
-                           args + nargs, 0, kwnames, &_parser, &depth)) {
+  if (kwnames != NULL &&
+      !_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser, &depth)) {
     return NULL;
   }
   return js2python_convert(GET_JSREF(self), depth);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -649,24 +649,18 @@ PyMethodDef JsProxy_Dir_MethodDef = {
   PyDoc_STR("Returns a list of the members and methods on the object."),
 };
 
-/**
- * The to_py method, uses METH_FASTCALL calling convention.
- */
 static PyObject*
-JsProxy_toPy(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
+JsProxy_toPy(PyObject* self,
+             PyObject* const* args,
+             Py_ssize_t nargs,
+             PyObject* kwnames)
 {
-  if (nargs > 1) {
-    PyErr_Format(
-      PyExc_TypeError, "to_py expected at most 1 argument, got %zd", nargs);
-    return NULL;
-  }
+  static const char* const _keywords[] = { "depth", 0 };
+  static struct _PyArg_Parser _parser = { "|$i:toPy", _keywords, 0 };
   int depth = -1;
-  if (nargs == 1) {
-    int overflow;
-    depth = PyLong_AsLongAndOverflow(args[0], &overflow);
-    if (overflow == 0 && depth == -1 && PyErr_Occurred()) {
-      return NULL;
-    }
+  if (kwnames != NULL && !_PyArg_ParseStackAndKeywords(
+                           args + nargs, 0, kwnames, &_parser, &depth)) {
+    return NULL;
   }
   return js2python_convert(GET_JSREF(self), depth);
 }
@@ -674,7 +668,7 @@ JsProxy_toPy(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 PyMethodDef JsProxy_toPy_MethodDef = {
   "to_py",
   (PyCFunction)JsProxy_toPy,
-  METH_FASTCALL,
+  METH_FASTCALL | METH_KEYWORDS,
 };
 
 /**

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -349,15 +349,16 @@ class PyProxyClass {
   /**
    * Converts the ``PyProxy`` into a Javascript object as best as possible. By
    * default does a deep conversion, if a shallow conversion is desired, you
-   * can use ``proxy.toJs(1)``.
+   * can use ``proxy.toJs({depth : 1})``.
    * See :ref:`Explicit Conversion of PyProxy
    * <type-translations-pyproxy-to-js>` for more info.
    *
-   * @param {number} depth How many layers deep to perform the conversion.
+   * @param {object} options
+   * @param {number} options.depth How many layers deep to perform the conversion.
    * Defaults to infinite.
    * @return {any} The Javascript object resulting from the conversion.
    */
-  toJs(depth = -1) {
+  toJs({ depth = -1 } = {}) {
     let ptrobj = _getPtr(this);
     let idresult;
     let proxies = Module.hiwire.new_value([]);

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -474,11 +474,13 @@ python2js_with_depth(PyObject* x, int depth, JsRef proxies)
 }
 
 static PyObject*
-to_js(PyObject* _mod, PyObject* args)
+to_js(PyObject* _mod, PyObject* args, PyObject* kwargs)
 {
   PyObject* obj;
   int depth = -1;
-  if (!PyArg_ParseTuple(args, "O|i:to_js", &obj, &depth)) {
+  char* keywords[] = ["depth"];
+  if (!PyArg_ParseTupleAndKeywords(
+        args, kwargs, "O|i:to_js", keywords, &obj, &depth)) {
     return NULL;
   }
   if (obj == Py_None || PyBool_Check(obj) || PyLong_Check(obj) ||
@@ -512,7 +514,7 @@ static PyMethodDef methods[] = {
   {
     "to_js",
     to_js,
-    METH_VARARGS,
+    METH_VARARGS | METH_KEYWORDS,
   },
   { NULL } /* Sentinel */
 };

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -474,7 +474,10 @@ python2js_with_depth(PyObject* x, int depth, JsRef proxies)
 }
 
 static PyObject*
-to_js(PyObject* _mod, PyObject* args, PyObject* kwargs)
+to_js(PyObject* self,
+      PyObject* const* args,
+      Py_ssize_t nargs,
+      PyObject* kwnames)
 {
   PyObject* obj = NULL;
   int depth = -1;

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -478,7 +478,7 @@ to_js(PyObject* _mod, PyObject* args, PyObject* kwargs)
 {
   PyObject* obj;
   int depth = -1;
-  char* keywords[] = ["depth"];
+  char* keywords[] = { "depth", 0 };
   if (!PyArg_ParseTupleAndKeywords(
         args, kwargs, "O|i:to_js", keywords, &obj, &depth)) {
     return NULL;
@@ -513,7 +513,7 @@ finally:
 static PyMethodDef methods[] = {
   {
     "to_js",
-    to_js,
+    (PyCFunction)to_js,
     METH_VARARGS | METH_KEYWORDS,
   },
   { NULL } /* Sentinel */

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -476,13 +476,15 @@ python2js_with_depth(PyObject* x, int depth, JsRef proxies)
 static PyObject*
 to_js(PyObject* _mod, PyObject* args, PyObject* kwargs)
 {
-  PyObject* obj;
+  PyObject* obj = NULL;
   int depth = -1;
-  char* keywords[] = { "depth", 0 };
-  if (!PyArg_ParseTupleAndKeywords(
-        args, kwargs, "O|$i:to_js", keywords, &obj, &depth)) {
+  static const char* const _keywords[] = { "depth", 0 };
+  static struct _PyArg_Parser _parser = { "O|$i:to_js", _keywords, 0 };
+  if (kwnames != NULL && !_PyArg_ParseStackAndKeywords(
+                           args, nargs, kwnames, &_parser, &obj, &depth)) {
     return NULL;
   }
+
   if (obj == Py_None || PyBool_Check(obj) || PyLong_Check(obj) ||
       PyFloat_Check(obj) || PyUnicode_Check(obj) || JsProxy_Check(obj) ||
       JsException_Check(obj)) {
@@ -514,7 +516,7 @@ static PyMethodDef methods[] = {
   {
     "to_js",
     (PyCFunction)to_js,
-    METH_VARARGS | METH_KEYWORDS,
+    METH_FASTCALL | METH_KEYWORDS,
   },
   { NULL } /* Sentinel */
 };

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -480,7 +480,7 @@ to_js(PyObject* _mod, PyObject* args, PyObject* kwargs)
   int depth = -1;
   char* keywords[] = { "depth", 0 };
   if (!PyArg_ParseTupleAndKeywords(
-        args, kwargs, "O|i:to_js", keywords, &obj, &depth)) {
+        args, kwargs, "O|$i:to_js", keywords, &obj, &depth)) {
     return NULL;
   }
   if (obj == Py_None || PyBool_Check(obj) || PyLong_Check(obj) ||

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -249,11 +249,12 @@ export function unregisterJsModule(name) {
  * See :ref:`type-translations-jsproxy-to-py` for more information.
  *
  * @param {*} obj
- * @param {number} depth Optional argument to limit the depth of the
+ * @param {object} options
+ * @param {number} options.depth Optional argument to limit the depth of the
  * conversion.
  * @returns {PyProxy} The object converted to Python.
  */
-export function toPy(obj, depth = -1) {
+export function toPy(obj, { depth = -1 } = {}) {
   // No point in converting these, it'd be dumb to proxy them so they'd just
   // get converted back by `js2python` at the end
   switch (typeof obj) {

--- a/src/js/index.test-d.ts
+++ b/src/js/index.test-d.ts
@@ -75,7 +75,7 @@ async function main() {
   expectType<void>(px.destroy("blah"));
   expectType<void>(px.destroy());
   expectType<any>(px.toJs());
-  expectType<any>(px.toJs(10));
+  expectType<any>(px.toJs({depth : 10}));
   expectType<string>(px.toString());
   expectType<string>(px.type);
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -44,12 +44,12 @@ try:
         def new(self, *args, **kwargs) -> "JsProxy":
             """Construct a new instance of the Javascript object"""
 
-        def to_py(self, depth: int = -1) -> Any:
+        def to_py(self, *, depth: int = -1) -> Any:
             """Convert the :class:`JsProxy` to a native Python object as best as
             possible.
 
             By default does a deep conversion, if a shallow conversion is
-            desired, you can use ``proxy.to_py(1)``. See
+            desired, you can use ``proxy.to_py(depth=1)``. See
             :ref:`type-translations-jsproxy-to-py` for more information.
             """
             pass

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -722,7 +722,7 @@ def test_tojs4(selenium):
         """
         let a = pyodide.runPython("[1,[2,[3,[4,[5,[6,[7]]]]]]]")
         for(let i=0; i < 7; i++){
-            let x = a.toJs(i);
+            let x = a.toJs({depth : i});
             for(let j=0; j < i; j++){
                 assert(() => Array.isArray(x), `i: ${i}, j: ${j}`);
                 x = x[1];
@@ -740,7 +740,7 @@ def test_tojs5(selenium):
         """
         let a = pyodide.runPython("[1, (2, (3, [4, (5, (6, [7]))]))]")
         for(let i=0; i < 7; i++){
-            let x = a.toJs(i);
+            let x = a.toJs({depth : i});
             for(let j=0; j < i; j++){
                 assert(() => Array.isArray(x), `i: ${i}, j: ${j}`);
                 x = x[1];

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -859,7 +859,7 @@ def test_to_py(selenium):
         for(let i = 0; i < 4; i++){
             result.push(pyodide.runPython(`
                 from js import a
-                repr(a.to_py(${i}))
+                repr(a.to_py(depth=${i}))
             `));
         }
         return result;
@@ -880,7 +880,7 @@ def test_to_py(selenium):
         for(let i = 0; i < 4; i++){
             result.push(pyodide.runPython(`
                 from js import a
-                repr(a.to_py(${i}))
+                repr(a.to_py(depth=${i}))
             `));
         }
         return result;


### PR DESCRIPTION
I think this is clearer (especially because I don't expect the `depth` argument to be used all that much) and I want to add other optional named arguments.