### PR TITLE
 Add pyproxies named argument to toJs

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -103,6 +103,10 @@ EM_JS_NUM(int, hiwire_init, (), {
         );
         throw e;
       } else {
+        console.error(
+          `Internal error: Argument '${idval}' to hiwire.get_value is falsy`
+          + ' (but error indicator is not set).'
+        );
         throw new Error(
           `Internal error: Argument '${idval}' to hiwire.get_value is falsy`
           + ' (but error indicator is not set).'

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -373,7 +373,6 @@ class PyProxyClass {
       proxies_id = Module.hiwire.new_value(pyproxies);
     } else {
       proxies_id = Module.hiwire.new_value([]);
-      s;
     }
     try {
       idresult = Module._python2js_with_depth(ptrobj, depth, proxies_id);

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -353,13 +353,13 @@ class PyProxyClass {
    * <type-translations-pyproxy-to-js>` for more info.
    *
    * @param {object} options
-   * @param {number} options.depth How many layers deep to perform the
+   * @param {number} [options.depth] How many layers deep to perform the
    * conversion. Defaults to infinite.
-   * @param {array} options.pyproxies If provided, ``toJs`` will store all
+   * @param {array} [options.pyproxies] If provided, ``toJs`` will store all
    * PyProxies created in this list. This allows you to easily destroy all the
    * PyProxies by iterating the list without having to recurse over the
    * generated structure.
-   * @param {bool} options.create_pyproxies If false, `toJs` will throw a
+   * @param {bool} [options.create_pyproxies] If false, `toJs` will throw a
    * ``ConversionError`` rather than producing a ``PyProxy``.
    * @return {any} The Javascript object resulting from the conversion.
    */

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -355,24 +355,25 @@ class PyProxyClass {
    * @param {object} options
    * @param {number} options.depth How many layers deep to perform the
    * conversion. Defaults to infinite.
-   * @param {array} options.pyproxies If a list, ``toJs`` will store all
+   * @param {array} options.pyproxies If provided, ``toJs`` will store all
    * PyProxies created in this list. This allows you to easily destroy all the
    * PyProxies by iterating the list without having to recurse over the
-   * generated structure. If the value ``null`` is passed, then `toJs` will not
-   * creating any PyProxies, if it would create a ``PyProxy`` instead a
-   * ``ConversionError`` is raised.
+   * generated structure.
+   * @param {bool} options.create_pyproxies If false, `toJs` will throw a
+   * ``ConversionError`` rather than producing a ``PyProxy``.
    * @return {any} The Javascript object resulting from the conversion.
    */
-  toJs({ depth = -1, pyproxies } = {}) {
+  toJs({ depth = -1, pyproxies, create_pyproxies = true } = {}) {
     let ptrobj = _getPtr(this);
     let idresult;
     let proxies_id;
-    if (pyproxies === null) {
+    if (!create_pyproxies) {
       proxies_id = 0;
-    } else if (pyproxies === undefined) {
-      proxies_id = Module.hiwire.new_value([]);
-    } else {
+    } else if (pyproxies) {
       proxies_id = Module.hiwire.new_value(pyproxies);
+    } else {
+      proxies_id = Module.hiwire.new_value([]);
+      s;
     }
     try {
       idresult = Module._python2js_with_depth(ptrobj, depth, proxies_id);

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -358,7 +358,9 @@ class PyProxyClass {
    * @param {array} [options.pyproxies] If provided, ``toJs`` will store all
    * PyProxies created in this list. This allows you to easily destroy all the
    * PyProxies by iterating the list without having to recurse over the
-   * generated structure.
+   * generated structure. The most common use case is to create a new empty
+   * list, pass the list as `pyproxies`, and then later iterate over `pyproxies`
+   * to destroy all of created proxies.
    * @param {bool} [options.create_pyproxies] If false, `toJs` will throw a
    * ``ConversionError`` rather than producing a ``PyProxy``.
    * @return {any} The Javascript object resulting from the conversion.

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -486,6 +486,16 @@ to_js(PyObject* self,
   static const char* const _keywords[] = {
     "", "depth", "pyproxies", "create_pyproxies", 0
   };
+  // See argparse docs on format strings:
+  // https://docs.python.org/3/c-api/arg.html?highlight=pyarg_parse#parsing-arguments
+  // O|$iOp:to_js
+  // O            - Object
+  //  |           - start of optional args
+  //   $          - start of kwonly args
+  //    i         - signed integer
+  //     O        - Object
+  //      p       - predicate (ie bool)
+  //       :to_js - name of this function for error messages
   static struct _PyArg_Parser _parser = { "O|$iOp:to_js", _keywords, 0 };
   if (kwnames != NULL && !_PyArg_ParseStackAndKeywords(args,
                                                        nargs,

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -518,7 +518,7 @@ to_js(PyObject* self,
                       "Expected a JsProxy for the pyproxies argument");
       FAIL();
     }
-    proxies = JsProxy_AsJs(self); /* borrowed */
+    proxies = JsProxy_AsJs(pyproxies); /* borrowed */
     if (!JsArray_Check(proxies)) {
       PyErr_SetString(PyExc_TypeError,
                       "Expected a Js Array for the pyproxies argument");

--- a/src/js/index.test-d.ts
+++ b/src/js/index.test-d.ts
@@ -75,7 +75,11 @@ async function main() {
   expectType<void>(px.destroy("blah"));
   expectType<void>(px.destroy());
   expectType<any>(px.toJs());
+  expectType<any>(px.toJs({}));
   expectType<any>(px.toJs({depth : 10}));
+  expectType<any>(px.toJs({create_pyproxies : false}));
+  expectType<any>(px.toJs({create_pyproxies : true}));
+  expectType<any>(px.toJs({pyproxies : []}));
   expectType<string>(px.toString());
   expectType<string>(px.type);
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -23,6 +23,9 @@ try:
         def js_error(self):
             """The original Javascript error"""
 
+    class ConversionError(Exception):
+        """An error thrown when conversion between Javascript and Python fails."""
+
     class JsProxy:
         """A proxy to make a Javascript object behave like a Python object
 
@@ -122,7 +125,13 @@ try:
 
     # from python2js
 
-    def to_js(obj: Any, depth: int = -1) -> JsProxy:
+    def to_js(
+        obj: Any,
+        *,
+        depth: int = -1,
+        pyproxies: JsProxy = None,
+        create_pyproxies: bool = True
+    ) -> JsProxy:
         """Convert the object to Javascript.
 
         This is similar to :any:`PyProxy.toJs`, but for use from Python. If the

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -141,6 +141,23 @@ try:
         used :any:`pyodide.create_proxy`.
 
         See :ref:`type-translations-pyproxy-to-js` for more information.
+
+        Parameters
+        ----------
+        obj : Any
+            The Python object to convert
+
+        depth : int, default=-1
+            The maximum depth to do the conversion. Negative numbers are treated
+            as infinite. Set this to 1 to do a shallow conversion.
+
+        pyproxies: JsProxy, default = None
+            Should be a Javascript ``Array``. If provided, any ``PyProxies`` generated
+            will be stored here.
+
+        create_pyproxies: bool, default=True
+            If you set this to False, :any:`to_js` will raise an error
+
         """
         return obj
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -153,7 +153,9 @@ try:
 
         pyproxies: JsProxy, default = None
             Should be a Javascript ``Array``. If provided, any ``PyProxies`` generated
-            will be stored here.
+            will be stored here. You can later use :any:`destroy_proxies` if you want
+            to destroy the proxies from Python (or from Javascript you can just iterate
+            over the ``Array`` and destroy the proxies).
 
         create_pyproxies: bool, default=True
             If you set this to False, :any:`to_js` will raise an error

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -161,6 +161,16 @@ try:
         """
         return obj
 
+    def destroy_proxies(pyproxies: JsProxy):
+        """Destroy all PyProxies in a Javascript array.
+
+        pyproxies must be a JsProxy of type PyProxy[]. Intended for use with the
+        arrays created from the "pyproxies" argument of :any:`toJs` and
+        :any:`to_js`. This method is necessary because indexing the Array from
+        Python automatically unwraps the PyProxy into the wrapped Python object.
+        """
+        pass
+
 
 finally:
     __name__ = _save_name

--- a/src/py/pyodide/__init__.py
+++ b/src/py/pyodide/__init__.py
@@ -11,7 +11,7 @@
 # pytest mocks for js or pyodide_js, so make sure to test "if IN_BROWSER" before
 # importing from these.
 
-from ._core import JsProxy, JsException, create_once_callable, create_proxy, to_js, IN_BROWSER  # type: ignore
+from ._core import JsProxy, JsException, create_once_callable, create_proxy, to_js, IN_BROWSER, ConversionError  # type: ignore
 from _pyodide._base import (
     eval_code,
     eval_code_async,
@@ -50,4 +50,5 @@ __all__ = [
     "create_once_callable",
     "create_proxy",
     "should_quiet",
+    "ConversionError",
 ]

--- a/src/py/pyodide/__init__.py
+++ b/src/py/pyodide/__init__.py
@@ -11,7 +11,7 @@
 # pytest mocks for js or pyodide_js, so make sure to test "if IN_BROWSER" before
 # importing from these.
 
-from ._core import JsProxy, JsException, create_once_callable, create_proxy, to_js, IN_BROWSER, ConversionError  # type: ignore
+from ._core import JsProxy, JsException, create_once_callable, create_proxy, to_js, IN_BROWSER, ConversionError, destroy_proxies  # type: ignore
 from _pyodide._base import (
     eval_code,
     eval_code_async,
@@ -51,4 +51,5 @@ __all__ = [
     "create_proxy",
     "should_quiet",
     "ConversionError",
+    "destroy_proxies",
 ]

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -13,6 +13,14 @@ from _pyodide_core import (
     create_proxy,
     create_once_callable,
     to_js,
+    ConversionError,
 )
 
-__all__ = ["JsProxy", "JsException", "create_proxy", "create_once_callable", "to_js"]
+__all__ = [
+    "JsProxy",
+    "JsException",
+    "create_proxy",
+    "create_once_callable",
+    "to_js",
+    "ConversionError",
+]

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -8,12 +8,13 @@ if "_pyodide_core" not in sys.modules:
     IN_BROWSER = False
 
 from _pyodide_core import (
-    JsProxy,
-    JsException,
+    ConversionError,
     create_proxy,
     create_once_callable,
+    JsProxy,
+    JsException,
     to_js,
-    ConversionError,
+    destroy_proxies,
 )
 
 __all__ = [
@@ -23,4 +24,5 @@ __all__ = [
     "create_once_callable",
     "to_js",
     "ConversionError",
+    "destroy_proxies",
 ]

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -305,11 +305,6 @@ def test_python2js_track_proxies(selenium):
 def test_wrong_way_track_proxies(selenium):
     selenium.run_js(
         """
-        self.destroyProxies = function(l){
-            for(let p of l){
-                p.destroy();
-            }
-        };
         self.checkDestroyed = function(l){
             for(let e of l){
                 if(pyodide.isPyProxy(e)){
@@ -320,8 +315,8 @@ def test_wrong_way_track_proxies(selenium):
             }
         };
         pyodide.runPython(`
-            from js import Array, Object, destroyProxies, checkDestroyed
-            from pyodide import to_js, ConversionError
+            from js import Array, Object, checkDestroyed
+            from pyodide import to_js, ConversionError, destroy_proxies
             from pyodide_js import isPyProxy
             from unittest import TestCase
 
@@ -332,7 +327,7 @@ def test_wrong_way_track_proxies(selenium):
             proxylist = Array.new()
             r = to_js(x, pyproxies=proxylist)
             assert len(proxylist) == 10
-            destroyProxies(proxylist)
+            destroy_proxies(proxylist)
             checkDestroyed(r)
             with TestCase().assertRaises(TypeError):
                 to_js(x, pyproxies=[])


### PR DESCRIPTION
This adds an argument called `pyproxies` to `toJs`. If passed a Javascript list, we collect all the `PyProxies` created by `toJs` into the list. This makes it easy to destroy them all when done (without needing to recursively walk the structure). 

I also added an optional argument `create_pyproxies` which is a boolean that defaults to true. If set to `False` we raise a `ConversionError` rather than creating a PyProxy. 

I also added these arguments to `to_js`.