### PR TITLE
DOC Update copyright notice in docs to include Pyodide contributors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,7 @@ sys.path = path_dirs + sys.path
 # -- Project information -----------------------------------------------------
 
 project = "Pyodide"
-copyright = "2019, Mozilla"
-author = "Mozilla"
+copyright = "2019-2021, Pyodide contributors and Mozilla"
 
 import pyodide
 import micropip  # noqa


### PR DESCRIPTION
Changes the copyright notice on each documentation page from,
```
By Mozilla
© Copyright 2019, Mozilla.
```
to
```
© Copyright 2019-2021, Pyodide contributors and Mozilla.
```
which more accurately reflects the current situation. 

As far as I understand, contributors keep copyright for their contribution anyway.