### PR TITLE
Update mkpkg.py

### DIFF
--- a/pyodide-build/pyodide_build/io.py
+++ b/pyodide-build/pyodide_build/io.py
@@ -35,6 +35,12 @@ PACKAGE_CONFIG_SPEC: Dict[str, Dict[str, Any]] = {
     "test": {
         "imports": list,  # List[str]
     },
+    "about": {
+        "home": str,
+        "PyPi": str,
+        "summary": str,
+        "license": str,
+    },
 }
 
 

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -63,7 +63,8 @@ def make_package(package: str, version: Optional[str] = None):
     Creates a template that will work for most pure Python packages,
     but will have to be edited for more complex things.
     """
-    import yaml
+    from ruamel.yaml import YAML
+    yaml = YAML()
 
     pypi_metadata = _get_metadata(package, version)
     sdist_metadata = _extract_sdist(pypi_metadata)
@@ -71,17 +72,23 @@ def make_package(package: str, version: Optional[str] = None):
     url = sdist_metadata["url"]
     sha256 = sdist_metadata["digests"]["sha256"]
     version = pypi_metadata["info"]["version"]
-
+    
+    homepage = pypi_metadata["info"]["home_page"]
+    summary = pypi_metadata["info"]["summary"]
+    license = pypi_metadata["info"]["license"]
+    pypi = "https://pypi.org/project/" + package
+    
     yaml_content = {
         "package": {"name": package, "version": version},
         "source": {"url": url, "sha256": sha256},
         "test": {"imports": [package]},
+        "about": {"home": homepage, "PyPi": pypi, "summary": summary, "license": license}
     }
 
     if not (PACKAGES_ROOT / package).is_dir():
         os.makedirs(PACKAGES_ROOT / package)
     with open(PACKAGES_ROOT / package / "meta.yaml", "w") as fd:
-        yaml.dump(yaml_content, fd, default_flow_style=False)
+        yaml.dump(yaml_content, fd)
 
 
 class bcolors:

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -64,6 +64,7 @@ def make_package(package: str, version: Optional[str] = None):
     but will have to be edited for more complex things.
     """
     from ruamel.yaml import YAML
+
     yaml = YAML()
 
     pypi_metadata = _get_metadata(package, version)
@@ -72,17 +73,22 @@ def make_package(package: str, version: Optional[str] = None):
     url = sdist_metadata["url"]
     sha256 = sdist_metadata["digests"]["sha256"]
     version = pypi_metadata["info"]["version"]
-    
+
     homepage = pypi_metadata["info"]["home_page"]
     summary = pypi_metadata["info"]["summary"]
     license = pypi_metadata["info"]["license"]
     pypi = "https://pypi.org/project/" + package
-    
+
     yaml_content = {
         "package": {"name": package, "version": version},
         "source": {"url": url, "sha256": sha256},
         "test": {"imports": [package]},
-        "about": {"home": homepage, "PyPi": pypi, "summary": summary, "license": license}
+        "about": {
+            "home": homepage,
+            "PyPi": pypi,
+            "summary": summary,
+            "license": license,
+        },
     }
 
     if not (PACKAGES_ROOT / package).is_dir():


### PR DESCRIPTION
This PR is for issue https://github.com/pyodide/pyodide/issues/977

It modifies the `make_package` function in `pyodide-build/pyodide_build/mkpkg.py`

During the creation of metadata.yaml file, it adds four fields of general information about the package - link to homepage, link to PyPi, summary, and license. 

Example of information which would be added at the end of [metadata.yaml file in pandas folder](https://github.com/mainsail-org/pyodide/blob/main/packages/pandas/meta.yaml):

```yaml
about:
  home: https://pandas.pydata.org
  PyPi: https://pypi.org/project/pandas
  summary: Powerful data structures for data analysis, time series, and statistics
  license: BSD-3-Clause
```

### Questions: 
- Are the field names okay? I used conventions from [conda](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#about-section)
- In order to preserve the order of how keys are dumped to yaml file, I used ```ruamel.yaml``` package, instead of ```yaml```. I've noticed it was used already in ```update_package``` function, and it was suggested in the issue. For this reason, I also deleted the argument ```default_flow_style=False``` which doesn't exist in ruamel. Is that alright? 
- Are there any other fields that would be useful to add? For example, a link to the json endpoint on PyPi's API. Here's an example link for pandas: https://pypi.org/pypi/pandas/json