### PR TITLE
Increase recursion limit

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -94,6 +94,13 @@ run_python_simple_inner(char* code)
 int
 numpy_patch_init();
 
+int
+get_python_stack_depth()
+{
+  PyThreadState* tstate = PyThreadState_GET();
+  return tstate->recursion_depth;
+}
+
 /**
  * Bootstrap steps here:
  *  1. Initialize init_dict so that runPythonSimple will work.

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -147,7 +147,7 @@ function fixRecursionLimit() {
     recurse();
   } catch (err) {}
 
-  let recursionLimit = Math.min(depth / 30, 800);
+  let recursionLimit = Math.min(depth / 40, 700);
   Module.runPythonSimple(
     `import sys; sys.setrecursionlimit(int(${recursionLimit}))`
   );

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -154,7 +154,7 @@ function fixRecursionLimit() {
     recurse();
   } catch (err) {}
 
-  let recursionLimit = Math.min(depth / 30, 600);
+  let recursionLimit = Math.min(depth / 25, 500);
   Module.runPythonSimple(
     `import sys; sys.setrecursionlimit(int(${recursionLimit}))`
   );

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -147,7 +147,10 @@ function fixRecursionLimit() {
     recurse();
   } catch (err) {}
 
-  let recursionLimit = Math.min(depth / 20, 1000);
+  const py_stack_usage = 20;
+  // benchmark-stack-size currently shows `js_depth/py_depth` is 19 in Firefox
+  // and 8 in Chrome. 20 is rounded up from this.
+  let recursionLimit = Math.min(depth / py_stack_usage, 1000);
   Module.runPythonSimple(
     `import sys; sys.setrecursionlimit(int(${recursionLimit}))`
   );

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -154,7 +154,7 @@ function fixRecursionLimit() {
     recurse();
   } catch (err) {}
 
-  let recursionLimit = Math.min(depth / 40, 700);
+  let recursionLimit = Math.min(depth / 30, 600);
   Module.runPythonSimple(
     `import sys; sys.setrecursionlimit(int(${recursionLimit}))`
   );

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -147,7 +147,7 @@ function fixRecursionLimit() {
     recurse();
   } catch (err) {}
 
-  let recursionLimit = Math.min(depth / 50, 400);
+  let recursionLimit = Math.min(depth / 20, 1000);
   Module.runPythonSimple(
     `import sys; sys.setrecursionlimit(int(${recursionLimit}))`
   );

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -147,10 +147,7 @@ function fixRecursionLimit() {
     recurse();
   } catch (err) {}
 
-  const py_stack_usage = 20;
-  // benchmark-stack-size currently shows `js_depth/py_depth` is 19 in Firefox
-  // and 8 in Chrome. 20 is rounded up from this.
-  let recursionLimit = Math.min(depth / py_stack_usage, 1000);
+  let recursionLimit = Math.min(depth / 30, 800);
   Module.runPythonSimple(
     `import sys; sys.setrecursionlimit(int(${recursionLimit}))`
   );


### PR DESCRIPTION
#1699 reduced the stack usage by a lot. `benchmark-stack-size` shows `js_depth/py_depth` is 19 in Firefox and 8 in Chrome, so dividing `stack_depth` by 20 to get the Python recursion depth seems reasonable.

I guess we'll find out if certain call patterns lead to callstacks with lots of "fat frames" that lead to segfaults. Most of the stack overflows we were seeing before were from pure Python code so I'm not that worried about this. (I'm pretty sure all Python ==> Python function calls take up exactly the same amount of stack space.)