### PR TITLE
Improve selenium fatal error message

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -98,6 +98,7 @@ class SeleniumWrapper:
                 let pyodide = await loadPyodide({ indexURL : './', fullStdLib: false, jsglobals : self });
                 self.pyodide = pyodide;
                 globalThis.pyodide = pyodide;
+                pyodide._module.inTestHoist = true; // improve some error messages for tests
                 pyodide.globals.get;
                 pyodide.pyodide_py.eval_code;
                 pyodide.pyodide_py.eval_code_async;

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -64,7 +64,14 @@ Module.fatal_error = function (e) {
     "Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers."
   );
   console.error("The cause of the fatal error was:");
-  console.error(e);
+  if (Module.inTestHoist) {
+    // Test hoist won't print the error object in a useful way so convert it to
+    // string.
+    console.error(e.toString());
+    console.error(e.stack);
+  } else {
+    console.error(e);
+  }
   try {
     Module.dump_traceback();
     for (let key of Object.keys(Module.public_api)) {

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -514,8 +514,10 @@ def test_fatal_error(selenium_standalone):
         x = re.sub("/lib/python.*/", "", x)
         x = re.sub("/lib/python.*/", "", x)
         x = re.sub("warning: no [bB]lob.*\n", "", x)
-        x = re.sub("Error: intentionally triggered fatal error!", "{}", x)
+        x = re.sub("Error: intentionally triggered fatal error!\n", "", x)
         x = re.sub(" +at .*\n", "", x)
+        x = re.sub(".*@https?://[0-9.:]*/.*\n", "", x)
+        x = x.replace("\n\n", "\n")
         return x
 
     assert (
@@ -526,7 +528,6 @@ def test_fatal_error(selenium_standalone):
                 Python initialization complete
                 Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.
                 The cause of the fatal error was:
-                {}
                 Stack (most recent call first):
                   File "<exec>", line 8 in h
                   File "<exec>", line 6 in g


### PR DESCRIPTION
This fixes it so that selenium also prints out the js stack when there is a fatal error.