### PR TITLE
Fix bug in console.html when runPython returns None [skip ci]

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -81,11 +81,15 @@
                   })
                 );
               }
-              if (value.destroy) {
+              if (value && value.destroy) {
                 value.destroy();
               }
             } catch (e) {
-              term.error(fut.formatted_error.trimEnd());
+              if (e.constructor.name === "PythonError") {
+                term.error(fut.formatted_error.trimEnd());
+              } else {
+                throw e;
+              }
             }
             fut.destroy();
           }


### PR DESCRIPTION
1. Fixed error handling code assumes error came from Python but error could also come from a bug in our code.
2. if `value` is `null` or `undefined` then trying to check whether `destroy` exists throws.