### PR TITLE
Add dict_converter parameter to toJs

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -118,7 +118,7 @@ substitutions:
   called on a Javascript iterable of two-element Arrays as the final step of
   converting dictionaries. For instance, pass `Object.fromEntries` to convert to
   an object or `Array.from` to convert to an array of pairs.
-  {pr}`1726`
+  {pr}`1742`
 
 
 ### pyodide-build

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -108,6 +108,18 @@ substitutions:
   now takes `depth` as a named argument. Also `to_js` and `to_py` only take
   depth as a keyword argument.
   {pr}`1721`
+- {{ API }} `toJs` and `to_js` now take an option `pyproxies`, if a Javascript
+  Array is passed for this, then any proxies created during conversion will be
+  placed into this array. This allows easy cleanup later. The `create_pyproxies`
+  option can be used to disable creation of pyproxies during conversion
+  (instead a `ConversionError` is raised).
+  {pr}`1726`
+- {{ API }} `toJs` and `to_js` now take an option `dict_converter` which will be
+  called on a Javascript iterable of two-element Arrays as the final step of
+  converting dictionaries. For instance, pass `Object.fromEntries` to convert to
+  an object or `Array.from` to convert to an array of pairs.
+  {pr}`1726`
+
 
 ### pyodide-build
 

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -363,12 +363,23 @@ class PyProxyClass {
    * to destroy all of created proxies.
    * @param {bool} [options.create_pyproxies] If false, `toJs` will throw a
    * ``ConversionError`` rather than producing a ``PyProxy``.
+   * @param {bool} [options.dict_converter] A function to be called on an
+   * iterable of pairs `[key, value]`. Convert this iterable of pairs to the
+   * desired output. For instance, `Object.fromEntries` would convert the dict
+   * to an object, `Array.from` converts it to an array of entries, and `(it) =>
+   * new Map(it)` converts it to a `Map` (which is the default behavior).
    * @return {any} The Javascript object resulting from the conversion.
    */
-  toJs({ depth = -1, pyproxies, create_pyproxies = true } = {}) {
+  toJs({
+    depth = -1,
+    pyproxies,
+    create_pyproxies = true,
+    dict_converter,
+  } = {}) {
     let ptrobj = _getPtr(this);
     let idresult;
     let proxies_id;
+    let dict_converter_id = 0;
     if (!create_pyproxies) {
       proxies_id = 0;
     } else if (pyproxies) {
@@ -376,8 +387,16 @@ class PyProxyClass {
     } else {
       proxies_id = Module.hiwire.new_value([]);
     }
+    if (dict_converter) {
+      dict_converter_id = Module.hiwire.new_value(dict_converter);
+    }
     try {
-      idresult = Module._python2js_with_depth(ptrobj, depth, proxies_id);
+      idresult = Module._python2js_custom_dict_converter(
+        ptrobj,
+        depth,
+        proxies_id,
+        dict_converter_id
+      );
     } catch (e) {
       Module.fatal_error(e);
     } finally {

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -401,6 +401,7 @@ class PyProxyClass {
       Module.fatal_error(e);
     } finally {
       Module.hiwire.decref(proxies_id);
+      Module.hiwire.decref(dict_converter_id);
     }
     if (idresult === 0) {
       Module._pythonexc2js();

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -361,13 +361,13 @@ class PyProxyClass {
    * generated structure. The most common use case is to create a new empty
    * list, pass the list as `pyproxies`, and then later iterate over `pyproxies`
    * to destroy all of created proxies.
-   * @param {bool} [options.create_pyproxies] If false, `toJs` will throw a
+   * @param {bool} [options.create_pyproxies] If false, ``toJs`` will throw a
    * ``ConversionError`` rather than producing a ``PyProxy``.
    * @param {bool} [options.dict_converter] A function to be called on an
-   * iterable of pairs `[key, value]`. Convert this iterable of pairs to the
-   * desired output. For instance, `Object.fromEntries` would convert the dict
-   * to an object, `Array.from` converts it to an array of entries, and `(it) =>
-   * new Map(it)` converts it to a `Map` (which is the default behavior).
+   * iterable of pairs ``[key, value]``. Convert this iterable of pairs to the
+   * desired output. For instance, ``Object.fromEntries`` would convert the dict
+   * to an object, ``Array.from`` converts it to an array of entries, and ``(it) =>
+   * new Map(it)`` converts it to a ``Map`` (which is the default behavior).
    * @return {any} The Javascript object resulting from the conversion.
    */
   toJs({

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -562,6 +562,11 @@ _JsArray_PostProcess(ConversionContext context, JsRef array)
   return _JsArray_PostProcess_helper(context.jscontext, array);
 }
 
+/**
+ * dict_converter should be a Javascript function that converts an Iterable of
+ * pairs into the desired Javascript object. If dict_converter is NULL, we use
+ * python2js_with_depth which converts dicts to Map (the default)
+ */
 JsRef
 python2js_custom_dict_converter(PyObject* x,
                                 int depth,
@@ -569,6 +574,7 @@ python2js_custom_dict_converter(PyObject* x,
                                 JsRef dict_converter)
 {
   if (dict_converter == NULL) {
+    // No custom converter provided, go back to default convertion to Map.
     return python2js_with_depth(x, depth, proxies);
   }
   JsRef jscontext = (JsRef)EM_ASM_INT(

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -571,10 +571,12 @@ python2js_custom_dict_converter(PyObject* x,
   if (dict_converter == NULL) {
     return python2js_with_depth(x, depth, proxies);
   }
-  JsRef jscontext = (JsRef)EM_ASM_INT({
-    return Module.hiwire.new_value(
-      { dict_converter : Module.hiwire.get_value(dict_converter) });
-  });
+  JsRef jscontext = (JsRef)EM_ASM_INT(
+    {
+      return Module.hiwire.new_value(
+        { dict_converter : Module.hiwire.get_value($0) });
+    },
+    dict_converter);
   ConversionContext context = {
     .depth = depth,
     .proxies = proxies,
@@ -669,8 +671,9 @@ to_js(PyObject* self,
     py_result = js2python(js_result);
   }
 finally:
-  hiwire_CLEAR(js_result);
   hiwire_CLEAR(proxies);
+  hiwire_CLEAR(js_dict_converter);
+  hiwire_CLEAR(js_result);
   return py_result;
 }
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -131,7 +131,7 @@ try:
         depth: int = -1,
         pyproxies: JsProxy = None,
         create_pyproxies: bool = True,
-        dict_converter: Callable[[Iterable[JsProxy]], JsProxy] = None
+        dict_converter: Callable[[Iterable[JsProxy]], JsProxy] = None,
     ) -> JsProxy:
         """Convert the object to Javascript.
 
@@ -145,20 +145,21 @@ try:
 
         Parameters
         ----------
-        obj : Any The Python object to convert
+        obj : Any
+            The Python object to convert
 
-        depth : int, default=-1 The maximum depth to do the conversion. Negative
-            numbers are treated as infinite. Set this to 1 to do a shallow
-            conversion.
+        depth : int, default=-1
+            The maximum depth to do the conversion. Negative numbers are treated
+            as infinite. Set this to 1 to do a shallow conversion.
 
-        pyproxies: JsProxy, default = None Should be a Javascript ``Array``. If
-            provided, any ``PyProxies`` generated will be stored here. You can
-            later use :any:`destroy_proxies` if you want to destroy the proxies
-            from Python (or from Javascript you can just iterate over the
-            ``Array`` and destroy the proxies).
+        pyproxies: JsProxy, default = None
+            Should be a Javascript ``Array``. If provided, any ``PyProxies`` generated
+            will be stored here. You can later use :any:`destroy_proxies` if you want
+            to destroy the proxies from Python (or from Javascript you can just iterate
+            over the ``Array`` and destroy the proxies).
 
-        create_pyproxies: bool, default=True If you set this to False,
-            :any:`to_js` will raise an error
+        create_pyproxies: bool, default=True
+            If you set this to False, :any:`to_js` will raise an error
 
         dict_converter: Callable[[Iterable[JsProxy]], JsProxy], defauilt = None
             This converter if provided recieves a (Javascript) iterable of

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -131,7 +131,7 @@ try:
         depth: int = -1,
         pyproxies: JsProxy = None,
         create_pyproxies: bool = True,
-        dict_converter: Callable[Iterable[JsProxy], JsProxy] = None
+        dict_converter: Callable[[Iterable[JsProxy]], JsProxy] = None
     ) -> JsProxy:
         """Convert the object to Javascript.
 
@@ -160,7 +160,7 @@ try:
         create_pyproxies: bool, default=True If you set this to False,
             :any:`to_js` will raise an error
 
-        dict_converter: Callable[Iterable[JsProxy], JsProxy], defauilt = None
+        dict_converter: Callable[[Iterable[JsProxy]], JsProxy], defauilt = None
             This converter if provided recieves a (Javascript) iterable of
             (Javascript) pairs [key, value]. It is expected to return the
             desired result of the dict conversion. Some suggested values for

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1,6 +1,6 @@
 # type: ignore
 
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
 # All docstrings for public `core` APIs should be extracted from here. We use
 # the utilities in `docstring.py` and `docstring.c` to format them
@@ -130,7 +130,8 @@ try:
         *,
         depth: int = -1,
         pyproxies: JsProxy = None,
-        create_pyproxies: bool = True
+        create_pyproxies: bool = True,
+        dict_converter: Callable[Iterable[JsProxy], JsProxy] = None
     ) -> JsProxy:
         """Convert the object to Javascript.
 
@@ -144,22 +145,30 @@ try:
 
         Parameters
         ----------
-        obj : Any
-            The Python object to convert
+        obj : Any The Python object to convert
 
-        depth : int, default=-1
-            The maximum depth to do the conversion. Negative numbers are treated
-            as infinite. Set this to 1 to do a shallow conversion.
+        depth : int, default=-1 The maximum depth to do the conversion. Negative
+            numbers are treated as infinite. Set this to 1 to do a shallow
+            conversion.
 
-        pyproxies: JsProxy, default = None
-            Should be a Javascript ``Array``. If provided, any ``PyProxies`` generated
-            will be stored here. You can later use :any:`destroy_proxies` if you want
-            to destroy the proxies from Python (or from Javascript you can just iterate
-            over the ``Array`` and destroy the proxies).
+        pyproxies: JsProxy, default = None Should be a Javascript ``Array``. If
+            provided, any ``PyProxies`` generated will be stored here. You can
+            later use :any:`destroy_proxies` if you want to destroy the proxies
+            from Python (or from Javascript you can just iterate over the
+            ``Array`` and destroy the proxies).
 
-        create_pyproxies: bool, default=True
-            If you set this to False, :any:`to_js` will raise an error
+        create_pyproxies: bool, default=True If you set this to False,
+            :any:`to_js` will raise an error
 
+        dict_converter: Callable[Iterable[JsProxy], JsProxy], defauilt = None
+            This converter if provided recieves a (Javascript) iterable of
+            (Javascript) pairs [key, value]. It is expected to return the
+            desired result of the dict conversion. Some suggested values for
+            this argument:
+
+                js.Map.new -- similar to the default behavior
+                js.Array.from -- convert to an array of entries
+                js.Object.fromEntries -- convert to a Javascript object
         """
         return obj
 

--- a/src/py/_pyodide/console.py
+++ b/src/py/_pyodide/console.py
@@ -392,8 +392,6 @@ class Console:
 
         The actual error object is stored into `sys.last_value`.
         """
-        print("!!!!!!!!!!!")
-        print("formattraceback!")
         try:
             sys.last_type = type(e)
             sys.last_value = e

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -403,6 +403,63 @@ def test_wrong_way_conversions(selenium):
     )
 
 
+def test_dict_converter(selenium):
+    assert (
+        selenium.run_js(
+            """
+            self.arrayFrom = Array.from;
+            return pyodide.runPython(`
+                from js import arrayFrom
+                from pyodide import to_js
+                res = to_js({ x : x + 2 for x in range(5)}, dict_converter=arrayFrom)
+                res
+            `)
+            """
+        )
+        == [[0, 2], [1, 3], [2, 4], [3, 5], [4, 6]]
+    )
+
+    assert (
+        selenium.run_js(
+            """
+            let px = pyodide.runPython("{ x : x + 2 for x in range(5)}");
+            let result = px.toJs({dict_converter : Array.from});
+            px.destroy();
+            return result;
+            """
+        )
+        == [[0, 2], [1, 3], [2, 4], [3, 5], [4, 6]]
+    )
+
+    assert (
+        selenium.run_js(
+            """
+            return pyodide.runPython(`
+                from js import Object
+                from pyodide import to_js
+                res = to_js({ x : x + 2 for x in range(5)}, dict_converter=Object.fromEntries)
+                res
+            `);
+            """
+        )
+        == {"0": 2, "1": 3, "2": 4, "3": 5, "4": 6}
+    )
+
+    assert (
+        selenium.run_js(
+            """
+            let px = pyodide.runPython("{ x : x + 2 for x in range(5)}");
+            let result = px.toJs({dict_converter : Object.fromEntries});
+            px.destroy();
+            return result;
+        """
+        )
+        == {"0": 2, "1": 3, "2": 4, "3": 5, "4": 6}
+    )
+
+    selenium.run("del res; del arrayFrom; del Object")
+
+
 def test_python2js_long_ints(selenium):
     assert selenium.run("2**30") == 2 ** 30
     assert selenium.run("2**31") == 2 ** 31


### PR DESCRIPTION
This resolves #1529 by allowing `dict_converter=Object.fromEntries`.

Perhaps we should rename the options for `toJs` to follow the Javascript naming conventions (so then `to_js` would have `dict_converter` and `toJs` would have `dictConverter`.