### PR TITLE
Release 0.18.0a1

### DIFF
--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pyodide",
-  "version": "0.18.0dev0",
+  "version": "0.18.0a1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyodide",
-  "version": "0.18.0dev0",
+  "version": "0.18.0a1",
   "devDependencies": {
     "prettier": "^2.2.1",
     "terser": "^5.7.0",

--- a/src/py/pyodide/__init__.py
+++ b/src/py/pyodide/__init__.py
@@ -34,7 +34,7 @@ if IN_BROWSER:
     asyncio.set_event_loop_policy(WebLoopPolicy())
 
 
-__version__ = "0.18.0dev0"
+__version__ = "0.18.0a1"
 
 __all__ = [
     "open_url",


### PR DESCRIPTION
I think that would be pretty much it for the  0.18.0a1 (alpha) release. Then once it's merged, we need to,
 - create `0.18.0a1` git tag
 - release pyodide-build to https://pypi.org/project/pyodide-build/ (I'll do it)
 - release the npm package. We still need to decide under which name https://github.com/pyodide/pyodide/discussions/1403#discussioncomment-972302 I think I would have a preference for just `pyodide`. It might be a bit short to do it today, we could also release the npm package early next week. 
 - Finally this commit would need to be reverted once the release is done.

To be merged after https://github.com/pyodide/pyodide/pull/1700 and https://github.com/pyodide/pyodide/pull/1742