### PR TITLE
Split webworker tests into separate CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,6 +317,7 @@ workflows:
       - test-main:
           name: test-core-chrome-webworker
           test-params: -k chrome src/tests/test_webworker.py
+          requires:
             - test-core-chrome
       - test-main:
           name: test-core-firefox-webworker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ workflows:
             - build-core
       - test-main:
           name: test-core-node
-          test-params: -k "node and not webworker" src packages/micropip
+          test-params: -k node src packages/micropip
           requires:
             - build-core
 
@@ -324,11 +324,6 @@ workflows:
           test-params: -k firefox src/tests/test_webworker.py
           requires:
             - test-core-firefox
-      - test-main:
-          name: test-core-node-webworker
-          test-params: -k node src/tests/test_webworker.py
-          requires:
-            - test-core-node
 
       - test-main:
           name: test-packages-chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,21 +297,38 @@ workflows:
       - build-packages:
           requires:
             - build-core
+
       - test-main:
           name: test-core-chrome
-          test-params: -k chrome src packages/micropip
+          test-params: -k "chrome and not webworker" src packages/micropip
           requires:
             - build-core
       - test-main:
           name: test-core-firefox
-          test-params: -k firefox src packages/micropip
+          test-params: -k "firefox and not webworker" src packages/micropip
           requires:
             - build-core
       - test-main:
           name: test-core-node
-          test-params: -k node src packages/micropip
+          test-params: -k "node and not webworker" src packages/micropip
           requires:
             - build-core
+
+      - test-main:
+          name: test-core-chrome-webworker
+          test-params: -k chrome src/tests/test_webworker.py
+            - test-core-chrome
+      - test-main:
+          name: test-core-firefox-webworker
+          test-params: -k firefox src/tests/test_webworker.py
+          requires:
+            - test-core-firefox
+      - test-main:
+          name: test-core-node-webworker
+          test-params: -k node src/tests/test_webworker.py
+          requires:
+            - test-core-node
+
       - test-main:
           name: test-packages-chrome
           test-params: -k chrome packages/test* packages/*/test*
@@ -327,6 +344,7 @@ workflows:
           test-params: -k "node and not numpy" packages/test* packages/*/test*
           requires:
             - build-packages
+
       - test-emsdk:
           requires:
             - build-core


### PR DESCRIPTION
The webworker tests fail a lot and cause `deploy-dev` not to activate. This would separate them out and trigger `deploy-dev` even if webworker tests time out.