### PR TITLE
Update webworker.md (#1755) [skip ci]

### DIFF
--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -111,7 +111,7 @@ async function loadPyodideAndPackages() {
   self.pyodide = await loadPyodide({
     indexURL: "https://cdn.jsdelivr.net/pyodide/dev/full/",
   });
-  await pyodide.loadPackage(["numpy", "pytz"]);
+  await self.pyodide.loadPackage(["numpy", "pytz"]);
 }
 let pyodideReadyPromise = loadPyodideAndPackages();
 


### PR DESCRIPTION
If I understand this correctly, loadPyodide now returns a pyodide object and doesn't attach to the global namespace. I think this should now refer to the `self.pyodide` instead of `pyodide`