### PR TITLE
Fix handling when console.html code returns a future

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -90,7 +90,7 @@
                   })
                 );
               }
-              if (value && value.destroy) {
+              if (pyodide.isPyProxy(value)) {
                 value.destroy();
               }
             } catch (e) {

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -31,15 +31,19 @@
           `
             import sys
             import js
+            from pyodide import to_js
             from pyodide.console import PyodideConsole, repr_shorten, BANNER
             import __main__
             BANNER = "Welcome to the Pyodide terminal emulator 🐍\\n" + BANNER
             js.pyconsole = PyodideConsole(__main__.__dict__)
+            async def await_fut(fut):
+              return to_js([await fut]);
         `,
           namespace
         );
         let repr_shorten = namespace.get("repr_shorten");
         let banner = namespace.get("BANNER");
+        let await_fut = namespace.get("await_fut");
         namespace.destroy();
 
         let ps1 = ">>> ",
@@ -71,9 +75,14 @@
               default:
                 throw new Error(`Unexpected type ${ty}`);
             }
+            // In Javascript, await automatically also awaits any results of
+            // awaits, so if an async function returns a future, it will await
+            // the inner future too. This is not what we want so we
+            // temporarily put it into a list to protect it.
+            let wrapped = await_fut(fut);
             // complete case, get result / error and print it.
             try {
-              let value = await fut;
+              let [value] = await wrapped;
               if (value !== undefined) {
                 term.echo(
                   repr_shorten.callKwargs(value, {
@@ -90,8 +99,10 @@
               } else {
                 throw e;
               }
+            } finally {
+              fut.destroy();
+              wrapped.destroy();
             }
-            fut.destroy();
           }
           term.resume();
           await sleep(10);

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -322,6 +322,14 @@ def test_console_html(console_html_fixture):
         await term.ready;
         assert(() => term.get_output().trim() === ">>> 1+1\n2", term.get_output().trim());
 
+        // Check that terminal handles coroutine return values correctly.
+        term.clear();
+        term.exec("async def f(): return 7\n");
+        await term.ready;
+        term.exec("f()");
+        await term.ready;
+        console.log(term.get_output().trim());
+        assert(() => /<coroutine object f at 0x[a-f0-9]*>/.test(term.get_output().trim()), term.get_output().trim());
 
         term.clear();
         term.exec("1+");


### PR DESCRIPTION
In Javascript, if `then` resolves to an `awaitable`, it automatically also awaits the awaitable. We would rather just return the awaitable. So we temporarily put the future into a list which protects it from being automatically awaited, then take it back out again.