### PR TITLE
Improve PyodideConsole error messages when code causes a lexer error 

### DIFF
--- a/src/py/_pyodide/console.py
+++ b/src/py/_pyodide/console.py
@@ -12,6 +12,7 @@ from contextlib import _RedirectStream  # type: ignore
 import rlcompleter
 import platform
 import sys
+from tokenize import TokenError
 import traceback
 from typing import Literal
 from typing import (
@@ -97,8 +98,13 @@ class _Compile(Compile):
 
     def __call__(self, source, filename, symbol) -> CodeRunner:  # type: ignore
         return_mode = self.return_mode
-        if self.quiet_trailing_semicolon and should_quiet(source):
-            return_mode = None
+        try:
+            if self.quiet_trailing_semicolon and should_quiet(source):
+                return_mode = None
+        except TokenError:
+            # Invalid code, let the Python parser throw the error later.
+            pass
+
         code_runner = CodeRunner(
             source,
             mode=symbol,

--- a/src/py/_pyodide/console.py
+++ b/src/py/_pyodide/console.py
@@ -101,7 +101,7 @@ class _Compile(Compile):
         try:
             if self.quiet_trailing_semicolon and should_quiet(source):
                 return_mode = None
-        except TokenError:
+        except (TokenError, SyntaxError):
             # Invalid code, let the Python parser throw the error later.
             pass
 


### PR DESCRIPTION
`should_quiet` tries to lex the code leading to errors if the code has a lexing error. The error messages that the Python compiler generates are better, so we catch the lexing errors generated from `should_quiet` to allow these better later errors to be generated instead.