### PR TITLE
DOC Post-release documentation improvements

### DIFF
--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -48,13 +48,29 @@ the latest release branch named `stable` (due to ReadTheDocs constraints).
    git push upstream stable --force
    ```
    Wait for the CI to pass and create the release on GitHub.
-6. Build the pre-built Docker image locally and push,
+6. Release the pyodide-build package,
+   ```bash
+   pip install twine build
+   cd pyodide-build/
+   python -m build .
+   ls dist/   # check the produced files
+   twine check dist/*X.Y.Z*
+   twine upload dist/*X.Y.Z*
+   ```
+7. Release the Pyodide Javascript package,
+
+   ```bash
+   cd src/js
+   npm publish
+   ```
+
+8. Build the pre-built Docker image locally and push,
    ```bash
    docker build -t pyodide/pyodide:X.Y.Z -f Dockerfile-prebuilt --build-arg VERSION=BB .
    docker push
    ```
    where `BB` is the last version of the `pyodide-env` Docker image.
-7. Revert Step 1. and increment the version in
+9. Revert Step 1. and increment the version in
    `src/py/pyodide/__init__.py` to the next version specified by
    Semantic Versioning.
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -11,7 +11,9 @@ substitutions:
 
 # Change Log
 
-## [0.18.0]
+## Version 0.18.0
+
+_August 3rd, 2021_
 
 ### General
 
@@ -163,6 +165,14 @@ substitutions:
 - {{ Enhancement }} matplotlib now comes with a new renderer based on the html5 canvas element. {pr}`1579`
   It is optional and the current default backend is still the agg backend compiled to wasm.
 - {{ Enhancement }} Updated a number of packages included in Pyodide.
+
+### List of contributors
+
+Albertas Gimbutas, Andreas Klostermann, arfy slowy, daoxian,
+Devin Neal, fuyutarow, Grimmer, Guido Zuidhof, Gyeongjae Choi, Hood
+Chatham, Ian Clester, Itay Dafna, Jeremy Tuloup, jmsmdy, LinasNas, Madhur
+Tandon, Michael Christensen, Nicholas Bollweg, Ondřej Staněk, Paul m. p. P,
+Piet Brömmel, Roman Yurchak, stefnotch, Syrus Akbary, Teon L Brooks, Waldir
 
 ## Version 0.17.0
 


### PR DESCRIPTION
A few documentation improvements,
 - add the list of the contributors and a date for the 0.18.0 release
 - add instructions on how to publish pyodide-build to PyPi and src/js to npm.
 

cc @hoodmane 