### PR TITLE
Bump main to 0.19.0dev0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,7 @@ htmlhelp_basename = "Pyodidedoc"
 epub_exclude_files = ["search.html"]
 
 if "READTHEDOCS" in os.environ:
-    env = {"PYODIDE_BASE_URL": "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/"}
+    env = {"PYODIDE_BASE_URL": "https://cdn.jsdelivr.net/pyodide/dev/full/"}
     os.makedirs("_build/html", exist_ok=True)
     res = subprocess.check_output(
         ["make", "-C", "..", "docs/_build/html/console.html"],

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -33,20 +33,20 @@ community-driven open-source project. The decision making process is outlined in
 ## Citing
 
 If you use Pyodide for a scientific publication, we would appreciate citations.
-Please find us [on Zenodo](https://zenodo.org/record/5135072) and use the citation
+Please find us [on Zenodo](https://zenodo.org/record/5156931) and use the citation
 for the version you are using. You can replace the full author
 list from there with "The Pyodide development team" like in the example below:
 
 ```
-@software{michael_droettboom_2021_5135072,
+@software{pyodide_2021,
   author       = {The Pyodide development team},
   title        = {pyodide/pyodide},
-  month        = jul,
+  month        = aug,
   year         = 2021,
   publisher    = {Zenodo},
-  version      = {0.18.0a1},
-  doi          = {10.5281/zenodo.5135072},
-  url          = {https://doi.org/10.5281/zenodo.5135072}
+  version      = {0.18.0},
+  doi          = {10.5281/zenodo.5156931},
+  url          = {https://doi.org/10.5281/zenodo.5156931}
 }
 ```
 

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -129,12 +129,12 @@ installs from PyPi.
   <body>
     <script
       type="text/javascript"
-      src="https://cdn.jsdelivr.net/pyodide/v0.18.0/full/pyodide.js"
+      src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"
     ></script>
     <script type="text/javascript">
       async function main() {
         let pyodide = await loadPyodide({
-          indexURL: "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/",
+          indexURL: "https://cdn.jsdelivr.net/pyodide/dev/full/",
         });
         await pyodide.loadPackage("micropip");
         await pyodide.runPythonAsync(`

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -11,7 +11,7 @@ Try Pyodide in a [REPL](https://pyodide.org/en/latest/console.html) directly in 
 To include Pyodide in your project you can use the following CDN URL:
 
 ```text
-https://cdn.jsdelivr.net/pyodide/v0.18.0/full/pyodide.js
+https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js
 ```
 
 You can also download a release from [Github
@@ -24,7 +24,7 @@ and returns {js:mod}`the Pyodide top level namespace <pyodide>`.
 
 ```pyodide
 async function main() {
-  let pyodide = await loadPyodide({ indexURL : "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/" });
+  let pyodide = await loadPyodide({ indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/" });
   // Pyodide is now ready to use...
   console.log(pyodide.runPython(`
     import sys
@@ -60,7 +60,7 @@ Create and save a test `index.html` page with the following contents:
 <!DOCTYPE html>
 <html>
   <head>
-      <script src="https://cdn.jsdelivr.net/pyodide/v0.18.0/full/pyodide.js"></script>
+      <script src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
   </head>
   <body>
     Pyodide test page <br>
@@ -68,7 +68,7 @@ Create and save a test `index.html` page with the following contents:
     <script type="text/javascript">
       async function main(){
         let pyodide = await loadPyodide({
-          indexURL : "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/"
+          indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/"
         });
         console.log(pyodide.runPython(`
             import sys
@@ -88,7 +88,7 @@ Create and save a test `index.html` page with the following contents:
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.18.0/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
   </head>
 
   <body>
@@ -115,7 +115,7 @@ Create and save a test `index.html` page with the following contents:
       // init Pyodide
       async function main() {
         let pyodide = await loadPyodide({
-          indexURL: "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/",
+          indexURL: "https://cdn.jsdelivr.net/pyodide/dev/full/",
         });
         output.value += "Ready!\n";
         return pyodide;

--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -105,11 +105,11 @@ shown below:
 // Setup your project to serve `py-worker.js`. You should also serve
 // `pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`,
 // and `.wasm` files as well:
-importScripts("https://cdn.jsdelivr.net/pyodide/v0.18.0/full/pyodide.js");
+importScripts("https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js");
 
 async function loadPyodideAndPackages() {
   self.pyodide = await loadPyodide({
-    indexURL: "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/",
+    indexURL: "https://cdn.jsdelivr.net/pyodide/dev/full/",
   });
   await self.pyodide.loadPackage(["numpy", "pytz"]);
 }

--- a/pyodide-build/setup.cfg
+++ b/pyodide-build/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyodide-build
-version = 0.18.0
+version = 0.19.0dev0
 author = Pyodide developers
 description = "Tools for building Pyodide"
 long_description = file: README.md

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyodide",
-  "version": "0.18.0-dev.0",
+  "version": "0.19.0-dev.0",
   "description": "The Pyodide JavaScript package",
   "keywords": [
     "python",

--- a/src/py/pyodide/__init__.py
+++ b/src/py/pyodide/__init__.py
@@ -34,7 +34,7 @@ if IN_BROWSER:
     asyncio.set_event_loop_policy(WebLoopPolicy())
 
 
-__version__ = "0.18.0"
+__version__ = "0.19.0dev0"
 
 __all__ = [
     "open_url",


### PR DESCRIPTION
Partially reverts https://github.com/pyodide/pyodide/commit/250c48038b7b71f72d8f345fbec57ce3c7c14e7b following the release.