### PR TITLE
Documentation on using Pyodide with Node.js [skip ci]

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,8 @@ Using Pyodide
    :maxdepth: 2
 
    usage/quickstart.md
-   usage/webworker.md
    usage/downloading-and-deploying.md
+   usage/index.md
    usage/loading-packages.md
    usage/type-conversions.md
    usage/wasm-constraints.md

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -29,7 +29,7 @@ Pyodide with {any}`loadPyodide` specifying a index URL for packages:
 ```
 
 See the {ref}`quickstart` for a walk through tutorial as well as
-{ref}`loading_packages` and {ref}`type-translations` for more in depth
+{ref}`loading_packages` and {ref}`type-translations` for a more in depth
 discussion about existing capabilities.
 
 You can also use the [Pyodide NPM
@@ -38,33 +38,9 @@ application.
 
 ```{note}
 To avoid confusion, note that:
- - `https://cdn.jsdelivr.net/pyodide/` distributes Python packages built with Pyodide as well as `pyodide.js`
- - `https://cdn.jsdelivr.net/npm/pyodide@0.18.0/` is a mirror of the Pyodide NPM package, which includes none of the WASM files
+ - `cdn.jsdelivr.net/pyodide/` distributes Python packages built with Pyodide as well as `pyodide.js`
+ - `cdn.jsdelivr.net/npm/pyodide@0.18.0/` is a mirror of the Pyodide NPM package, which includes none of the WASM files
 ```
-
-### Supported browsers
-
-Pyodide works in any modern web browser with WebAssembly support.
-
-**Tier 1** browsers are tested as part of the test suite with continuous integration,
-
-| Browser | Minimal supported version¹            |
-| ------- | ------------------------------------- |
-| Firefox | 60.0 (released May 9, 2018)           |
-| Chrome  | 71.0.3578 (released December 4, 2018) |
-
-¹ Earlier versions might also work, but newer browser versions generally
-provide more reliable WebAssembly support and will run Pyodide faster.
-
-**Tier 2** browsers are known to work but are not systematically tested in
-Pyodide,
-
-| Browser | Minimal supported version¹  |
-| ------- | --------------------------- |
-| Safari  | 13.4 (released May 9, 2018) |
-
-Other browsers with WebAssembly support might also work however they are not
-officially supported.
 
 ## Web Workers
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -12,13 +12,13 @@ Pyodide with {any}`loadPyodide` specifying a index URL for packages:
 <!DOCTYPE html>
 <html>
   <head>
-      <script src="https://cdn.jsdelivr.net/pyodide/v0.18.0/full/pyodide.js"></script>
+      <script src="https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js"></script>
   </head>
   <body>
     <script type="text/javascript">
       async function main(){
         let pyodide = await loadPyodide({
-          indexURL : "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/"
+          indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/"
         });
         console.log(pyodide.runPython("1 + 2"));
       }

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,0 +1,119 @@
+# Using Pyodide
+
+Pyodide may be used in any context where you want to run Python inside a web
+browser or a backend JavaScript environment.
+
+## Web browsers
+
+To use Pyodide on a web page you need to load `pyodide.js` and initialize
+Pyodide with {any}`loadPyodide` specifying a index URL for packages:
+
+```html-pyodide
+<!DOCTYPE html>
+<html>
+  <head>
+      <script src="https://cdn.jsdelivr.net/pyodide/v0.18.0/full/pyodide.js"></script>
+  </head>
+  <body>
+    <script type="text/javascript">
+      async function main(){
+        let pyodide = await loadPyodide({
+          indexURL : "https://cdn.jsdelivr.net/pyodide/v0.18.0/full/"
+        });
+        console.log(pyodide.runPython("1 + 2"));
+      }
+      main();
+    </script>
+  </body>
+</html>
+```
+
+See the {ref}`quickstart` for a walk through tutorial as well as
+{ref}`loading_packages` and {ref}`type-translations` for more in depth
+discussion about existing capabilities.
+
+You can also use the [Pyodide NPM
+package](https://www.npmjs.com/package/pyodide) to integrate Pyodide into your
+application.
+
+```{note}
+To avoid confusion, note that:
+ - `https://cdn.jsdelivr.net/pyodide/` distributes Python packages built with Pyodide as well as `pyodide.js`
+ - `https://cdn.jsdelivr.net/npm/pyodide@0.18.0/` is a mirror of the Pyodide NPM package, which includes none of the WASM files
+```
+
+### Supported browsers
+
+Pyodide works in any modern web browser with WebAssembly support.
+
+**Tier 1** browsers are tested as part of the test suite with continuous integration,
+
+| Browser | Minimal supported version¹            |
+| ------- | ------------------------------------- |
+| Firefox | 60.0 (released May 9, 2018)           |
+| Chrome  | 71.0.3578 (released December 4, 2018) |
+
+¹ Earlier versions might also work, but newer browser versions generally
+provide more reliable WebAssembly support and will run Pyodide faster.
+
+**Tier 2** browsers are known to work but are not systematically tested in
+Pyodide,
+
+| Browser | Minimal supported version¹  |
+| ------- | --------------------------- |
+| Safari  | 13.4 (released May 9, 2018) |
+
+Other browsers with WebAssembly support might also work however they are not
+officially supported.
+
+## Web Workers
+
+By default, WebAssembly runs in the main browser thread, and it can make UI non
+responsive for long running computations.
+
+To avoid this situation, one solution is to run {ref}`using_from_webworker <Pyodide in a WebWorker>`.
+
+## Node.js
+
+As of version 0.18.0 Pyodide can experimentally run in Node.js.
+
+Install the [Pyodide npm package](https://www.npmjs.com/package/pyodide),
+
+```
+npm install pyodide
+```
+
+Download and extract Pyodide packages from [Github
+releases](https://github.com/pyodide/pyodide/releases)
+(**pyodide-build-\*.tar.bz2** file). The version of the release needs to match
+exactly the version of this package.
+
+Then you can load Pyodide in Node.js as follows,
+
+```js
+let pyodide_pkg = await import("pyodide/pyodide.js");
+
+let pyodide = await pyodide_pkg.loadPyodide({
+  indexURL: "<pyodide artifacts folder>",
+});
+
+await pyodide.runPythonAsync("1+1");
+```
+
+```{note}
+To start Node.js REPL with support for top level await, use `node --experimental-repl-await`.
+```
+
+```{warning}
+Download of packages from PyPi is currently not cached when run in
+Node.js. Packages will be re-downloaded each time `micropip.install` is run.
+
+For this same reason, installing Pyodide packages from the CDN is explicitly not supported for now.
+```
+
+```{eval-rst}
+.. toctree::
+   :hidden:
+
+   webworker.md
+```

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -47,7 +47,7 @@ To avoid confusion, note that:
 By default, WebAssembly runs in the main browser thread, and it can make UI non
 responsive for long running computations.
 
-To avoid this situation, one solution is to run {ref}`using_from_webworker <Pyodide in a WebWorker>`.
+To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`.
 
 ## Node.js
 

--- a/packages/micropip/src/micropip/micropip.py
+++ b/packages/micropip/src/micropip/micropip.py
@@ -283,6 +283,10 @@ def install(requirements: Union[str, List[str]]):
     with C extensions that are built in Pyodide. If a pure Python package is not
     found in the Pyodide repository it will be loaded from PyPi.
 
+    When used in web browsers downloads from PyPi will be cached. When run in
+    Node.js, packages are currently not cached, and will be re-downloaded each
+    time ``micropip.install`` is run.
+
     Parameters
     ----------
     requirements : ``str | List[str]``

--- a/packages/micropip/src/micropip/micropip.py
+++ b/packages/micropip/src/micropip/micropip.py
@@ -283,7 +283,7 @@ def install(requirements: Union[str, List[str]]):
     with C extensions that are built in Pyodide. If a pure Python package is not
     found in the Pyodide repository it will be loaded from PyPi.
 
-    When used in web browsers downloads from PyPi will be cached. When run in
+    When used in web browsers, downloads from PyPi will be cached. When run in
     Node.js, packages are currently not cached, and will be re-downloaded each
     time ``micropip.install`` is run.
 


### PR DESCRIPTION
- Documentation on using Pyodide with Node.js  Closes https://github.com/pyodide/pyodide/issues/1725
- Also trying to reduce confusion between different files distributed by Pyodide.
