### PR TITLE
Fix terminal Ctrl+C handling

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -11,6 +11,15 @@ substitutions:
 
 # Change Log
 
+## Unreleased
+
+### Console
+
+- {{Fix}} Ctrl+C handling in console now works correctly with multiline input.
+  New behavior more closely approximates the behavior of the native Python
+  console.
+  {pr}`1790`
+
 ## Version 0.18.0
 
 _August 3rd, 2021_

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -12,6 +12,7 @@
     <style>
       .terminal {
         --size: 1.5;
+        --color: rgba(255, 255, 255, 0.8);
       }
     </style>
   </head>
@@ -30,20 +31,23 @@
         pyodide.runPython(
           `
             import sys
-            import js
             from pyodide import to_js
             from pyodide.console import PyodideConsole, repr_shorten, BANNER
             import __main__
             BANNER = "Welcome to the Pyodide terminal emulator 🐍\\n" + BANNER
-            js.pyconsole = PyodideConsole(__main__.__dict__)
+            pyconsole = PyodideConsole(__main__.__dict__)
             async def await_fut(fut):
               return to_js([await fut]);
+            def clear_console():
+              pyconsole.buffer = []
         `,
           namespace
         );
         let repr_shorten = namespace.get("repr_shorten");
         let banner = namespace.get("BANNER");
         let await_fut = namespace.get("await_fut");
+        let pyconsole = namespace.get("pyconsole");
+        let clear_console = namespace.get("clear_console");
         namespace.destroy();
 
         let ps1 = ">>> ",
@@ -116,6 +120,16 @@
           completion: function (command, callback) {
             callback(pyconsole.complete(command).toJs()[0]);
           },
+          keymap : {
+            "CTRL+C": async function (event, original) {
+              clear_console();
+              term.echo_command();
+              term.echo("KeyboardInterrupt")
+              term.set_command("");
+              term.set_prompt(ps1);
+              return true;
+            }
+          }
         });
         window.term = term;
         pyconsole.stdout_callback = (s) => term.echo(s, { newline: false });

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -120,16 +120,16 @@
           completion: function (command, callback) {
             callback(pyconsole.complete(command).toJs()[0]);
           },
-          keymap : {
+          keymap: {
             "CTRL+C": async function (event, original) {
               clear_console();
               term.echo_command();
-              term.echo("KeyboardInterrupt")
+              term.echo("KeyboardInterrupt");
               term.set_command("");
               term.set_prompt(ps1);
               return true;
-            }
-          }
+            },
+          },
         });
         window.term = term;
         pyconsole.stdout_callback = (s) => term.echo(s, { newline: false });

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -127,7 +127,6 @@
               term.echo("KeyboardInterrupt");
               term.set_command("");
               term.set_prompt(ps1);
-              return true;
             },
           },
         });


### PR DESCRIPTION
This resolves #1787 and should bring repl behavior a bit closer to what happens in native console. I also made the text a bit whiter because I think the text contrast is slightly low.