### PR TITLE
DOCS Fix typo in webworker example

### DIFF
--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -127,8 +127,8 @@ self.onmessage = async (event) => {
   // Now is the easy part, the one that is similar to working in the main thread:
   try {
     await self.pyodide.loadPackagesFromImports(python);
-    let result = await self.pyodide.runPythonAsync(python);
-    self.postMessage({ result });
+    let results = await self.pyodide.runPythonAsync(python);
+    self.postMessage({ results });
   } catch (error) {
     self.postMessage({ error: error.message });
   }


### PR DESCRIPTION
When copy pasting the code in the examples the results where always null because of a typo in the webworker.js example. 