### PR TITLE
Fix exposure of setInterruptBuffer

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,10 @@ substitutions:
   console.
   {pr}`1790`
 
+- {{Fix}} The `setInterruptBuffer` command is now publically exposed again, as
+  it was before.
+  {pr}`1797`
+
 ## Version 0.18.0
 
 _August 3rd, 2021_

--- a/src/core/keyboard_interrupt.c
+++ b/src/core/keyboard_interrupt.c
@@ -23,22 +23,3 @@ pyodide_callback(void)
   }
   return 0;
 }
-
-int
-keyboard_interrupt_init()
-{
-  EM_ASM(
-    {
-      Module.setInterruptBuffer = function(buffer)
-      {
-        Module.interrupt_buffer = buffer;
-        if (buffer) {
-          _PyPyodide_SetPyodideCallback($0);
-        } else {
-          _PyPyodide_SetPyodideCallback(0);
-        }
-      };
-    },
-    pyodide_callback);
-  return 0;
-}

--- a/src/core/keyboard_interrupt.c
+++ b/src/core/keyboard_interrupt.c
@@ -23,3 +23,13 @@ pyodide_callback(void)
   }
   return 0;
 }
+
+void
+set_pyodide_callback(int x)
+{
+  if (x) {
+    PyPyodide_SetPyodideCallback(pyodide_callback);
+  } else {
+    PyPyodide_SetPyodideCallback(NULL);
+  }
+}

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -161,7 +161,6 @@ main(int argc, char** argv)
   TRY_INIT(python2js_buffer);
   TRY_INIT_WITH_CORE_MODULE(JsProxy);
   TRY_INIT_WITH_CORE_MODULE(pyproxy);
-  TRY_INIT(keyboard_interrupt);
 
   PyObject* module_dict = PyImport_GetModuleDict(); /* borrowed */
   if (PyDict_SetItemString(module_dict, "_pyodide_core", core_module)) {

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -312,11 +312,7 @@ Module.restoreState = (state) => Module.pyodide_py._state.restore_state(state);
  */
 export function setInterruptBuffer(interrupt_buffer) {
   Module.interrupt_buffer = interrupt_buffer;
-  if (interrupt_buffer) {
-    Module._PyPyodide_SetPyodideCallback(Module._pyodide_callback);
-  } else {
-    Module._PyPyodide_SetPyodideCallback(0);
-  }
+  Module._set_pyodide_callback(!!interrupt_buffer);
 }
 
 export function makePublicAPI() {

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -310,9 +310,14 @@ Module.restoreState = (state) => Module.pyodide_py._state.restore_state(state);
 /**
  * @param {TypedArray} interrupt_buffer
  */
-function setInterruptBuffer(interrupt_buffer) {}
-setInterruptBuffer = Module.setInterruptBuffer;
-export { setInterruptBuffer };
+export function setInterruptBuffer(interrupt_buffer) {
+  Module.interrupt_buffer = interrupt_buffer;
+  if (interrupt_buffer) {
+    Module._PyPyodide_SetPyodideCallback(Module._pyodide_callback);
+  } else {
+    Module._PyPyodide_SetPyodideCallback(0);
+  }
+}
 
 export function makePublicAPI() {
   /**
@@ -333,7 +338,6 @@ export function makePublicAPI() {
    * @type {FS} The Emscripten File System API.
    */
   const FS = Module.FS;
-
   let namespace = {
     globals,
     FS,

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -239,9 +239,7 @@ def test_keyboard_interrupt(selenium):
         try {
             pyodide.runPython(`
                 from js import triggerKeyboardInterrupt
-                x = 0
-                while True:
-                    x += 1
+                for x in range(100000):
                     if x == 2000:
                         triggerKeyboardInterrupt()
             `)

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -232,7 +232,7 @@ def test_keyboard_interrupt(selenium):
     x = selenium.run_js(
         """
         x = new Int8Array(1)
-        pyodide._module.setInterruptBuffer(x)
+        pyodide.setInterruptBuffer(x)
         self.triggerKeyboardInterrupt = function(){
             x[0] = 2;
         }
@@ -246,7 +246,8 @@ def test_keyboard_interrupt(selenium):
                         triggerKeyboardInterrupt()
             `)
         } catch(e){}
-        return pyodide.runPython('x')
+        pyodide.setInterruptBuffer(undefined);
+        return pyodide.globals.get('x')
         """
     )
     assert 2000 < x < 2500

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -231,8 +231,8 @@ def test_hiwire_is_promise(selenium):
 def test_keyboard_interrupt(selenium):
     x = selenium.run_js(
         """
-        x = new Int8Array(1)
-        pyodide.setInterruptBuffer(x)
+        let x = new Int8Array(1);
+        pyodide.setInterruptBuffer(x);
         self.triggerKeyboardInterrupt = function(){
             x[0] = 2;
         }
@@ -242,10 +242,10 @@ def test_keyboard_interrupt(selenium):
                 for x in range(100000):
                     if x == 2000:
                         triggerKeyboardInterrupt()
-            `)
+            `);
         } catch(e){}
         pyodide.setInterruptBuffer(undefined);
-        return pyodide.globals.get('x')
+        return pyodide.globals.get('x');
         """
     )
     assert 2000 < x < 2500


### PR DESCRIPTION
During the rollup rearrangement we messed up the exposure of `setInterruptBuffer` because of initialization order issues. This fixes it. Also, I updated the test to use the public `setInterruptBuffer` entrypoint so we'd see a test failure if a similar problem arises in the future. Resolves #1795.