### PR TITLE
ENH Change to minimal build by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,7 @@ jobs:
           no_output_timeout: 1200
           command: |
             ccache -z
-            # The following packages are currently used in the main pyodide test suite
-            PYODIDE_PACKAGES="micropip,pyparsing,pytz,packaging,Jinja2" make
+            PYODIDE_PACKAGES="core" make
             ccache -s
 
       - run:
@@ -108,7 +107,7 @@ jobs:
           no_output_timeout: 1800
           command: |
             ccache -z
-            make -C packages
+            PYODIDE_PACKAGES='*' make -C packages
             ccache -s
 
       - run:

--- a/Dockerfile-prebuilt
+++ b/Dockerfile-prebuilt
@@ -11,4 +11,4 @@ COPY . pyodide
 # the rm at the end deletes the build results such that the resulting image can still be used for building pyodide
 # from source (including partial and customized builds). Due to the previous run of make, builds
 # executed with this image will be much faster than the ones executed with pyodide-env
-RUN cd pyodide && make && rm -r ./build
+RUN cd pyodide && PYODIDE_PACKAGES='*' make && rm -r ./build

--- a/Makefile
+++ b/Makefile
@@ -226,11 +226,6 @@ check:
 	./tools/dependency-check.sh
 
 
-minimal :
-	PYODIDE_PACKAGES+=",micropip" make
-
-
 debug :
 	EXTRA_CFLAGS+=" -D DEBUG_F" \
-	PYODIDE_PACKAGES+=", micropip, pyparsing, pytz, packaging, " \
 	make

--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -94,10 +94,19 @@ Dependencies of the listed packages will be built automatically as well. The
 package names must match the folder names in `packages/` exactly; in particular
 they are case sensitive.
 
-To build a minimal version of Pyodide, set `PYODIDE_PACKAGES="micropip"`. The
-packages micropip and distutils are always automatically included (but an empty
-`PYODIDE_PACKAGES` is interpreted as unset). As a shorthand for this, one can
-say `make minimal`.
+If `PYODIDE_PACKAGES` is not set, a minimal set of packages necessairy to run
+the core test suite is installed, including "micropip", "pyparsing", "pytz",
+"packaging", "Jinja2". This is equivalent to setting `PYODIDE_PACKAGES='core'`
+meta-package. Other supported meta-packages are,
+
+- "min-scipy-stack": includes the "core" meta-package as well as some of the
+  core packages from the scientific python stack and their dependencies:
+  "numpy", "scipy", "pandas", "matplotlib", "scikit-learn", "joblib",
+  "pytest". This option is non exaustive and is mainly intended to make build
+  faster while testing a diverse set of scientific packages.
+- "\*" builds all packages
+
+micropip and distutils are always automatically included.
 
 ## Environment variables
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,12 @@ substitutions:
   console.
   {pr}`1790`
 
+### pyodide-build
+
+- By default only a minimal set of packages is built. To build all packages set `PYODIDE_PACKAGES='*'`
+  In addition, `make minimal` was removed, since it is now equivalent to `make` without extra arguments.
+  {pr}`1801`
+
 ## Version 0.18.0
 
 _August 3rd, 2021_

--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -22,7 +22,10 @@ def registered_packages() -> List[str]:
 
 @functools.cache
 def built_packages() -> List[str]:
-    """Returns a list of built package names"""
+    """Returns a list of built package names.
+
+    This functions lists the names of the .data files in the build/ directory.
+    """
     if not BUILD_DIR.exists():
         return []
     registered_packages_ = registered_packages()

--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -1,12 +1,16 @@
 import pytest
 import os
 from pathlib import Path
+import functools
+
 from pyodide_build.common import _parse_package_subset
 from pyodide_build.io import parse_package_config
 
 PKG_DIR = Path(__file__).parent
+BUILD_DIR = PKG_DIR.parent / "build"
 
 
+@functools.cache
 def registered_packages():
     """Returns a list of registered package names"""
     packages = []

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -148,10 +148,10 @@ class Package(BasePackage):
 
 
 def generate_dependency_graph(
-    packages_dir: Path, package_list: Optional[str]
+    packages_dir: Path, packages: Optional[Set[str]]
 ) -> Dict[str, BasePackage]:
-    """
-    This generates a dependency graph for the packages listed in package_list.
+    """This generates a dependency graph for listed packages.
+
     A node in the graph is a BasePackage object defined above, which maintains
     a list of dependencies and also dependents. That is, each node stores both
     incoming and outgoing edges.
@@ -163,7 +163,7 @@ def generate_dependency_graph(
 
     Parameters:
      - packages_dir: directory that contains packages
-     - package_list: set of packages to build. If None, then all packages in
+     - packages: set of packages to build. If None, then all packages in
        packages_dir are compiled.
 
     Returns:
@@ -172,7 +172,6 @@ def generate_dependency_graph(
 
     pkg_map: Dict[str, BasePackage] = {}
 
-    packages: Optional[Set[str]] = common._parse_package_subset(package_list)
     if packages is None:
         packages = set(
             str(x) for x in packages_dir.iterdir() if (x / "meta.yaml").is_file()
@@ -308,7 +307,9 @@ def generate_packages_json(pkg_map: Dict[str, BasePackage]) -> Dict:
 
 
 def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
-    pkg_map = generate_dependency_graph(packages_dir, args.only)
+    packages = common._parse_package_subset(args.only)
+
+    pkg_map = generate_dependency_graph(packages_dir, packages)
 
     build_from_graph(pkg_map, outputdir, args)
 

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -23,8 +23,11 @@ def _parse_package_subset(query: Optional[str]) -> Optional[Set[str]]:
        while testing a diverse set of scientific packages.
      - '*': corresponds to all packages (returns None)
 
+    Note: None as input is equivalent to PYODIDE_PACKAGES being unset and leads
+    to only the core packages being built.
+
     Returns:
-      a set of package names to build or None.
+      a set of package names to build or None (build all packages).
     """
     if query is None:
         query = "core"

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -12,13 +12,46 @@ def _parse_package_subset(query: Optional[str]) -> Optional[Set[str]]:
     Also add the list of mandatory packages: ["pyparsing", "packaging",
     "micropip"]
 
+    Supports folowing meta-packages,
+     - 'core': corresponds to packages needed to run the core test suite
+       {"micropip", "pyparsing", "pytz", "packaging", "Jinja2"}. This is the default option
+       if query is None.
+     - 'min-scipy-stack': includes the "core" meta-package as well as some of the
+       core packages from the scientific python stack and their dependencies:
+       {"numpy", "scipy", "pandas", "matplotlib", "scikit-learn", "joblib", "pytest"}.
+       This option is non exaustive and is mainly intended to make build faster
+       while testing a diverse set of scientific packages.
+     - '*': corresponds to all packages (returns None)
+
     Returns:
       a set of package names to build or None.
     """
     if query is None:
-        return None
+        query = "core"
+
+    core_packages = {"micropip", "pyparsing", "pytz", "packaging", "Jinja2"}
+    core_scipy_packages = {
+        "numpy",
+        "scipy",
+        "pandas",
+        "matplotlib",
+        "scikit-learn",
+        "joblib",
+        "pytest",
+    }
     packages = {el.strip() for el in query.split(",")}
     packages.update(["pyparsing", "packaging", "micropip"])
+    # handle meta-packages
+    if "*" in packages:
+        # build all packages
+        return None
+    elif "core" in packages:
+        packages |= core_packages
+        packages.discard("core")
+    elif "min-scipy-stack" in packages:
+        packages |= core_packages | core_scipy_packages
+        packages.discard("min-scipy-stack")
+
     # Hack to deal with the circular dependence between soupsieve and
     # beautifulsoup4
     if "beautifulsoup4" in packages:

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -13,12 +13,8 @@ def test_generate_dependency_graph():
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"beautifulsoup4"})
 
     assert set(pkg_map.keys()) == {
-        "packaging",
-        "pyparsing",
-        "distutils",
         "soupsieve",
         "beautifulsoup4",
-        "micropip",
     }
     assert pkg_map["soupsieve"].dependencies == []
     assert pkg_map["soupsieve"].dependents == {"beautifulsoup4"}
@@ -27,7 +23,9 @@ def test_generate_dependency_graph():
 
 
 def test_generate_packages_json():
-    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"beautifulsoup4"})
+    pkg_map = buildall.generate_dependency_graph(
+        PACKAGES_DIR, {"beautifulsoup4", "micropip"}
+    )
 
     package_data = buildall.generate_packages_json(pkg_map)
     assert set(package_data.keys()) == {"info", "packages"}
@@ -59,7 +57,7 @@ def test_build_dependencies(n_jobs, monkeypatch):
 
     monkeypatch.setattr(buildall, "Package", MockPackage)
 
-    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml"})
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml", "micropip"})
 
     Args = namedtuple("args", ["n_jobs"])
     buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs))

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -10,7 +10,7 @@ PACKAGES_DIR = (Path(__file__).parents[3] / "packages").resolve()
 
 
 def test_generate_dependency_graph():
-    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, "beautifulsoup4")
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"beautifulsoup4"})
 
     assert set(pkg_map.keys()) == {
         "packaging",
@@ -27,7 +27,7 @@ def test_generate_dependency_graph():
 
 
 def test_generate_packages_json():
-    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, "beautifulsoup4")
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"beautifulsoup4"})
 
     package_data = buildall.generate_packages_json(pkg_map)
     assert set(package_data.keys()) == {"info", "packages"}
@@ -59,7 +59,7 @@ def test_build_dependencies(n_jobs, monkeypatch):
 
     monkeypatch.setattr(buildall, "Package", MockPackage)
 
-    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, "lxml")
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml"})
 
     Args = namedtuple("args", ["n_jobs"])
     buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs))
@@ -100,7 +100,7 @@ def test_build_all_dependencies(n_jobs, monkeypatch):
 
     monkeypatch.setattr(buildall, "Package", MockPackage)
 
-    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, package_list=None)
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, packages=None)
 
     Args = namedtuple("args", ["n_jobs"])
     buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs))
@@ -116,7 +116,7 @@ def test_build_error(n_jobs, monkeypatch):
 
     monkeypatch.setattr(buildall, "Package", MockPackage)
 
-    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, "lxml")
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml"})
 
     with pytest.raises(ValueError, match="Failed build"):
         Args = namedtuple("args", ["n_jobs"])

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -11,7 +11,6 @@ from pyodide_build.common import (
 
 
 def test_parse_package_subset():
-    assert _parse_package_subset(None) is None
     # micropip is always included
     assert _parse_package_subset("numpy,pandas") == {
         "pyparsing",
@@ -39,6 +38,37 @@ def test_parse_package_subset():
         "b",
         "c",
         "d",
+    }
+    # "*" means select all packages
+    assert _parse_package_subset("*") == None
+
+    assert _parse_package_subset("core") == {
+        "pyparsing",
+        "packaging",
+        "pytz",
+        "Jinja2",
+        "micropip",
+    }
+    # by default core packages are built
+    assert _parse_package_subset(None) == _parse_package_subset("core")
+
+    assert _parse_package_subset("min-scipy-stack") == {
+        "pyparsing",
+        "packaging",
+        "pytz",
+        "Jinja2",
+        "micropip",
+        "numpy",
+        "scipy",
+        "pandas",
+        "matplotlib",
+        "scikit-learn",
+        "joblib",
+        "pytest",
+    }
+    # reserved key words can be combined with other packages
+    assert _parse_package_subset("core, unknown") == _parse_package_subset("core") | {
+        "unknown"
     }
 
 

--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pyodide",
-  "version": "0.18.0-dev.0",
+  "version": "0.19.0-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
With this PR `make` only builds the packages needed for the core test suite (previously equivalent to `make minimal`), 
 - `make minimal` is removed as redundant
 - To build all packages `PYODIDE_PACKAGES='*'` can be used.
 - This supports meta packages `core` and `min-scipy-stack` (cf PR docs for a description)

The end goal in a follow up PR is to switch to only building packages in `min-scipy-stack`, instead of all, to make CI faster.


Closes https://github.com/pyodide/pyodide/issues/1295