### PR TITLE
Fix string conversion from javascript to python

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,9 @@ substitutions:
   console.
   {pr}`1790`
 
+- {{Fix}} Conversion of very large strings from Javascript to Python works
+  again. {pr}`1806`
+
 ## Version 0.18.0
 
 _August 3rd, 2021_

--- a/packages/cffi/test_cffi.py
+++ b/packages/cffi/test_cffi.py
@@ -2,7 +2,7 @@ from pyodide_build.testing import run_in_pyodide
 
 
 @run_in_pyodide(packages=["cffi"])
-def test_blah():
+def test_cffi_asprintf():
     from cffi import FFI
 
     ffi = FFI()

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -64,11 +64,12 @@ EM_JS_NUM(errcode, js2python_init, (), {
     // have Javascript write directly into its buffer.  We first need
     // to determine if is needs to be a 1-, 2- or 4-byte string, since
     // Python handles all 3.
-    let codepoints = [];
+    let max_code_point = 0;
     for (let c of value) {
-      codepoints.push(c.codePointAt(0));
+      let code_point = c.codePointAt(0);
+      max_code_point =
+        code_point > max_code_point ? code_point : max_code_point;
     }
-    let max_code_point = Math.max(... codepoints);
 
     let result = _PyUnicode_New(codepoints.length, max_code_point);
     // clang-format off
@@ -79,11 +80,20 @@ EM_JS_NUM(errcode, js2python_init, (), {
 
     let ptr = _PyUnicode_Data(result);
     if (max_code_point > 0xffff) {
-      HEAPU32.subarray(ptr / 4, ptr / 4 + codepoints.length).set(codepoints);
+      for (let c of value) {
+        HEAPU32[ptr / 4] = c.codePointAt(0);
+        ptr += 4;
+      }
     } else if (max_code_point > 0xff) {
-      HEAPU16.subarray(ptr / 2, ptr / 2 + codepoints.length).set(codepoints);
+      for (let c of value) {
+        HEAPU16[ptr / 2] = c.codePointAt(0);
+        ptr += 2;
+      }
     } else {
-      HEAPU8.subarray(ptr, ptr + codepoints.length).set(codepoints);
+      for (let c of value) {
+        HEAPU8[ptr] = c.codePointAt(0);
+        ptr += 1;
+      }
     }
 
     return result;

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -65,13 +65,15 @@ EM_JS_NUM(errcode, js2python_init, (), {
     // to determine if is needs to be a 1-, 2- or 4-byte string, since
     // Python handles all 3.
     let max_code_point = 0;
+    let num_code_points = 0;
     for (let c of value) {
+      num_code_points++;
       let code_point = c.codePointAt(0);
       max_code_point =
         code_point > max_code_point ? code_point : max_code_point;
     }
 
-    let result = _PyUnicode_New(codepoints.length, max_code_point);
+    let result = _PyUnicode_New(num_code_points, max_code_point);
     // clang-format off
     if (result === 0) {
       // clang-format on

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -28,6 +28,29 @@ def test_string_conversion(selenium_module_scope, s):
         )
 
 
+def test_large_string_conversion(selenium):
+    assert (
+        selenium.run_js(
+            """
+            self.longstr = "ab".repeat(200_000);
+            pyodide.runPython(`from js import longstr`);
+            self.longstr = undefined;
+            return pyodide.runPython(`longstr.count('ab')`);
+            """
+        )
+        == 200000
+    )
+    selenium.run_js(
+        """
+        let s = pyodide.runPython(`"ab" * 20_000`);
+        assert(() => s.length === 40_000);
+        for(let n = 0; n < 20_000; n++){
+            assert(() => s.slice(2*n, 2*n+2) === "ab");
+        }
+        """
+    )
+
+
 @given(
     n=strategies.one_of(
         strategies.integers(min_value=-(2 ** 53), max_value=2 ** 53),

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -35,7 +35,11 @@ def test_large_string_conversion(selenium):
             self.longstr = "ab".repeat(200_000);
             pyodide.runPython(`from js import longstr`);
             self.longstr = undefined;
-            return pyodide.runPython(`longstr.count('ab')`);
+            return pyodide.runPython(`
+                res = longstr.count('ab')
+                del longstr
+                res
+            `);
             """
         )
         == 200000


### PR DESCRIPTION
I introduced a bug in v0.18.0 that breaks conversion of long strings, thanks to @ibdafna and @ryanking13 for finding it. Hopefully this should fix the bug. Resolves #1801.