### PR TITLE
Fix run_docker to not ignore PYODIDE_SYSTEM_PORT

### DIFF
--- a/run_docker
+++ b/run_docker
@@ -73,8 +73,9 @@ do
         fi
         if [[ -n ${PYODIDE_SYSTEM_PORT} ]]; then
           echo "WARNING: will use the env var PYODIDE_SYSTEM_PORT=${PYODIDE_SYSTEM_PORT} instead of the provided port"
+        else
+          PYODIDE_SYSTEM_PORT=$2
         fi
-        DEFAULT_PYODIDE_SYSTEM_PORT=$2
         shift 2
       ;;
       --non-interactive)
@@ -101,12 +102,12 @@ PYODIDE_SYSTEM_PORT=${PYODIDE_SYSTEM_PORT:-${DEFAULT_PYODIDE_SYSTEM_PORT}}
 PYODIDE_DOCKER_IMAGE=${PYODIDE_DOCKER_IMAGE:-${DEFAULT_PYODIDE_DOCKER_IMAGE}}
 
 # in case the port is not a number, do not bind the port
-case $DEFAULT_PYODIDE_SYSTEM_PORT in
+case $PYODIDE_SYSTEM_PORT in
   none)
   PORT_CONFIGURATION_LINE=""
   ;;
   ''|*[!0-9]*) # contains a non-digit character, therefore it is not a number
-  echo "WARNING: Invalid port argument '$DEFAULT_PYODIDE_SYSTEM_PORT'. Port binding disabled."
+  echo "WARNING: Invalid port argument '$PYODIDE_SYSTEM_PORT'. Port binding disabled."
   PORT_CONFIGURATION_LINE=""
   ;;
   *)


### PR DESCRIPTION
This PR fixes wrong behavior in `run_docker` which ignores PYODIDE_SYSTEM_PORT env variable.

This behavior can be checked by:

```sh
$ PYODIDE_SYSTEM_PORT=9999 ./run_docker python -m http.server &
$ docker ps
# CONTAINER ID   IMAGE                    COMMAND                  CREATED          STATUS          PORTS     NAMES
# b243be0d3f1a   pyodide/pyodide-env:19   "/bin/bash -c '     …"   25 seconds ago   Up 14 seconds             musing_wozniak
```