### PR TITLE
MAINT Simplify error handling in js2python.c

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -225,6 +225,12 @@ char* error__js_filename_string = "???.js";
 EM_JS_NUM(errcode, error_handling_init_js, (), {
   Module.handle_js_error = function(e)
   {
+    if (e instanceof Module._PropagatePythonError) {
+      // Python error indicator is already set in this case. If this branch is
+      // not taken, Python error indicator should be unset, and we have to set
+      // it. I think in this case we don't want to tamper with the traceback?
+      return;
+    }
     let restored_error = false;
     if (e instanceof Module.PythonError) {
       // Try to restore the original Python exception.
@@ -259,6 +265,20 @@ EM_JS_NUM(errcode, error_handling_init_js, (), {
     }
   };
   Module.PythonError = PythonError;
+  // A special marker. If we call a CPython API from an EM_JS function and the
+  // CPython API sets an error, we might want to return an error status back to
+  // C keeping the current Python error flag. This signals to the EM_JS wrappers
+  // that the Python error flag is set and to leave it alone and return the
+  // appropriate error value (either NULL or -1).
+  class _PropagatePythonError extends Error
+  {
+    constructor()
+    {
+      super("If you are seeing this message, an internal Pyodide error has "
+            "occurred." +
+            "Please report it to the Pyodide maintainers.");
+    }
+  } Module._PropagatePythonError = _PropagatePythonError;
   return 0;
 })
 

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -274,9 +274,8 @@ EM_JS_NUM(errcode, error_handling_init_js, (), {
   {
     constructor()
     {
-      super("If you are seeing this message, an internal Pyodide error has "
-            "occurred." +
-            "Please report it to the Pyodide maintainers.");
+      super("If you are seeing this message, an internal Pyodide error has " +
+            "occurred. Please report it to the Pyodide maintainers.");
     }
   } Module._PropagatePythonError = _PropagatePythonError;
   return 0;

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -228,7 +228,7 @@ EM_JS_NUM(errcode, error_handling_init_js, (), {
     if (e instanceof Module._PropagatePythonError) {
       // Python error indicator is already set in this case. If this branch is
       // not taken, Python error indicator should be unset, and we have to set
-      // it. I think in this case we don't want to tamper with the traceback?
+      // it. In this case we don't want to tamper with the traceback.
       return;
     }
     let restored_error = false;

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -46,6 +46,11 @@ EM_JS_REF(PyObject*, js2python, (JsRef id), {
   let value = Module.hiwire.get_value(id);
   try {
     let result = Module._js2python_convertImmutable(value);
+    // clang-format off
+    if (result !== undefined) {
+      // clang-format on
+      return result;
+    }
   } catch (e) {
     // Assertion: Python error indicator is set if and only if error is a
     // TempError.
@@ -55,12 +60,7 @@ EM_JS_REF(PyObject*, js2python, (JsRef id), {
       throw e;
     }
   }
-  // clang-format off
-  if (result !== undefined) {
-    return result;
-  }
   return _JsProxy_create(id);
-  // clang-format on
 })
 
 EM_JS_REF(PyObject*, js2python_convert, (JsRef id, int depth), {

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -53,6 +53,10 @@ EM_JS_REF(PyObject*, js2python, (JsRef id), {
   return _JsProxy_create(id);
 })
 
+/**
+ * Convert a Javascript object to Python to a given depth. This is the
+ * implementation of `toJs`.
+ */
 EM_JS_REF(PyObject*, js2python_convert, (JsRef id, int depth), {
   return Module.js2python_convert(id, new Map(), depth);
 });
@@ -348,6 +352,10 @@ EM_JS_NUM(errcode, js2python_init, (), {
     return _JsProxy_create(id);
   };
 
+  /**
+   * Convert a Javascript object to Python to a given depth. The `cache`
+   * argument should be a new empty map (it is needed for recursive calls).
+   */
   Module.js2python_convert = function(id, cache, depth)
   {
     let value = Module.hiwire.get_value(id);

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -277,7 +277,7 @@ export function toPy(obj, { depth = -1 } = {}) {
   let result = 0;
   try {
     obj_id = Module.hiwire.new_value(obj);
-    py_result = Module.__js2python_convert(obj_id, new Map(), depth);
+    py_result = Module.js2python_convert(obj_id, new Map(), depth);
     if (py_result === 0) {
       Module._pythonexc2js();
     }

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -277,9 +277,13 @@ export function toPy(obj, { depth = -1 } = {}) {
   let result = 0;
   try {
     obj_id = Module.hiwire.new_value(obj);
-    py_result = Module.js2python_convert(obj_id, new Map(), depth);
-    if (py_result === 0) {
-      Module._pythonexc2js();
+    try {
+      py_result = Module.js2python_convert(obj_id, new Map(), depth);
+    } catch (e) {
+      if (e instanceof Module._PropagatePythonError) {
+        Module._pythonexc2js();
+      }
+      throw e;
     }
     if (Module._JsProxy_Check(py_result)) {
       // Oops, just created a JsProxy. Return the original object.


### PR DESCRIPTION
This simplifies error handling in js2python a bit. In the old version, we propagate errors manually in the Javascript code: when an error branch is reached, the function returns 0, then each calling function checks this and returns 0. The code also does an odd thing where it throws `TempError` and then usually recatches it in the same function, effectively as a `goto fail`. I think this is because much of the code was rather directly converted from C to Javascript.

In this case what we want to do is if we call any CPython API that returns an error, we want to unwind all Javascript calls until we hit `EM_JS` and then return an error to C without adjusting the Python error flag. I added a special mechanism for this to `error_handling.c`: in this case we throw a `Module._PropagatePythonError`.

I also made internal Javascript helpers for `error_handling.c` private to the file and improved function naming a bit.