### PR TITLE
Fix refcount error in restore_sys_last_exception

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -40,7 +40,7 @@ substitutions:
   it was before.
   {pr}`1797`
 
-- {{Fix}} Fixed a serious but rare bug in the error handling code.
+- {{Fix}} Fixed a use after free bug in the error handling code.
   {pr}`1816`
 
 ## Version 0.18.0

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,9 @@ substitutions:
   console.
   {pr}`1790`
 
+- {{Fix}} Fixed a serious but rare bug in the error handling code.
+  {pr}`1816`
+
 ### Python / JavaScript type conversions
 
 - {{Fix}} Conversion of very large strings from Javascript to Python works

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -118,6 +118,11 @@ restore_sys_last_exception(void* value)
   if (value != last_value) {
     return 0;
   }
+  // PyErr_Restore steals a reference to each of its arguments so need to incref
+  // them first.
+  Py_INCREF(last_type);
+  Py_INCREF(last_value);
+  Py_INCREF(last_traceback);
   PyErr_Restore(last_type, last_value, last_traceback);
   success = true;
 finally:

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -289,6 +289,28 @@ def test_run_python_last_exc(selenium):
     )
 
 
+def test_restore_error(selenium):
+    selenium.run_js(
+        """
+        function f(){
+            pyodide.runPython(`
+                err = Exception('hi')
+                raise err
+            `);
+        }
+        pyodide.runPython(`
+            from js import f
+            try:
+                f()
+            except Exception as e:
+                assert err == e
+            finally:
+                del err
+        `);
+        """
+    )
+
+
 def test_async_leak(selenium):
     assert 0 == selenium.run_js(
         """

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -574,6 +574,7 @@ def test_reentrant_error(selenium):
 
 
 def test_restore_error(selenium):
+    # See PR #1816.
     selenium.run_js(
         """
         self.f = function(){

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -576,7 +576,7 @@ def test_reentrant_error(selenium):
 def test_restore_error(selenium):
     selenium.run_js(
         """
-        function f(){
+        self.f = function(){
             pyodide.runPython(`
                 err = Exception('hi')
                 raise err

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -584,12 +584,15 @@ def test_restore_error(selenium):
         }
         pyodide.runPython(`
             from js import f
+            import sys
             try:
                 f()
             except Exception as e:
                 assert err == e
+                assert e == sys.last_value
             finally:
                 del err
+            assert sys.getrefcount(sys.last_value) == 2
         `);
         """
     )

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -289,28 +289,6 @@ def test_run_python_last_exc(selenium):
     )
 
 
-def test_restore_error(selenium):
-    selenium.run_js(
-        """
-        function f(){
-            pyodide.runPython(`
-                err = Exception('hi')
-                raise err
-            `);
-        }
-        pyodide.runPython(`
-            from js import f
-            try:
-                f()
-            except Exception as e:
-                assert err == e
-            finally:
-                del err
-        `);
-        """
-    )
-
-
 def test_async_leak(selenium):
     assert 0 == selenium.run_js(
         """
@@ -593,6 +571,28 @@ def test_reentrant_error(selenium):
         """
     )
     assert caught
+
+
+def test_restore_error(selenium):
+    selenium.run_js(
+        """
+        function f(){
+            pyodide.runPython(`
+                err = Exception('hi')
+                raise err
+            `);
+        }
+        pyodide.runPython(`
+            from js import f
+            try:
+                f()
+            except Exception as e:
+                assert err == e
+            finally:
+                del err
+        `);
+        """
+    )
 
 
 @pytest.mark.skip_refcount_check


### PR DESCRIPTION
According to the docs, [`PyErr_Restore`](https://docs.python.org/3/c-api/exceptions.html?highlight=repr#c.PyErr_Restore) steals a reference to each of its arguments (this also makes sense because it makes the common `PyErr_Fetch` / `PyErr_Restore` usage work nicely).
Anyways, I did not correctly take this into account in the definition of `restore_sys_last_exception`. As a result, bad things happen every time this code path is hit. This might be why `test_reentrant_error` fails sporadically. I found another test that consistently causes use after free errors (which doesn't lead to a fatal error because the problem occurs inside of the error handling code).