### PR TITLE
Ensure that dup'd file descriptors share position and flags

### DIFF
--- a/emsdk/patches/fix-dup.patch
+++ b/emsdk/patches/fix-dup.patch
@@ -1,22 +1,50 @@
-From 52c0b163bad96cde2081c734680b9ec485fea908 Mon Sep 17 00:00:00 2001
+From 05458d136277cf801c22f7d8bdac99d6b157209d Mon Sep 17 00:00:00 2001
 From: Hood <hood@mit.edu>
 Date: Wed, 8 Sep 2021 17:49:15 -0700
 Subject: [PATCH] Fix dup
 
 ---
+ src/library_fs.js                | 11 ++++++++++-
  src/library_syscall.js           | 12 ++++++------
  tests/third_party/posixtestsuite |  2 +-
- 2 files changed, 7 insertions(+), 7 deletions(-)
+ 3 files changed, 17 insertions(+), 8 deletions(-)
 
 This should fix two problems with the `dup` system calls:
-1. Pipes cannot be duplicated (https://github.com/emscripten-core/emscripten/issues/14640)
-2. `TemporaryFiles` cannot be duplicated (https://github.com/emscripten-core/emscripten/issues/15012)
+1. `dup` expects that every file descriptor has a corresponding file (so pipes and (https://github.com/emscripten-core/emscripten/issues/14640)
+   files that have been unlinked (https://github.com/emscripten-core/emscripten/issues/15012) cannot be duplicated ).
+2. The dup'd file descriptor does not share flags and position with the original file desciptor.
 
-Both of these issues cause trouble with pytest. There is an upstream pull request that would fix this problem:
+This is a simplification of an upstream pull request that would fix this problem.
 https://github.com/emscripten-core/emscripten/pull/9396/files
+This patch is simpler than the upstream one but leaves NODERAWFS broken.
 
-This patch only partially resolves the problems with `dup` (it doesn't fully duplicate the changes in the emscripten PR) but I think it will be good enough to fix pytest.
 
+diff --git a/emsdk/upstream/emscripten/src/library_fs.js b/emsdk/upstream/emscripten/src/library_fs.js
+index 4ca59469c..85a10ecea 100644
+--- a/emsdk/upstream/emscripten/src/library_fs.js
++++ b/emsdk/upstream/emscripten/src/library_fs.js
+@@ -425,11 +425,20 @@ FS.staticInit();` +
+           },
+           isAppend: {
+             get: function() { return (this.flags & {{{ cDefine('O_APPEND') }}}); }
+-          }
++          },
++          flags: {
++            get: function() { return this.shared.flags; },
++            set: function(value) { this.shared.flags = value; }
++          },
++          position: {
++            get: function() { return this.shared.position; },
++            set: function(value) { this.shared.position = value; }
++          },
+         };
+       }
+       // clone it, so we can return an instance of FSStream
+       var newStream = new FS.FSStream();
++      newStream.shared = {};
+       for (var p in stream) {
+         newStream[p] = stream[p];
+       }
 diff --git a/emsdk/upstream/emscripten/src/library_syscall.js b/emsdk/upstream/emscripten/src/library_syscall.js
 index 96d2ec0c3..0001624ec 100644
 --- a/emsdk/upstream/emscripten/src/library_syscall.js

--- a/emsdk/patches/fix-dup.patch
+++ b/emsdk/patches/fix-dup.patch
@@ -1,13 +1,12 @@
-From 05458d136277cf801c22f7d8bdac99d6b157209d Mon Sep 17 00:00:00 2001
+From d9181272105915622a3eb8940e08aaf6e00f385c Mon Sep 17 00:00:00 2001
 From: Hood <hood@mit.edu>
 Date: Wed, 8 Sep 2021 17:49:15 -0700
 Subject: [PATCH] Fix dup
 
 ---
- src/library_fs.js                | 11 ++++++++++-
- src/library_syscall.js           | 12 ++++++------
- tests/third_party/posixtestsuite |  2 +-
- 3 files changed, 17 insertions(+), 8 deletions(-)
+ src/library_fs.js      |  7 ++++++-
+ src/library_syscall.js | 12 ++++++------
+ 2 files changed, 12 insertions(+), 7 deletions(-)
 
 This should fix two problems with the `dup` system calls:
 1. `dup` expects that every file descriptor has a corresponding file (so pipes and (https://github.com/emscripten-core/emscripten/issues/14640)
@@ -20,23 +19,19 @@ This patch is simpler than the upstream one but leaves NODERAWFS broken.
 
 
 diff --git a/emsdk/upstream/emscripten/src/library_fs.js b/emsdk/upstream/emscripten/src/library_fs.js
-index 4ca59469c..85a10ecea 100644
+index 4ca59469c..519fab972 100644
 --- a/emsdk/upstream/emscripten/src/library_fs.js
 +++ b/emsdk/upstream/emscripten/src/library_fs.js
-@@ -425,11 +425,20 @@ FS.staticInit();` +
+@@ -425,11 +425,16 @@ FS.staticInit();` +
            },
            isAppend: {
              get: function() { return (this.flags & {{{ cDefine('O_APPEND') }}}); }
 -          }
 +          },
-+          flags: {
-+            get: function() { return this.shared.flags; },
-+            set: function(value) { this.shared.flags = value; }
-+          },
-+          position: {
-+            get: function() { return this.shared.position; },
-+            set: function(value) { this.shared.position = value; }
-+          },
++          get flags() { return this.shared.flags; },
++          set flags(value) { this.shared.flags = value; },
++          get position() { return this.shared.position; },
++          set position(value) { this.shared.position = value; },
          };
        }
        // clone it, so we can return an instance of FSStream

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -189,9 +189,39 @@ def test_dup_temp_file():
     fd2 = os.dup2(tf.fileno(), 50)
     s = b"hello there!"
     tf.write(s)
+    tf2 = open(fd1, "w+")
+    assert tf2.tell() == len(s)
     # This next assertion actually demonstrates a bug in dup: the correct value
     # to return should be b"".
-    assert os.read(fd1, 50) == s
+    assert os.read(fd1, 50) == b""
+    tf2.seek(1)
+    assert tf.tell() == 1
+    assert tf.read(100) == b"ello there!"
+
+
+@run_in_pyodide
+def test_dup_stdout():
+    # Test redirecting stdout using low level os.dup operations.
+    # This sort of redirection is used in pytest.
+    import os
+    import sys
+    from tempfile import TemporaryFile
+
+    tf = TemporaryFile(buffering=0)
+    save_stdout = os.dup(sys.stdout.fileno())
+    os.dup2(tf.fileno(), sys.stdout.fileno())
+    print("hi!!")
+    print("there...")
+    assert tf.tell() == len("hi!!\nthere...\n")
+    os.dup2(save_stdout, sys.stdout.fileno())
+    print("not captured")
+    os.dup2(tf.fileno(), sys.stdout.fileno())
+    print("captured")
+    assert tf.tell() == len("hi!!\nthere...\ncaptured\n")
+    os.dup2(save_stdout, sys.stdout.fileno())
+    os.close(save_stdout)
+    tf.seek(0)
+    assert tf.read(1000).decode() == "hi!!\nthere...\ncaptured\n"
 
 
 @pytest.mark.skip_pyproxy_check


### PR DESCRIPTION
This is a continuation of #1823. This should make pytest work better by ensuring that a duplicate file descriptor shares position with the original one. pytest does something like:
```
stdout_redirect_file = TemporaryFile()
saved_stdout_fd = os.dup(sys.stdout.fileno())

def redirect_stdout():
	os.dup2(stdout_redirect_file.fileno(), sys.stdout.fileno())

def restore_stdout():
    os.dup2(saved_stdout_fd, sys.stdout.fileno())
```
The problem comes up when `stdout` is redirected, restored, and redirected again. Instead of adding new writes to `stdout` to the end of the `stdout_redirect_file`, they write over `stdout_redirect_file` from the beginning. The intended behavior is that they would be added to the end. This is because `stdout_redirect_file` is always positioned at the beginning of the file so every time `redirect_stdout` is called, `stdout` is moved to point to the beginning of the file. 

On the other hand, if `dup2` behaved the way the posix spec says, then the position of `stdout_redirect_file` is updated whenever `stdout` is written, and so after repeated calls to `redirect_stdout`, writes to stdout will still be appended to the end of the file.