### PR TITLE
FIX pyodide-build mkpkg usability

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,13 +15,16 @@ substitutions:
 
 ### pyodide-build
 
-- By default only a minimal set of packages is built. To build all packages set
-  `PYODIDE_PACKAGES='*'` In addition, `make minimal` was removed, since it is
-  now equivalent to `make` without extra arguments. {pr}`1801`
+- {{API}} By default only a minimal set of packages is built. To build all
+  packages set `PYODIDE_PACKAGES='*'` In addition, `make minimal` was removed,
+  since it is now equivalent to `make` without extra arguments. {pr}`1801`
 
-- Changes to environment variables in the build script are now seen in the
-  compile and post build scripts.
+- {{Enhancement}} Changes to environment variables in the build script are now
+  seen in the compile and post build scripts.
   {pr}`1706`
+
+- {{Fix}} Fix usability issues with `pyodide-build mkpkg` CLI.
+  {pr}`1828`
 
 ### Uncategorized
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -342,29 +342,29 @@ def make_parser(parser):
         "--cflags",
         type=str,
         nargs="?",
-        default=common.get_make_flag("SIDE_MODULE_CFLAGS"),
-        help="Extra compiling flags",
+        default=None,
+        help="Extra compiling flags. Default: SIDE_MODULE_CFLAGS",
     )
     parser.add_argument(
         "--cxxflags",
         type=str,
         nargs="?",
-        default=common.get_make_flag("SIDE_MODULE_CXXFLAGS"),
-        help="Extra C++ specific compiling flags",
+        default=None,
+        help=("Extra C++ specific compiling flags. " "Default: SIDE_MODULE_CXXFLAGS"),
     )
     parser.add_argument(
         "--ldflags",
         type=str,
         nargs="?",
-        default=common.get_make_flag("SIDE_MODULE_LDFLAGS"),
-        help="Extra linking flags",
+        default=None,
+        help="Extra linking flags. Default: SIDE_MODULE_LDFLAGS",
     )
     parser.add_argument(
         "--target",
         type=str,
         nargs="?",
-        default=common.get_make_flag("TARGETPYTHONROOT"),
-        help="The path to the target Python installation",
+        default=None,
+        help="The path to the target Python installation. Default: TARGETPYTHONROOT",
     )
     parser.add_argument(
         "--install-dir",
@@ -405,6 +405,15 @@ def make_parser(parser):
 def main(args):
     packages_dir = Path(args.dir[0]).resolve()
     outputdir = Path(args.output[0]).resolve()
+    if args.cflags is None:
+        args.cflags = common.get_make_flag("SIDE_MODULE_CFLAGS")
+    if args.cxxflags is None:
+        args.cxxflags = common.get_make_flag("SIDE_MODULE_CXXFLAGS")
+    if args.ldflags is None:
+        args.ldflags = common.get_make_flag("SIDE_MODULE_LDFLAGS")
+    if args.target is None:
+        args.target = common.get_make_flag("TARGETPYTHONROOT")
+
     build_packages(packages_dir, outputdir, args)
 
 

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -139,7 +139,6 @@ def success(msg):
 
 
 def update_package(package: str, update_patched: bool = True):
-    from ruamel.yaml import YAML
 
     YAML = _import_ruamel_yaml()
 

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -13,7 +13,7 @@ import warnings
 
 from .io import parse_package_config
 
-PACKAGES_ROOT = Path(__file__).parent.parent / "packages"
+PACKAGES_ROOT = Path(__file__).parents[2] / "packages"
 
 
 class MkpkgFailedException(Exception):
@@ -52,10 +52,23 @@ def _get_metadata(package: str, version: Optional[str] = None) -> Dict:
             pypi_metadata = json.load(fd)
     except urllib.error.HTTPError as e:
         raise MkpkgFailedException(
-            f"Failed to load metadata for {package}{version} from https://pypi.org/pypi/{package}{version}/json: {e}"
+            f"Failed to load metadata for {package}{version} from "
+            f"https://pypi.org/pypi/{package}{version}/json: {e}"
         )
 
     return pypi_metadata
+
+
+def _import_ruamel_yaml():
+    """Import ruamel.yaml with a better error message is not installed."""
+    try:
+        from ruamel.yaml import YAML
+    except ImportError as err:
+        raise ImportError(
+            "No module named 'ruamel'. "
+            "It can be installed with pip install ruamel.yaml"
+        ) from err
+    return YAML
 
 
 def make_package(package: str, version: Optional[str] = None):
@@ -63,7 +76,8 @@ def make_package(package: str, version: Optional[str] = None):
     Creates a template that will work for most pure Python packages,
     but will have to be edited for more complex things.
     """
-    from ruamel.yaml import YAML
+    print(f"Creating meta.yaml package for {package}")
+    YAML = _import_ruamel_yaml()
 
     yaml = YAML()
 
@@ -93,8 +107,10 @@ def make_package(package: str, version: Optional[str] = None):
 
     if not (PACKAGES_ROOT / package).is_dir():
         os.makedirs(PACKAGES_ROOT / package)
-    with open(PACKAGES_ROOT / package / "meta.yaml", "w") as fd:
+    out_path = PACKAGES_ROOT / package / "meta.yaml"
+    with open(out_path, "w") as fd:
         yaml.dump(yaml_content, fd)
+    success(f"Output written to {out_path}")
 
 
 class bcolors:
@@ -124,6 +140,8 @@ def success(msg):
 
 def update_package(package: str, update_patched: bool = True):
     from ruamel.yaml import YAML
+
+    YAML = _import_ruamel_yaml()
 
     yaml = YAML()
 

--- a/pyodide-build/pyodide_build/tests/test_mkpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_mkpkg.py
@@ -13,13 +13,17 @@ from pyodide_build.io import parse_package_config
 # unlikely to fail.
 
 
-def test_mkpkg(tmpdir, monkeypatch):
+def test_mkpkg(tmpdir, monkeypatch, capsys):
+    assert pyodide_build.mkpkg.PACKAGES_ROOT.exists()
+
     base_dir = Path(str(tmpdir))
     monkeypatch.setattr(pyodide_build.mkpkg, "PACKAGES_ROOT", base_dir)
     pyodide_build.mkpkg.make_package("idna")
     assert os.listdir(base_dir) == ["idna"]
     meta_path = base_dir / "idna" / "meta.yaml"
     assert meta_path.exists()
+    captured = capsys.readouterr()
+    assert f"Output written to {meta_path}" in captured.out
 
     db = parse_package_config(meta_path)
 


### PR DESCRIPTION
Fix usability issues with `pyodide-build mkpkg` reported by @sylvain-ri in https://github.com/pyodide/pyodide/issues/1724#issuecomment-917015583,
 - avoid calling `get_make_flag` for default parameters, which results in ` KeyError: 'SIDE_MODULE_CFLAGS'` error if the command is run from a different folder than the pyodide root. Though there is still the assumption that pyodide-build was installed from the pyodide repo, instead of from PyPi -- we would need to fix that separately.
 - print the output where the `meta.yaml` is written
 - fix `pyodide_build.mkpkg.PACKAGES_ROOT` which got broken by https://github.com/pyodide/pyodide/pull/1566 I think