### PR TITLE
ENH Improve logging when building packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - -core-{{ checksum "Makefile.envs" }}-{{ checksum "python/Makefile" }}-v20210910-
+            - -core-{{ checksum "Makefile.envs" }}-{{ checksum "cpython/Makefile" }}-v20210910-
 
       - run:
           name: build emsdk
@@ -89,7 +89,7 @@ jobs:
       - save_cache:
           paths:
             - /root/.ccache
-          key: -core-{{ checksum "Makefile.envs" }}-{{ checksum "python/Makefile" }}-v20210910-
+          key: -core-{{ checksum "Makefile.envs" }}-{{ checksum "cpython/Makefile" }}-v20210910-
 
       - run:
           name: Clean up workspace

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -221,7 +221,7 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     # dependents, because the ordering ought not to change after insertion.
     build_queue: PriorityQueue = PriorityQueue()
 
-    print("Packages that would be built: " + ", ".join(pkg_map))
+    print("Building the following packages: " + ", ".join(pkg_map))
 
     for pkg in pkg_map.values():
         if len(pkg.dependencies) == 0:

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -221,7 +221,7 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     # dependents, because the ordering ought not to change after insertion.
     build_queue: PriorityQueue = PriorityQueue()
 
-    print("Building the following packages: " + ", ".join(pkg_map))
+    print("Packages that would be built: " + ", ".join(sorted(pkg_map.keys())))
 
     for pkg in pkg_map.values():
         if len(pkg.dependencies) == 0:
@@ -229,10 +229,9 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
 
     built_queue: Queue = Queue()
     thread_lock = Lock()
-    queue_idx = 0
+    queue_idx = 1
 
     def builder(n):
-        print(f"Starting thread {n}")
         nonlocal queue_idx
         while True:
             pkg = build_queue.get()
@@ -249,7 +248,8 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
                 return
 
             print(
-                f"[{pkg._queue_idx}/{len(pkg_map)}] (thread {n}) built {pkg.name} in {perf_counter() - t0:.1f} s"
+                f"[{pkg._queue_idx}/{len(pkg_map)}] (thread {n}) "
+                f"built {pkg.name} in {perf_counter() - t0:.1f} s"
             )
             built_queue.put(pkg)
             # Release the GIL so new packages get queued

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -221,7 +221,7 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     # dependents, because the ordering ought not to change after insertion.
     build_queue: PriorityQueue = PriorityQueue()
 
-    print("Packages that would be built: " + ", ".join(sorted(pkg_map.keys())))
+    print("Building the following packages: " + ", ".join(sorted(pkg_map.keys())))
 
     for pkg in pkg_map.values():
         if len(pkg.dependencies) == 0:

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -12,7 +12,7 @@ from queue import Queue, PriorityQueue
 import shutil
 import subprocess
 import sys
-from threading import Thread
+from threading import Thread, Lock
 from time import sleep, perf_counter
 from typing import Dict, Set, Optional, List, Any
 
@@ -220,18 +220,27 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     # Insert packages into build_queue. We *must* do this after counting
     # dependents, because the ordering ought not to change after insertion.
     build_queue: PriorityQueue = PriorityQueue()
+
+    print("Packages that would be built: " + ", ".join(pkg_map))
+
     for pkg in pkg_map.values():
         if len(pkg.dependencies) == 0:
             build_queue.put(pkg)
 
     built_queue: Queue = Queue()
+    thread_lock = Lock()
+    queue_idx = 0
 
     def builder(n):
         print(f"Starting thread {n}")
+        nonlocal queue_idx
         while True:
             pkg = build_queue.get()
+            with thread_lock:
+                pkg._queue_idx = queue_idx
+                queue_idx += 1
 
-            print(f"Thread {n} building {pkg.name}")
+            print(f"[{pkg._queue_idx}/{len(pkg_map)}] (thread {n}) building {pkg.name}")
             t0 = perf_counter()
             try:
                 pkg.build(outputdir, args)
@@ -239,7 +248,9 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
                 built_queue.put(e)
                 return
 
-            print(f"Thread {n} built {pkg.name} in {perf_counter() - t0:.1f} s")
+            print(
+                f"[{pkg._queue_idx}/{len(pkg_map)}] (thread {n}) built {pkg.name} in {perf_counter() - t0:.1f} s"
+            )
             built_queue.put(pkg)
             # Release the GIL so new packages get queued
             sleep(0.01)


### PR DESCRIPTION
Small improvements to the output shown when building packages

**before**
```
Starting thread 1
Thread 1 building pyparsing
Starting thread 2
Thread 2 building distutils
Thread 2 built distutils in 0.0 s
Starting thread 3
Starting thread 4
Thread 3 building regex
Thread 1 built pyparsing in 2.2 s
Thread 4 building packaging
Thread 4 built packaging in 1.9 s
Thread 2 building micropip
Thread 3 built regex in 5.2 s
Thread 2 built micropip in 1.9 s
```

**after**
```
Packages that would be built: packaging, regex, pyparsing, micropip, distutils
[1/5] (thread 1) building pyparsing
[2/5] (thread 2) building distutils
[3/5] (thread 3) building regex
[2/5] (thread 2) built distutils in 0.0 s
[1/5] (thread 1) built pyparsing in 2.2 s
[4/5] (thread 4) building packaging
[4/5] (thread 4) built packaging in 1.9 s
[5/5] (thread 2) building micropip
[3/5] (thread 3) built regex in 5.3 s
[5/5] (thread 2) built micropip in 1.9 s
```