### PR TITLE
Update docs following #1573 [skip ci]

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -193,7 +193,7 @@ def f(*args):
 document.body.addEventListener('click', f)
 ```
 
-Now every time you click, an error will be raised (see {ref}`type-translations-proxy-arguments`).
+Now every time you click, an error will be raised (see {ref}`call-js-from-py`).
 
 To do this correctly use {func}`pyodide.create_proxy` as follows:
 

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -255,13 +255,29 @@ resp = await js.fetch('example.com/some_api', to_js({
 
 ## How can I control the behavior of stdin / stdout / stderr?
 
-This works much the same as it does in native Python: you can overwrite
-`sys.stdin`, `sys.stdout`, and `sys.stderr` respectively. If you want to do it
-temporarily, it's recommended to use
+If you wish to override `stdin`, `stdout` or `stderr` for the entire Pyodide
+runtime, you can pass options to {any}`loadPyodide <globalThis.loadPyodide>`: If
+you say
+
+```
+loadPyodide({
+  ..., stdin: stdin_func, stdout: stdout_func, stderr: stderr_func
+});
+```
+
+then every time a line is written to `stdout` (resp. `stderr`), `stdout_func`
+(resp `stderr_func`) will be called on the line. Everytime `stdin` is read,
+`stdin_func` will be called with zero arguments. It is expected to return a
+string which is interpreted as a line of text.
+
+Temporary redirection works much the same as it does in native Python: you can
+overwrite `sys.stdin`, `sys.stdout`, and `sys.stderr` respectively. If you want
+to do it temporarily, it's recommended to use
 [`contextlib.redirect_stdout`](https://docs.python.org/3/library/contextlib.html#contextlib.redirect_stdout)
 and
 [`contextlib.redirect_stderr`](https://docs.python.org/3/library/contextlib.html#contextlib.redirect_stderr).
-There is no `contextlib.redirect_stdin` but it is easy to make your own as follows:
+There is no `contextlib.redirect_stdin` but it is easy to make your own as
+follows:
 
 ```py
 from contextlib import _RedirectStream

--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -407,6 +407,34 @@ the promise is finished, the result is converted to Python and the converted
 value is used to resolve the `Future`. Then the result is destroyed if it is a
 `PyProxy`. Any PyProxies created in converting the arguments are also destroyed.
 
+As a result of this, if a `PyProxy` is persisted to be used later, then it must
+either be copied using {any}`PyProxy.copy` in Javascript or it must be created
+with {any}`pyodide.create_proxy` or `pyodide.create_once_callable`.
+If it's only going to be called once use `pyodide.create_once_callable`:
+
+```py
+from pyodide import create_once_callable
+from js import setTimeout
+def my_callback():
+    print("hi")
+setTimeout(create_once_callable(my_callback), 1000)
+```
+
+If it's going to be called many times use `create_proxy`:
+
+```py
+from pyodide import create_proxy
+from js import document
+def my_callback():
+    print("hi")
+proxy = document.create_proxy(my_callback)
+document.body.addEventListener("click", proxy)
+# ...
+# make sure to hold on to proxy
+document.body.removeEventListener("click", proxy)
+proxy.destroy()
+```
+
 ## Buffers
 
 ### Using Javascript Typed Arrays from Python

--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -378,6 +378,8 @@ let result = test.callKwargs([1,2,3,4], { offset : 7});
 // result is the array [8, 12, 16, 23]
 ```
 
+(call-js-from-py)=
+
 ### Calling Javascript functions from Python
 
 What happens when calling a Javascript function from Python is a bit more

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -31,7 +31,7 @@ try:
 
         For more information see the :ref:`type-translations` documentation. In
         particular, see
-        :ref:`the list of __dunder__ methods <type-translations_jsproxy-dunders>`
+        :ref:`the list of __dunder__ methods <type-translations-jsproxy>`
         that are (conditionally) implemented on :any:`JsProxy`.
         """
 


### PR DESCRIPTION
I added some updates to the docs following #1573. I deleted the old "avoiding memory leaks in ffi calls" section and wrote a new section describing more specifically what goes on when calling cross-language functions. New text is a bit shorter and better organized.

There are also some unrelated updates to the FAQ.