### PR TITLE
Fix `IN_NODE`: avoid error with unrelated global.

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -19,6 +19,12 @@ substitutions:
   error, it will return an empty list instead of raising a `SyntaxError`.
   {pr}`1819`
 
+### Javascript package
+
+- {{Fix}} {any}`loadPyodide <globalThis.loadPyodide>` no longer fails in the
+  presence of a user-defined global named `process`.
+  {pr}`1849`
+
 ### Python / JavaScript type conversions
 
 - {{Enhancement}} Updated the calling convention when a Javascript function is

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -1,7 +1,7 @@
 import { Module } from "./module.js";
 
 const IN_NODE =
-  typeof process !== "undefined" && process.release.name !== "undefined";
+  typeof process !== "undefined" && process.release && process.release.name === "node";
 
 /** @typedef {import('./pyproxy.js').PyProxy} PyProxy */
 /** @private */

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -1,7 +1,9 @@
 import { Module } from "./module.js";
 
 const IN_NODE =
-  typeof process !== "undefined" && process.release && process.release.name === "node";
+  typeof process !== "undefined" &&
+  process.release &&
+  process.release.name === "node";
 
 /** @typedef {import('./pyproxy.js').PyProxy} PyProxy */
 /** @private */

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -70,7 +70,7 @@ if (globalThis.document) {
     // This is async only for consistency
     globalThis.importScripts(url);
   };
-} else if (typeof process !== "undefined" && process.release.name === "node") {
+} else if (IN_NODE) {
   const pathPromise = import("path").then((M) => M.default);
   const fetchPromise = import("node-fetch").then((M) => M.default);
   const vmPromise = import("vm").then((M) => M.default);


### PR DESCRIPTION
Fixes #1846.