### PR TITLE
Allow manually destroying borrowed attribute proxies

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -32,6 +32,10 @@ substitutions:
   arguments and return values are automatically destroyed when the function is
   finished. {pr}`1573`
 
+- {{Fix}} It is now possible to destroy borrowed attribute `PyProxy` of a
+  `PyProxy` (as introduced by {pr}`1636`) before destroying the root `PyProxy`.
+  {pr}`1854`
+
 ### pyodide-build
 
 - {{API}} By default only a minimal set of packages is built. To build all

--- a/pyodide-build/pyodide_build/testing.py
+++ b/pyodide-build/pyodide_build/testing.py
@@ -80,17 +80,13 @@ def run_in_pyodide(
                     selenium.run_js(
                         f"""
                         let eval_code = pyodide.pyodide_py.eval_code;
-                        try {{
-                            eval_code.callKwargs(
-                                {{
-                                    source : atob({encoded}.join("")),
-                                    globals : pyodide._module.globals,
-                                    filename : {filename!r}
-                                }}
-                            )
-                        }} finally {{
-                            eval_code.destroy();
-                        }}
+                        eval_code.callKwargs(
+                            {{
+                                source : atob({encoded}.join("")),
+                                globals : pyodide._module.globals,
+                                filename : {filename!r}
+                            }}
+                        )
                         """
                     )
                     # When invoking the function, use the default filename <eval>

--- a/pyodide-build/pyodide_build/testing.py
+++ b/pyodide-build/pyodide_build/testing.py
@@ -86,7 +86,7 @@ def run_in_pyodide(
                                 globals : pyodide._module.globals,
                                 filename : {filename!r}
                             }}
-                        )
+                        );
                         """
                     )
                     # When invoking the function, use the default filename <eval>

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -294,8 +294,8 @@ _pyproxy_getattr(PyObject* pyobj, JsRef idkey, JsRef proxyCache)
   FAIL_IF_NULL(idresult);
   if (pyproxy_Check(idresult)) {
     // If a getter returns a different object every time, this could potentially
-    // fill up the cache with a lot of junk. However, there is no other option
-    // that makes sense from the point of the user.
+    // fill up the cache with a lot of junk. If this is a problem, the user will
+    // have to manually destroy the attributes.
     proxy_cache_set(proxyCache, pydescr, hiwire_incref(idresult));
   }
 

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -119,7 +119,7 @@ Module.pyproxy_new = function (ptrobj, cache) {
   }
   cache.refcnt++;
   Object.defineProperty(target, "$$", {
-    value: { ptr: ptrobj, type: "PyProxy", borrowed: false, cache },
+    value: { ptr: ptrobj, type: "PyProxy", cache },
   });
   Module._Py_IncRef(ptrobj);
   let proxy = new Proxy(target, PyProxyHandlers);
@@ -189,9 +189,6 @@ Module.getPyProxyClass = function (flags) {
 
 // Static methods
 Module.PyProxy_getPtr = _getPtr;
-Module.pyproxy_mark_borrowed = function (proxy) {
-  proxy.$$.borrowed = true;
-};
 
 const pyproxy_cache_destroyed_msg =
   "This borrowed attribute proxy was automatically destroyed in the " +
@@ -336,9 +333,7 @@ class PyProxyClass {
    *        destroyed".
    */
   destroy(destroyed_msg) {
-    if (!this.$$.borrowed) {
-      Module.pyproxy_destroy(this, destroyed_msg);
-    }
+    Module.pyproxy_destroy(this, destroyed_msg);
   }
   /**
    * Make a new PyProxy pointing to the same Python object.

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -522,8 +522,9 @@ def test_destroy_attribute(selenium):
     selenium.run_js(
         """
         let test = pyodide.runPython(`
-            class test:
+            class Test:
                 a = {}
+            test = Test()
             test
         `);
         pyodide.runPython(`

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -518,6 +518,42 @@ def test_nested_attribute_access():
     assert self.Float64Array.BYTES_PER_ELEMENT == 8
 
 
+def test_destroy_attribute(selenium):
+    selenium.run_js(
+        """
+        let test = pyodide.runPython(`
+            class test:
+                a = {}
+            test
+        `);
+        pyodide.runPython(`
+            assert sys.getrefcount(test) == 3
+            assert sys.getrefcount(test.a) == 2
+        `);
+        test.a;
+        pyodide.runPython(`
+            assert sys.getrefcount(test) == 3
+            assert sys.getrefcount(test.a) == 3
+        `);
+        test.a.destroy();
+        pyodide.runPython(`
+            assert sys.getrefcount(test) == 3
+            assert sys.getrefcount(test.a) == 2
+        `);
+        test.a;
+        pyodide.runPython(`
+            assert sys.getrefcount(test) == 3
+            assert sys.getrefcount(test.a) == 3
+        `);
+        test.destroy();
+        pyodide.runPython(`
+            assert sys.getrefcount(test) == 2
+            assert sys.getrefcount(test.a) == 2
+        `);
+        """
+    )
+
+
 @run_in_pyodide
 def test_window_isnt_super_weird_anymore():
     import js

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -527,6 +527,7 @@ def test_destroy_attribute(selenium):
             test
         `);
         pyodide.runPython(`
+            import sys
             assert sys.getrefcount(test) == 3
             assert sys.getrefcount(test.a) == 2
         `);


### PR DESCRIPTION
This should fix #1853. A JsProxy created by an attribute lookup `let p_attr = p.attr` should be destroyed when either:
1. `p.destroy()` is called, or
2. `p_attr.destroy()` is called.

This way manual cleanup of attributes is not needed as long as the root object is destroyed. This gives a way to  deal with cases like #1853 where the root object should stick around but its attributes need to be destroyed.