### PR TITLE
Added TypedArray methods tostring, tobytes, and tobytearray to help minimize copies

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -773,7 +773,7 @@ EM_JS_NUM(errcode, hiwire_assign_from_ptr, (JsRef idobj, void* ptr), {
 EM_JS_NUM(
 errcode,
 hiwire_get_buffer_info,
-(JsRef idobj, Py_ssize_t* byteLength, char** format_ptr, Py_ssize_t* size_ptr, bool* checked_ptr),
+(JsRef idobj, Py_ssize_t* byteLength_ptr, char** format_ptr, Py_ssize_t* size_ptr, bool* checked_ptr),
 {
   let jsobj = Module.hiwire.get_value(idobj);
   let byteLength = jsobj.byteLength;

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -772,12 +772,14 @@ EM_JS_NUM(errcode, hiwire_assign_from_ptr, (JsRef idobj, void* ptr), {
 // clang-format off
 EM_JS_NUM(
 errcode,
-hiwire_get_buffer_datatype,
-(JsRef idobj, char** format_ptr, Py_ssize_t* size_ptr, bool* checked_ptr),
+hiwire_get_buffer_info,
+(JsRef idobj, Py_ssize_t* byteLength, char** format_ptr, Py_ssize_t* size_ptr, bool* checked_ptr),
 {
   let jsobj = Module.hiwire.get_value(idobj);
+  let byteLength = jsobj.byteLength;
   let [format_utf8, size, checked] = Module.get_buffer_datatype(jsobj);
   // Store results into arguments
+  DEREF_U32(byteLength_ptr, 0) = byteLength;
   DEREF_U32(format_ptr, 0) = format_utf8;
   DEREF_U32(size_ptr, 0) = size;
   DEREF_U8(checked_ptr, 0) = checked;

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -563,6 +563,7 @@ hiwire_assign_from_ptr(JsRef idobj, void* ptr);
  */
 errcode
 hiwire_get_buffer_info(JsRef idobj,
+                       Py_ssize_t* byteLength_ptr,
                        char** format_ptr,
                        Py_ssize_t* size_ptr,
                        bool* check_assignments);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -562,10 +562,10 @@ hiwire_assign_from_ptr(JsRef idobj, void* ptr);
  * Get a data type identifier for a given typedarray.
  */
 errcode
-hiwire_get_buffer_datatype(JsRef idobj,
-                           char** format_ptr,
-                           Py_ssize_t* size_ptr,
-                           bool* check_assignments);
+hiwire_get_buffer_info(JsRef idobj,
+                       char** format_ptr,
+                       Py_ssize_t* size_ptr,
+                       bool* check_assignments);
 
 /**
  * Get a subarray from a TypedArray

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -346,7 +346,7 @@ EM_JS_NUM(errcode, js2python_init, (), {
     }
     if (toStringTag === "[object ArrayBuffer]" || ArrayBuffer.isView(value)){
       let [format_utf8, itemsize] = Module.get_buffer_datatype(value);
-      return _JsBuffer_CloneIntoPython(id, value.byteLength, format_utf8, itemsize);
+      return _JsBuffer_CopyIntoMemoryView(id, value.byteLength, format_utf8, itemsize);
     }
     // clang-format on
     return _JsProxy_create(id);

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -108,25 +108,25 @@ class JsProxy:
         an ArrayBuffer view.
         """
 
-    def tomemoryview(self):
+    def tomemoryview(self) -> memoryview:
         """Convert the buffer to a memoryview.
 
         Copies the data once. This currently has the same effect as :any:`to_py`.
         """
 
-    def tobytes(self):
+    def tobytes(self) -> bytes:
         """Convert the buffer to a bytes object.
 
         Copies the data once.
         """
 
-    def tobytearray(self):
+    def tobytearray(self) -> bytearray:
         """Convert the buffer to a bytearray object.
 
         Copies the data once.
         """
 
-    def tostring(self, encoding=None):
+    def tostring(self, encoding=None) -> str:
         """Convert the buffer to a string object.
 
         Copies the data twice.

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -108,6 +108,29 @@ class JsProxy:
         an ArrayBuffer view.
         """
 
+    def tobytes(self):
+        """Convert the buffer to a bytes object.
+
+        Copies the data once.
+        """
+
+    def tobytearray(self):
+        """Convert the buffer to a bytearray object.
+
+        Copies the data once.
+        """
+
+    def tostring(self, encoding=None):
+        """Convert the buffer to a string object.
+
+        Copies the data twice.
+
+        The encoding argument will be passed to the Javascript ``TextDecoder``
+        constructor. It should be one of the encodings listed in the table here:
+        `https://encoding.spec.whatwg.org/#names-and-labels`. The default
+        encoding is utf8.
+        """
+
 
 # from pyproxy.c
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -108,6 +108,12 @@ class JsProxy:
         an ArrayBuffer view.
         """
 
+    def tomemoryview(self):
+        """Convert the buffer to a memoryview.
+
+        Copies the data once. This currently has the same effect as :any:`to_py`.
+        """
+
     def tobytes(self):
         """Convert the buffer to a bytes object.
 
@@ -125,7 +131,8 @@ class JsProxy:
 
         Copies the data twice.
 
-        The encoding argument will be passed to the Javascript ``TextDecoder``
+        The encoding argument will be passed to the Javascript
+        [``TextDecoder``](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder)
         constructor. It should be one of the encodings listed in the table here:
         `https://encoding.spec.whatwg.org/#names-and-labels`. The default
         encoding is utf8.


### PR DESCRIPTION
Currently we convert Javascript TypedArrays to memoryviews. This works well if we are planning to use them with numpy or similar. However, if we are planning to convert to a type like `string`, `bytes`, or `bytearray` it forces us to make an extra copy of the data. This adds direct conversions so that we can convert to `bytes` and `bytesarray` with one copy instead of two and to string with two copies instead of three.