### PR TITLE
Don't destroy attribute proxies if root proxy is leaked and GC'd

### DIFF
--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -31,7 +31,6 @@ Module.isPyProxy = isPyProxy;
 
 if (globalThis.FinalizationRegistry) {
   Module.finalizationRegistry = new FinalizationRegistry(([ptr, cache]) => {
-    pyproxy_decref_cache(cache);
     try {
       Module._Py_DecRef(ptr);
     } catch (e) {


### PR DESCRIPTION
This resolves #1855. I think it's an improvement?