### PR TITLE
Fix pyproxy iteration error handling

### DIFF
--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -211,6 +211,38 @@ def test_pyproxy_iter(selenium):
     assert result == result2
 
 
+def test_pyproxy_iter_error(selenium):
+    selenium.run_js(
+        """
+        let t = pyodide.runPython(`
+            class T:
+                def __iter__(self):
+                    raise Exception('hi')
+            T()
+        `);
+        assertThrows(() => t[Symbol.iterator](), "PythonError", "hi");
+        """
+    )
+
+
+def test_pyproxy_iter_error2(selenium):
+    selenium.run_js(
+        """
+        let gen = pyodide.runPython(`
+            def g():
+                yield 1
+                yield 2
+                raise Exception('hi')
+                yield 3
+            g()
+        `);
+        assert(() => gen.next().value === 1);
+        assert(() => gen.next().value === 2);
+        assertThrows(() => gen.next(), "PythonError", "hi");
+        """
+    )
+
+
 def test_pyproxy_get_buffer(selenium):
     selenium.run_js(
         """


### PR DESCRIPTION
There is a bug in the `Symbol.iterator` method: if `__iter__` raises an error, then `PyProxy[Symbol.iterator]()` should also raise an error. Instead, the error is delayed into the iterator. If the error flag is cleared for unrelated reasons, this leads to an internal error:
```js
let t = pyodide.runPython(`
    class T:
        def __iter__(self):
            raise Exception('hi')
    T()
`);
let it = t[Symbol.iterator]();
pyodide.runPython(""); // Clears error flag
it.next();
```
Yields:
```
Python exception:
TypeError: Pyodide internal error: no exception type or valu
```

Anyways I fixed this bug and cleaned up the code a bit.