### PR TITLE
Fix Sphinx latex build error

### DIFF
--- a/docs/sphinx_pyodide/sphinx_pyodide/packages.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/packages.py
@@ -65,6 +65,7 @@ def get_packages_summary_directive(app):
             self, packages: Dict[str, Any], columns: Tuple[str]
         ) -> List[Any]:
             table_spec = addnodes.tabular_col_spec()
+            table_spec["spec"] = r"\X{1}{2}\X{1}{2}"
 
             table = nodes.table("", classes=["longtable"])
 


### PR DESCRIPTION
After #1874, building latex document in [readthedocs fails](https://readthedocs.org/projects/pyodide/builds/14917077/).
(It can be reproduced with `make latex` in local environments)

This behavior was not checked by CI,
since the readthedocs CI checks only whether html document correctly builds.