### PR TITLE
Fix issue with javascript attribute garbage collection introduced in gcd-attributes.

### DIFF
--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -657,6 +657,7 @@ def test_pyproxy_gc_destroy(selenium):
         """
     )
     selenium.collect_garbage()
+    selenium.collect_garbage()
     selenium.run(
         """
         get_ref_count(4)


### PR DESCRIPTION
This resolves #1884. Fixes a leak when a `PyProxy` is cleaned up by `FinalizationRegistry` that was introduced in #1870. No changelog entry needed b/c it's covered by #1870.