### PR TITLE
Fix webpack compatibility issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,10 @@ jobs:
             npx tsd
             npm install
             npm test
+            git clone -b test_circle_meant_error --single-branch https://github.com/grimmer0125/webpack-pyodide-demo.git
+            cd webpack-pyodide-demo
+            npm install 
+            npx webpack
 
   benchmark:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,9 @@ jobs:
             npx tsd
             npm install
             npm test
+      - run:
+          name: check if webpack cli works well with load-pyodide.js
+          command: | 
             git clone https://github.com/grimmer0125/webpack-pyodide-demo.git
             cd webpack-pyodide-demo
             git checkout test_circle_meant_error
@@ -231,6 +234,8 @@ jobs:
             cp ../load-pyodide.js node_modules/pyodide/load-pyodide.js                  
             head -20 node_modules/pyodide/load-pyodide.js
             npx webpack
+            cd ..
+            rm -rf webpack-pyodide-demo          
 
   benchmark:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,9 +224,12 @@ jobs:
             npx tsd
             npm install
             npm test
-            git clone -b test_circle_meant_error --single-branch https://github.com/grimmer0125/webpack-pyodide-demo.git
+            git clone https://github.com/grimmer0125/webpack-pyodide-demo.git
             cd webpack-pyodide-demo
-            npm install 
+            git checkout test_circle_meant_error
+            npm install     
+            cp ../load-pyodide.js node_modules/pyodide/load-pyodide.js                  
+            head -20 node_modules/pyodide/load-pyodide.js
             npx webpack
 
   benchmark:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,15 +227,14 @@ jobs:
       - run:     
           name: check if webpack cli works well with load-pyodide.js
           command: | 
-            git clone https://github.com/grimmer0125/webpack-pyodide-demo.git
-            cd webpack-pyodide-demo
-            git checkout test_circle_meant_error
+            git clone https://github.com/pyodide/pyodide-webpack-example.git
+            cd pyodide-webpack-example
             npm install     
             cp ../src/js/load-pyodide.js node_modules/pyodide/load-pyodide.js                  
             head -20 node_modules/pyodide/load-pyodide.js
             npx webpack
             cd ..
-            rm -rf webpack-pyodide-demo          
+            rm -rf pyodide-webpack-example          
 
   benchmark:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,14 +224,14 @@ jobs:
             npx tsd
             npm install
             npm test
-      - run:
+      - run:     
           name: check if webpack cli works well with load-pyodide.js
           command: | 
             git clone https://github.com/grimmer0125/webpack-pyodide-demo.git
             cd webpack-pyodide-demo
             git checkout test_circle_meant_error
             npm install     
-            cp ../load-pyodide.js node_modules/pyodide/load-pyodide.js                  
+            cp ../src/js/load-pyodide.js node_modules/pyodide/load-pyodide.js                  
             head -20 node_modules/pyodide/load-pyodide.js
             npx webpack
             cd ..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,8 +233,7 @@ jobs:
             cp ../src/js/load-pyodide.js node_modules/pyodide/load-pyodide.js                  
             head -20 node_modules/pyodide/load-pyodide.js
             npx webpack
-            cd ..
-            rm -rf pyodide-webpack-example          
+   
 
   benchmark:
     <<: *defaults

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -31,6 +31,10 @@ substitutions:
   presence of a user-defined global named `process`.
   {pr}`1849`
 
+- {{Fix}} Webpack building compatibility issues and a {any}`loadPyodide <globalThis.loadPyodide>`
+  runtime issue due to webpack are solved. 
+  {pr}`1900`  
+
 ### Python / JavaScript type conversions
 
 - {{Enhancement}} Updated the calling convention when a JavaScript function is

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -71,9 +71,9 @@ if (globalThis.document) {
     globalThis.importScripts(url);
   };
 } else if (IN_NODE) {
-  const pathPromise = import("path").then((M) => M.default);
+  const pathPromise = import(/* webpackIgnore: true */ "path").then((M) => M.default);
   const fetchPromise = import("node-fetch").then((M) => M.default);
-  const vmPromise = import("vm").then((M) => M.default);
+  const vmPromise = import(/* webpackIgnore: true */ "vm").then((M) => M.default);
   loadScript = async (url) => {
     if (url.includes("://")) {
       // If it's a url, have to load it with fetch and then eval it.

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -16,8 +16,7 @@ export async function initializePackageIndex(indexURL) {
   baseURL = indexURL;
   let package_json;
   if (IN_NODE) {
-    const fs = await import("fs");
-    const fsPromises = fs.promises;
+    const fsPromises = await import(/* webpackIgnore: true */ "fs/promises");
     const package_string = await fsPromises.readFile(
       `${indexURL}packages.json`
     );

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -64,7 +64,7 @@ function _uri_to_package_name(package_uri) {
 export let loadScript;
 if (globalThis.document) {
   // browser
-  loadScript = (url) => import(url);
+  loadScript = (url) => import(/* webpackIgnore: true */ url);
 } else if (globalThis.importScripts) {
   // webworker
   loadScript = async (url) => {

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -16,7 +16,8 @@ export async function initializePackageIndex(indexURL) {
   baseURL = indexURL;
   let package_json;
   if (IN_NODE) {
-    const fsPromises = await import("fs/promises");
+    const fs = await import("fs");
+    const fsPromises = fs.promises;
     const package_string = await fsPromises.readFile(
       `${indexURL}packages.json`
     );

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -71,9 +71,13 @@ if (globalThis.document) {
     globalThis.importScripts(url);
   };
 } else if (IN_NODE) {
-  const pathPromise = import(/* webpackIgnore: true */ "path").then((M) => M.default);
+  const pathPromise = import(/* webpackIgnore: true */ "path").then(
+    (M) => M.default
+  );
   const fetchPromise = import("node-fetch").then((M) => M.default);
-  const vmPromise = import(/* webpackIgnore: true */ "vm").then((M) => M.default);
+  const vmPromise = import(/* webpackIgnore: true */ "vm").then(
+    (M) => M.default
+  );
   loadScript = async (url) => {
     if (url.includes("://")) {
       // If it's a url, have to load it with fetch and then eval it.

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -63,7 +63,7 @@ function _uri_to_package_name(package_uri) {
 export let loadScript;
 if (globalThis.document) {
   // browser
-  loadScript = (url) => import(/* webpackIgnore: true */ url);
+  loadScript = async (url) => await import(/* webpackIgnore: true */ url);
 } else if (globalThis.importScripts) {
   // webworker
   loadScript = async (url) => {


### PR DESCRIPTION
This is to solve 
1) #1875 for Creat React App environment and **2.** environment
2) Fix webpack building error when using `npx webpack` with its default and minimal setting for your front-end code. Error: import("path") and import("vm") & **1.**
3) after fixing **1 & 2**, `import` of loadScript` in the browser will throw `module not found` error since the `import` function is already polluted by `webpack`. It is a runtime issue. 

Besides this PR, `Pydodie npm` also needs #1849 to make it work.
