### PR TITLE
Patch statsmodels to enforce compatibility mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ packages/.artifacts
 packages/*/build.log*
 packages/build-logs
 dist/
+.DS_Store

--- a/packages/statsmodels/meta.yaml
+++ b/packages/statsmodels/meta.yaml
@@ -5,6 +5,9 @@ package:
 source:
   url: https://github.com/statsmodels/statsmodels/archive/refs/tags/v0.9.0.tar.gz
   sha256: 4ab219c776bf5b2187645c0ccb00cf8564c6c17541ae66ab96503f07368197d3
+  
+  patches:
+    - patches/enforce-compatiblity-mode.patch
 
 build:
   ldflags: -L$(NUMPY_LIB)

--- a/packages/statsmodels/patches/enforce-compatiblity-mode.patch
+++ b/packages/statsmodels/patches/enforce-compatiblity-mode.patch
@@ -1,0 +1,50 @@
+commit 945a1458fd8c6ca9acf07da703fc3cddfbb1ff48
+Author: Marc Pabst <github@marcpabst.com>
+Date:   Mon Oct 25 12:28:34 2021 +0200
+
+    Enforce compatibility mode.
+
+diff --git a/statsmodels/tsa/statespace/tools.py b/statsmodels/tsa/statespace/tools.py
+index 7ddab4e8c..5e9a37bff 100644
+--- a/statsmodels/tsa/statespace/tools.py
++++ b/statsmodels/tsa/statespace/tools.py
+@@ -37,21 +37,24 @@ def set_mode(compatibility=None):
+     global compatibility_mode, has_trmm
+ 
+     # Determine mode automatically if none given
+-    if compatibility is None:
+-        try:
+-            from scipy.linalg import cython_blas
+-            compatibility = False
+-        except ImportError:
+-            compatibility = True
+-
+-    # If compatibility was False, make sure that is possible
+-    if not compatibility:
+-        try:
+-            from scipy.linalg import cython_blas
+-        except ImportError:
+-            warnings.warn('Minimum dependencies not met. Compatibility mode'
+-                          ' enabled.')
+-            compatibility = True
++    # if compatibility is None:
++    #     try:
++    #         from scipy.linalg import cython_blas
++    #         compatibility = False
++    #     except ImportError:
++    #         compatibility = True
++
++    # # If compatibility was False, make sure that is possible
++    # if not compatibility:
++    #     try:
++    #         from scipy.linalg import cython_blas
++    #     except ImportError:
++    #         warnings.warn('Minimum dependencies not met. Compatibility mode'
++    #                       ' enabled.')
++    #         compatibility = True
++
++    # set compatibility mode
++    compatibility = True
+ 
+     # Initialize the appropriate mode
+     if not compatibility:

--- a/packages/statsmodels/patches/enforce-compatiblity-mode.patch
+++ b/packages/statsmodels/patches/enforce-compatiblity-mode.patch
@@ -27,21 +27,6 @@ index 7ddab4e8c..5e9a37bff 100644
 -            warnings.warn('Minimum dependencies not met. Compatibility mode'
 -                          ' enabled.')
 -            compatibility = True
-+    # if compatibility is None:
-+    #     try:
-+    #         from scipy.linalg import cython_blas
-+    #         compatibility = False
-+    #     except ImportError:
-+    #         compatibility = True
-+
-+    # # If compatibility was False, make sure that is possible
-+    # if not compatibility:
-+    #     try:
-+    #         from scipy.linalg import cython_blas
-+    #     except ImportError:
-+    #         warnings.warn('Minimum dependencies not met. Compatibility mode'
-+    #                       ' enabled.')
-+    #         compatibility = True
 +
 +    # set compatibility mode
 +    compatibility = True


### PR DESCRIPTION
As discussed in #537, I added a small patch that forces `statsmodels` into compatibility mode to avoid it crashing upon import. 

However, I'm experiencing some problems building pyodide at the moment (even with the docker image) so I'd appreciate if anyone other than me could give it a try.