### PR TITLE
Add specification for compiling logbook

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -94,6 +94,8 @@ substitutions:
 - {{ Fix }} The built-in pwd module of Python, which provides Unix specific
   feature, is now unvendored.
   {pr}`1883`
+  
+- New packages: `logbook`
 
 ### Uncategorized
 

--- a/packages/logbook/meta.yaml
+++ b/packages/logbook/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: logbook
+  version: 1.5.2
+
+source:
+  url: https://github.com/getlogbook/logbook/archive/refs/tags/1.5.2.tar.gz
+  sha256: 3eebcb13a41636004a2d03d875bc1c2ccc4afb02dc13f45320b147fee79c9739
+
+build:
+  library: true
+  script: |
+    python -c 'from Cython.Build.Cythonize import main; main(["./logbook/_speedups.pyx"])'
+
+test:
+  imports:
+  - logbook

--- a/packages/logbook/meta.yaml
+++ b/packages/logbook/meta.yaml
@@ -6,8 +6,12 @@ source:
   url: https://github.com/getlogbook/logbook/archive/refs/tags/1.5.2.tar.gz
   sha256: 3eebcb13a41636004a2d03d875bc1c2ccc4afb02dc13f45320b147fee79c9739
 
+requirements:
+  run:
+    - distutils
+    - setuptools
+
 build:
-  library: true
   script: |
     python -c 'from Cython.Build.Cythonize import main; main(["./logbook/_speedups.pyx"])'
 

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -24,7 +24,7 @@ source:
 build:
   skip_host: False
   # set linker and C flags to error on anything to do with function declarations being wrong.
-  # In webassembbly, any conflicts mean that a randomly selected 50% of calls to the function
+  # In webassembly, any conflicts mean that a randomly selected 50% of calls to the function
   # will fail. Better to fail at compile or link time.
   cflags: |
     -include math.h

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -27,7 +27,7 @@ source:
 
 build:
   # set linker and C flags to error on anything to do with function declarations being wrong.
-  # In webassembbly, any conflicts mean that a randomly selected 50% of calls to the function
+  # In webassembly, any conflicts mean that a randomly selected 50% of calls to the function
   # will fail. Better to fail at compile or link time.
   cflags: |
     -I $(PYODIDE_ROOT)/packages/numpy/config


### PR DESCRIPTION
For a project I'm attempting with pyodide I need a pure Python package that has `logbook` as a dependency, hence this compilation specification.