### PR TITLE
DOC Add information about Open Source Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: # TODO Replace with up to 4 GitHub Sponsors-enabled username: pyodide
+open_collective: pyodide

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -57,6 +57,16 @@ list from there with "The Pyodide development team" like in the example below:
 - Twitter: [twitter.com/pyodide](https://twitter.com/pyodide)
 - Stack Overflow: [stackoverflow.com/questions/tagged/pyodide](https://stackoverflow.com/questions/tagged/pyodide)
 
+## Donations
+
+We accept donnations to the Pyodide project at
+[opencollective.com/pyodide](https://opencollective.com/pyodide). All donations
+are processed by the [Open Source Collective](https://www.oscollective.org/) -- a non
+profit organization that acts as our fiscal host.
+
+Funds will be mostly spent to organize in-person code sprints and to cover
+infrastructure costs for distributing packages built with Pyodide.
+
 ## License
 
 Pyodide uses the [Mozilla Public License Version

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -59,10 +59,10 @@ list from there with "The Pyodide development team" like in the example below:
 
 ## Donations
 
-We accept donnations to the Pyodide project at
+We accept donations to the Pyodide project at
 [opencollective.com/pyodide](https://opencollective.com/pyodide). All donations
-are processed by the [Open Source Collective](https://www.oscollective.org/) -- a non
-profit organization that acts as our fiscal host.
+are processed by the [Open Source Collective](https://www.oscollective.org/) -- a 
+nonprofit organization that acts as our fiscal host.
 
 Funds will be mostly spent to organize in-person code sprints and to cover
 infrastructure costs for distributing packages built with Pyodide.


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide/issues/1916

Adds,
 - a short paragraph about donations to the "about" page
 - [`.github/FUNDING.yml` file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository) which would add a "Sponsor this project" subsection to the right toolbar on Github (example [here](https://github.com/NixOS/nixpkgs)) 