### PR TITLE
FIX Explicitly use host Python version when building packages

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,6 +1,7 @@
 export PYODIDE_ROOT=$(abspath ..)
 PYODIDE_LIBRARIES=$(abspath ./.artifacts)
 CPYTHONROOT=$(PYODIDE_ROOT)/cpython
+HOSTPYTHON=$${HOSTPYTHON:-python3.9}
 include ../Makefile.envs
 
 export NUMPY_LIB=$(PYODIDE_ROOT)/packages/numpy/build/numpy-1.17.5/install/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/core/lib/
@@ -19,7 +20,7 @@ all: .artifacts/bin/pyodide-build
 
 .artifacts/bin/pyodide-build: ../pyodide-build/pyodide_build/**
 	mkdir -p $(PYODIDE_LIBRARIES)
-	python3 -m pip install -e ../pyodide-build --no-deps --prefix $(PYODIDE_LIBRARIES)
+	$(HOSTPYTHON) -m pip install -e ../pyodide-build --no-deps --prefix $(PYODIDE_LIBRARIES)
 
 update-all:
 	for pkg in $$(find . -maxdepth 1 ! -name ".*" -type d -exec basename {} \; | tail -n +2); do \

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,7 +1,6 @@
 export PYODIDE_ROOT=$(abspath ..)
 PYODIDE_LIBRARIES=$(abspath ./.artifacts)
 CPYTHONROOT=$(PYODIDE_ROOT)/cpython
-HOSTPYTHON=$${HOSTPYTHON:-python3.9}
 include ../Makefile.envs
 
 export NUMPY_LIB=$(PYODIDE_ROOT)/packages/numpy/build/numpy-1.17.5/install/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/core/lib/


### PR DESCRIPTION
This change prevents the use of unintended Python versions when building packages.

Related: #1899