### PR TITLE
Add pull request template for Pyodide Github repository [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
-<!-- Thanks for contributing to Pyodide! Any improvements are welcome,
-     so don't be afraid of making a PR. To help make things go a bit more
-     smoothly we would appreciate that you go through this template. -->
+<!-- Thank you for contributing to Pyodide! All improvements are welcome,
+     so don't be afraid to make a PR. -->
 
 ### Description
 
@@ -8,15 +7,16 @@
      - reasoning for the change
      - some details of updated code
      - any noteworthy choices to be aware of
-     If there is a relavant issues, please refer those by #<issue_id> -->
+	Please refer to any related issues by #<issue_id> -->
 
 ### Checklists
 
-- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry if necessary?
-- [ ] Add / update tests if necessary?
-- [ ] Add new / update outdated documentation?
+Not all of these steps are necessary for every PR.
 
-<!-- [IMPORTANT] Notes on CI failure: 
-     Currently, we are having some issues with selenium based tests.
-     Don't panic if your PR fails on CI because of timeouts.
-     It's mostly not your fault. We will investigate :) -->
+- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry or explain why an entry is not needed
+- [ ] Add / update tests
+- [ ] Add new / update outdated documentation
+<!-- [IMPORTANT] Note on CI failures: 
+     Currently, we are having issues with selenium-based tests.
+     Don't panic if the CI fails on your PR because of timeouts.
+     It's probably not your fault. We will investigate :) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!-- Thanks for contributing to Pyodide! Any improvements are welcome,
+     so don't be afraid of making a PR. To help make things go a bit more
+     smoothly we would appreciate that you go through this template. -->
+
+### Description
+
+<!-- Please explain what your PR is about:
+     - reasoning for the change
+     - some details of updated code
+     - any noteworthy choices to be aware of
+     If there is a relavant issues, please refer those by #<issue_id> -->
+
+### Checklists
+
+- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/docs/project/changelog.md) entry if necessary?
+- [ ] Add / update tests if necessary?
+- [ ] Add new / update outdated documentation?
+
+<!-- [IMPORTANT] Notes on CI failure: 
+     Currently, we are having some issues with selenium based tests.
+     Don't panic if your PR fails on CI because of timeouts.
+     It's mostly not your fault. We will investigate :) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ### Checklists
 
-- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/docs/project/changelog.md) entry if necessary?
+- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry if necessary?
 - [ ] Add / update tests if necessary?
 - [ ] Add new / update outdated documentation?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,11 @@
 <!-- Thank you for contributing to Pyodide! All improvements are welcome,
      so don't be afraid to make a PR. -->
 
+<!-- [IMPORTANT] Note on CI failures: 
+     Currently, we are having issues with selenium-based tests.
+     Don't panic if the CI fails on your PR because of timeouts.
+     It's probably not your fault. We will investigate :) -->
+
 ### Description
 
 <!-- Please explain what your PR is about:
@@ -16,7 +21,3 @@ Not all of these steps are necessary for every PR.
 - [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry or explain why an entry is not needed
 - [ ] Add / update tests
 - [ ] Add new / update outdated documentation
-<!-- [IMPORTANT] Note on CI failures: 
-     Currently, we are having issues with selenium-based tests.
-     Don't panic if the CI fails on your PR because of timeouts.
-     It's probably not your fault. We will investigate :) -->


### PR DESCRIPTION
This PR adds a pull request template.
(Some words are borrowed from [psf/black](https://github.com/psf/black/blob/main/.github/PULL_REQUEST_TEMPLATE.md))

The template contains:

- Description
- Checklists
  - adding changelog
  - adding tests
  - adding documentation
- **Notes about CI failure** (https://github.com/pyodide/pyodide/pull/1920#issuecomment-957870962)