### PR TITLE
MAINT Rearrange emsdk Makefile to do less stuff before applying patches

### DIFF
--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -6,10 +6,10 @@ all: emsdk/.complete
 emsdk/.complete: ../Makefile.envs $(wildcard patches/*.patch)
 	if [ -d emsdk ]; then rm -rf emsdk; fi
 	git clone --depth 1 https://github.com/emscripten-core/emsdk.git
-	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION) ccache-git-emscripten-64bit
-	git clone https://github.com/WebAssembly/binaryen.git emsdk/binaryen
-	cd emsdk/binaryen && git checkout $(PYODIDE_BINARYEN_VERSION)
+	git clone -b $(PYODIDE_BINARYEN_VERSION) --depth 1 https://github.com/WebAssembly/binaryen.git emsdk/binaryen
+	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	cat patches/*.patch | patch -p1
+	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION) ccache-git-emscripten-64bit
 	cd emsdk && ./emsdk activate --embedded --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	cd emsdk/binaryen && cmake -DBUILD_STATIC_LIB=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 	make -C emsdk/binaryen -j5 wasm-opt


### PR DESCRIPTION
It takes a while to build `ccache`. Avoid doing this before applying patches so that it takes less time to get to patch fail. I also changed it so that we clone only the branch we need of binaryen with depth 1.