### PR TITLE
MAINT simpler bootstrap

### DIFF
--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -3,9 +3,6 @@
  * the callPyObject method, but of course one can also execute arbitrary code
  * via the various __dundermethods__ associated to classes.
  *
- * The only entrypoint into Python that avoids this file is our bootstrap method
- * runPythonSimple which is defined in main.c
- *
  * Any time we call into wasm, the call should be wrapped in a try catch block.
  * This way if a JavaScript error emerges from the wasm, we can escalate it to a
  * fatal error.

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -19,7 +19,7 @@ export { loadPackage, loadedPackages, isPyProxy };
  *
  * @type {PyProxy}
  */
-let pyodide_py = {}; // actually defined in runPythonSimple in loadPyodide (see pyodide.js)
+let pyodide_py = {}; // actually defined in loadPyodide (see pyodide.js)
 
 /**
  *
@@ -30,7 +30,7 @@ let pyodide_py = {}; // actually defined in runPythonSimple in loadPyodide (see 
  *
  * @type {PyProxy}
  */
-let globals = {}; // actually defined in runPythonSimple in loadPyodide (see pyodide.js)
+let globals = {}; // actually defined in loadPyodide (see pyodide.js)
 
 /**
  * A JavaScript error caused by a Python exception.
@@ -75,7 +75,7 @@ export class PythonError {
  *
  * @type {string}
  */
-export let version = ""; // actually defined in runPythonSimple in loadPyodide (see pyodide.js)
+export let version = ""; // actually defined in loadPyodide (see pyodide.js)
 
 /**
  * Runs a string of Python code from JavaScript.

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -259,9 +259,10 @@ async function _loadPackage(names, messageCallback, errorCallback) {
 
   // We have to invalidate Python's import caches, or it won't
   // see the new files.
-  Module.runPythonSimple(
-    "import importlib\n" + "importlib.invalidate_caches()\n"
-  );
+  Module.runPythonInternal(`
+    import importlib
+    importlib.invalidate_caches();
+  `);
 }
 
 // This is a promise that is resolved iff there are no pending package loads.

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -162,7 +162,7 @@ function wrapPythonGlobals(globals_dict, builtins_dict) {
  * It finishes the bootstrap so that once it is complete, it is possible to use
  * the core `pyodide` apis. (But package loading is not ready quite yet.)
  */
-function finalizeBootstrap() {
+function finalizeBootstrap(jsglobals) {
   // First make internal dict so that we can use runPythonInternal.
   // runPythonInternal uses a separate namespace so we don't pollute the main
   // environment with variables from our setup.
@@ -179,7 +179,7 @@ function finalizeBootstrap() {
   // Set up key Javascript modules.
   let importhook = Module._pyodide._importhook;
   importhook.register_js_finder();
-  importhook.register_js_module("js", config.jsglobals);
+  importhook.register_js_module("js", jsglobals);
 
   let pyodide = makePublicAPI();
   importhook.register_js_module("pyodide_js", pyodide);
@@ -268,7 +268,7 @@ export async function loadPyodide(config) {
   // being called.
   await moduleLoaded;
 
-  let pyodide = finalizeBootstrap();
+  let pyodide = finalizeBootstrap(config.jsglobals);
   // Module.runPython works starting here.
 
   await packageIndexReady;

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -275,7 +275,7 @@ export async function loadPyodide(config) {
   if (config.fullStdLib) {
     await loadPackage(["distutils"]);
   }
-
+  pyodide.runPython("print('Python initialization complete')");
   return pyodide;
 }
 globalThis.loadPyodide = loadPyodide;

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -124,7 +124,7 @@ function calculateRecursionLimit() {
     recurse();
   } catch (err) {}
 
-  const recursionLimit = Math.min(depth / 25, 500);
+  const recursionLimit = Math.floor(Math.min(depth / 25, 500));
   return recursionLimit;
 }
 

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -162,7 +162,7 @@ function wrapPythonGlobals(globals_dict, builtins_dict) {
  * It finishes the bootstrap so that once it is complete, it is possible to use
  * the core `pyodide` apis. (But package loading is not ready quite yet.)
  */
-function finalizeBootstrap(jsglobals) {
+function finalizeBootstrap(config) {
   // First make internal dict so that we can use runPythonInternal.
   // runPythonInternal uses a separate namespace so we don't pollute the main
   // environment with variables from our setup.
@@ -179,7 +179,7 @@ function finalizeBootstrap(jsglobals) {
   // Set up key Javascript modules.
   let importhook = Module._pyodide._importhook;
   importhook.register_js_finder();
-  importhook.register_js_module("js", jsglobals);
+  importhook.register_js_module("js", config.jsglobals);
 
   let pyodide = makePublicAPI();
   importhook.register_js_module("pyodide_js", pyodide);
@@ -268,7 +268,7 @@ export async function loadPyodide(config) {
   // being called.
   await moduleLoaded;
 
-  let pyodide = finalizeBootstrap(config.jsglobals);
+  let pyodide = finalizeBootstrap(config);
   // Module.runPython works starting here.
 
   await packageIndexReady;

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -97,6 +97,11 @@ Module.fatal_error = function (e) {
 };
 
 let runPythonInternal_dict; // Initialized in finalizeBootstrap
+/**
+ * @private
+ * Just like `runPython` except uses a different globals dict and gets
+ * `eval_code` from `_pyodide` so that it can work before `pyodide` is imported.
+ */
 Module.runPythonInternal = function (code) {
   return Module._pyodide._base.eval_code(code, runPythonInternal_dict);
 };
@@ -125,6 +130,13 @@ function fixRecursionLimit() {
   );
 }
 
+/**
+ * @private
+ * A proxy around globals that falls back to checking for a builtin if has or
+ * get fails to find a global with the given key. Note that this proxy is
+ * transparent to js2python: it won't notice that this wrapper exists at all and
+ * will translate this proxy to the globals dictionary.
+ */
 function wrapPythonGlobals(globals_dict, builtins_dict) {
   return new Proxy(globals_dict, {
     get(target, symbol) {
@@ -132,13 +144,13 @@ function wrapPythonGlobals(globals_dict, builtins_dict) {
         return (key) => {
           let result = target.get(key);
           if (result === undefined) {
-            result = Module.builtins.get(key);
+            result = builtins_dict.get(key);
           }
           return result;
         };
       }
       if (symbol === "has") {
-        return (key) => target.has(key) || Module.builtins.has(key);
+        return (key) => target.has(key) || builtins_dict.has(key);
       }
       return Reflect.get(target, symbol);
     },

--- a/src/py/_pyodide/__init__.py
+++ b/src/py/_pyodide/__init__.py
@@ -9,3 +9,7 @@
 # All pure Python code that doesn't require imports from js, pyodide_js, or
 # _pyodide_core belongs in _pyodide. Code that requires such imports belongs in
 # pyodide.
+from . import _base
+from . import _importhook
+
+__all__ = ["_base", "_importhook"]

--- a/src/py/_pyodide/_importhook.py
+++ b/src/py/_pyodide/_importhook.py
@@ -106,14 +106,14 @@ unregister_js_module = jsfinder.unregister_js_module
 def register_js_finder():
     """A bootstrap function, called near the end of Pyodide initialization.
 
-    It is called from runPythonSimple in pyodide.js once `_pyodide_core` is ready
+    It is called in ``loadPyodide`` in ``pyodide.js`` once ``_pyodide_core`` is ready
     to set up the js import mechanism.
 
-        1. Put the right value into the global variable `JsProxy` so that
-           `JsFinder.find_spec` can decide whether parent module is a Js module.
-        2. Add `jsfinder` to metapath to allow js imports.
+        1. Put the right value into the global variable ``JsProxy`` so that
+           ``JsFinder.find_spec`` can decide whether parent module is a Js module.
+        2. Add ``jsfinder`` to metapath to allow js imports.
 
-    This needs to be a function to allow the late import from `_pyodide_core`.
+    This needs to be a function to allow the late import from ``_pyodide_core``.
     """
     import _pyodide_core  # type: ignore
 

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -515,12 +515,6 @@ def test_pythonexc2js(selenium):
         selenium.run_js('return pyodide.runPython("5 / 0")')
 
 
-def test_run_python_simple_error(selenium):
-    msg = "ZeroDivisionError"
-    with pytest.raises(selenium.JavascriptException, match=msg):
-        selenium.run_js("return pyodide._module.runPythonSimple('5 / 0');")
-
-
 def test_js2python(selenium):
     selenium.run_js(
         """


### PR DESCRIPTION
I got rid of `runPythonSimple` and instead of wrapping a `dict` as the first `PyProxy`, I wrap `_pyodide`. We can't import `pyodide` until after we hook up the Python and Javascript globals. But with `_pyodide` we can call `register_js_finder`, `register_js_module`, and `eval_code`. Calling `eval_code` directly allows us to return results from Python right away which makes the rest of the boostrap setup simpler.