### PR TITLE
MAINT Be more careful about checking error code return values

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -77,6 +77,7 @@ export MAIN_MODULE_CFLAGS= $(CFLAGS_BASE) \
     	-Werror=sometimes-uninitialized \
     	-Werror=int-conversion \
     	-Werror=incompatible-pointer-types \
+		-Werror=unused-result \
 		-I$(PYTHONINCLUDE)
 
 

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -14,14 +14,14 @@ _Py_IDENTIFIER(last_type);
 _Py_IDENTIFIER(last_value);
 _Py_IDENTIFIER(last_traceback);
 
-EM_JS_NUM(errcode, console_error, (char* msg), {
+EM_JS(void, console_error, (char* msg), {
   let jsmsg = UTF8ToString(msg);
   console.error(jsmsg);
 });
 
 // Right now this is dead code (probably), please don't remove it.
 // Intended for debugging purposes.
-EM_JS_NUM(errcode, console_error_obj, (JsRef obj), {
+EM_JS(void, console_error_obj, (JsRef obj), {
   console.error(Module.hiwire.get_value(obj));
 });
 
@@ -210,10 +210,15 @@ finally:
   return jserror;
 }
 
-EM_JS_NUM(errcode, log_python_error, (JsRef jserror), {
-  let msg = Module.hiwire.get_value(jserror).message;
-  console.warn("Python exception:\n" + msg + "\n");
-  return 0;
+EM_JS(void, log_python_error, (JsRef jserror), {
+  // If a js error occurs in here, it's a weird edge case. This will probably
+  // never happen, but for maximum paranoia let's double check.
+  try {
+    let msg = Module.hiwire.get_value(jserror).message;
+    console.warn("Python exception:\n" + msg + "\n");
+  } catch (e) {
+    Module.fatal_error(e);
+  }
 });
 
 /**

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -34,11 +34,6 @@ JsRef
 wrap_exception();
 
 /**
- * Log an error to the console. Argument should be output of wrap_exception.
- */
-errcode log_python_error(JsRef);
-
-/**
  * Convert the active Python exception into a JavaScript Error object, print
  * an appropriate message to the console and throw the error.
  */
@@ -46,12 +41,12 @@ void _Py_NO_RETURN
 pythonexc2js();
 
 // Used by LOG_EM_JS_ERROR (behind DEBUG_F flag)
-errcode
+void
 console_error(char* msg);
 
 // Right now this is dead code (probably), please don't remove it.
 // Intended for debugging purposes.
-errcode
+void
 console_error_obj(JsRef obj);
 
 /**
@@ -94,8 +89,10 @@ console_error_obj(JsRef obj);
 #define EM_JS_DEFER(ret, func_name, args, body...)                             \
   EM_JS(ret, func_name, args, body)
 
+#define WARN_UNUSED __attribute__((warn_unused_result))
+
 #define EM_JS_REF(ret, func_name, args, body...)                               \
-  EM_JS_DEFER(ret, func_name, args, {                                          \
+  EM_JS_DEFER(ret WARN_UNUSED, func_name, args, {                              \
     "use strict";                                                              \
     try    /* intentionally no braces, body already has them */                \
       body /* <== body of func */                                              \
@@ -110,7 +107,7 @@ console_error_obj(JsRef obj);
   })
 
 #define EM_JS_NUM(ret, func_name, args, body...)                               \
-  EM_JS_DEFER(ret, func_name, args, {                                          \
+  EM_JS_DEFER(ret WARN_UNUSED, func_name, args, {                              \
     "use strict";                                                              \
     try    /* intentionally no braces, body already has them */                \
       body /* <== body of func */                                              \

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -89,6 +89,9 @@ console_error_obj(JsRef obj);
 #define EM_JS_DEFER(ret, func_name, args, body...)                             \
   EM_JS(ret, func_name, args, body)
 
+#define EM_JS_UNCHECKED(ret, func_name, args, body...)                         \
+  EM_JS(ret, func_name, args, body)
+
 #define WARN_UNUSED __attribute__((warn_unused_result))
 
 #define EM_JS_REF(ret, func_name, args, body...)                               \

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -265,9 +265,7 @@ EM_JS_REF(JsRef, hiwire_incref, (JsRef idval), {
   return Module.hiwire.new_value(Module.hiwire.get_value(idval));
 });
 
-EM_JS_NUM(errcode, hiwire_decref, (JsRef idval), {
-  Module.hiwire.decref(idval);
-});
+EM_JS(void, hiwire_decref, (JsRef idval), { Module.hiwire.decref(idval); });
 
 EM_JS_REF(JsRef, hiwire_int, (int val), {
   return Module.hiwire.new_value(val);
@@ -353,6 +351,10 @@ EM_JS(bool, JsArray_Check, (JsRef idobj), {
 EM_JS_REF(JsRef, JsArray_New, (), { return Module.hiwire.new_value([]); });
 
 EM_JS_NUM(errcode, JsArray_Push, (JsRef idarr, JsRef idval), {
+  Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
+});
+
+EM_JS(void, JsArray_Push_unchecked, (JsRef idarr, JsRef idval), {
   Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
 });
 
@@ -443,7 +445,7 @@ convert_va_args(va_list args)
     if (idarg == NULL) {
       break;
     }
-    JsArray_Push(idargs, idarg);
+    JsArray_Push_unchecked(idargs, idarg);
   }
   va_end(args);
   return idargs;
@@ -770,8 +772,8 @@ EM_JS_NUM(errcode, hiwire_assign_from_ptr, (JsRef idobj, void* ptr), {
 });
 
 // clang-format off
-EM_JS_NUM(
-errcode,
+EM_JS(
+void,
 hiwire_get_buffer_info,
 (JsRef idobj, Py_ssize_t* byteLength_ptr, char** format_ptr, Py_ssize_t* size_ptr, bool* checked_ptr),
 {

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -772,7 +772,7 @@ EM_JS_NUM(errcode, hiwire_assign_from_ptr, (JsRef idobj, void* ptr), {
 });
 
 // clang-format off
-EM_JS(
+EM_JS_UNCHECKED(
 void,
 hiwire_get_buffer_info,
 (JsRef idobj, Py_ssize_t* byteLength_ptr, char** format_ptr, Py_ssize_t* size_ptr, bool* checked_ptr),

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -491,21 +491,17 @@ hiwire_call_bound,
 });
 // clang-format on
 
-EM_JS_NUM(int, hiwire_HasMethod, (JsRef obj_id, JsRef name), {
+EM_JS(bool, hiwire_HasMethod, (JsRef obj_id, JsRef name), {
   // clang-format off
   let obj = Module.hiwire.get_value(obj_id);
   return obj && typeof obj[Module.hiwire.get_value(name)] === "function";
   // clang-format on
 })
 
-int
+bool
 hiwire_HasMethodId(JsRef obj, Js_Identifier* name)
 {
-  JsRef name_ref = JsString_FromId(name);
-  if (name_ref == NULL) {
-    return -1;
-  }
-  return hiwire_HasMethod(obj, name_ref);
+  return hiwire_HasMethod(obj, JsString_FromId(name));
 }
 
 // clang-format off
@@ -692,7 +688,7 @@ MAKE_OPERATOR(not_equal, !==);
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
-EM_JS_REF(JsRef, hiwire_is_iterator, (JsRef idobj), {
+EM_JS(bool, hiwire_is_iterator, (JsRef idobj), {
   let jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return typeof jsobj.next === 'function';
@@ -709,7 +705,7 @@ EM_JS_NUM(int, hiwire_next, (JsRef idobj, JsRef* result_ptr), {
   return done;
 });
 
-EM_JS_REF(JsRef, hiwire_is_iterable, (JsRef idobj), {
+EM_JS(bool, hiwire_is_iterable, (JsRef idobj), {
   let jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return typeof jsobj[Symbol.iterator] === 'function';
@@ -741,23 +737,6 @@ EM_JS(bool, hiwire_is_typedarray, (JsRef idobj), {
   // clang-format off
   return ArrayBuffer.isView(jsobj) || jsobj.constructor.name === "ArrayBuffer";
   // clang-format on
-});
-
-EM_JS(bool, hiwire_is_on_wasm_heap, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  // clang-format off
-  return jsobj.buffer === Module.HEAPU8.buffer;
-  // clang-format on
-});
-
-EM_JS_NUM(int, hiwire_get_byteOffset, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  return jsobj['byteOffset'];
-});
-
-EM_JS_NUM(int, hiwire_get_byteLength, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  return jsobj['byteLength'];
 });
 
 EM_JS_NUM(errcode, hiwire_assign_to_ptr, (JsRef idobj, void* ptr), {

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -4,6 +4,7 @@
 #include "Python.h"
 #include "stdalign.h"
 #include "types.h"
+#define WARN_UNUSED __attribute__((warn_unused_result))
 
 /**
  * hiwire: A super-simple framework for converting values between C and
@@ -97,7 +98,7 @@ hiwire_incref(JsRef idval);
 /**
  * Decrease the reference count on an object.
  */
-errcode
+void
 hiwire_decref(JsRef idval);
 
 /**
@@ -191,8 +192,14 @@ JsArray_New();
 /**
  * Push a value to the end of a JavaScript array.
  */
-errcode
+errcode WARN_UNUSED
 JsArray_Push(JsRef idobj, JsRef idval);
+
+/**
+ * Same as JsArray_Push but panics on failure
+ */
+void
+JsArray_Push_unchecked(JsRef idobj, JsRef idval);
 
 /**
  * Create a new JavaScript object.
@@ -221,13 +228,13 @@ JsObject_GetString(JsRef idobj, const char* ptrname);
 /**
  * Set an object member by string.
  */
-errcode
+errcode WARN_UNUSED
 JsObject_SetString(JsRef idobj, const char* ptrname, JsRef idval);
 
 /**
  * Delete an object member by string.
  */
-errcode
+errcode WARN_UNUSED
 JsObject_DeleteString(JsRef idobj, const char* ptrname);
 
 /**
@@ -241,10 +248,10 @@ JsArray_Get(JsRef idobj, int idx);
 /**
  * Set an object member by integer.
  */
-errcode
+errcode WARN_UNUSED
 JsArray_Set(JsRef idobj, int idx, JsRef idval);
 
-errcode
+errcode WARN_UNUSED
 JsArray_Delete(JsRef idobj, int idx);
 
 /**
@@ -549,19 +556,19 @@ hiwire_get_byteOffset(JsRef idobj);
  * Copies the buffer contents of a given ArrayBuffer view or ArrayBuffer into
  * the memory at ptr.
  */
-errcode
+errcode WARN_UNUSED
 hiwire_assign_to_ptr(JsRef idobj, void* ptr);
 
 /**
  * Copies the memory at ptr into a given ArrayBuffer view or ArrayBuffer.
  */
-errcode
+errcode WARN_UNUSED
 hiwire_assign_from_ptr(JsRef idobj, void* ptr);
 
 /**
  * Get a data type identifier for a given typedarray.
  */
-errcode
+void
 hiwire_get_buffer_info(JsRef idobj,
                        Py_ssize_t* byteLength_ptr,
                        char** format_ptr,
@@ -583,7 +590,7 @@ JsMap_New();
 /**
  * Does map.set(key, value).
  */
-errcode
+errcode WARN_UNUSED
 JsMap_Set(JsRef mapid, JsRef keyid, JsRef valueid);
 
 /**
@@ -595,7 +602,7 @@ JsSet_New();
 /**
  * Does set.add(key).
  */
-errcode
+errcode WARN_UNUSED
 JsSet_Add(JsRef mapid, JsRef keyid);
 
 #endif /* HIWIRE_H */

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -289,10 +289,10 @@ hiwire_call_va(JsRef idobj, ...);
 JsRef
 hiwire_call_bound(JsRef idfunc, JsRef idthis, JsRef idargs);
 
-int
+bool
 hiwire_HasMethod(JsRef obj, JsRef name);
 
-int
+bool
 hiwire_HasMethodId(JsRef obj, Js_Identifier* name);
 
 /**
@@ -478,7 +478,7 @@ hiwire_greater_than_equal(JsRef ida, JsRef idb);
 /**
  * Check if `typeof obj.next === "function"`
  */
-JsRef
+bool
 hiwire_is_iterator(JsRef idobj);
 
 /**
@@ -494,7 +494,7 @@ hiwire_next(JsRef idobj, JsRef* result);
 /**
  * Check if `typeof obj[Symbol.iterator] === "function"`
  */
-JsRef
+bool
 hiwire_is_iterable(JsRef idobj);
 
 /**
@@ -526,31 +526,6 @@ JsObject_Values(JsRef idobj);
  */
 bool
 hiwire_is_typedarray(JsRef idobj);
-
-/**
- * Returns 1 if the value is a typedarray whose buffer is part of the WASM heap.
- */
-bool
-hiwire_is_on_wasm_heap(JsRef idobj);
-
-/**
- * Returns the value of `obj.byteLength`.
- *
- * There is no error checking. Caller must ensure that hiwire_is_typedarray is
- * true. If these conditions are not met, returns `0`.
- */
-int
-hiwire_get_byteLength(JsRef idobj);
-
-/**
- * Returns the value of obj.byteOffset.
- *
- * There is no error checking. Caller must ensure that hiwire_is_typedarray is
- * true and hiwire_is_on_wasm_heap is true. If these conditions are not met,
- * returns `0`.
- */
-int
-hiwire_get_byteOffset(JsRef idobj);
 
 /**
  * Copies the buffer contents of a given ArrayBuffer view or ArrayBuffer into

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -419,7 +419,9 @@ JsProxy_subscript_array(PyObject* o, PyObject* item)
       return NULL;
     if (i < 0) {
       int length = hiwire_get_length(self->js);
-      FAIL_IF_MINUS_ONE(length);
+      if (length == -1) {
+        return NULL;
+      }
       i += length;
     }
     JsRef result = JsArray_Get(self->js, i);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -452,6 +452,7 @@ JsProxy_subscript_array(PyObject* o, PyObject* item)
 static int
 JsProxy_ass_subscript_array(PyObject* o, PyObject* item, PyObject* pyvalue)
 {
+  bool success = false;
   JsProxy* self = (JsProxy*)o;
   Py_ssize_t i;
   if (PySlice_Check(item)) {
@@ -474,7 +475,6 @@ JsProxy_ass_subscript_array(PyObject* o, PyObject* item, PyObject* pyvalue)
     return -1;
   }
 
-  bool success = false;
   JsRef idvalue = NULL;
   if (pyvalue == NULL) {
     if (JsArray_Delete(self->js, i)) {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -452,8 +452,9 @@ JsProxy_subscript_array(PyObject* o, PyObject* item)
 static int
 JsProxy_ass_subscript_array(PyObject* o, PyObject* item, PyObject* pyvalue)
 {
-  bool success = false;
   JsProxy* self = (JsProxy*)o;
+  bool success = false;
+  JsRef idvalue = NULL;
   Py_ssize_t i;
   if (PySlice_Check(item)) {
     PyErr_SetString(PyExc_NotImplementedError,
@@ -475,7 +476,6 @@ JsProxy_ass_subscript_array(PyObject* o, PyObject* item, PyObject* pyvalue)
     return -1;
   }
 
-  JsRef idvalue = NULL;
   if (pyvalue == NULL) {
     if (JsArray_Delete(self->js, i)) {
       if (!PyErr_Occurred()) {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -417,8 +417,11 @@ JsProxy_subscript_array(PyObject* o, PyObject* item)
     i = PyNumber_AsSsize_t(item, PyExc_IndexError);
     if (i == -1 && PyErr_Occurred())
       return NULL;
-    if (i < 0)
-      i += hiwire_get_length(self->js);
+    if (i < 0) {
+      int length = hiwire_get_length(self->js);
+      FAIL_IF_MINUS_ONE(length);
+      i += length;
+    }
     JsRef result = JsArray_Get(self->js, i);
     if (result == NULL) {
       if (!PyErr_Occurred()) {
@@ -457,8 +460,11 @@ JsProxy_ass_subscript_array(PyObject* o, PyObject* item, PyObject* pyvalue)
     i = PyNumber_AsSsize_t(item, PyExc_IndexError);
     if (i == -1 && PyErr_Occurred())
       return -1;
-    if (i < 0)
-      i += hiwire_get_length(self->js);
+    if (i < 0) {
+      int length = hiwire_get_length(self->js);
+      FAIL_IF_MINUS_ONE(length);
+      i += length;
+    }
   } else {
     PyErr_Format(PyExc_TypeError,
                  "list indices must be integers or slices, not %.200s",

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1222,7 +1222,7 @@ finally:
     // arguments in async_done_callback instead of here. Otherwise, destroy the
     // arguments and return value now.
     if (idresult != NULL && hiwire_is_pyproxy(idresult)) {
-      JsArray_Push(proxies, idresult);
+      JsArray_Push_unchecked(proxies, idresult);
     }
     destroy_proxies(proxies,
                     "This borrowed proxy was automatically destroyed at the "

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -25,7 +25,7 @@ EM_JS(int, pyproxy_Check, (JsRef x), {
   return Module.isPyProxy(val);
 });
 
-EM_JS(errcode, destroy_proxies, (JsRef proxies_id, char* msg_ptr), {
+EM_JS(void, destroy_proxies, (JsRef proxies_id, char* msg_ptr), {
   let msg = undefined;
   if (msg_ptr) {
     msg = UTF8ToString(msg_ptr);

--- a/src/core/pyproxy.h
+++ b/src/core/pyproxy.h
@@ -27,7 +27,7 @@ pyproxy_Check(JsRef x);
 /**
  * Destroy a list of PyProxies. Steals the reference to the list.
  */
-errcode
+void
 destroy_proxies(JsRef proxies_id, char* msg);
 
 /**

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -138,7 +138,7 @@ _python2js_sequence(ConversionContext context, PyObject* x)
     FAIL_IF_NULL(pyitem);
     jsitem = _python2js(context, pyitem);
     FAIL_IF_NULL(jsitem);
-    JsArray_Push(jsarray, jsitem);
+    JsArray_Push_unchecked(jsarray, jsitem);
     Py_CLEAR(pyitem);
     hiwire_CLEAR(jsitem);
   }
@@ -328,7 +328,7 @@ _python2js_deep(ConversionContext context, PyObject* x)
   }
   if (context.proxies) {
     JsRef proxy = pyproxy_new(x);
-    JsArray_Push(context.proxies, proxy);
+    JsArray_Push_unchecked(context.proxies, proxy);
     return proxy;
   }
   PyErr_SetString(conversion_error, "No conversion known for x.");
@@ -422,7 +422,7 @@ python2js_inner(PyObject* x, JsRef proxies, bool track_proxies)
   JsRef proxy = pyproxy_new(x);
   FAIL_IF_NULL(proxy);
   if (track_proxies) {
-    JsArray_Push(proxies, proxy);
+    JsArray_Push_unchecked(proxies, proxy);
   }
   return proxy;
 finally:

--- a/src/core/python2js_buffer.h
+++ b/src/core/python2js_buffer.h
@@ -18,7 +18,7 @@
 JsRef
 _python2js_buffer(PyObject* x);
 
-errcode
+errcode WARN_UNUSED
 python2js_buffer_init();
 
 #endif /* PYTHON2JS_BUFFER_H */


### PR DESCRIPTION
If we use a function defined with `EM_JS_NUM(errcode, ...)` we need to actually check the error code. If we don't ever check the error code, then we can make all errors fatal by defining it with `EM_JS(void, ...)` instead. I added `WARN_UNUSED` to some functions to help detect these mistakes in the future.