### PR TITLE
MAINT Avoid catching fatal errors in EM_JS wrappers

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -234,6 +234,9 @@ char* error__js_filename_string = "???.js";
 EM_JS_NUM(errcode, error_handling_init_js, (), {
   Module.handle_js_error = function(e)
   {
+    if (e.pyodide_fatal_error) {
+      throw e;
+    }
     if (e instanceof Module._PropagatePythonError) {
       // Python error indicator is already set in this case. If this branch is
       // not taken, Python error indicator should be unset, and we have to set
@@ -287,7 +290,8 @@ EM_JS_NUM(errcode, error_handling_init_js, (), {
       super("If you are seeing this message, an internal Pyodide error has " +
             "occurred. Please report it to the Pyodide maintainers.");
     }
-  } Module._PropagatePythonError = _PropagatePythonError;
+  };
+  Module._PropagatePythonError = _PropagatePythonError;
   return 0;
 })
 

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -57,6 +57,8 @@ Module.fatal_error = function (e) {
     console.error(e);
     return;
   }
+  // Mark e so we know not to handle it later in EM_JS wrappers
+  e.pyodide_fatal_error = true;
   fatal_error_occurred = true;
   console.error(
     "Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers."

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -52,6 +52,9 @@ let fatal_error_occurred = false;
  * @private
  */
 Module.fatal_error = function (e) {
+  if (e.pyodide_fatal_error) {
+    return;
+  }
   if (fatal_error_occurred) {
     console.error("Recursive call to fatal_error. Inner error was:");
     console.error(e);

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -770,6 +770,30 @@ def test_reentrant_error(selenium):
     assert caught
 
 
+def test_reentrant_fatal(selenium_standalone):
+    assert selenium.run_js(
+        """
+        function f(){
+            pyodide.globals.get("trigger_fatal_error")();
+        }
+        self.success = true;
+        try {
+            pyodide.runPython(`
+                from _pyodide_core import trigger_fatal_error
+                from js import f
+                try:
+                    f()
+                except Exception as e:
+                    # This code shouldn't be executed
+                    import js
+                    js.success = False
+            `);
+        } catch(e){}
+        return success;
+        """
+    )
+
+
 def test_restore_error(selenium):
     # See PR #1816.
     selenium.run_js(

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -771,6 +771,7 @@ def test_reentrant_error(selenium):
 
 
 def test_reentrant_fatal(selenium_standalone):
+    selenium = selenium_standalone
     assert selenium.run_js(
         """
         function f(){


### PR DESCRIPTION
If we raise a fatal error, we don't want to catch it later.