### PR TITLE
DOC Typo and grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ browser.
 
 Pyodide brings the Python 3.9 runtime to the browser via WebAssembly thanks to
 [Emscripten](https://emscripten.org/).
-It build the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and
+It builds the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and
 scikit-learn. The [packages directory](packages) lists over 75 packages which
-are currently available. In addition it's possible to install pure Python wheels
+are currently available. In addition, it's possible to install pure Python wheels
 from PyPi.
 
 Pyodide provides transparent conversion of objects between JavaScript and
@@ -67,7 +67,7 @@ environments](https://pyodide.org/en/stable/project/related-projects.html#notebo
 Please view the [contributing
 guide](https://pyodide.org/en/stable/development/contributing.html) for tips
 on filing issues, making changes, and submitting pull requests. Pyodide is an
-independent and community-driven open-source project. The decision making
+independent and community-driven open-source project. The decision-making
 process is outlined in the [Project
 governance](https://pyodide.org/en/stable/project/governance.html).
 

--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -95,7 +95,7 @@ PYODIDE_PACKAGES="toolz,attrs" make
 
 Dependencies of the listed packages will be built automatically as well. The
 package names must match the folder names in `packages/` exactly; in particular
-they are case sensitive.
+they are case-sensitive.
 
 If `PYODIDE_PACKAGES` is not set, a minimal set of packages necessairy to run
 the core test suite is installed, including "micropip", "pyparsing", "pytz",
@@ -103,7 +103,7 @@ the core test suite is installed, including "micropip", "pyparsing", "pytz",
 `PYODIDE_PACKAGES='core'`
 meta-package. Other supported meta-packages are,
 
-- "min-scipy-stack": includes the "core" meta-package as well as some of the
+- "min-scipy-stack": includes the "core" meta-package as well as some
   core packages from the scientific python stack and their dependencies:
   "numpy", "scipy", "pandas", "matplotlib", "scikit-learn", "joblib",
   "pytest". This option is non exaustive and is mainly intended to make build
@@ -126,7 +126,7 @@ The following environment variables additionally impact the build:
 - `EXTRA_LDFLAGS` : Add extra linker flags.
 
 Setting `EXTRA_CFLAGS="-D DEBUG_F"` provides detailed diagnostic information
-whenever error branches are taken inside of the Pyodide core code. These error
+whenever error branches are taken inside the Pyodide core code. These error
 messages are frequently helpful even when the problem is a fatal configuration
 problem and Pyodide cannot even be initialized. These error branches occur also
 in correctly working code, but they are relatively uncommon so in practice the

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -17,7 +17,7 @@ pip install pre-commit
 pre-commit install
 ```
 
-This will run a set of linters at each commit. Currently it runs yaml syntax
+This will run a set of linters at each commit. Currently, it runs yaml syntax
 validation and is removing trailing whitespaces.
 
 ## Code of Conduct
@@ -27,7 +27,7 @@ core members to adhere to.
 
 ## Development
 
-Work on Pyodide happens on Github. Core members and contributors can make Pull
+Work on Pyodide happens on GitHub. Core members and contributors can make Pull
 Requests to fix issues and add features, which all go through the same review
 process. We’ll detail how you can start making PRs below.
 
@@ -87,7 +87,7 @@ comment asking if you can take over, and we’ll figure it out from there.
 We use [pytest](https://pytest.org), driving
 [Selenium](https://www.seleniumhq.org) as our testing framework. Every PR will
 automatically run through our tests, and our test framework will alert you on
-Github if your PR doesn’t pass all of them. If your PR fails a test, try to
+GitHub if your PR doesn’t pass all of them. If your PR fails a test, try to
 figure out whether or not you can update your code to make the test pass again,
 or ask for help. As a policy we will not accept a PR that fails any of our
 tests, and will likely ask you to add tests if your PR adds new functionality.
@@ -106,7 +106,7 @@ See {ref}`contributing-core`.
 
 ## Documentation
 
-Documentation is a critical part of any open source project and we are very
+Documentation is a critical part of any open source project, and we are very
 welcome to any documentation improvements. Pyodide has a documentation written
 in Markdown in the `docs/` folder. We use the
 [MyST](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#targets-and-cross-referencing)

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -4,7 +4,7 @@
 
 ## Making a release
 
-For branch organization we use a variation of the [Github
+For branch organization we use a variation of the [GitHub
 Flow](https://guides.github.com/introduction/flow/) with
 the latest release branch named `stable` (due to ReadTheDocs constraints).
 
@@ -17,7 +17,7 @@ the latest release branch named `stable` (due to ReadTheDocs constraints).
    the release version `vX.Y.Z` (note the presence of the leading `v`). This
    also applies to `docs/conf.py`
 2. Set version in `src/py/pyodide/__init__.py`
-3. Make sure the change log is up to date.
+3. Make sure the change log is up-to-date.
    - Indicate the release date in the change log.
    - Generate the list of contributors for the release at the end of the
      changelog entry with,

--- a/docs/development/meta-yaml.md
+++ b/docs/development/meta-yaml.md
@@ -23,7 +23,7 @@ The name of the package. It must match the name of the package used when
 expanding the tarball, which is sometimes different from the name of the package
 in the Python namespace when installed. It must also match the name of the
 directory in which the `meta.yaml` file is placed. It can only contain
-alpha-numeric characters, `-`, and `_`.
+alphanumeric characters, `-`, and `_`.
 
 ### `package/version`
 
@@ -112,7 +112,7 @@ Should be set to true for library packages. Library packages are packages that a
 
 ### `build/sharedlibrary`
 
-Should be set to true for shared library packages. Shared library packages are packages that are needed for other packages, but are loaded dynamically when Pyodide is run. For shared library packages, the script specified in the `build/script` section is run to compile the library. The script should build the shared library and copy into into a subfolder of the source folder called `install`. Files or folders in this install folder will be packaged to make the Pyodide package. See the [CLAPACK meta.yaml](https://github.com/pyodide/pyodide/blob/main/packages/CLAPACK/meta.yaml) for an example of a shared library specification.
+Should be set to true for shared library packages. Shared library packages are packages that are needed for other packages, but are loaded dynamically when Pyodide is run. For shared library packages, the script specified in the `build/script` section is run to compile the library. The script should build the shared library and copy it into a subfolder of the source folder called `install`. Files or folders in this install folder will be packaged to make the Pyodide package. See the [CLAPACK meta.yaml](https://github.com/pyodide/pyodide/blob/main/packages/CLAPACK/meta.yaml) for an example of a shared library specification.
 
 ### `build/script`
 
@@ -120,7 +120,7 @@ The script section is required for a library package (`build/library` set to tru
 
 ### `build/post`
 
-Shell commands to run after building the library. These are run inside of
+Shell commands to run after building the library. These are run with
 `bash`, and there are two special environment variables defined:
 
 - `$SITEPACKAGES`: The `site-packages` directory into which the package has been installed.

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -63,7 +63,7 @@ libraries, it is often useful to verify if the package was already built on
 [conda-forge](https://conda-forge.org/) and open the corresponding `meta.yaml`
 file. This can be done either by checking if the URL
 `https://github.com/conda-forge/<package-name>-feedstock/blob/master/recipe/meta.yaml`
-exists, or by searching the [conda-forge Github
+exists, or by searching the [conda-forge GitHub
 org](https://github.com/conda-forge/) for the package name.
 
 The `meta.yaml` in Pyodide was inspired by the one in conda, however it is
@@ -146,13 +146,13 @@ source:
 
 requirements:
   run:
-   - <requirement>
-  
+    - <requirement>
+
 build:
   library: true
   script: |
-      emconfigure ./configure
-      emmake make -j ${PYODIDE_JOBS:-3}
+    emconfigure ./configure
+    emmake make -j ${PYODIDE_JOBS:-3}
 ```
 
 You can use the `meta.yaml` of other C libraries such as

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -10,7 +10,7 @@ Pyodide brings the Python 3.9 runtime to the browser via WebAssembly thanks to
 It builds the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and
 scikit-learn. The [packages
 directory](https://github.com/pyodide/pyodide/tree/main/packages) lists over
-75 packages which are currently available. In addition it's possible to install
+75 packages which are currently available. In addition, it's possible to install
 pure Python wheels from PyPi.
 
 Pyodide provides transparent conversion of objects between JavaScript and
@@ -28,7 +28,7 @@ communication.
 
 See the {ref}`contributing guide <how_to_contribute>` for tips on filing issues,
 making changes, and submitting pull requests. Pyodide is an independent and
-community-driven open-source project. The decision making process is outlined in
+community-driven open-source project. The decision-making process is outlined in
 {ref}`project-governance`.
 
 ## Citing

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -35,7 +35,7 @@ See issue {issue}`1120`.
 
 ## Simplification of the package loading system
 
-Currently Pyodide has two way of loading packages:
+Currently, Pyodide has two ways of loading packages:
 
 - `loadPackage` for packages built with Pyodide and
 - `micropip.install` for pure Python packages from PyPi.
@@ -50,7 +50,7 @@ See issues {issue}`1470` and {issue}`1100`.
 
 SciPy is a cornerstone of scientific computing in Python. It's a challenging
 package to build for WebAssembly because it is large, includes Fortran code, and
-requires BLAS and LAPACK libraries. Currently Pyodide includes scipy 0.17.1 from 2016.
+requires BLAS and LAPACK libraries. Currently, Pyodide includes scipy 0.17.1 from 2016.
 Updating it is a blocker for using more recent versions of packages such
 as scikit-learn, scikit-image, statsmodels, and MNE.
 
@@ -69,7 +69,7 @@ See issue {issue}`795`.
 ## Improve support for WebWorkers
 
 WebWorkers are necessary in order to run computational tasks in the browser
-without hanging the user interface. Currently Pyodide can run in a WebWorker,
+without hanging the user interface. Currently, Pyodide can run in a WebWorker,
 however the user experience and reliability can be improved.
 
 See issue {issue}`1504`.
@@ -89,7 +89,7 @@ See issue {issue}`1503`.
 
 Python packages make an extensive use of packages such as `requests` to
 synchronously fetch data. We currently can't use such packages since sockets
-are not available in Pyodide. We could however try to re-implement some of the
+are not available in Pyodide. We could however try to re-implement some
 stdlib libraries with Web APIs, potentially making this possible.
 
 Because http.client is a synchronous API, we first need support for synchronous

--- a/docs/usage/downloading-and-deploying.md
+++ b/docs/usage/downloading-and-deploying.md
@@ -20,9 +20,9 @@ To access a particular file, append the file name to `indexURL`. For instance,
 The previous CDN `pyodide-cdn2.iodide.io` is deprecated and should not be used.
 ```
 
-### Github releases
+### GitHub releases
 
-You can also download Pyodide packages from [Github
+You can also download Pyodide packages from [GitHub
 releases](https://github.com/pyodide/pyodide/releases)
 (`pyodide-build-*.tar.bz2` file) serve them yourself, as explained in the
 following section.
@@ -51,7 +51,7 @@ your browser console to see the output from Python via Pyodide!
 ### Remote deployments
 
 Any solution that is able to host static files and correctly sets WASM
-MIME type, and CORS headers would work. For instance, you can use Github Pages
+MIME type, and CORS headers would work. For instance, you can use GitHub Pages
 or similar services.
 
 For additional suggestions for optimizing size and load times, see the [Emscripten

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -6,7 +6,7 @@ browser or a backend JavaScript environment.
 ## Web browsers
 
 To use Pyodide on a web page you need to load `pyodide.js` and initialize
-Pyodide with {any}`loadPyodide <globalThis.loadPyodide>` specifying a index URL for packages:
+Pyodide with {any}`loadPyodide <globalThis.loadPyodide>` specifying an index URL for packages:
 
 ```html-pyodide
 <!DOCTYPE html>
@@ -58,7 +58,7 @@ Latest browser versions generally provide more reliable WebAssembly support
 and will run Pyodide faster, so their use is recommended.
 ```
 
-**Tier 2** browsers are known to work but they are not systematically tested in
+**Tier 2** browsers are known to work, but they are not systematically tested in
 Pyodide,
 
 | Browser | Minimal supported version | Release date      |
@@ -71,8 +71,8 @@ officially supported.
 
 ## Web Workers
 
-By default, WebAssembly runs in the main browser thread, and it can make UI non
-responsive for long running computations.
+By default, WebAssembly runs in the main browser thread, and it can make UI
+non-responsive for long-running computations.
 
 To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`.
 
@@ -86,7 +86,7 @@ Install the [Pyodide npm package](https://www.npmjs.com/package/pyodide),
 npm install pyodide
 ```
 
-Download and extract Pyodide packages from [Github
+Download and extract Pyodide packages from [GitHub
 releases](https://github.com/pyodide/pyodide/releases)
 (**pyodide-build-\*.tar.bz2** file). The version of the release needs to match
 exactly the version of this package.

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -53,7 +53,7 @@ Multiple packages can also be loaded at the same time by passing a list to `load
 pyodide.loadPackage(["cycler", "pytz"]);
 ```
 
-{any}`pyodide.loadPackage` returns a `Promise` which resolves when all of the
+{any}`pyodide.loadPackage` returns a `Promise` which resolves when all the
 packages are finished loading:
 
 ```javascript

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -14,7 +14,7 @@ To include Pyodide in your project you can use the following CDN URL:
 https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js
 ```
 
-You can also download a release from [Github
+You can also download a release from [GitHub
 releases](https://github.com/pyodide/pyodide/releases) or build Pyodide
 yourself. See {ref}`downloading_deploying` for more details.
 

--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -107,7 +107,7 @@ Python:
 | `null`      | `None`                            |
 
 \* A number is converted to an `int` if it is between -2^{53} and 2^{53}
-inclusive and its fractional part is zero. Otherwise it is converted to a
+inclusive and its fractional part is zero. Otherwise, it is converted to a
 float.
 
 ## Proxying
@@ -192,7 +192,7 @@ JavaScript uses `array[7]`. For these cases, we translate:
 When most Python objects are translated to JavaScript a {any}`PyProxy` is
 produced.
 
-Fewer operations can be overloaded in JavaScript than in Python so some
+Fewer operations can be overloaded in JavaScript than in Python, so some
 operations are more cumbersome on a {any}`PyProxy` than on a {any}`JsProxy`. The
 following operations are supported:
 
@@ -402,7 +402,7 @@ f(a=2, b=3)
 then the JavaScript function receives one argument which is a JavaScript object
 `{a : 2, b : 3}`.
 
-When a JavaScript function is called and it returns anything but a promise, if
+When a JavaScript function is called, and it returns anything but a promise, if
 the result is a `PyProxy` it is destroyed. Also, any arguments that are
 PyProxies that were created in the process of argument conversion are also
 destroyed. If the `PyProxy` was created in Python using
@@ -418,7 +418,7 @@ result is converted to Python and the converted value is used to resolve the
 created in converting the arguments are also destroyed at this point.
 
 As a result of this, if a `PyProxy` is persisted to be used later, then it must
-either be copied using {any}`PyProxy.copy` in JavaScript or it must be created
+either be copied using {any}`PyProxy.copy` in JavaScript, or it must be created
 with {any}`pyodide.create_proxy` or `pyodide.create_once_callable`. If it's only
 going to be called once use `pyodide.create_once_callable`:
 
@@ -450,8 +450,8 @@ proxy.destroy()
 ### Using JavaScript Typed Arrays from Python
 
 JavaScript ArrayBuffers and ArrayBuffer views (`Int8Array` and friends) are
-proxied into Python. Python can't directly access arrays if they are outside of
-the wasm heap so it's impossible to directly use these proxied buffers as Python
+proxied into Python. Python can't directly access arrays if they are outside
+the WASM heap, so it's impossible to directly use these proxied buffers as Python
 buffers. You can convert such a proxy to a Python `memoryview` using the `to_py`
 api. This makes it easy to correctly convert the array to a Numpy array using
 `numpy.asarray`:
@@ -514,7 +514,7 @@ the buffer is bitmapped image data. If for instance you have a 3d buffer shaped
 1920 x 1080 x 4, then `toJs` will be extremely slow. In this case you could use
 {any}`PyProxy.getBuffer`. On the other hand, if you have a 3d buffer shaped 1920
 x 4 x 1080, the performance of `toJs` will most likely be satisfactory.
-Typically the innermost dimension won't matter for performance.
+Typically, the innermost dimension won't matter for performance.
 
 The {any}`PyProxy.getBuffer` method can be used to retrieve a reference to a
 JavaScript typed array that points to the data backing the Python object,
@@ -570,7 +570,7 @@ functions filtered out), use that.
 ```{admonition} Be careful Proxying Stack Frames
 :class: warning
 If you make a {any}`PyProxy` of ``sys.last_value``, you should be especially
-careful to {any}`destroy() <PyProxy.destroy>` it when you are done with it or
+careful to {any}`destroy() <PyProxy.destroy>` it when you are done with it, or
 you may leak a large amount of memory if you don't.
 ```
 
@@ -606,7 +606,7 @@ objects on the custom namespaces.
 
 ### Importing Python objects into JavaScript
 
-A Python object in the `__main__` global scope can imported into JavaScript
+A Python object in the `__main__` global scope can be imported into JavaScript
 using the {any}`pyodide.globals.get <PyProxy.get>` method. Given the name of the
 Python object to import, it returns the object translated to JavaScript.
 

--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -34,13 +34,13 @@ In this example process we will have three parties involved:
 
 - The **web worker** is responsible for running scripts in its own separate thread.
 - The **worker API** exposes a consumer-to-provider communication interface.
-- The **consumer**s want to run some scripts outside the main thread so they don't block the main thread.
+- The **consumer**s want to run some scripts outside the main thread, so they don't block the main thread.
 
 ### Consumers
 
 Our goal is to run some Python code in another thread, this other thread will
-not have access to the main thread objects. Therefore we will need an API that takes
-as input not only the Python `script` we wan to run, but also the `context` on which
+not have access to the main thread objects. Therefore, we will need an API that takes
+as input not only the Python `script` we want to run, but also the `context` on which
 it relies (some JavaScript variables that we would normally get access to if we
 were running the Python script in the main thread). Let's first describe what API
 we would like to have.
@@ -78,7 +78,7 @@ async function main() {
 main();
 ```
 
-Before writing the API, lets first have a look at how the worker operates.
+Before writing the API, let's first have a look at how the worker operates.
 How does our web worker run the `script` using a given `context`.
 
 ### Web worker
@@ -138,7 +138,7 @@ self.onmessage = async (event) => {
 ### The worker API
 
 Now that we established what the two sides need and how they operate,
-lets connect them using this simple API (`py-worker.js`). This part is
+let's connect them using this simple API (`py-worker.js`). This part is
 optional and only a design choice, you could achieve similar results
 by exchanging message directly between your main thread and the webworker.
 You would just need to call `.postMessages()` with the right arguments as
@@ -157,7 +157,7 @@ export function run(script, context, onSuccess, onError) {
 }
 
 // Transform the run (callback) form to a more modern async form.
-// This is what allows to write:
+// This is what allows writing:
 //    const {results, error} = await asyncRun(script, context);
 // Instead of:
 //    run(script, context, successCallback, errorCallback);

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -223,7 +223,7 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     threads listening to build_queue. When the thread is free, it takes an
     item off build_queue and builds it. Once the package is built, it sends the
     package to the built_queue. The main thread listens to the built_queue and
-    checks if any of the dependents are ready to be built. If so, it add the
+    checks if any of the dependents are ready to be built. If so, it adds the
     package to the build queue.
     """
 
@@ -358,7 +358,7 @@ def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
 
 def make_parser(parser):
     parser.description = (
-        "Build all of the packages in a given directory\n\n"
+        "Build all the packages in a given directory\n\n"
         "Unless the --only option is provided\n\n"
         "Note: this is a private endpoint that should not be used "
         "outside of the pyodide Makefile."

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -172,7 +172,7 @@ def patch(path: Path, srcpath: Path, pkg: Dict[str, Any], args):
     if (srcpath / ".patched").is_file():
         return
 
-    # Apply all of the patches
+    # Apply all the patches
     orig_dir = Path.cwd()
     pkgdir = path.parent.resolve()
     os.chdir(srcpath)
@@ -252,7 +252,7 @@ def compile(path: Path, srcpath: Path, pkg: Dict[str, Any], args, bash_runner):
 def unvendor_tests(install_prefix: Path, test_install_prefix: Path) -> int:
     """Unvendor test files and folders
 
-    This function recursively walks though install_prefix and moves anything
+    This function recursively walks through install_prefix and moves anything
     that looks like a test folder under test_install_prefix.
 
 
@@ -261,7 +261,7 @@ def unvendor_tests(install_prefix: Path, test_install_prefix: Path) -> int:
     install_prefix
         the folder where the package was installed
     test_install_prefix
-        the folder where to move the tests. If it doesn't exits, it will be
+        the folder where to move the tests. If it doesn't exist, it will be
         created.
 
     Returns

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -10,7 +10,7 @@ The gist is:
   wrappers that store the arguments in a log, and then delegate along to the
   real native compiler and linker.
 
-- Remove all of the native build products.
+- Remove all the native build products.
 
 - Play back the log, replacing the native compiler with emscripten and
   adjusting include paths and flags as necessary for cross-compiling to
@@ -109,7 +109,7 @@ def collect_args(basename):
 
 def make_symlinks(env):
     """
-    Makes sure all of the symlinks that make this script look like a compiler
+    Makes sure all the symlinks that make this script look like a compiler
     exist.
     """
     TOOLSDIR = Path(common.get_make_flag("TOOLSDIR"))

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -339,7 +339,7 @@ export function makePublicAPI() {
    * which can be used to extend the in-memory filesystem with features like `persistence
    * <https://emscripten.org/docs/api_reference/Filesystem-API.html#persistent-data>`_.
    *
-   * While all of the file systems implementations are enabled, only the default
+   * While all the file systems implementations are enabled, only the default
    * ``MEMFS`` is guaranteed to work in all runtime settings. The implementations
    * are available as members of ``FS.filesystems``:
    * ``IDBFS``, ``NODEFS``, ``PROXYFS``, ``WORKERFS``.

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -353,7 +353,7 @@ export async function loadPackage(names, messageCallback, errorCallback) {
   // it needs to have access to it.
   // not needed for so in standard module because those are linked together
   // correctly, it is only where linking goes across modules that it needs to
-  // be done. Hence we only put this extra preload plugin in during the shared
+  // be done. Hence, we only put this extra preload plugin in during the shared
   // library load
   let oldPlugin;
   for (let p in Module.preloadPlugins) {

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -45,7 +45,7 @@ let fatal_error_occurred = false;
  * Dumps the Python traceback, shows a JavaScript traceback, and prints a clear
  * message indicating a fatal error. It then dummies out the public API so that
  * further attempts to use Pyodide will clearly indicate that Pyodide has failed
- * and can no longer be used. pyodide._module is left accessible and it is
+ * and can no longer be used. pyodide._module is left accessible, and it is
  * possible to continue using Pyodide for debugging purposes if desired.
  *
  * @argument e {Error} The cause of the fatal error.
@@ -169,7 +169,7 @@ function wrapPythonGlobals(globals_dict, builtins_dict) {
  */
 function finalizeBootstrap(config) {
   // First make internal dict so that we can use runPythonInternal.
-  // runPythonInternal uses a separate namespace so we don't pollute the main
+  // runPythonInternal uses a separate namespace, so we don't pollute the main
   // environment with variables from our setup.
   runPythonInternal_dict = Module._pyodide._base.eval_code("{}");
 

--- a/src/py/_pyodide/_base.py
+++ b/src/py/_pyodide/_base.py
@@ -54,7 +54,7 @@ def should_quiet(source: str) -> bool:
 def _last_assign_to_expr(mod: ast.Module):
     """
     Implementation of 'last_expr_or_assign' return_mode.
-    It modify the supplyied AST module so that the last
+    It modifies the supplyied AST module so that the last
     statement's value can be returned in 'last_expr' return_mode.
     """
     # Largely inspired from IPython:
@@ -197,12 +197,12 @@ class CodeRunner:
 
         The "mode" to compile in. One of ``"exec"``, ``"single"``, or ``"eval"``. Defaults
         to ``"exec"``. For most purposes it's unnecessary to use this argument.
-        See the documentation for the built in
+        See the documentation for the built-in
         `compile <https://docs.python.org/3/library/functions.html#compile>` function.
 
     flags : ``int``
 
-        The flags to compile with. See the documentation for the built in
+        The flags to compile with. See the documentation for the built-in
         `compile <https://docs.python.org/3/library/functions.html#compile>` function.
 
     Attributes:

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -51,7 +51,7 @@ class JsProxy:
         """Convert the :class:`JsProxy` to a native Python object as best as
         possible.
 
-        By default does a deep conversion, if a shallow conversion is
+        By default, does a deep conversion, if a shallow conversion is
         desired, you can use ``proxy.to_py(depth=1)``. See
         :ref:`type-translations-jsproxy-to-py` for more information.
         """
@@ -176,7 +176,7 @@ def to_js(
     """Convert the object to JavaScript.
 
     This is similar to :any:`PyProxy.toJs`, but for use from Python. If the
-    object would be implicitly translated to JavaScript, it will be returned
+    object can be implicitly translated to JavaScript, it will be returned
     unchanged. If the object cannot be converted into JavaScript, this
     method will return a :any:`JsProxy` of a :any:`PyProxy`, as if you had
     used :any:`pyodide.create_proxy`.

--- a/src/py/_pyodide/console.py
+++ b/src/py/_pyodide/console.py
@@ -87,7 +87,7 @@ class _Compile(Compile):
     Instances of this class behave much like the built-in compile function,
     but if one is used to compile text containing a future statement, it
     "remembers" and compiles all subsequent program texts with the statement in
-    force. It uses CodeRunner instead of the built in compile.
+    force. It uses CodeRunner instead of the built-in compile.
     """
 
     def __init__(


### PR DESCRIPTION
Some typo and grammar fixes, checkecked with LanguageTool via vim-grammarous.

There aren't that many, mostly improves punctuation, spelling  of GitHub with a capital H, among some other fixes.

(Running the CI since it also touches docstrings)