### PR TITLE
DOC Replace "PyPi" to "PyPI" in docs and yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pyodide brings the Python 3.9 runtime to the browser via WebAssembly thanks to
 It builds the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and
 scikit-learn. The [packages directory](packages) lists over 75 packages which
 are currently available. In addition, it's possible to install pure Python wheels
-from PyPi.
+from PyPI.
 
 Pyodide provides transparent conversion of objects between JavaScript and
 Python. When used inside a browser, Python has full access to the Web APIs.

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -10,12 +10,12 @@ should start this process with package dependencies.
 
 ### 1. Determining if creating a Pyodide package is necessary
 
-Most pure Python packages can be installed directly from PyPi with
+Most pure Python packages can be installed directly from PyPI with
 {func}`micropip.install` if they have a pure Python wheel. Check if this is the
 case by going to the `pypi.org/project/<package-name>` URL and checking if the
 "Download files" tab contains a file that ends with `*py3-none-any.whl`.
 
-If the wheel is not on PyPi, but nevertheless you believe there is nothing
+If the wheel is not on PyPI, but nevertheless you believe there is nothing
 preventing it (it is a Python package without C extensions):
 
 - you can create the wheel yourself by running,
@@ -27,7 +27,7 @@ preventing it (it is a Python package without C extensions):
   are located. See the [Python packaging
   guide](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives)
   for more details.
-  Then upload the wheel file somewhere (not to PyPi) and install it with
+  Then upload the wheel file somewhere (not to PyPI) and install it with
   micropip via its URL.
 - you can also open an issue in the package repository asking the
   authors to upload the wheel.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ browser.
 Pyodide brings the Python 3.9 runtime to the browser via WebAssembly, along
 with the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and
 scikit-learn. Over 75 packages are currently available. In addition it's
-possible to install pure Python wheels from PyPi.
+possible to install pure Python wheels from PyPI.
 
 Pyodide provides transparent conversion of objects between JavaScript and
 Python. When used inside a browser, Python has full access to the Web APIs.

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -11,7 +11,7 @@ It builds the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy
 scikit-learn. The [packages
 directory](https://github.com/pyodide/pyodide/tree/main/packages) lists over
 75 packages which are currently available. In addition, it's possible to install
-pure Python wheels from PyPi.
+pure Python wheels from PyPI.
 
 Pyodide provides transparent conversion of objects between JavaScript and
 Python. When used inside a browser, Python has full access to the Web APIs.

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -580,7 +580,7 @@ by 0.16.1 with identical contents.
 - The `pyodide.py` file was transformed to a pyodide-py package. The imports
   remain the same so this change is transparent to the users
   {pr}`909`.
-- FIX Get last version from PyPi when installing a module via micropip
+- FIX Get last version from PyPI when installing a module via micropip
   {pr}`846`.
 - Suppress REPL results returned by `pyodide.eval_code` by adding a semicolon
   {pr}`876`.
@@ -661,7 +661,7 @@ _May 19, 2020_
 
 - Upgrades Pyodide to CPython 3.7.4.
 - micropip no longer uses a CORS proxy to install pure Python packages from
-  PyPi. Packages are now installed from PyPi directly.
+  PyPI. Packages are now installed from PyPI directly.
 - micropip can now be used from web workers.
 - Adds support for installing pure Python wheels from arbitrary URLs with
   micropip.

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -38,7 +38,7 @@ See issue {issue}`1120`.
 Currently, Pyodide has two ways of loading packages:
 
 - `loadPackage` for packages built with Pyodide and
-- `micropip.install` for pure Python packages from PyPi.
+- `micropip.install` for pure Python packages from PyPI.
 
 The relationship between these tools is confusing and could be simplified.
 Furthermore, the dependency resolution logic and packaging / build system could
@@ -59,7 +59,7 @@ See issue {issue}`549`.
 ## Better project sustainability
 
 Some of the challenges that Pyodide faces, such as maintaining a collection of
-build recipes, dependency resolution from PyPi, etc are already solved in either
+build recipes, dependency resolution from PyPI, etc are already solved in either
 Python or JavaScript ecosystems. We should therefore strive to better re-use
 existing tooling, and seeking synergies with existing initiatives in this space,
 such as conda-forge.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -108,7 +108,7 @@ To start Node.js REPL with support for top level await, use `node --experimental
 ```
 
 ```{warning}
-Download of packages from PyPi is currently not cached when run in
+Download of packages from PyPI is currently not cached when run in
 Node.js. Packages will be re-downloaded each time `micropip.install` is run.
 
 For this same reason, installing Pyodide packages from the CDN is explicitly not supported for now.

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -6,7 +6,7 @@ Only the Python standard library is available after importing Pyodide.
 To use other packages, you’ll need to load them using either:
 
 - {any}`pyodide.loadPackage` for packages built with Pyodide, or
-- {any}`micropip.install` for pure Python packages with wheels available on PyPi or
+- {any}`micropip.install` for pure Python packages with wheels available on PyPI or
   from other URLs.
 
 ```{note}
@@ -18,7 +18,7 @@ If you use {any}`pyodide.loadPackagesFromImports` Pyodide will automatically
 download all packages that the code snippet imports. This is particularly useful
 for making a repl since users might import unexpected packages. At present,
 {any}`loadPackagesFromImports <pyodide.loadPackagesFromImports>` will not
-download packages from PyPi, it will only download packages included in the
+download packages from PyPI, it will only download packages included in the
 Pyodide distribution. See {ref}`packages-in-pyodide` to check the full list of packages included in Pyodide.
 
 ## Loading packages with {any}`pyodide.loadPackage`
@@ -89,7 +89,7 @@ pyodide.runPythonAsync(`
 ```
 
 Micropip implements file integrity validation by checking the hash of the
-downloaded wheel against pre-recorded hash digests from the PyPi JSON API.
+downloaded wheel against pre-recorded hash digests from the PyPI JSON API.
 
 (micropip-installing-from-arbitrary-urls)=
 
@@ -117,7 +117,7 @@ If the file is on a remote server, the server must set Cross-Origin Resource Sha
 (CORS) headers to allow access. Otherwise, you can prepend a CORS proxy to the
 URL. Note however that using third-party CORS proxies has security implications,
 particularly since we are not able to check the file integrity, unlike with
-installs from PyPi.
+installs from PyPI.
 
 ## Example
 

--- a/packages/cffi/meta.yaml
+++ b/packages/cffi/meta.yaml
@@ -14,6 +14,6 @@ test:
     - cffi
 about:
   home: http://cffi.readthedocs.org
-  PyPi: https://pypi.org/project/cffi
+  PyPI: https://pypi.org/project/cffi
   summary: Foreign Function Interface for Python calling C code.
   license: MIT

--- a/packages/micropip/src/micropip/micropip.py
+++ b/packages/micropip/src/micropip/micropip.py
@@ -121,7 +121,7 @@ def _extract_wheel(fd):
 def _validate_wheel(data, fileinfo):
     if fileinfo.get("digests") is None:
         # No checksums available, e.g. because installing
-        # from a different location than PyPi.
+        # from a different location than PyPI.
         return
     sha256 = fileinfo["digests"]["sha256"]
     m = hashlib.sha256()
@@ -278,9 +278,9 @@ def install(requirements: Union[str, List[str]]):
 
     This only works for packages that are either pure Python or for packages
     with C extensions that are built in Pyodide. If a pure Python package is not
-    found in the Pyodide repository it will be loaded from PyPi.
+    found in the Pyodide repository it will be loaded from PyPI.
 
-    When used in web browsers, downloads from PyPi will be cached. When run in
+    When used in web browsers, downloads from PyPI will be cached. When run in
     Node.js, packages are currently not cached, and will be re-downloaded each
     time ``micropip.install`` is run.
 
@@ -297,7 +297,7 @@ def install(requirements: Union[str, List[str]]):
 
         - If the requirement does not end in ``.whl``, it will interpreted as the
           name of a package. A package by this name must either be present in the
-          Pyodide repository at `indexURL <globalThis.loadPyodide>` or on PyPi
+          Pyodide repository at `indexURL <globalThis.loadPyodide>` or on PyPI
 
     Returns
     -------

--- a/packages/pycparser/meta.yaml
+++ b/packages/pycparser/meta.yaml
@@ -9,6 +9,6 @@ test:
     - pycparser
 about:
   home: https://github.com/eliben/pycparser
-  PyPi: https://pypi.org/project/pycparser
+  PyPI: https://pypi.org/project/pycparser
   summary: C parser in Python
   license: BSD

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 0.17.1
 
 source:
-  # We can't use the version from PyPi as it includes Cythonized files
+  # We can't use the version from PyPI as it includes Cythonized files
   # generated with an older Cython that does not support Python 3.7
   # This requires,
   #    pip install Cython Tempita

--- a/pyodide-build/pyodide_build/io.py
+++ b/pyodide-build/pyodide_build/io.py
@@ -38,7 +38,7 @@ PACKAGE_CONFIG_SPEC: Dict[str, Dict[str, Any]] = {
     },
     "about": {
         "home": str,
-        "PyPi": str,
+        "PyPI": str,
         "summary": str,
         "license": str,
     },

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -43,7 +43,7 @@ def _extract_sdist(pypi_metadata: Dict[str, Any]) -> Dict:
 
 
 def _get_metadata(package: str, version: Optional[str] = None) -> Dict:
-    """Download metadata for a package from PyPi"""
+    """Download metadata for a package from PyPI"""
     version = ("/" + version) if version is not None else ""
     url = f"https://pypi.org/pypi/{package}{version}/json"
 
@@ -99,7 +99,7 @@ def make_package(package: str, version: Optional[str] = None):
         "test": {"imports": [package]},
         "about": {
             "home": homepage,
-            "PyPi": pypi,
+            "PyPI": pypi,
             "summary": summary,
             "license": license,
         },
@@ -160,7 +160,7 @@ def update_package(package: str, update_patched: bool = True):
     pypi_ver = pypi_metadata["info"]["version"]
     local_ver = yaml_content["package"]["version"]
     if pypi_ver <= local_ver:
-        print(f"{package} already up to date. Local: {local_ver} PyPi: {pypi_ver}")
+        print(f"{package} already up to date. Local: {local_ver} PyPI: {pypi_ver}")
         sys.exit(0)
 
     print(f"{package} is out of date: {local_ver} <= {pypi_ver}.")

--- a/pyodide-build/pyodide_build/tests/test_mkpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_mkpkg.py
@@ -8,7 +8,7 @@ from pkg_resources import parse_version
 import pyodide_build.mkpkg
 from pyodide_build.io import parse_package_config
 
-# Following tests make real network calls to the PyPi JSON API.
+# Following tests make real network calls to the PyPI JSON API.
 # Since the response is fully cached, and small, it is very fast and is
 # unlikely to fail.
 


### PR DESCRIPTION
### Description

Replace the spelling `PyPi` to `PyPI`  (**Py**thon **P**ackaging **I**ndex)

Running CI because it updates key of meta.yaml

### Checklists

- [x] Add / update tests
