### PR TITLE
Fix wasm-ld unknown arguments error (#1963)

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -99,6 +99,10 @@ substitutions:
 - {{ Enhancement }} Better support for ccache when building Pyodide
   {pr}`1805`
 
+- {{Fix}} Fix compile error `wasm-ld: error: unknown argument: --sort-common`
+  and `wasm-ld: error: unknown argument: --as-needed` in ArchLinux.
+  {pr}`1965`
+
 ### micropip
 
 - {{Fix}} micropip now raises error when installing non-pure python wheel directly from url.

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -313,11 +313,19 @@ def handle_command(line, args, dryrun=False):
         # some gcc flags that clang does not support actually
         if arg == "-Bsymbolic-functions":
             continue
-        if arg == "-Wl,-Bsymbolic-functions":
-            continue
-        # breaks emscripten see https://github.com/emscripten-core/emscripten/issues/14460
-        if arg == "-Wl,--strip-all":
-            continue
+        # ignore some link flags
+        # it should not check if `arg == "-Wl,-xxx"` and ignore directly here,
+        # because arg may be something like "-Wl,-xxx,-yyy" where we only want
+        # to ignore "-xxx" but not "-yyy".
+        if arg.startswith("-Wl"):
+            arg = arg.replace(",-Bsymbolic-functions", "")
+            # breaks emscripten see https://github.com/emscripten-core/emscripten/issues/14460
+            arg = arg.replace(",--strip-all", "")
+            # wasm-ld does not regconize some link flags
+            arg = arg.replace(",--sort-common", "")
+            arg = arg.replace(",--as-needed", "")
+            if arg == "-Wl":
+                continue
         # threading is disabled for now
         if arg == "-pthread":
             continue

--- a/pyodide-build/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide-build/pyodide_build/tests/test_pywasmcross.py
@@ -85,6 +85,16 @@ def test_handle_command():
     assert handle_command_wrap("gcc /usr/file.c", args) is None
 
 
+def test_handle_command_ldflags():
+    # Make sure to remove unsupported link flags for wasm-ld
+
+    args = BuildArgs()
+    assert (
+        handle_command_wrap("gcc -Wl,--strip-all,--as-needed -Wl,--sort-common,-z,now,-Bsymbolic-functions -shared -c test.o -o test.so", args)
+        == "emcc -Wl,-z,now -c test.o -o test.so"
+    )
+
+
 @pytest.mark.parametrize(
     "in_ext, out_ext, executable, flag_name",
     [


### PR DESCRIPTION
### Description

In ArchLinux, `--sort-common` and `--as-needed` was added
into `LDSHARED` of sysconfigdata, which cannot be recognized
by wasm-ld, so it is needed to remove them manually.

the only change is `pywasmcross.py:handle_command`,
I add two check for argument started with "-Wl", which
cannot be dealed with by wasm-ld

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
