### PR TITLE
ENH Makefile targets for cpython partial and full clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ all: check \
 	build/pyodide.asm.js \
 	build/pyodide.js \
 	build/console.html \
-	build/test.data \
 	build/distutils.data \
 	build/packages.json \
+	build/test.data \
 	build/test.html \
 	build/webworker.js \
 	build/webworker_dev.js
@@ -173,11 +173,13 @@ clean:
 	make -C packages clean
 	echo "The Emsdk, CPython are not cleaned. cd into those directories to do so."
 
-
-clean-all: clean
-	make -C emsdk clean
+clean-python: clean
 	make -C cpython clean
-	rm -fr cpython/build
+
+clean-all:
+	make -C emsdk clean
+	make -C cpython clean-all
+
 
 %.o: %.c $(CPYTHONLIB) $(wildcard src/core/*.h src/core/python2js_buffer.js)
 	$(CC) -o $@ -c $< $(MAIN_MODULE_CFLAGS) -Isrc/core/

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -50,8 +50,11 @@ $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) remove_modules.txt
 
 
 clean:
-	-rm -fr $(BUILD)
-	-rm -fr $(INSTALL)
+	-rm -fr $(ROOT)/build
+	-rm -fr $(ROOT)/installs
+
+clean-all: clean
+	-rm -fr $(ROOT)/downloads
 
 
 $(TARBALL):


### PR DESCRIPTION
### Description

This PR is a preliminary for several other PRs I plan regarding Pyodide binary size reduction. It introduces further targets to partially or fully clean cpython.

- `make clean-python` cleans the cpython builds (as before, but also all sources)
- `make clean-all` cleans the cpython builds, cpython downloads and emsdk

The previous `make -C cpython clean` did only clean the Python build and install, but not the patched sources. Another run of `make -C cpython` then failed because of already patched sources in `$(ROOT)/build/Python-$(PYVERSION)`.

### Checklists

I think there are no further documentation and checks required on this, if you think different please let me know.