### PR TITLE
Use python-minifier to minify the Python stdlib for saving about 2.4 MB

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -47,6 +47,14 @@ $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) remove_modules.txt
 	rmdir `cat pybuilddir.txt`
 	rm pybuilddir.txt
 	cd $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/ && rm -rf `cat $(ROOT)/remove_modules.txt`
+	\
+	# Minify the Python standard library using pyminify
+	if [ "$(PYODIDE_MINIFY)" == "1" ]; then \
+		for py in `find $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR) -name "*.py"`; \
+			do echo "Minifying $${py}..."; \
+			pyminify --remove-literal-statements $${py} > $${py}.min; mv $${py}.min $${py}; \
+		done \
+	fi
 
 
 clean:
@@ -140,6 +148,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.configured $(INSTALL)/lib/lib
 		  ./configure \
 			  CFLAGS="${PYTHON_CFLAGS}" \
 			  CPPFLAGS="-I$(SQLITEBUILD) -I$(BZIP2BUILD) -I$(ZLIBBUILD)" \
+			  $(if $(PYODIDE_MINIFY) == "1", --without-doc-strings, ) \
 			  --without-pymalloc \
 			  --disable-shared \
 			  --disable-ipv6 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@
   pytest-rerunfailures
   pytest-xdist
   selenium==4.0.0.b3
+  python-minifier


### PR DESCRIPTION
### Description

This pull request uses [python-minifier](https://github.com/dflook/python-minifier) to minify the Python standard library that is shipped with Pyodide by just removing literal statements. These are any literal values that stand on their own and are not used, including doc-strings or code that is "multi-line commented" as a string somewhere in the code.

To try it out using the Docker build, run these commands first:

```bash
$ pip install python-minifier
$ export PATH=/src/.docker_home/.local/bin:$PATH
```

The Pyodide docker image should be rebuilt with python-minifier pre-installed in case this pull request is being accepted.

#### make

This is the result of a current, ordinary main branch `make` run.
```
5.2M  pyodide.asm.data
 12M  pyodide.asm.wasm
```

#### PYODIDE_MINIFY=1 make

Running `PYODIDE_MINIFY=1 make` with this pull request invokes the standard library minimization using python-minifier (pyminify-command), and saves about 2.4 MB in total.

```
2.8M  pyodide.asm.data
 12M  pyodide.asm.wasm
```

#### --with-doc-strings / --without-doc-strings

The pull request contains also flagging `--without-doc-strings` as option to CPython's configure-script. The result is nearly the same, but the `--without-doc-strings`-version is 323343 bytes smaller in total, which is significantly much.

##### --with-doc-strings (default)
```
 2905177  pyodide.asm.data
12180003  pyodide.asm.wasm
 1995476  pyodide.asm.js
```

##### --without-doc-strings
```
 2904974  pyodide.asm.data
11856660  pyodide.asm.wasm
 1995473  pyodide.asm.js
```

#### Conclusion

This feature should just be an option to save some download bandwidth, especially for cases where no active Python development is wanted, but just a Python interpreter is required running in the browser. The flag `PYODIDE_MINIFY=1` is __not__ intended to be a standard setting.

What's your opinion on this?

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [ ] Run full test-suite with `PYODIDE_MINIFY=1 make`
- [ ] Update [pyodide/pyodide-env](https://hub.docker.com/r/pyodide/pyodide-env) to preinstalled `python-minifier`
- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add new documentation
