### PR TITLE
MAINT remove `--memory-init-file 0` and consolidate link flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,19 +46,8 @@ build/pyodide.asm.js: \
 	$(CPYTHONLIB)
 	date +"[%F %T] Building pyodide.asm.js..."
 	[ -d build ] || mkdir build
-	$(CXX) -s EXPORT_NAME="'_createPyodideModule'" -o build/pyodide.asm.js $(filter %.o,$^) \
-		$(MAIN_MODULE_LDFLAGS) -s FORCE_FILESYSTEM=1 \
-		-lidbfs.js \
-		-lnodefs.js \
-		-lproxyfs.js \
-		-lworkerfs.js \
-		--preload-file $(CPYTHONLIB)@/lib/python$(PYMAJOR).$(PYMINOR) \
-		--preload-file src/py/lib@/lib/python$(PYMAJOR).$(PYMINOR)/\
-		--preload-file src/py/@/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/ \
-		--exclude-file "*__pycache__*" \
-		--exclude-file "*/test/*" \
-		--exclude-file "*/tests/*" \
-		--exclude-file "*/distutils/*"
+	$(CXX) -o build/pyodide.asm.js $(filter %.o,$^) \
+		$(MAIN_MODULE_LDFLAGS)
    # Strip out C++ symbols which all start __Z.
    # There are 4821 of these and they have VERY VERY long names.
    # To show some stats on the symbols you can use the following:

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -64,8 +64,7 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) -s MAIN_MODULE=1 \
     --use-preload-plugins \
 	-s USE_FREETYPE=1 \
 	-s USE_LIBPNG=1 \
-	-s USE_LIBJPEG=1 \
-	--memory-init-file 0 \
+	-s USE_LIBJPEG=1
 
 export SIDE_MODULE_CXXFLAGS = $(CXXFLAGS_BASE)
 

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -52,19 +52,33 @@ export LDFLAGS_BASE=\
 export CXXFLAGS_BASE=
 
 export SIDE_MODULE_LDFLAGS=	$(LDFLAGS_BASE) -s SIDE_MODULE=1
-export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) -s MAIN_MODULE=1 \
+export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
+	-s MAIN_MODULE=1 \
+	-s EXPORT_NAME="'_createPyodideModule'" \
 	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv", "_main"]' \
 	-lpython$(PYMAJOR).$(PYMINOR) \
 	-lffi \
 	-lsqlite3 \
 	-lbz2 \
 	-lstdc++ \
+	-lidbfs.js \
+	-lnodefs.js \
+	-lproxyfs.js \
+	-lworkerfs.js \
+	-s USE_FREETYPE=1 \
+	-s USE_LIBPNG=1 \
+	-s USE_LIBJPEG=1 \
+	-s FORCE_FILESYSTEM=1 \
 	-s TOTAL_MEMORY=20971520 \
 	-s ALLOW_MEMORY_GROWTH=1 \
     --use-preload-plugins \
-	-s USE_FREETYPE=1 \
-	-s USE_LIBPNG=1 \
-	-s USE_LIBJPEG=1
+	--preload-file $(CPYTHONLIB)@/lib/python$(PYMAJOR).$(PYMINOR) \
+	--preload-file src/py/lib@/lib/python$(PYMAJOR).$(PYMINOR)/\
+	--preload-file src/py/@/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/ \
+	--exclude-file "*__pycache__*" \
+	--exclude-file "*/test/*" \
+	--exclude-file "*/tests/*" \
+	--exclude-file "*/distutils/*"
 
 export SIDE_MODULE_CXXFLAGS = $(CXXFLAGS_BASE)
 


### PR DESCRIPTION
Remove `--memory-init-file 0` and consolidate all linker flags into Makefile.envs `MAIN_MODULE_LDFLAGS`.
Resolves #1972.