### PR TITLE
MAINT Simplify shared library preload plugin

### DIFF
--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -294,22 +294,22 @@ async function acquirePackageLock() {
 export let loadedPackages = {};
 
 let sharedLibraryWasmPlugin;
-let originalWasmPlugin;
+let origWasmPlugin;
 let wasmPluginIndex;
 function initSharedLibraryWasmPlugin() {
   for (let p in Module.preloadPlugins) {
     if (Module.preloadPlugins[p].canHandle("test.so")) {
-      originalWasmPlugin = Module.preloadPlugins[p];
+      origWasmPlugin = Module.preloadPlugins[p];
       wasmPluginIndex = p;
       break;
     }
   }
   sharedLibraryWasmPlugin = {
-    canHandle: originalWasmPlugin.canHandle,
+    canHandle: origWasmPlugin.canHandle,
     handle(byteArray, name, onload, onerror) {
-      originalWasmPlugin.handle(byteArray, name, onload, onerror);
-      originalWasmPlugin.asyncWasmLoadPromise = (async () => {
-        await originalWasmPlugin.asyncWasmLoadPromise;
+      origWasmPlugin.handle(byteArray, name, onload, onerror);
+      origWasmPlugin.asyncWasmLoadPromise = (async () => {
+        await origWasmPlugin.asyncWasmLoadPromise;
         Module.loadDynamicLibrary(name, {
           global: true,
           nodelete: true,

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -328,7 +328,7 @@ function initSharedLibraryWasmPlugin() {
 // done. Hence, we only put this extra preload plugin in during the shared
 // library load
 function useSharedLibraryWasmPlugin() {
-  if (!dynamicLoadHandler) {
+  if (!sharedLibraryWasmPlugin) {
     initSharedLibraryWasmPlugin();
   }
   Module.preloadPlugins[wasmPluginIndex] = sharedLibraryWasmPlugin;

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -264,7 +264,6 @@ export async function loadPyodide(config) {
   setStandardStreams(config.stdin, config.stdout, config.stderr);
   setHomeDirectory(config.homedir);
 
-  Module.locateFile = (path) => baseURL + path;
   let moduleLoaded = new Promise((r) => (Module.postRun = r));
 
   const scriptSrc = `${baseURL}pyodide.asm.js`;


### PR DESCRIPTION
I factored out `addPackage` from `recursiveDependencies` so that instead of closing over `toLoad`, it takes it explicitly as an argument. I think this improves readability.

I also factored out the "sharedLibraryPreloadPlugin" from `loadPackage` into helper functions `useSharedLibraryWasmPlugin` and `restoreOrigWasmPlugin`. These are idempotent, so we can also call `restoreOrigWasmPlugin` in the finally block just in case. Also, I made the `sharedLibraryWasmPlugin` a normal object instead of a `Proxy`. I think the original `Proxy` looked intimidating. It wasn't clear to me that the plugin only had two methods `canHandle` and `handle`.