### PR TITLE
ENH Add `keep_going` parameter to `micropip.install()`

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -108,8 +108,9 @@ substitutions:
 - {{Fix}} micropip now raises error when installing non-pure python wheel directly from url.
   {pr}`1859`
 
-- {{Enhancement}} When installation failed, micropip now shows all identifiable
-  dependents that don't have pure python wheels.
+- {{Enhancement}} micropip.install() now accepts `keep_going` parameter that, if set to True,
+  make micropip report all identifiable dependencies that don't have pure Python wheels when
+  installation has failed.
   {pr}`1976`
 
 ### packages

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -108,9 +108,9 @@ substitutions:
 - {{Fix}} micropip now raises error when installing non-pure python wheel directly from url.
   {pr}`1859`
 
-- {{Enhancement}} micropip.install() now accepts `keep_going` parameter that, if set to True,
-  make micropip report all identifiable dependencies that don't have pure Python wheels when
-  installation has failed.
+- {{Enhancement}} {func}`micropip.install` now accepts a `keep_going` parameter. If set to True,
+  micropip reports all identifiable dependencies that don't have pure Python wheels, instead of
+  failing after processing the fist one.
   {pr}`1976`
 
 ### packages

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -110,7 +110,7 @@ substitutions:
 
 - {{Enhancement}} {func}`micropip.install` now accepts a `keep_going` parameter. If set to True,
   micropip reports all identifiable dependencies that don't have pure Python wheels, instead of
-  failing after processing the fist one.
+  failing after processing the first one.
   {pr}`1976`
 
 ### packages

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -108,6 +108,10 @@ substitutions:
 - {{Fix}} micropip now raises error when installing non-pure python wheel directly from url.
   {pr}`1859`
 
+- {{Enhancement}} When installation failed, micropip now shows all identifiable
+  dependents that don't have pure python wheels.
+  {pr}`1976`
+
 ### packages
 
 - {{ Enhancement }} Unit tests are now unvendored from Python packages and

--- a/packages/micropip/src/micropip/micropip.py
+++ b/packages/micropip/src/micropip/micropip.py
@@ -167,7 +167,7 @@ class _PackageManager:
         return transaction
 
     async def install(
-        self, requirements: Union[str, List[str]], ctx=None, keep_going: bool =False
+        self, requirements: Union[str, List[str]], ctx=None, keep_going: bool = False
     ):
         transaction = await self.gather_requirements(requirements, ctx, keep_going)
 
@@ -256,8 +256,10 @@ class _PackageManager:
             if transaction["keep_going"]:
                 transaction["failed"].append(req)
             else:
-                raise ValueError(f"Couldn't find a pure Python 3 wheel for '{req}'. "
-                                           "You can use `micropip.intall(..., keep_going=True)` to get a list of all packages with missing wheels.")
+                raise ValueError(
+                    f"Couldn't find a pure Python 3 wheel for '{req}'. "
+                    "You can use `micropip.intall(..., keep_going=True)` to get a list of all packages with missing wheels."
+                )
         else:
             await self.add_wheel(req.name, wheel, ver, req.extras, ctx, transaction)
 

--- a/packages/micropip/src/micropip/micropip.py
+++ b/packages/micropip/src/micropip/micropip.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 from packaging.markers import default_environment
 
 from pathlib import Path
-from typing import Dict, Any, Union, List, Tuple
+from typing import Dict, Any, Union, List, Tuple, Optional
 from zipfile import ZipFile
 
 from .externals.pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
@@ -266,7 +266,7 @@ class _PackageManager:
 
     def find_wheel(
         self, metadata: Dict[str, Any], req: Requirement
-    ) -> Tuple[Union[str, None], Union[str, None]]:
+    ) -> Tuple[Any, Optional[Version]]:
         """Parse metadata to find the latest version of pure python wheel.
 
         Parameters
@@ -278,9 +278,9 @@ class _PackageManager:
 
         Returns
         -------
-        fileinfo : str or None
-            The filename of the Python wheel, or None if there is no pure Python wheel.
-        ver : str or None
+        fileinfo : Dict[str, Any] or None
+            The metadata of the Python wheel, or None if there is no pure Python wheel.
+        ver : Version or None
             The version of the Python wheel, or None if there is no pure Python wheel.
         """
         releases = metadata.get("releases", {})

--- a/packages/micropip/src/micropip/micropip.py
+++ b/packages/micropip/src/micropip/micropip.py
@@ -264,7 +264,25 @@ class _PackageManager:
 
         transaction["wheels"].append((name, wheel, version))
 
-    def find_wheel(self, metadata, req: Requirement):
+    def find_wheel(
+        self, metadata: Dict[str, Any], req: Requirement
+    ) -> Tuple[Union[str, None], Union[str, None]]:
+        """Parse metadata to find the latest version of pure python wheel.
+
+        Parameters
+        ----------
+        metadata : ``Dict[str, Any]``
+
+            Package search result from PyPI,
+            See: https://warehouse.pypa.io/api-reference/json.html
+
+        Returns
+        -------
+        fileinfo : str or None
+            The filename of the Python wheel, or None if there is no pure Python wheel.
+        ver : str or None
+            The version of the Python wheel, or None if there is no pure Python wheel.
+        """
         releases = metadata.get("releases", {})
         candidate_versions = sorted(
             (Version(v) for v in req.specifier.filter(releases)),  # type: ignore

--- a/packages/micropip/src/micropip/micropip.py
+++ b/packages/micropip/src/micropip/micropip.py
@@ -143,7 +143,7 @@ class _PackageManager:
         self.installed_packages = {}
 
     async def gather_requirements(
-        self, requirements: Union[str, List[str]], ctx=None, keep_going=False
+        self, requirements: Union[str, List[str]], ctx=None, keep_going: bool = False
     ):
         ctx = ctx or default_environment()
         ctx.setdefault("extra", None)
@@ -167,7 +167,7 @@ class _PackageManager:
         return transaction
 
     async def install(
-        self, requirements: Union[str, List[str]], ctx=None, keep_going=False
+        self, requirements: Union[str, List[str]], ctx=None, keep_going: bool =False
     ):
         transaction = await self.gather_requirements(requirements, ctx, keep_going)
 
@@ -256,7 +256,8 @@ class _PackageManager:
             if transaction["keep_going"]:
                 transaction["failed"].append(req)
             else:
-                raise ValueError(f"Couldn't find a pure Python 3 wheel for '{req}'")
+                raise ValueError(f"Couldn't find a pure Python 3 wheel for '{req}'. "
+                                           "You can use `micropip.intall(..., keep_going=True)` to get a list of all packages with missing wheels.")
         else:
             await self.add_wheel(req.name, wheel, ver, req.extras, ctx, transaction)
 
@@ -341,14 +342,13 @@ def install(requirements: Union[str, List[str]], keep_going: bool = False):
     keep_going : ``bool``, default: False
 
         This parameter decides the behavior of the micropip when it encounters a
-        non-pure Python package while doing dependency resolution:
+        Python package without a pure Python wheel while doing dependency
+        resolution:
 
-        - If ``False``, an error will be raised when the micropip finds the first
-          non-pure Python package.
+        - If ``False``, an error will be raised on first package with a missing wheel.
 
-        - If ``True``, the micropip will continue searching other dependencies
-          even after it finds non-pure Python packages, and report all non-pure
-          Python packages it could found with an error.
+        - If ``True``, the micropip will keep going after the first error, and report a list
+          of errors at the end.
 
     Returns
     -------

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -236,3 +236,22 @@ def test_install_mixed_case2(selenium_standalone_micropip, jinja2):
         `);
         """
     )
+
+
+def test_report_all_failed_dependencies():
+    pytest.importorskip("packaging")
+    from micropip import micropip
+
+    pkg = "nonpure-dummy"  # dummy package which requires both tensorflow and torch
+
+    msg = "tensorflow"
+    with pytest.raises(ValueError, match=msg):
+        asyncio.get_event_loop().run_until_complete(
+            micropip.PACKAGE_MANAGER.install(pkg)
+        )
+
+    msg = "torch"
+    with pytest.raises(ValueError, match=msg):
+        asyncio.get_event_loop().run_until_complete(
+            micropip.PACKAGE_MANAGER.install(pkg)
+        )

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -238,7 +238,7 @@ def test_install_mixed_case2(selenium_standalone_micropip, jinja2):
     )
 
 
-def test_report_all_failed_dependencies(monkeypatch):
+def test_install_keep_going(monkeypatch):
     pytest.importorskip("packaging")
     from micropip import micropip
 
@@ -286,4 +286,6 @@ def test_report_all_failed_dependencies(monkeypatch):
     # report order is non-deterministic
     msg = "(dep1|dep2).*(dep2|dep1)"
     with pytest.raises(ValueError, match=msg):
-        asyncio.get_event_loop().run_until_complete(micropip.install(dummy_pkg_name))
+        asyncio.get_event_loop().run_until_complete(
+            micropip.install(dummy_pkg_name, keep_going=True)
+        )

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -238,20 +238,14 @@ def test_install_mixed_case2(selenium_standalone_micropip, jinja2):
     )
 
 
-def test_report_all_failed_dependencies():
+def test_report_all_failed_dependencies(monkeypatch):
     pytest.importorskip("packaging")
     from micropip import micropip
 
     pkg = "nonpure-dummy"  # dummy package which requires both tensorflow and torch
 
-    msg = "tensorflow"
+    msg = "torch.*tensorflow"
     with pytest.raises(ValueError, match=msg):
         asyncio.get_event_loop().run_until_complete(
-            micropip.PACKAGE_MANAGER.install(pkg)
-        )
-
-    msg = "torch"
-    with pytest.raises(ValueError, match=msg):
-        asyncio.get_event_loop().run_until_complete(
-            micropip.PACKAGE_MANAGER.install(pkg)
+            micropip.install(pkg)
         )

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -48,7 +48,6 @@ def mock_get_pypi_json(pkg_map):
     return _mock_get_pypi_json
 
 
-# monkeypatch `fetch_bytes` so that it returns dummy Wheel bytes containing multiple requirements
 def mock_fetch_bytes(pkg_name, metadata, version="1.0.0"):
     """Returns mock function of `fetch_bytes` which returns dummy wheel bytes.
 

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -23,9 +23,7 @@ def mock_get_pypi_json(pkg_map):
     Returns
     -------
     ``Function``
-
         A mock function of ``_get_pypi_json`` which returns dummy JSON data of PyPI API.
-
     """
 
     async def _mock_get_pypi_json(pkgname, **kwargs):
@@ -54,23 +52,18 @@ def mock_fetch_bytes(pkg_name, metadata, version="1.0.0"):
     Parameters
     ----------
     pkg_name : ``str``
-
         Name of the Python package
 
     metadata : ``str``
-
         Metadata of the dummy wheel file
 
     version : ``str``
-
         Version of the dummy wheel file
 
     Returns
     -------
     ``Function``
-
         A mock function of ``fetch_bytes`` which return dummy wheel bytes
-
     """
 
     async def _mock_fetch_bytes(url, **kwargs):


### PR DESCRIPTION
### Description

Add `keep_going` parameter to `micropip.install()` which make micropip report all (identifiable) dependent non-pure Python packages when installation failed.

Closes: #1966

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests