### PR TITLE
Better test discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,6 @@ update_base_url: \
 	build/webworker.js
 
 
-test: all
-	pytest src emsdk/tests packages/*/test* pyodide-build -v
 
 lint: node_modules/.installed
 	# check for unused imports, the rest is done by black

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,9 @@
 """
 Various common utilities for testing.
 """
-
+import re
 import contextlib
+import functools
 import json
 import multiprocessing
 import textwrap
@@ -59,6 +60,11 @@ def pytest_configure(config):
         return result
 
     config.cwd_relative_nodeid = cwd_relative_nodeid
+
+
+@functools.cache
+def _package_is_built(package_name: str) -> bool:
+    return (BUILD_PATH / f"{package_name}.data").exists()
 
 
 class JavascriptException(Exception):
@@ -463,8 +469,47 @@ def extra_checks_test_wrapper(selenium, trace_hiwire_refs, trace_pyproxies):
         assert delta_keys <= 0
 
 
+def _maybe_skip_test(item):
+    """If necessary skip test at the fixture level, to avoid
+
+    loading the selenium_standalone fixture which takes a long time.
+    """
+    # Testing a package. Skip the test if the package is not built.
+    match = re.match(
+        r".*/packages/(?P<name>[\w\-]+)/test_[\w\-]+\.py", str(item.parent.fspath)
+    )
+    if match:
+        package_name = match.group("name")
+        if not _package_is_built(package_name):
+            pytest.skip(f"package '{package_name}' is not built.")
+
+    # Common package import test. Skip it if the package is not built.
+    if str(item.fspath).endswith("test_packages_common.py") and item.name.startswith(
+        "test_import"
+    ):
+        match = re.match(
+            r"test_import\[(firefox|chrome|node)-(?P<name>[\w-]+)\]", item.name
+        )
+        if match:
+            package_name = match.group("name")
+            if not _package_is_built(package_name):
+                # If the test is going to be skipped remove the selenium_standalone as it takes
+                # a long time to initialize
+                pytest.skip(f"package '{package_name}' is not built.")
+        else:
+            raise AssertionError(
+                f"Could't parse package name from {item.name}. This should not happen!"
+            )
+
+
 @contextlib.contextmanager
 def selenium_common(request, web_server_main, load_pyodide=True):
+    """Returns an initialized selenium object.
+
+    If `_should_skip_test` indicate that the test will be skipped,
+    return None, as initializing Pyodide for selenium is expensive
+    """
+
     server_hostname, server_port, server_log = web_server_main
     if request.param == "firefox":
         cls = FirefoxWrapper
@@ -488,6 +533,9 @@ def selenium_common(request, web_server_main, load_pyodide=True):
 
 @pytest.fixture(params=["firefox", "chrome", "node"], scope="function")
 def selenium_standalone(request, web_server_main):
+    # Avoid loading the fixture if the test is going to be skipped
+    _maybe_skip_test(request.node)
+
     with selenium_common(request, web_server_main) as selenium:
         with set_webdriver_script_timeout(
             selenium, script_timeout=parse_driver_timeout(request)
@@ -500,6 +548,9 @@ def selenium_standalone(request, web_server_main):
 
 @contextlib.contextmanager
 def selenium_standalone_noload_common(request, web_server_main):
+    # Avoid loading the fixture if the test is going to be skipped
+    _maybe_skip_test(request.node)
+
     with selenium_common(request, web_server_main, load_pyodide=False) as selenium:
         with set_webdriver_script_timeout(
             selenium, script_timeout=parse_driver_timeout(request)
@@ -512,6 +563,8 @@ def selenium_standalone_noload_common(request, web_server_main):
 
 @pytest.fixture(params=["firefox", "chrome"], scope="function")
 def selenium_webworker_standalone(request, web_server_main):
+    # Avoid loading the fixture if the test is going to be skipped
+
     with selenium_standalone_noload_common(request, web_server_main) as selenium:
         yield selenium
 
@@ -520,6 +573,7 @@ def selenium_webworker_standalone(request, web_server_main):
 def selenium_standalone_noload(request, web_server_main):
     """Only difference between this and selenium_webworker_standalone is that
     this also tests on node."""
+    # Avoid loading the fixture if the test is going to be skipped
     with selenium_standalone_noload_common(request, web_server_main) as selenium:
         yield selenium
 

--- a/conftest.py
+++ b/conftest.py
@@ -494,8 +494,10 @@ def _maybe_skip_test(item, delayed=False):
             skip_msg = f"package '{package_name}' is not built."
 
     # Common package import test. Skip it if the package is not built.
-    if str(item.fspath).endswith("test_packages_common.py") and item.name.startswith(
-        "test_import"
+    if (
+        skip_msg is None
+        and str(item.fspath).endswith("test_packages_common.py")
+        and item.name.startswith("test_import")
     ):
         match = re.match(
             r"test_import\[(firefox|chrome|node)-(?P<name>[\w-]+)\]", item.name

--- a/conftest.py
+++ b/conftest.py
@@ -61,6 +61,17 @@ def pytest_configure(config):
     config.cwd_relative_nodeid = cwd_relative_nodeid
 
 
+def pytest_collection_modifyitems(config, items):
+    """Called after collect is completed.
+    Parameters
+    ----------
+    config : pytest config
+    items : list of collected items
+    """
+    for item in items:
+        _maybe_skip_test(item, delayed=True)
+
+
 def _package_is_built(package_name: str) -> bool:
     return (BUILD_PATH / f"{package_name}.data").exists()
 
@@ -467,11 +478,12 @@ def extra_checks_test_wrapper(selenium, trace_hiwire_refs, trace_pyproxies):
         assert delta_keys <= 0
 
 
-def _maybe_skip_test(item):
+def _maybe_skip_test(item, delayed=False):
     """If necessary skip test at the fixture level, to avoid
 
     loading the selenium_standalone fixture which takes a long time.
     """
+    skip_msg = None
     # Testing a package. Skip the test if the package is not built.
     match = re.match(
         r".*/packages/(?P<name>[\w\-]+)/test_[\w\-]+\.py", str(item.parent.fspath)
@@ -479,7 +491,7 @@ def _maybe_skip_test(item):
     if match:
         package_name = match.group("name")
         if not _package_is_built(package_name):
-            pytest.skip(f"package '{package_name}' is not built.")
+            skip_msg = f"package '{package_name}' is not built."
 
     # Common package import test. Skip it if the package is not built.
     if str(item.fspath).endswith("test_packages_common.py") and item.name.startswith(
@@ -491,13 +503,22 @@ def _maybe_skip_test(item):
         if match:
             package_name = match.group("name")
             if not _package_is_built(package_name):
-                # If the test is going to be skipped remove the selenium_standalone as it takes
-                # a long time to initialize
-                pytest.skip(f"package '{package_name}' is not built.")
+                # If the test is going to be skipped remove the
+                # selenium_standalone as it takes a long time to initialize
+                skip_msg = f"package '{package_name}' is not built."
         else:
             raise AssertionError(
                 f"Couldn't parse package name from {item.name}. This should not happen!"
             )
+
+    # TODO: also use this hook to skip doctests we cannot run (or run them
+    # inside the selenium wrapper)
+
+    if skip_msg is not None:
+        if delayed:
+            item.add_marker(pytest.mark.skip(reason=skip_msg))
+        else:
+            pytest.skip(skip_msg)
 
 
 @contextlib.contextmanager
@@ -561,6 +582,8 @@ def selenium_standalone_noload_common(request, web_server_main):
 
 @pytest.fixture(params=["firefox", "chrome"], scope="function")
 def selenium_webworker_standalone(request, web_server_main):
+    # Avoid loading the fixture if the test is going to be skipped
+    _maybe_skip_test(request.node)
     with selenium_standalone_noload_common(request, web_server_main) as selenium:
         yield selenium
 
@@ -569,6 +592,8 @@ def selenium_webworker_standalone(request, web_server_main):
 def selenium_standalone_noload(request, web_server_main):
     """Only difference between this and selenium_webworker_standalone is that
     this also tests on node."""
+    # Avoid loading the fixture if the test is going to be skipped
+    _maybe_skip_test(request.node)
     with selenium_standalone_noload_common(request, web_server_main) as selenium:
         yield selenium
 

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,6 @@ Various common utilities for testing.
 """
 import re
 import contextlib
-import functools
 import json
 import multiprocessing
 import textwrap
@@ -62,7 +61,6 @@ def pytest_configure(config):
     config.cwd_relative_nodeid = cwd_relative_nodeid
 
 
-@functools.cache
 def _package_is_built(package_name: str) -> bool:
     return (BUILD_PATH / f"{package_name}.data").exists()
 
@@ -498,7 +496,7 @@ def _maybe_skip_test(item):
                 pytest.skip(f"package '{package_name}' is not built.")
         else:
             raise AssertionError(
-                f"Could't parse package name from {item.name}. This should not happen!"
+                f"Couldn't parse package name from {item.name}. This should not happen!"
             )
 
 
@@ -563,8 +561,6 @@ def selenium_standalone_noload_common(request, web_server_main):
 
 @pytest.fixture(params=["firefox", "chrome"], scope="function")
 def selenium_webworker_standalone(request, web_server_main):
-    # Avoid loading the fixture if the test is going to be skipped
-
     with selenium_standalone_noload_common(request, web_server_main) as selenium:
         yield selenium
 
@@ -573,7 +569,6 @@ def selenium_webworker_standalone(request, web_server_main):
 def selenium_standalone_noload(request, web_server_main):
     """Only difference between this and selenium_webworker_standalone is that
     this also tests on node."""
-    # Avoid loading the fixture if the test is going to be skipped
     with selenium_standalone_noload_common(request, web_server_main) as selenium:
         yield selenium
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -21,7 +21,7 @@ and check that they are in your `PATH`.
 To run the pytest suite of tests, type on the command line:
 
 ```bash
-pytest src/ pyodide-build/ packages/*/test_*
+pytest
 ```
 
 There are 3 test locations that are collected by pytest,
@@ -30,6 +30,12 @@ There are 3 test locations that are collected by pytest,
 - `pyodide-build/pyodide_build/tests/`: tests related to Pyodide build system
   (do not require selenium to run)
 - `packages/*/test_*`: package specific tests.
+
+Additionally you can run emsdk specific tests with,
+
+```
+make -C emsdk test
+```
 
 ### Running the JavaScript test suite
 

--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -72,7 +72,12 @@ def test_parse_package(name):
 @pytest.mark.driver_timeout(40)
 @pytest.mark.parametrize("name", registered_packages())
 def test_import(name, selenium_standalone):
-    # check that we can parse the meta.yaml
+    if name not in built_packages():
+        raise AssertionError(
+            "Implementation error. Test for an unbuilt package "
+            "should have been skipped in conftest.py:pytest_collection_modifyitems"
+        )
+
     meta = parse_package_config(PKG_DIR / name / "meta.yaml")
 
     if name in UNSUPPORTED_PACKAGES[selenium_standalone.browser]:
@@ -81,9 +86,6 @@ def test_import(name, selenium_standalone):
                 name, selenium_standalone.browser
             )
         )
-
-    if name not in built_packages():
-        pytest.skip(f"{name} was skipped due to PYODIDE_PACKAGES")
 
     selenium_standalone.run("import glob, os")
 

--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -75,7 +75,7 @@ def test_import(name, selenium_standalone):
     if name not in built_packages():
         raise AssertionError(
             "Implementation error. Test for an unbuilt package "
-            "should have been skipped in conftest.py:pytest_collection_modifyitems"
+            "should have been skipped in selenium_standalone fixture"
         )
 
     meta = parse_package_config(PKG_DIR / name / "meta.yaml")

--- a/pyodide-build/pyodide_build/testing.py
+++ b/pyodide-build/pyodide_build/testing.py
@@ -131,16 +131,11 @@ def set_webdriver_script_timeout(selenium, script_timeout: Optional[Union[int, f
 
     Parameters
     ----------
-    selenum : {SeleniumWrapper, None}
+    selenum : SeleniumWrapper
        a SeleniumWrapper wrapper instance, or None
     script_timeout : int | float
        value of the timeout in seconds
     """
-    if selenium is None:
-        # selenium was not initialized, passtrhough without doing anything
-        yield
-        return
-
     if script_timeout is not None:
         selenium.set_script_timeout(script_timeout)
     yield

--- a/pyodide-build/pyodide_build/testing.py
+++ b/pyodide-build/pyodide_build/testing.py
@@ -131,11 +131,16 @@ def set_webdriver_script_timeout(selenium, script_timeout: Optional[Union[int, f
 
     Parameters
     ----------
-    selenum : SeleniumWrapper
-       a SeleniumWrapper wrapper instance
+    selenum : {SeleniumWrapper, None}
+       a SeleniumWrapper wrapper instance, or None
     script_timeout : int | float
        value of the timeout in seconds
     """
+    if selenium is None:
+        # selenium was not initialized, passtrhough without doing anything
+        yield
+        return
+
     if script_timeout is not None:
         selenium.set_script_timeout(script_timeout)
     yield

--- a/pyodide-build/pyodide_build/testing.py
+++ b/pyodide-build/pyodide_build/testing.py
@@ -132,7 +132,7 @@ def set_webdriver_script_timeout(selenium, script_timeout: Optional[Union[int, f
     Parameters
     ----------
     selenum : SeleniumWrapper
-       a SeleniumWrapper wrapper instance, or None
+       a SeleniumWrapper wrapper instance
     script_timeout : int | float
        value of the timeout in seconds
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,21 @@
 [tool:pytest]
-norecursedirs = build cpython emsdk/
-addopts = --doctest-modules
+norecursedirs =
+    build
+    cpython
+    emsdk
+    .artifacts
+addopts =
+    --doctest-modules
+    --ignore="packages/matplotlib/src"
 markers =
     skip_refcount_check: Dont run refcount checks
     skip_pyproxy_check: Dont run pyproxy allocation checks
     driver_timeout: Set script timeout in WebDriver
+testpaths =
+    src
+    pyodide-build
+    packages
+
 
 [bumpversion]
 current_version = 0.18.0


### PR DESCRIPTION
This improves the pytest test discovery with the following points,
 - Running `pytest` with no arguments (or `pytest .`) now correctly collects all available tests (except for emsdk ones which require the compiler setup and have to be run separately with `make -C emsdk test`)
 - Running `pytest` on packages now skips package tests that are not built. This is done at the selenium fixture level and so will also apply to new tests.
 - `packages/test_packages_common.py::test_import` now will skip the test before loading the selenium_standalone fixture which is slow. Previously it was first loading the slow fixture, and then skipping.
 - removes `make test` as I think pytest should not be used via make, as then one loses access  to all useful flags (e.g. `--pdb`, `-n auto` (for parallelism), `-s` for printing stdout, etc)

Closes https://github.com/pyodide/pyodide/issues/1979