### PR TITLE
Fix missing import of pytest

### DIFF
--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -1,3 +1,4 @@
+import pytest
 from pyodide_build.testing import run_in_pyodide
 
 


### PR DESCRIPTION
There is an import missing for pytest, which failed on CircleCI, see [here](https://app.circleci.com/pipelines/github/pyodide/pyodide/3188/workflows/b885811f-5219-4a2f-86e6-1c04bf22fdd3/jobs/33730)
The file was introduced by 51ad246f1063e5f604901393321d7926c12e9b86.

@hoodmane can you please re-check, if there are maybe some more import missing?