### PR TITLE
Use cli command tsc to compile TypeScript files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ node_modules/.installed : src/js/package.json
 	touch node_modules/.installed
 
 build/pyodide.js: src/js/*.js src/js/pyproxy.gen.js node_modules/.installed
-	npx typescript --project src/js
+	npx tsc --project src/js
 	npx rollup -c src/js/rollup.config.js
 
 src/js/pyproxy.gen.js : src/core/pyproxy.* src/core/*.h


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures: 
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Actually, I can not try `npx typescript --project src/js` successfully and I'm even not sure whether `typescript --project` is a valid CLI or not (can not find out on Google). 

But `tsc` is sure to be an official TypeScript CLI command to invoke compilation. 
- https://www.typescriptlang.org/docs/handbook/compiler-options.html
- https://code.visualstudio.com/docs/typescript/typescript-compiling 
- https://www.typescriptlang.org/tsconfig
- https://docs.microsoft.com/en-us/visualstudio/javascript/compile-typescript-code-npm?view=vs-2022

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
