### PR TITLE
MAINT use npm ci to make sure the consistent dependencies installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,14 +227,14 @@ jobs:
           command: |
             cd src/js
             npx tsd
-            npm install
+            npm ci
             npm test
       - run:     
           name: check if webpack cli works well with load-pyodide.js
           command: | 
             git clone https://github.com/pyodide/pyodide-webpack-example.git
             cd pyodide-webpack-example
-            npm install     
+            npm ci     
             cp ../src/js/load-pyodide.js node_modules/pyodide/load-pyodide.js                  
             head -20 node_modules/pyodide/load-pyodide.js
             npx webpack

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ env:
 
 
 node_modules/.installed : src/js/package.json
-	cd src/js && npm install --save-dev
+	cd src/js && npm ci
 	ln -sfn src/js/node_modules/ node_modules
 	touch node_modules/.installed
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ env:
 	env
 
 
-node_modules/.installed : src/js/package.json
+node_modules/.installed : src/js/package.json package-lock.json
 	cd src/js && npm ci
 	ln -sfn src/js/node_modules/ node_modules
 	touch node_modules/.installed

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ env:
 	env
 
 
-node_modules/.installed : src/js/package.json package-lock.json
+node_modules/.installed : src/js/package.json src/js/package-lock.json
 	cd src/js && npm ci
 	ln -sfn src/js/node_modules/ node_modules
 	touch node_modules/.installed


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures: 
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

This is to make sure the installed npm packages which are the same as `package-lock.json`. `npm ci` is included as of npm 5.7.1 (4 years ago) and is the recommended way for CI. `npm install` may install different versions from `package-lock.json` 

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->
