### PR TITLE
Fix typo in micropip.install() error

### DIFF
--- a/packages/micropip/src/micropip/micropip.py
+++ b/packages/micropip/src/micropip/micropip.py
@@ -258,7 +258,7 @@ class _PackageManager:
             else:
                 raise ValueError(
                     f"Couldn't find a pure Python 3 wheel for '{req}'. "
-                    "You can use `micropip.intall(..., keep_going=True)` to get a list of all packages with missing wheels."
+                    "You can use `micropip.install(..., keep_going=True)` to get a list of all packages with missing wheels."
                 )
         else:
             await self.add_wheel(req.name, wheel, ver, req.extras, ctx, transaction)

--- a/tools/pytest_wrapper.py
+++ b/tools/pytest_wrapper.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         print("More than 9 tests failed. Not rerunning")
         sys.exit(1)
 
-    print("Rerunnning failed tests sequentially")
+    print("Rerunning failed tests sequentially")
     remove_num_threads_option(args)
     try:
         subprocess.run(["pytest", "--lf"] + args, check=True)


### PR DESCRIPTION
\+ typo in pytest_wrapper