### PR TITLE
Add pyristent to main pyodide distribution

### DIFF
--- a/packages/pyrsistent/meta.yaml
+++ b/packages/pyrsistent/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: pyrsistent
+  version: 0.18.0
+source:
+  url: https://files.pythonhosted.org/packages/f4/d7/0fa558c4fb00f15aabc6d42d365fcca7a15fcc1091cd0f5784a14f390b7f/pyrsistent-0.18.0.tar.gz
+  sha256: 773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b
+test:
+  imports:
+  - pyrsistent
+about:
+  home: http://github.com/tobgu/pyrsistent/
+  PyPI: https://pypi.org/project/pyrsistent
+  summary: Persistent/Functional/Immutable data structures
+  license: MIT


### PR DESCRIPTION
pyrsistent is a dependency of (modern) jsonschema which is used by
altair, a popular python visualization library. Modern versions of it
use a C extension for speed, so let's make this part of the pyodide
distribution to ease installation.

As things stand, we can only use altair by resorting to a hack to
install an older version of jsonschema. Examples of this in the wild:

https://irydium.dev/repl?id=1a551ce8-f88c-11eb-866c-0a4e9a1089db
https://github.com/jtpio/jupyterlite/blob/main/examples/pyolite/altair.ipynb
