### PR TITLE
MAINT Store zipped build folder as circleci artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,11 @@ jobs:
             rm -rf cpython/{build,downloads}
             rm -rf emsdk/emsdk/binaryen
 
+      - run:
+          name: Zip build directory
+          command: |
+            tar cjf pyodide-build.tar.bz2  build
+
       - persist_to_workspace:
           root: .
           paths:
@@ -104,6 +109,9 @@ jobs:
 
       - store_artifacts:
           path: /root/repo/build/
+
+      - store_artifacts:
+          path: /root/repo/pyodide-build.tar.bz2
 
   build-packages:
     <<: *defaults
@@ -143,6 +151,11 @@ jobs:
             - /root/.ccache
           key: -pkg-{{ checksum "Makefile.envs" }}-v20210911-
 
+      - run:
+          name: Zip build directory
+          command: |
+            tar cjf pyodide-build.tar.bz2  build
+
       - persist_to_workspace:
           root: .
           paths:
@@ -151,6 +164,9 @@ jobs:
 
       - store_artifacts:
           path: /root/repo/build/
+
+      - store_artifacts:
+          path: /root/repo/pyodide-build.tar.bz2
 
       - store_artifacts:
           path: /root/repo/packages/build-logs
@@ -229,16 +245,15 @@ jobs:
             npx tsd
             npm ci
             npm test
-      - run:     
+      - run:
           name: check if webpack cli works well with load-pyodide.js
-          command: | 
+          command: |
             git clone https://github.com/pyodide/pyodide-webpack-example.git
             cd pyodide-webpack-example
-            npm ci     
-            cp ../src/js/load-pyodide.js node_modules/pyodide/load-pyodide.js                  
+            npm ci
+            cp ../src/js/load-pyodide.js node_modules/pyodide/load-pyodide.js
             head -20 node_modules/pyodide/load-pyodide.js
             npx webpack
-   
 
   benchmark:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - run:
           name: Zip build directory
           command: |
-            tar cjf pyodide-build.tar.bz2  build
+            tar cjf pyodide-build.tar.gz  build
 
       - persist_to_workspace:
           root: .
@@ -111,7 +111,7 @@ jobs:
           path: /root/repo/build/
 
       - store_artifacts:
-          path: /root/repo/pyodide-build.tar.bz2
+          path: /root/repo/pyodide-build.tar.gz
 
   build-packages:
     <<: *defaults
@@ -154,7 +154,7 @@ jobs:
       - run:
           name: Zip build directory
           command: |
-            tar cjf pyodide-build.tar.bz2  build
+            tar cjf pyodide-build.tar.gz  build
 
       - persist_to_workspace:
           root: .
@@ -166,7 +166,7 @@ jobs:
           path: /root/repo/build/
 
       - store_artifacts:
-          path: /root/repo/pyodide-build.tar.bz2
+          path: /root/repo/pyodide-build.tar.gz
 
       - store_artifacts:
           path: /root/repo/packages/build-logs


### PR DESCRIPTION
The goal is to make it easier to run the circleci build locally. With this we should be able to download a zip archive of the full build directory then serve it to localhost.