### PR TITLE
ENH Add a check for the browser shim of process when determining if the runtime is Node

### DIFF
--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -4,7 +4,8 @@ const IN_NODE =
   typeof process !== "undefined" &&
   process.release &&
   process.release.name === "node" &&
-  typeof process.browser === "undefined";
+  typeof process.browser ===
+    "undefined"; /* This last condition checks if we run the browser shim of process */
 
 /** @typedef {import('./pyproxy.js').PyProxy} PyProxy */
 /** @private */

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -3,7 +3,8 @@ import { Module } from "./module.js";
 const IN_NODE =
   typeof process !== "undefined" &&
   process.release &&
-  process.release.name === "node";
+  process.release.name === "node" && 
+  process.browser !== true;
 
 /** @typedef {import('./pyproxy.js').PyProxy} PyProxy */
 /** @private */

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -3,8 +3,8 @@ import { Module } from "./module.js";
 const IN_NODE =
   typeof process !== "undefined" &&
   process.release &&
-  process.release.name === "node" && 
-  process.browser !== true;
+  process.release.name === "node" &&
+  typeof process.browser === "undefined";
 
 /** @typedef {import('./pyproxy.js').PyProxy} PyProxy */
 /** @private */


### PR DESCRIPTION
### Description

There's a browser shim for process, in which case we don't want to set `IN_NODE` to `true`.

From: https://www.npmjs.com/package/process
> It also exposes a "browser" member (i.e. process.browser) which is true in this implementation but undefined in node. This can be used in isomorphic code that adjusts it's behavior depending on which environment it's running in.

This fixes that packages like `starboard-notebook` have to patch `pyodide` at install time.