### PR TITLE
ENH Add micropip.list()

### DIFF
--- a/packages/micropip/src/micropip/__init__.py
+++ b/packages/micropip/src/micropip/__init__.py
@@ -1,3 +1,3 @@
-from .micropip import install
+from .micropip import install, list
 
-__all__ = ["install"]
+__all__ = ["install", "list"]

--- a/packages/micropip/src/micropip/package.py
+++ b/packages/micropip/src/micropip/package.py
@@ -1,0 +1,71 @@
+from collections.abc import Collection
+from dataclasses import dataclass, field, astuple
+from pathlib import Path
+from typing import List, Dict, Iterable
+
+__all__: List[str] = []
+
+
+def _format_table(headers: List[str], table: List[Iterable]) -> str:
+    def format_row(values, widths, filler=""):
+        columns = " | ".join(f"{x:{filler}<{w}}" for x, w in zip(values, widths))
+        return f"| {columns} |"
+
+    col_width = [max(len(x) for x in col) for col in zip(headers, *table)]
+    rows = []
+
+    rows.append(format_row(headers, col_width))
+    rows.append(format_row([""] * len(col_width), col_width, filler="-"))
+    for line in table:
+        rows.append(format_row(line, col_width))
+
+    return "\n".join(rows)
+
+
+@dataclass
+class PackageMetadata:
+    name: str
+    version: str = ""
+    source: str = ""
+
+    def __iter__(self):
+        return iter(astuple(self))
+
+    @staticmethod
+    def keys():
+        return [key.capitalize() for key in PackageMetadata.__dataclass_fields__.keys()]
+
+
+class PackageList(Collection):
+    def __init__(self):
+        self.packages: Dict[str, PackageMetadata] = {}
+
+    def __repr__(self):
+        return self.tabularize()
+
+    def __len__(self):
+        return len(self.packages)
+
+    def __iter__(self):
+        return iter(self.packages.values())
+
+    def __contains__(self, pkg_name: str):  # type: ignore
+        return pkg_name in self.package_names
+
+    def __setitem__(self, key: str, item: PackageMetadata):
+        self.packages[key] = item
+
+    def __getitem__(self, key: str):
+        return self.packages[key]
+
+    @property
+    def package_names(self):
+        return [pkg.name for pkg in self]
+
+    def update(self, pkg: Dict[str, PackageMetadata]):
+        self.packages.update(pkg)
+
+    def tabularize(self):
+        headers = PackageMetadata.keys()
+        table = list(self.packages.values())
+        return _format_table(headers, table)


### PR DESCRIPTION
### Summary

Closes: #1967

Adds a new API `micropip.list()` which returns a list of installed packages.

### Detail

- `PackageMetadata`: a dataclass object that contains (name, version, source) of a package
- `PackageList`: a dict-like object that maps package name to PackageMetadata
  - has custom `__repr__()` to print list of packages in tabularized format
- `micropip.list()` returns `PackageList` instance which contains list of installed packages
- open to better names and better container design 😀

```
>>> import micropip
>>> await micropip.install("black")
>>> await micropip.install("https://files.pythonhosted.org/packages/89/06/2c2d3034b4d6bf22f2a4ae546d16925898658a33b4400cfb7e2c1e2871a3/pytz-2020.5-py2.py3-none-any.whl")
>>> pkgs = micropip.list()
>>> print(pkgs)
| Name              | Version  | Source                                                                                                                                      |
| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
| regex             | 2021.7.6 | pyodide                                                                                                                                     |
| click             | 8.0.3    | pypi                                                                                                                                        |
| typing-extensions | 4.0.1    | pypi                                                                                                                                        |
| platformdirs      | 2.4.0    | pypi                                                                                                                                        |
| pathspec          | 0.9.0    | pypi                                                                                                                                        |
| tomli             | 1.2.2    | pypi                                                                                                                                        |
| mypy-extensions   | 0.4.3    | pypi                                                                                                                                        |
| black             | 21.11b1  | pypi                                                                                                                                        |
| pytz              | 2020.5   | https://files.pythonhosted.org/packages/89/06/2c2d3034b4d6bf22f2a4ae546d16925898658a33b4400cfb7e2c1e2871a3/pytz-2020.5-py2.py3-none-any.whl |
>>> "regex" in pkgs
True
>>> "pytz" in pkgs
True
>>> "numpy" in pkgs
False
```

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
<!-- - [ ] Add new / update outdated documentation -->
