### PR TITLE
MAINT Load main pyodide package as a tar file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: check \
 	build/console.html \
 	build/distutils.data \
 	build/packages.json \
-	build/pyodide_py.tar
+	build/pyodide_py.tar \
 	build/test.data \
 	build/test.html \
 	build/webworker.js \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ all: check \
 	build/console.html \
 	build/distutils.data \
 	build/packages.json \
+	build/pyodide_py.tar
 	build/test.data \
 	build/test.html \
 	build/webworker.js \
@@ -26,6 +27,9 @@ all: check \
 
 $(CPYTHONLIB)/tzdata :
 	pip install tzdata --target=$(CPYTHONLIB)
+
+build/pyodide_py.tar: $(wildcard src/py/pyodide/*.py)  $(wildcard src/py/_pyodide/*.py)
+	cd src/py && tar --exclude '*__pycache__*' -cvf ../../build/pyodide_py.tar pyodide _pyodide
 
 build/pyodide.asm.js: \
 	src/core/docstring.o \
@@ -40,8 +44,6 @@ build/pyodide.asm.js: \
 	src/core/python2js_buffer.o \
 	src/core/python2js.o \
 	$(wildcard src/py/lib/*.py) \
-	$(wildcard src/py/pyodide/*.py) \
-	$(wildcard src/py/_pyodide/*.py) \
 	$(CPYTHONLIB)/tzdata \
 	$(CPYTHONLIB)
 	date +"[%F %T] Building pyodide.asm.js..."

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -75,7 +75,6 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	--use-preload-plugins \
 	--preload-file $(CPYTHONLIB)@/lib/python$(PYMAJOR).$(PYMINOR) \
 	--preload-file src/py/lib@/lib/python$(PYMAJOR).$(PYMINOR)/\
-	--preload-file src/py/@/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/ \
 	--exclude-file "*__pycache__*" \
 	--exclude-file "*/test/*" \
 	--exclude-file "*/tests/*" \

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -122,7 +122,8 @@ main(int argc, char** argv)
 }
 
 int
-pyodide_init(void){
+pyodide_init(void)
+{
   PyObject* _pyodide = NULL;
   PyObject* core_module = NULL;
   JsRef _pyodide_proxy = NULL;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -100,6 +100,13 @@ get_python_stack_depth()
 int
 main(int argc, char** argv)
 {
+  EM_ASM({
+    // For some reason emscripten doesn't make UTF8ToString available on Module
+    // by default...
+    Module.UTF8ToString = UTF8ToString;
+    Module.wasmTable = wasmTable;
+  });
+
   // This exits and prints a message to stderr on failure,
   // no status code to check.
   initialize_python();
@@ -110,7 +117,12 @@ main(int argc, char** argv)
   if (sizeof(JsRef) != sizeof(int)) {
     FATAL_ERROR("JsRef doesn't have the same size as int.");
   }
+  emscripten_exit_with_live_runtime();
+  return 0;
+}
 
+int
+pyodide_init(void){
   PyObject* _pyodide = NULL;
   PyObject* core_module = NULL;
   JsRef _pyodide_proxy = NULL;
@@ -124,13 +136,6 @@ main(int argc, char** argv)
   if (core_module == NULL) {
     FATAL_ERROR("Failed to create core module.");
   }
-
-  EM_ASM({
-    // For some reason emscripten doesn't make UTF8ToString available on Module
-    // by default...
-    Module.UTF8ToString = UTF8ToString;
-    Module.wasmTable = wasmTable;
-  });
 
   TRY_INIT_WITH_CORE_MODULE(error_handling);
   TRY_INIT(hiwire);
@@ -156,6 +161,5 @@ main(int argc, char** argv)
 
   Py_CLEAR(_pyodide);
   Py_CLEAR(core_module);
-  emscripten_exit_with_live_runtime();
   return 0;
 }

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -43,6 +43,17 @@ export async function initializePackageIndex(indexURL) {
   }
 }
 
+export async function fetchTarFile(indexURL, path) {
+  if (IN_NODE) {
+    const fsPromises = await import(/* webpackIgnore: true */ "fs/promises");
+    const tar_buffer = await fsPromises.readFile(`${indexURL}${path}`);
+    return tar_buffer.buffer;
+  } else {
+    let response = await fetch(`${indexURL}${path}`);
+    return await response.arrayBuffer();
+  }
+}
+
 ////////////////////////////////////////////////////////////
 // Package loading
 const DEFAULT_CHANNEL = "default channel";

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -43,7 +43,7 @@ export async function initializePackageIndex(indexURL) {
   }
 }
 
-export async function fetchTarFile(indexURL, path) {
+export async function _fetchBinaryFile(indexURL, path) {
   if (IN_NODE) {
     const fsPromises = await import(/* webpackIgnore: true */ "fs/promises");
     const tar_buffer = await fsPromises.readFile(`${indexURL}${path}`);

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -5,7 +5,7 @@ import { Module, setStandardStreams, setHomeDirectory } from "./module.js";
 import {
   loadScript,
   initializePackageIndex,
-  fetchTarFile,
+  _fetchBinaryFile,
   loadPackage,
 } from "./load-pyodide.js";
 import { makePublicAPI, registerJsModule } from "./api.js";
@@ -291,7 +291,10 @@ export async function loadPyodide(config) {
   }
   Module.indexURL = config.indexURL;
   let packageIndexReady = initializePackageIndex(config.indexURL);
-  let pyodide_py_tar_promise = fetchTarFile(config.indexURL, "pyodide_py.tar");
+  let pyodide_py_tar_promise = _fetchBinaryFile(
+    config.indexURL,
+    "pyodide_py.tar"
+  );
 
   setStandardStreams(config.stdin, config.stdout, config.stderr);
   setHomeDirectory(config.homedir);


### PR DESCRIPTION
Bundle Pyodide into a separate tar file and unpack it into the `site-packages` directory on startup. We can eventually allow people to provide their own custom file name as an argument to `loadPyodide`. Since we use `shutil.unpack_archive` the file could be a zip, tar, gztar, etc. In particular, this should eventually enable contributions to the Pyodide Python code by windows users (they can zip the files) without building Python or any of the C files.