### PR TITLE
Add tests for errors resolved after fpcast removal

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -139,6 +139,13 @@ substitutions:
   feature, is now unvendored.
   {pr}`1883`
 
+- {{Fix}} pillow and imageio now correctly encodes/decodes grayscale and
+  black-and-white JPEG image format.
+  {pr}`2028`
+
+- {{Fix}} numpy fft module now works correctly.
+  {pr}`2028`
+
 - New packages: `logbook`
 
 ### Uncategorized
@@ -198,7 +205,7 @@ substitutions:
 
 ### Packages
 
-- {{Fix}} pillow now correctly encodes/decodes JPEG image format. {pr}`1818`
+- {{Fix}} pillow now correctly encodes/decodes RGB JPEG image format. {pr}`1818`
 
 ### Micellaneous
 

--- a/packages/imageio/test_imageio.py
+++ b/packages/imageio/test_imageio.py
@@ -12,3 +12,13 @@ def test_imageio():
     image_out = imageio.imread(filename)
     assert image_out.shape == (100, 36)
     np.testing.assert_equal(image_in, image_out)
+
+
+@run_in_pyodide(packages=["numpy", "imageio"])
+def test_jpg():
+    import numpy as np
+    import imageio
+
+    img = np.zeros((5, 5), dtype=np.uint8)
+    imageio.imsave("img.jpg", img)
+    assert (imageio.imread("img.jpg") == img).all()

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -343,3 +343,15 @@ def test_get_buffer_error_messages(selenium):
             }
             """
         )
+
+
+def test_fft(selenium):
+    selenium.run_js(
+        """
+        await pyodide.loadPackage(['numpy']);
+        pyodide.runPython(`
+            import numpy
+            assert all(numpy.fft.fft([1, 1]) == [2, 0])
+        `);
+        """
+    )

--- a/packages/pillow/test_pillow.py
+++ b/packages/pillow/test_pillow.py
@@ -34,3 +34,19 @@ def test_pillow():
     with io.BytesIO() as asjpg:
         img.save(asjpg, format="JPEG")
         img = Image.open(asjpg)
+
+
+@run_in_pyodide(
+    packages=["pillow"],
+)
+def test_jpeg_modes():
+    from PIL import Image
+
+    rgb = Image.new("RGB", (4, 4))
+    rgb.save("rgb.jpg")
+
+    gray = Image.new("L", (4, 4))
+    gray.save("gray.jpg")
+
+    bw = Image.new("1", (4, 4))
+    bw.save("bw.jpg")


### PR DESCRIPTION
### Description

Closes #1693, closes #1632, closes #1781

```
Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.
The cause of the fatal error was:
TypeError: can't convert 23069936 to BigInt
Look in the browser console for more details.
```

Errors like the above that occurred in libjpeg (Pillow, imageio) (#1632) and numpy (#1693) were stemmed from the function pointer emulation (calling wrong function pointer address).

I still can't figure out the exact reason why those errors initially occurred, but thanks to #2019, those errors are resolved now :)

This PR adds tests that confirm those errors are fixed.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
