### PR TITLE
MAINT Check that sdist is actually a sdist in mkpkg

### DIFF
--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -30,7 +30,9 @@ def _extract_sdist(pypi_metadata: Dict[str, Any]) -> Dict:
 
     # The first one we can use. Usually a .tar.gz
     for entry in pypi_metadata["urls"]:
-        if entry["filename"].endswith(sdist_extensions):
+        if entry["packagetype"] == "sdist" and entry["filename"].endswith(
+            sdist_extensions
+        ):
             return entry
 
     raise MkpkgFailedException(


### PR DESCRIPTION
Check that `entry["packagetype"] == "sdist"` in mkpkg. With some recent modifications, I've been getting test failures because mkpkg decides that a wheel is the sdist. But we don't have to guess which files are sdists by file type, the API just tells us.