### PR TITLE
MAINT Add a test for shared libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,7 +430,7 @@ workflows:
 
       - test-main:
           name: test-core-chrome
-          test-params: -k "chrome and not webworker" src packages/micropip  packages/fpcast-test
+          test-params: -k "chrome and not webworker" src packages/micropip  packages/fpcast-test packages/sharedlib-test-py/
           requires:
             - build-core
           filters:
@@ -439,7 +439,7 @@ workflows:
 
       - test-main:
           name: test-core-firefox
-          test-params: -k "firefox and not webworker" src packages/micropip packages/fpcast-test
+          test-params: -k "firefox and not webworker" src packages/micropip packages/fpcast-test packages/sharedlib-test-py/
           requires:
             - build-core
           filters:
@@ -448,7 +448,7 @@ workflows:
 
       - test-main:
           name: test-core-node
-          test-params: -k node src packages/micropip packages/fpcast-test
+          test-params: -k node src packages/micropip packages/fpcast-test packages/sharedlib-test-py/
           requires:
             - build-core
           filters:

--- a/packages/sharedlib-test-py/meta.yaml
+++ b/packages/sharedlib-test-py/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: sharedlib-test-py
+  version: "1.0"
+requirements:
+  run:
+    - sharedlib-test
+source:
+  path: src
+build:
+  cflags: |
+    -I$(PYODIDE_ROOT)/packages/sharedlib-test/build/sharedlib-test-1.0/include
+test:
+  imports:
+    - sharedlib_test

--- a/packages/sharedlib-test-py/src/setup.py
+++ b/packages/sharedlib-test-py/src/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from setuptools import Extension, setup
+
+
+setup(
+    name="sharedlib-test-py",
+    version="1.0",
+    description="A package to test Pyodide shared libraries",
+    author="Pyodide team",
+    url="https://github.com/pyodide/pyodide",
+    ext_modules=[Extension("sharedlib_test", ["sharedlib-test.c"])],
+)

--- a/packages/sharedlib-test-py/src/sharedlib-test.c
+++ b/packages/sharedlib-test-py/src/sharedlib-test.c
@@ -1,0 +1,39 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "sharedlibtest.h"
+
+static PyObject *one(PyObject *self){
+    Py_RETURN_NONE;
+}
+
+static PyObject *do_the_thing_pywrapper(PyObject *self, PyObject *args){
+    int a,b;
+    if(!PyArg_ParseTuple(args, "ii:do_the_thing", &a, &b)){
+      return NULL;
+    }
+    int res = do_the_thing(a, b);
+    return PyLong_FromLong(res);
+}
+
+
+// These two structs are the same but it's important that they have to be
+// duplicated here or else we miss test coverage.
+static PyMethodDef Test_Functions[] = {
+    {"do_the_thing", do_the_thing_pywrapper, METH_VARARGS},
+    {0},
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "sharedlib_test",   /* name of module */
+    "Tests for shared library loading", /* module documentation, may be NULL */
+    -1,       /* size of per-interpreter state of the module,
+                 or -1 if the module keeps state in global variables. */
+    Test_Functions
+};
+
+
+PyMODINIT_FUNC PyInit_sharedlib_test(void)
+{
+    return PyModule_Create(&module);
+}

--- a/packages/sharedlib-test-py/test_sharedlib.py
+++ b/packages/sharedlib-test-py/test_sharedlib.py
@@ -1,0 +1,8 @@
+from pyodide_build.testing import run_in_pyodide
+
+
+@run_in_pyodide(packages=["sharedlib-test-py"])
+def test_sharedlib():
+    from sharedlib_test import do_the_thing
+
+    assert do_the_thing(4, 5) == 29

--- a/packages/sharedlib-test/meta.yaml
+++ b/packages/sharedlib-test/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: sharedlib-test
+  version: "1.0"
+
+source:
+  path: src
+
+build:
+  sharedlibrary: true
+  script: |
+    emcc -c main.c -o main.o -fPIC
+    mkdir install
+    emcc main.o -sSIDE_MODULE -o install/sharedlib-test.so

--- a/packages/sharedlib-test/src/include/sharedlibtest.h
+++ b/packages/sharedlib-test/src/include/sharedlibtest.h
@@ -1,0 +1,1 @@
+int do_the_thing(int a, int b);

--- a/packages/sharedlib-test/src/main.c
+++ b/packages/sharedlib-test/src/main.c
@@ -1,0 +1,3 @@
+int do_the_thing(int a, int b){
+    return a + b + a*b;
+}

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -40,6 +40,7 @@ def _parse_package_subset(query: Optional[str]) -> Set[str]:
         "Jinja2",
         "regex",
         "fpcast-test",
+        "sharedlib-test-py",
     }
     core_scipy_packages = {
         "numpy",


### PR DESCRIPTION
It's annoying that the only shared library is CLAPACK and that it is used by scipy which takes forever to build. scipy is also very complicated and can fail for reasons specific to scipy or for reasons general to other shared libraries. This adds a tiny shared library and a tiny C extension that uses it so we can get faster feedback about whether shared libraries are working correctly.