### PR TITLE
Fix test_parse_package_subset

### DIFF
--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -63,6 +63,7 @@ def test_parse_package_subset():
         "scikit-learn",
         "joblib",
         "pytest",
+        "sharedlib-test-py",
     }
     # reserved key words can be combined with other packages
     assert _parse_package_subset("core, unknown") == _parse_package_subset("core") | {

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -43,6 +43,7 @@ def test_parse_package_subset():
         "micropip",
         "regex",
         "fpcast-test",
+        "sharedlib-test-py",
     }
     # by default core packages are built
     assert _parse_package_subset(None) == _parse_package_subset("core")


### PR DESCRIPTION
I added `sharedlib-test-py` to core in #2042 but forgot to update the test.