### PR TITLE
Maint Clean up the loading guards a bit

### DIFF
--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -239,9 +239,18 @@ function finalizeBootstrap(config) {
  * @async
  */
 export async function loadPyodide(config) {
+  if (globalThis.__pyodide_module) {
+    throw new Error("Pyodide is already loading.");
+  }
   if (!config.indexURL) {
     throw new Error("Please provide indexURL parameter to loadPyodide");
   }
+
+  loadPyodide.inProgress = true;
+  // A global "mount point" for the package loaders to talk to pyodide
+  // See "--export-name=__pyodide_module" in buildpkg.py
+  globalThis.__pyodide_module = Module;
+
   const default_config = {
     fullStdLib: true,
     jsglobals: globalThis,
@@ -249,19 +258,6 @@ export async function loadPyodide(config) {
     homedir: "/home/pyodide",
   };
   config = Object.assign(default_config, config);
-  if (globalThis.__pyodide_module) {
-    if (globalThis.languagePluginURL) {
-      throw new Error(
-        "Pyodide is already loading because languagePluginURL is defined."
-      );
-    } else {
-      throw new Error("Pyodide is already loading.");
-    }
-  }
-  loadPyodide.inProgress = true;
-  // A global "mount point" for the package loaders to talk to pyodide
-  // See "--export-name=__pyodide_module" in buildpkg.py
-  globalThis.__pyodide_module = Module;
 
   if (!config.indexURL.endsWith("/")) {
     config.indexURL += "/";


### PR DESCRIPTION
We don't need to check for languagePluginURL anymore since that's been removed. We should throw because already loading before throwing because of a missing indexURL. If there's a missing indexURL, it should be possible to try again with a missing indexURL (not get a Pyodide already loading error).

This maintenance fixes these minor problems and makes the code a bit neater.