### PR TITLE
MAINT Don't include debug symbols in distribution

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -27,10 +27,9 @@ export PYODIDE_BASE_URL?=./
 export PYODIDE=1
 # This is the legacy environment variable used for the aforementioned purpose
 export PYODIDE_PACKAGE_ABI=1
-#
 
 # export DBGFLAGS=-g3 -gseparate-dwarf -sSEPARATE_DWARF_URL=http://localhost:8001/
-export DBGFLAGS=-g
+export DBGFLAGS=-g0
 
 export OPTFLAGS=-O2
 export CFLAGS_BASE=\


### PR DESCRIPTION
Should reduce built size a lot. But we used to be using `-g` so I don't know why there's a size issue now.