### PR TITLE
Fix reentrant error test

### DIFF
--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -759,7 +759,7 @@ def test_fatal_error(selenium_standalone):
 def test_reentrant_error(selenium):
     caught = selenium.run_js(
         """
-        function a(){
+        function raise_keyboard_interrupt(){
             pyodide.globals.get("pyfunc")();
         }
         let caught = false;
@@ -767,9 +767,9 @@ def test_reentrant_error(selenium):
             pyodide.runPython(`
                 def pyfunc():
                     raise KeyboardInterrupt
-                from js import a
+                from js import raise_keyboard_interrupt
                 try:
-                    a()
+                    raise_keyboard_interrupt()
                 except Exception as e:
                     pass
             `);

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -759,7 +759,7 @@ def test_fatal_error(selenium_standalone):
 def test_reentrant_error(selenium):
     caught = selenium.run_js(
         """
-        function raise_keyboard_interrupt(){
+        function raisePythonKeyboardInterrupt(){
             pyodide.globals.get("pyfunc")();
         }
         let caught = false;
@@ -767,9 +767,9 @@ def test_reentrant_error(selenium):
             pyodide.runPython(`
                 def pyfunc():
                     raise KeyboardInterrupt
-                from js import raise_keyboard_interrupt
+                from js import raisePythonKeyboardInterrupt
                 try:
-                    raise_keyboard_interrupt()
+                    raisePythonKeyboardInterrupt()
                 except Exception as e:
                     pass
             `);


### PR DESCRIPTION
### Description

`test_reentrant_error` is always failing on CI in the first place and successes in the retrial.
This is due to the duplicated function name used in the test.
