### PR TITLE
TST Fix install_archive test cleanup

### DIFF
--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -273,5 +273,5 @@ def test_install_archive(selenium):
                 """
             )
     finally:
-        (build_dir / "test_pkg.tar").unlink(missing_ok=True)
-        (test_dir / "test_pkg.tar").unlink(missing_ok=True)
+        (build_dir / "test_pkg.tar.gz").unlink(missing_ok=True)
+        (test_dir / "test_pkg.tar.gz").unlink(missing_ok=True)


### PR DESCRIPTION
### Description

Fix typo in the cleanup code of `test_install_archive` which removes the remaining archive files.
