### PR TITLE
MAINT Invoke pywasmcross via function calls

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -28,6 +28,10 @@ export PYTHONINCLUDE=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)/includ
 # Use env variable if defined, otherwise fallback to './'
 export PYODIDE_BASE_URL?=./
 
+# For packages that depend on numpy.
+# TODO: maybe move this somewhere else?
+export NUMPY_LIB=$(PYODIDE_ROOT)/packages/numpy/build/numpy-1.21.4/install/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/core/lib/
+
 # This environment variable is used for packages to detect if they are built
 # for pyodide during build time
 export PYODIDE=1

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -132,6 +132,9 @@ async function runPythonAsync(code, globals) {
   packages set `PYODIDE_PACKAGES='*'` In addition, `make minimal` was removed,
   since it is now equivalent to `make` without extra arguments. {pr}`1801`
 
+- It is now possible to use `pyodide-build buildall` and `pyodide-build buildpkg` directly.
+  {pr}`2063`
+
 - {{Enhancement}} Changes to environment variables in the build script are now
   seen in the compile and post build scripts.
   {pr}`1706`

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,9 +1,6 @@
 export PYODIDE_ROOT=$(abspath ..)
 include ../Makefile.envs
 
-export NUMPY_LIB=$(PYODIDE_ROOT)/packages/numpy/build/numpy-1.21.4/install/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/core/lib/
-
-
 ifeq ($(strip $(PYODIDE_PACKAGES)),)
 else
 	ONLY_PACKAGES=--only "$(PYODIDE_PACKAGES)"

--- a/pyodide-build/pyodide_build/__main__.py
+++ b/pyodide-build/pyodide_build/__main__.py
@@ -6,7 +6,6 @@ import sys
 
 from . import buildall
 from . import buildpkg
-from . import pywasmcross
 from . import serve
 from . import mkpkg
 from .common import get_make_environment_vars
@@ -22,7 +21,6 @@ def make_parser() -> argparse.ArgumentParser:
     for command_name, module in (
         ("buildpkg", buildpkg),
         ("buildall", buildall),
-        ("pywasmcross", pywasmcross),
         ("serve", serve),
         ("mkpkg", mkpkg),
     ):

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -19,9 +19,11 @@ from urllib import request
 import fnmatch
 from contextlib import contextmanager
 
+from . import pywasmcross
+
 
 @contextmanager
-def chdir(new_dir):
+def chdir(new_dir: str):
     orig_dir = Path.cwd()
     try:
         os.chdir(new_dir)
@@ -300,6 +302,27 @@ def patch(pkg_root: Path, srcpath: Path, src_metadata: Dict[str, Any]):
         fd.write(b"\n")
 
 
+def install_for_distribution():
+    commands = [
+        sys.executable,
+        "setup.py",
+        "install",
+        "--skip-build",
+        "--prefix=install",
+        "--old-and-unmanageable",
+    ]
+    try:
+        subprocess.check_call(commands)
+    except Exception:
+        print(
+            f'Warning: {" ".join(str(arg) for arg in commands)} failed '
+            f"with distutils, possibly due to the use of distutils "
+            f"that does not support the --old-and-unmanageable "
+            "argument. Re-trying the install without this argument."
+        )
+        subprocess.check_call(commands[:-1])
+
+
 def compile(
     pkg_root: Path,
     srcpath: Path,
@@ -348,34 +371,26 @@ def compile(
     if (srcpath / ".built").is_file():
         return
 
-    if build_metadata.get("skip_host", True):
-        bash_runner.env["SKIP_HOST"] = ""
+    skip_host = build_metadata.get("skip_host", True)
 
     replace_libs = ";".join(build_metadata.get("replace-libs", []))
 
     with chdir(srcpath):
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pyodide_build",
-                "pywasmcross",
-                "--cflags",
-                build_metadata["cflags"],
-                "--cxxflags",
-                build_metadata["cxxflags"],
-                "--ldflags",
-                build_metadata["ldflags"],
-                "--target-install-dir",
-                target_install_dir,
-                "--host-install-dir",
-                host_install_dir,
-                "--replace-libs",
-                replace_libs,
-            ],
-            check=True,
+        pywasmcross.capture_compile(
+            host_install_dir=host_install_dir,
+            skip_host=skip_host,
             env=bash_runner.env,
         )
+        pywasmcross.replay_compile(
+            cflags=build_metadata["cflags"],
+            cxxflags=build_metadata["cxxflags"],
+            ldflags=build_metadata["ldflags"],
+            target_install_dir=target_install_dir,
+            host_install_dir=host_install_dir,
+            replace_libs=replace_libs
+            # env=bash_runner.env
+        )
+        install_for_distribution()
 
     post = build_metadata.get("post")
     if post:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -717,7 +717,7 @@ def make_parser(parser: argparse.ArgumentParser):
         "--host-install-dir",
         type=str,
         nargs="?",
-        default="",
+        default=common.get_make_flag("HOSTINSTALLDIR"),
         help=(
             "Directory for installing built host packages. Defaults to setup.py "
             "default. Set to 'skip' to skip installation. Installation is "

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -387,7 +387,7 @@ def compile(
             ldflags=build_metadata["ldflags"],
             target_install_dir=target_install_dir,
             host_install_dir=host_install_dir,
-            replace_libs=replace_libs
+            replace_libs=replace_libs,
         )
         install_for_distribution()
 

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -21,15 +21,16 @@ from contextlib import contextmanager
 
 from . import pywasmcross
 
-
 @contextmanager
-def chdir(new_dir: str):
+def chdir(new_dir: os.PathLike[str]):
     orig_dir = Path.cwd()
     try:
         os.chdir(new_dir)
         yield
     finally:
         os.chdir(orig_dir)
+
+print(chdir.__annotations__)
 
 
 from . import common

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -388,7 +388,6 @@ def compile(
             target_install_dir=target_install_dir,
             host_install_dir=host_install_dir,
             replace_libs=replace_libs
-            # env=bash_runner.env
         )
         install_for_distribution()
 

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 
 from . import pywasmcross
 
+
 @contextmanager
 def chdir(new_dir: os.PathLike[str]):
     orig_dir = Path.cwd()
@@ -29,8 +30,6 @@ def chdir(new_dir: os.PathLike[str]):
         yield
     finally:
         os.chdir(orig_dir)
-
-print(chdir.__annotations__)
 
 
 from . import common

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -23,7 +23,7 @@ from . import pywasmcross
 
 
 @contextmanager
-def chdir(new_dir: os.PathLike[str]):
+def chdir(new_dir: "os.PathLike[str]"):
     orig_dir = Path.cwd()
     try:
         os.chdir(new_dir)

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -149,10 +149,9 @@ def capture_compile(*, host_install_dir: str, skip_host: bool, env: Dict[str, st
 
     cmd = [sys.executable, "setup.py", "install"]
     if skip_host:
-        cmd[-1] = "build"
         env["SKIP_HOST"] = "1"
-    elif host_install_dir:
-        cmd.extend(["--home", host_install_dir])
+    assert host_install_dir, "Missing host_install_dir"
+    cmd.extend(["--home", host_install_dir])
 
     result = subprocess.run(cmd, env=env)
     if result.returncode != 0:

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -143,6 +143,7 @@ def capture_make_command_wrapper_symlinks(env: Dict[str, str]):
 
 def capture_compile(*, host_install_dir: str, skip_host: bool, env: Dict[str, str]):
     TOOLSDIR = Path(common.get_make_flag("TOOLSDIR"))
+    env['PYODIDE'] = '1'
     env["PATH"] = str(TOOLSDIR) + ":" + os.environ["PATH"]
     capture_make_command_wrapper_symlinks(env)
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -569,12 +569,6 @@ def environment_substitute_args(
     return subbed_args
 
 
-# Hack to prevent mypy error:
-# "error: Single overload definition, multiple required"
-class _EmptyType:
-    __new__ = None  # type: ignore
-
-
 @overload
 def replay_compile(
     *,
@@ -589,7 +583,7 @@ def replay_compile(
 
 
 @overload
-def replay_compile(a: _EmptyType):
+def replay_compile(*, _this_is_just_here_to_appease_mypy: str):
     ...
 
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -183,7 +183,7 @@ def replay_f2c(args: List[str], dryrun: bool = False) -> Optional[List[str]]:
     --------
 
     >>> replay_f2c(['gfortran', 'test.f'], dryrun=True)
-    ['gfortran', 'test.c']
+    ['emcc', 'test.c']
     """
     new_args = ["emcc"]
     found_source = False

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -183,11 +183,11 @@ def replay_f2c(args: List[str], dryrun: bool = False) -> Optional[List[str]]:
     --------
 
     >>> replay_f2c(['gfortran', 'test.f'], dryrun=True)
-    ['emcc', 'test.c']
+    ['gcc', 'test.c']
     """
-    new_args = ["emcc"]
+    new_args = ["gcc"]
     found_source = False
-    for arg in args:
+    for arg in args[1:]:
         if arg.endswith(".f"):
             filename = os.path.abspath(arg)
             if not dryrun:
@@ -523,7 +523,7 @@ def replay_command(
     is_link_cmd = library_output is not None
 
     if line[0] == "gfortran":
-        tmp = replay_f2c(line[1:])
+        tmp = replay_f2c(line)
         if tmp is None:
             return None
         line = tmp

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -185,7 +185,7 @@ def replay_f2c(args: List[str], dryrun: bool = False) -> Optional[List[str]]:
     >>> replay_f2c(['gfortran', 'test.f'], dryrun=True)
     ['gfortran', 'test.c']
     """
-    new_args = []
+    new_args = ["emcc"]
     found_source = False
     for arg in args:
         if arg.endswith(".f"):
@@ -523,7 +523,7 @@ def replay_command(
     is_link_cmd = library_output is not None
 
     if line[0] == "gfortran":
-        tmp = replay_f2c(line)
+        tmp = replay_f2c(line[1:])
         if tmp is None:
             return None
         line = tmp

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -23,7 +23,7 @@ configuration with build.
 """
 
 
-import argparse
+from collections import namedtuple
 import importlib.machinery
 import json
 import os
@@ -34,7 +34,7 @@ import shutil
 import sys
 
 
-from typing import List, Dict, Set, Optional
+from typing import List, Dict, Set, Optional, overload
 
 # absolute import is necessary as this file will be symlinked
 # under tools
@@ -44,12 +44,17 @@ from pyodide_build._f2c_fixes import fix_f2c_clapack_calls
 
 symlinks = set(["cc", "c++", "ld", "ar", "gcc", "gfortran"])
 
-
-class EnvironmentRewritingArgument(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        for e_name, e_value in os.environ.items():
-            values = values.replace(f"$({e_name})", e_value)
-        setattr(namespace, self.dest, values)
+ReplayArgs = namedtuple(
+    "ReplayArgs",
+    [
+        "cflags",
+        "cxxflags",
+        "ldflags",
+        "host_install_dir",
+        "target_install_dir",
+        "replace_libs",
+    ],
+)
 
 
 def capture_command(command: str, args: List[str]) -> int:
@@ -136,16 +141,16 @@ def capture_make_command_wrapper_symlinks(env: Dict[str, str]):
         env[var] = symlink
 
 
-def capture_compile(host_install_dir: str):
+def capture_compile(*, host_install_dir: str, skip_host: bool, env: dict[str, str]):
     TOOLSDIR = Path(common.get_make_flag("TOOLSDIR"))
-    env = dict(os.environ)
-    capture_make_command_wrapper_symlinks(env)
     env["PATH"] = str(TOOLSDIR) + ":" + os.environ["PATH"]
+    capture_make_command_wrapper_symlinks(env)
 
     cmd = [sys.executable, "setup.py", "install"]
-    if host_install_dir == "skip":
+    if skip_host:
         cmd[-1] = "build"
-    elif host_install_dir != "":
+        env["SKIP_HOST"] = "1"
+    elif host_install_dir:
         cmd.extend(["--home", host_install_dir])
 
     result = subprocess.run(cmd, env=env)
@@ -153,7 +158,8 @@ def capture_compile(host_install_dir: str):
         build_log_path = Path("build.log")
         if build_log_path.exists():
             build_log_path.unlink()
-        sys.exit(result.returncode)
+        result.check_returncode()
+    clean_out_native_artifacts()
 
 
 def replay_f2c(args: List[str], dryrun: bool = False) -> Optional[List[str]]:
@@ -311,6 +317,37 @@ def replay_genargs_handle_dashI(arg: str, target_install_dir: str) -> Optional[s
     return arg
 
 
+def replay_genargs_handle_linker_opts(arg):
+    """
+    ignore some link flags
+    it should not check if `arg == "-Wl,-xxx"` and ignore directly here,
+    because arg may be something like "-Wl,-xxx,-yyy" where we only want
+    to ignore "-xxx" but not "-yyy".
+    """
+
+    assert arg.startswith("-Wl")
+    link_opts = arg.split(",")[1:]
+    new_link_opts = ["-Wl"]
+    for opt in link_opts:
+        if opt in [
+            "-Bsymbolic-functions",
+            # breaks emscripten see https://github.com/emscripten-core/emscripten/issues/14460
+            "--strip-all",
+            # wasm-ld does not regconize some link flags
+            "--sort-common",
+            "--as-needed",
+        ]:
+            continue
+        # ignore unsupported --sysroot compile argument used in conda
+        if opt.startswith("--sysroot="):
+            continue
+        new_link_opts.append(opt)
+    if len(new_link_opts) > 1:
+        return ",".join(new_link_opts)
+    else:
+        return None
+
+
 def replay_genargs_handle_argument(arg: str) -> Optional[str]:
     """
     Figure out how to replace a general argument.
@@ -326,32 +363,7 @@ def replay_genargs_handle_argument(arg: str) -> Optional[str]:
     """
     assert not arg.startswith("-I")  # should be handled by other functions
     assert not arg.startswith("-l")
-
-    # ignore some link flags
-    # it should not check if `arg == "-Wl,-xxx"` and ignore directly here,
-    # because arg may be something like "-Wl,-xxx,-yyy" where we only want
-    # to ignore "-xxx" but not "-yyy".
-    if arg.startswith("-Wl"):
-        link_opts = arg.split(",")[1:]
-        new_link_opts = []
-        for opt in link_opts:
-            if opt in [
-                "-Bsymbolic-functions",
-                # breaks emscripten see https://github.com/emscripten-core/emscripten/issues/14460
-                "--strip-all",
-                # wasm-ld does not regconize some link flags
-                "--sort-common",
-                "--as-needed",
-            ]:
-                continue
-            # ignore unsupported --sysroot compile argument used in conda
-            if opt.startswith("--sysroot="):
-                continue
-            new_link_opts.append(opt)
-        if new_link_opts:
-            return "-Wl," + ",".join(new_link_opts)
-        else:
-            return None
+    assert not arg.startswith("-Wl,")
 
     # Don't include any system directories
     if arg.startswith("-L/usr"):
@@ -379,7 +391,7 @@ def replay_genargs_handle_argument(arg: str) -> Optional[str]:
 
 
 def replay_command_generate_args(
-    line: List[str], args: argparse.Namespace, is_link_command: bool
+    line: List[str], args: ReplayArgs, is_link_command: bool
 ) -> List[str]:
     """
     A helper command for `replay_command` that generates the new arguments for
@@ -404,13 +416,15 @@ def replay_command_generate_args(
     replace_libs = parse_replace_libs(args.replace_libs)
     if line[0] == "ar":
         new_args = ["emar"]
-    elif line[0] == "c++":
+    elif line[0] == "c++" or line[0] == "g++":
         new_args = ["em++"]
-    else:
+    elif line[0] == "cc" or line[0] == "gcc":
         new_args = ["emcc"]
         # distutils doesn't use the c++ compiler when compiling c++ <sigh>
         if any(arg.endswith((".cpp", ".cc")) for arg in line):
             new_args = ["em++"]
+    else:
+        assert False, f"Unexpected command {line[0]}"
 
     if is_link_command:
         new_args.extend(args.ldflags.split())
@@ -455,6 +469,8 @@ def replay_command_generate_args(
             result = replay_genargs_handle_dashl(arg, replace_libs, used_libs)
         elif arg.startswith("-I"):
             result = replay_genargs_handle_dashI(arg, args.target_install_dir)
+        elif arg.startswith("-Wl"):
+            result = replay_genargs_handle_linker_opts(arg)
         else:
             result = replay_genargs_handle_argument(arg)
 
@@ -464,7 +480,7 @@ def replay_command_generate_args(
 
 
 def replay_command(
-    line: List[str], args: argparse.Namespace, dryrun: bool = False
+    line: List[str], args: ReplayArgs, dryrun: bool = False
 ) -> Optional[List[str]]:
     """Handle a compilation command
 
@@ -540,7 +556,45 @@ def replay_command(
     return new_args
 
 
-def replay_compile(args: argparse.Namespace):
+def environment_substitute_args(
+    args: Dict[str, str], env: Dict[str, str] = None
+) -> Dict[str, str]:
+    if env is None:
+        env = os.environ
+    subbed_args = {}
+    for arg, value in args.items():
+        for e_name, e_value in env.items():
+            value = value.replace(f"$({e_name})", e_value)
+        subbed_args[arg] = value
+    return subbed_args
+
+
+@overload
+def replay_compile(
+    *,
+    cflags: str,
+    cxxflags: str,
+    ldflags: str,
+    host_install_dir: str,
+    target_install_dir: str,
+    replace_libs: str,
+):
+    ...
+
+
+# Hack to prevent mypy error:
+# "error: Single overload definition, multiple required"
+class _EmptyType:
+    __new__ = None  # type: ignore
+
+
+@overload
+def replay_compile(a: _EmptyType):
+    ...
+
+
+def replay_compile(**kwargs):
+    args = ReplayArgs(**environment_substitute_args(kwargs))
     # If pure Python, there will be no build.log file, which is fine -- just do
     # nothing
     build_log_path = Path("build.log")
@@ -570,105 +624,9 @@ def clean_out_native_artifacts():
                 path.unlink()
 
 
-def install_for_distribution():
-    commands = [
-        sys.executable,
-        "setup.py",
-        "install",
-        "--skip-build",
-        "--prefix=install",
-        "--old-and-unmanageable",
-    ]
-    try:
-        subprocess.check_call(commands)
-    except Exception:
-        print(
-            f'Warning: {" ".join(str(arg) for arg in commands)} failed '
-            f"with distutils, possibly due to the use of distutils "
-            f"that does not support the --old-and-unmanageable "
-            "argument. Re-trying the install without this argument."
-        )
-        subprocess.check_call(commands[:-1])
-
-
-def build_wrap(args: argparse.Namespace):
-    build_log_path = Path("build.log")
-    if not build_log_path.is_file():
-        capture_compile(args.host_install_dir)
-    clean_out_native_artifacts()
-    replay_compile(args)
-    install_for_distribution()
-
-
-def make_parser(parser):
-    parser.description = (
-        "Cross compile a Python distutils package. "
-        "Run from the root directory of the package's source.\n\n"
-        "Note: this is a private endpoint that should not be used "
-        "outside of the Pyodide Makefile."
-    )
-    parser.add_argument(
-        "--cflags",
-        type=str,
-        nargs="?",
-        default=common.get_make_flag("SIDE_MODULE_CFLAGS"),
-        help="Extra compiling flags",
-        action=EnvironmentRewritingArgument,
-    )
-    parser.add_argument(
-        "--cxxflags",
-        type=str,
-        nargs="?",
-        default=common.get_make_flag("SIDE_MODULE_CXXFLAGS"),
-        help="Extra C++ specific compiling flags",
-        action=EnvironmentRewritingArgument,
-    )
-    parser.add_argument(
-        "--ldflags",
-        type=str,
-        nargs="?",
-        default=common.get_make_flag("SIDE_MODULE_LDFLAGS"),
-        help="Extra linking flags",
-        action=EnvironmentRewritingArgument,
-    )
-    parser.add_argument(
-        "--target-install-dir",
-        type=str,
-        nargs="?",
-        default=common.get_make_flag("TARGETINSTALLDIR"),
-        help="The path to the target Python installation",
-    )
-    parser.add_argument(
-        "--host-install-dir",
-        type=str,
-        nargs="?",
-        default="",
-        help=(
-            "Directory for installing built host packages. Defaults to setup.py "
-            "default. Set to 'skip' to skip installation. Installation is "
-            "needed if you want to build other packages that depend on this one."
-        ),
-    )
-    parser.add_argument(
-        "--replace-libs",
-        type=str,
-        nargs="?",
-        default="",
-        help="Libraries to replace in final link",
-        action=EnvironmentRewritingArgument,
-    )
-    return parser
-
-
-def main(args: argparse.Namespace):
-    build_wrap(args)
-
-
 if __name__ == "__main__":
     basename = Path(sys.argv[0]).name
     if basename in symlinks:
         sys.exit(capture_command(basename, sys.argv[1:]))
     else:
-        parser = make_parser(argparse.ArgumentParser())
-        args = parser.parse_args()
-        main(args)
+        raise Exception(f"Unexpected invocation '{basename}'")

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -575,6 +575,7 @@ def environment_substitute_args(
 class _EmptyType:
     __new__ = None  # type: ignore
 
+
 @overload
 def replay_compile(
     *,
@@ -586,6 +587,7 @@ def replay_compile(
     replace_libs: str,
 ):
     ...
+
 
 @overload
 def replay_compile(a: _EmptyType):

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -136,17 +136,17 @@ def capture_make_command_wrapper_symlinks(env: Dict[str, str]):
         env[var] = symlink
 
 
-def capture_compile(args: argparse.Namespace):
+def capture_compile(host_install_dir: str):
     TOOLSDIR = Path(common.get_make_flag("TOOLSDIR"))
     env = dict(os.environ)
     capture_make_command_wrapper_symlinks(env)
     env["PATH"] = str(TOOLSDIR) + ":" + os.environ["PATH"]
 
     cmd = [sys.executable, "setup.py", "install"]
-    if args.host_install_dir == "skip":
+    if host_install_dir == "skip":
         cmd[-1] = "build"
-    elif args.host_install_dir != "":
-        cmd.extend(["--home", args.host_install_dir])
+    elif host_install_dir != "":
+        cmd.extend(["--home", host_install_dir])
 
     result = subprocess.run(cmd, env=env)
     if result.returncode != 0:
@@ -570,7 +570,7 @@ def clean_out_native_artifacts():
                 path.unlink()
 
 
-def install_for_distribution(args: argparse.Namespace):
+def install_for_distribution():
     commands = [
         sys.executable,
         "setup.py",
@@ -594,10 +594,10 @@ def install_for_distribution(args: argparse.Namespace):
 def build_wrap(args: argparse.Namespace):
     build_log_path = Path("build.log")
     if not build_log_path.is_file():
-        capture_compile(args)
+        capture_compile(args.host_install_dir)
     clean_out_native_artifacts()
     replay_compile(args)
-    install_for_distribution(args)
+    install_for_distribution()
 
 
 def make_parser(parser):

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -143,7 +143,7 @@ def capture_make_command_wrapper_symlinks(env: Dict[str, str]):
 
 def capture_compile(*, host_install_dir: str, skip_host: bool, env: Dict[str, str]):
     TOOLSDIR = Path(common.get_make_flag("TOOLSDIR"))
-    env['PYODIDE'] = '1'
+    env["PYODIDE"] = "1"
     env["PATH"] = str(TOOLSDIR) + ":" + os.environ["PATH"]
     capture_make_command_wrapper_symlinks(env)
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -561,7 +561,7 @@ def environment_substitute_args(
     args: Dict[str, str], env: Dict[str, str] = None
 ) -> Dict[str, str]:
     if env is None:
-        env = os.environ
+        env = dict(os.environ)
     subbed_args = {}
     for arg, value in args.items():
         for e_name, e_value in env.items():
@@ -569,6 +569,11 @@ def environment_substitute_args(
         subbed_args[arg] = value
     return subbed_args
 
+
+# Hack to prevent mypy error:
+# "error: Single overload definition, multiple required"
+class _EmptyType:
+    __new__ = None  # type: ignore
 
 @overload
 def replay_compile(
@@ -581,13 +586,6 @@ def replay_compile(
     replace_libs: str,
 ):
     ...
-
-
-# Hack to prevent mypy error:
-# "error: Single overload definition, multiple required"
-class _EmptyType:
-    __new__ = None  # type: ignore
-
 
 @overload
 def replay_compile(a: _EmptyType):

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -141,7 +141,7 @@ def capture_make_command_wrapper_symlinks(env: Dict[str, str]):
         env[var] = symlink
 
 
-def capture_compile(*, host_install_dir: str, skip_host: bool, env: dict[str, str]):
+def capture_compile(*, host_install_dir: str, skip_host: bool, env: Dict[str, str]):
     TOOLSDIR = Path(common.get_make_flag("TOOLSDIR"))
     env["PATH"] = str(TOOLSDIR) + ":" + os.environ["PATH"]
     capture_make_command_wrapper_symlinks(env)

--- a/pyodide-build/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide-build/pyodide_build/tests/test_pywasmcross.py
@@ -1,12 +1,10 @@
-import sys
-import argparse
 from dataclasses import dataclass
 
 import pytest
 
 from pyodide_build.pywasmcross import replay_command  # noqa: E402
 from pyodide_build.pywasmcross import replay_f2c  # noqa: E402
-from pyodide_build.pywasmcross import make_parser
+from pyodide_build.pywasmcross import environment_substitute_args
 
 
 @dataclass
@@ -150,14 +148,17 @@ def test_environment_var_substitution(monkeypatch):
     monkeypatch.setenv("BOB", "Robert Mc Roberts")
     monkeypatch.setenv("FRED", "Frederick F. Freddertson Esq.")
     monkeypatch.setenv("JIM", "James Ignatius Morrison:Jimmy")
-    call_args = 'pywasmcross.py --ldflags "-l$(PYODIDE_BASE)" --cxxflags $(BOB) --cflags $(FRED) --replace-libs $(JIM)'
-    monkeypatch.setattr(sys, "argv", call_args.split(" "))
-    parser = argparse.ArgumentParser()
-    make_parser(parser)
-    args = parser.parse_args()
+    args = environment_substitute_args(
+        {
+            "ldflags": '"-l$(PYODIDE_BASE)"',
+            "cxxflags": "$(BOB)",
+            "cflags": "$(FRED)",
+            "replace_libs": "$(JIM)",
+        }
+    )
     assert (
-        args.cflags == "Frederick F. Freddertson Esq."
-        and args.cxxflags == "Robert Mc Roberts"
-        and args.ldflags == '"-lpyodide_build_dir"'
-        and args.replace_libs == "James Ignatius Morrison:Jimmy"
+        args["cflags"] == "Frederick F. Freddertson Esq."
+        and args["cxxflags"] == "Robert Mc Roberts"
+        and args["ldflags"] == '"-lpyodide_build_dir"'
+        and args["replace_libs"] == "James Ignatius Morrison:Jimmy"
     )

--- a/pyodide-build/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide-build/pyodide_build/tests/test_pywasmcross.py
@@ -121,12 +121,12 @@ def test_handle_command_optflags(in_ext, out_ext, executable, flag_name):
 
 
 def test_f2c():
-    assert f2c_wrap("gfortran test.f") == "gfortran test.c"
+    assert f2c_wrap("gfortran test.f") == "gcc test.c"
     assert f2c_wrap("gcc test.c") is None
     assert f2c_wrap("gfortran --version") is None
     assert (
         f2c_wrap("gfortran --shared -c test.o -o test.so")
-        == "gfortran --shared -c test.o -o test.so"
+        == "gcc --shared -c test.o -o test.so"
     )
 
 


### PR DESCRIPTION
I adjusted it so that instead of using `subprocess` to invoke `pywasmcross`, we just make function calls. 

There is a valid use case for directly invoking `buildpkg` from the command line so I think it is good that `buildall` uses `subprocess.call` and then it's possible to directly build a single package (since #2053). However, the arguments to `pywasmcross` frequently contain options with a bunch of newlines, making it impractical to invoke directly from the command line in any case. Instead, extra options should be added to `buildpkg` to control which steps are applied.

As a side effect of these changes, we get further clarity on what is happening with environment variables.