### PR TITLE
ENH improvements to pyodide-build

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -72,12 +72,13 @@ not strictly compatible.
 
 ### 3. Building the package and investigating issues
 
-Once the `meta.yaml` is ready, we build the package with,
-
+Once the `meta.yaml` is ready, build the package with the following commands
+from inside the package directory `packages/<package-name>`:
 ```
-PYODIDE_PACKAGES="<package-name>" make
+export PYTHONPATH="$PYTHONPATH:/path/to/pyodide/pyodide-build/"
+python -m pyodide_build buildpkg meta.yaml
+cp build/*.data build/*.js ../../build/
 ```
-
 and see if there are any errors. The detailed build log can be found under
 `packages/<package-name>/build.log`.
 

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -5,8 +5,8 @@
 ## Quickstart
 
 If you wish to use a package in Pyodide that is not already included, first you
-need to determine whether it is necessary to package it for Pyodide. Ideally, you
-should start this process with package dependencies.
+need to determine whether it is necessary to package it for Pyodide. Ideally,
+you should start this process with package dependencies.
 
 ### 1. Determining if creating a Pyodide package is necessary
 
@@ -23,14 +23,12 @@ preventing it (it is a Python package without C extensions):
   python -m pip install build
   python -m build
   ```
-  from within the package folder where the `setup.py`
-  are located. See the [Python packaging
-  guide](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives)
-  for more details.
-  Then upload the wheel file somewhere (not to PyPI) and install it with
-  micropip via its URL.
-- you can also open an issue in the package repository asking the
-  authors to upload the wheel.
+  from within the package folder where the `setup.py` are located. See the
+  [Python packaging guide](https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives)
+  for more details. Then upload the wheel file somewhere (not to PyPI) and
+  install it with micropip via its URL.
+- you can also open an issue in the package repository asking the authors to
+  upload the wheel.
 
 If however the package has C extensions or its code requires patching, then
 continue to the next steps.
@@ -42,9 +40,9 @@ any compilation commands.
 
 ### 2. Creating the `meta.yaml` file
 
-If your package is on PyPI, the
-easiest place to start is with the {ref}`mkpkg tool <pyodide-mkpkg>`.
-From the Pyodide root directory, install the tool with `pip install -e pyodide-build`, then run:
+If your package is on PyPI, the easiest place to start is with the 
+{ref}`mkpkg tool <pyodide-mkpkg>`. From the Pyodide root directory, install the
+tool with `pip install -e pyodide-build`, then run:
 
 `pyodide-build mkpkg <package-name>`
 
@@ -73,7 +71,7 @@ not strictly compatible.
 ### 3. Building the package and investigating issues
 
 Once the `meta.yaml` is ready, build the package with the following commands
-from inside the package directory `packages/<package-name>`:
+from inside the package directory `packages/<package-name>`
 ```
 export PYTHONPATH="$PYTHONPATH:/path/to/pyodide/pyodide-build/"
 python -m pyodide_build buildpkg meta.yaml
@@ -82,16 +80,16 @@ cp build/*.data build/*.js ../../build/
 and see if there are any errors. The detailed build log can be found under
 `packages/<package-name>/build.log`.
 
-If there are errors you might need to,
+If there are errors you might need to
 
 - patch the package by adding `.patch` files to `packages/<package-name>/patches`
 - add the patch files to the `source/patches` field in the `meta.yaml` file
 
-then re-start the build.
+then re-start the build. If the package is 
 
-In general, it is recommended to look into how other similar packages are built in Pyodide.
-If you still encounter difficulties in building your package, open a [new Pyodide
-issue](https://github.com/pyodide/pyodide/issues).
+In general, it is recommended to look into how other similar packages are built
+in Pyodide. If you still encounter difficulties in building your package, open a
+[new Pyodide issue](https://github.com/pyodide/pyodide/issues).
 
 To learn more about how packages are built in Pyodide, read the following
 sections.
@@ -121,18 +119,17 @@ libraries to the build. We automate the following steps:
     the virtual filesystem.
 
 Lastly, a `packages.json` file is output containing the dependency tree of all
-packages, so {any}`pyodide.loadPackage` can
-load a package's dependencies automatically.
+packages, so {any}`pyodide.loadPackage` can load a package's dependencies
+automatically.
 
 ## C library dependencies
 
 Some Python packages depend on certain C libraries, e.g. `lxml` depends on
 `libxml`.
 
-To package a C library, create a directory in `packages/` for the C library.
-In the directory, you should write `meta.yaml`
-that specifies metadata about the library.
-See {ref}`meta-yaml-spec` for more details.
+To package a C library, create a directory in `packages/` for the C library. In
+the directory, you should write `meta.yaml` that specifies metadata about the
+library. See {ref}`meta-yaml-spec` for more details.
 
 The minimal example of `meta.yaml` for a C library is:
 
@@ -160,19 +157,19 @@ You can use the `meta.yaml` of other C libraries such as
 [libxml](https://github.com/pyodide/pyodide/blob/main/packages/libxml/meta.yaml)
 as a starting point.
 
-After packaging a C library, it can be added as a dependency of a Python
-package like a normal dependency. See `lxml` and `libxml` for an example (and
-also `scipy` and `CLAPACK`).
+After packaging a C library, it can be added as a dependency of a Python package
+like a normal dependency. See `lxml` and `libxml` for an example (and also
+`scipy` and `CLAPACK`).
 
 _Remark:_ Certain C libraries come as emscripten ports, and do not have to be
-built manually. They can be used by adding e.g. `-s USE_ZLIB` in the `cflags`
-of the Python package. See e.g. `matplotlib` for an example.
+built manually. They can be used by adding e.g. `-s USE_ZLIB` in the `cflags` of
+the Python package. See e.g. `matplotlib` for an example.
 
 ## Structure of a Pyodide package
 
-This section describes the structure of a pure Python package, and how our
-build system creates it. In general, it is not recommended, to construct these
-by hand; instead create a Python wheel and install it with micropip.
+This section describes the structure of a pure Python package, and how our build
+system creates it. In general, it is not recommended, to construct these by
+hand; instead create a Python wheel and install it with micropip.
 
 Pyodide is obtained by compiling CPython into web assembly. As such, it loads
 packages the same way as CPython --- it looks for relevant files `.py` files in
@@ -181,17 +178,16 @@ packages the same way as CPython --- it looks for relevant files `.py` files in
 
 Suppose you have a Python library that consists of a single directory
 `/PATH/TO/LIB/` whose contents would go into
-`/lib/python3.9/site-packages/PACKAGE_NAME/` under a normal Python
-installation.
+`/lib/python3.9/site-packages/PACKAGE_NAME/` under a normal Python installation.
 
-The simplest version of the corresponding Pyodide package contains two files
---- `PACKAGE_NAME.data` and `PACKAGE_NAME.js`. The first file
-`PACKAGE_NAME.data` is a concatenation of all contents of `/PATH/TO/LIB`. When
-loading the package via `pyodide.loadPackage`, Pyodide will load and run
-`PACKAGE_NAME.js`. The script then fetches `PACKAGE_NAME.data` and extracts the
-contents to emscripten's virtual filesystem. Afterwards, since the files are
-now in `/lib/python3.9/`, running `import PACKAGE_NAME` in Python will
-successfully import the module as usual.
+The simplest version of the corresponding Pyodide package contains two files ---
+`PACKAGE_NAME.data` and `PACKAGE_NAME.js`. The first file `PACKAGE_NAME.data` is
+a concatenation of all contents of `/PATH/TO/LIB`. When loading the package via
+`pyodide.loadPackage`, Pyodide will load and run `PACKAGE_NAME.js`. The script
+then fetches `PACKAGE_NAME.data` and extracts the contents to emscripten's
+virtual filesystem. Afterwards, since the files are now in `/lib/python3.9/`,
+running `import PACKAGE_NAME` in Python will successfully import the module as
+usual.
 
 To construct this bundle, we use the `file_packager.py` script from emscripten.
 We invoke it as follows:
@@ -207,16 +203,16 @@ The arguments can be explained as follows:
 
 - PACKAGE_NAME.data indicates where to put the data file
 - --js-output=PACKAGE_NAME.js indicates where to put the javascript file
-- `--preload` instructs the package to look for the
-  file/directory before the separator `@` (namely `/PATH/TO/LIB/`) and place
-  it at the path after the `@` in the virtual filesystem (namely
+- `--preload` instructs the package to look for the file/directory before the
+  separator `@` (namely `/PATH/TO/LIB/`) and place it at the path after the `@`
+  in the virtual filesystem (namely
   `/lib/python3.9/site-packages/PACKAGE_NAME/`).
 
 `file_packager.sh` adds the following options:
 
 - `--lz4` to use LZ4 to compress the files
-- `--export-name=globalThis.__pyodide_module` tells `file_packager` where to find the main Emscripten
-  module for linking.
+- `--export-name=globalThis.__pyodide_module` tells `file_packager` where to
+  find the main Emscripten module for linking.
 - `--exclude *__pycache__*` to omit the pycache directories
 - `--use-preload-plugins` says to [automatically decode files based on their
   extension](https://emscripten.org/docs/porting/files/packaging_files.html#preloading-files)

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -77,15 +77,37 @@ export PYTHONPATH="$PYTHONPATH:/path/to/pyodide/pyodide-build/"
 python -m pyodide_build buildpkg meta.yaml
 cp build/*.data build/*.js ../../build/
 ```
-and see if there are any errors. The detailed build log can be found under
-`packages/<package-name>/build.log`.
+and see if there are any errors.
 
 If there are errors you might need to
 
 - patch the package by adding `.patch` files to `packages/<package-name>/patches`
 - add the patch files to the `source/patches` field in the `meta.yaml` file
 
-then re-start the build. If the package is 
+then re-start the build. If the package is on github, the easiest way to make patches is:
+1. Clone the package from github. You might want to use the options `--depth 1
+   --branch v1.7.2`. Replace the branch with the appropriate tag given the
+   version of the package you are trying to modify.
+2. Make whatever changes you want. Commit them.
+3. git format-patch HEAD~1 -o <pyodide-root>/packages/<package-name>/patches/
+
+By default, each time you run `buildpkg`, `pyodide-build` will delete the entire
+source directory and replace it with a fresh copy from the download url. This is
+to ensure build repeatability. For debugging purposes, this is likely to be
+undesirable. If you want to try out a modified source tree, you can pass the
+flag `--continue` and `buildpkg` will try to build from the existing source
+tree. This can cause various issues, but if it works it is much more convenient.
+
+Using the `--continue` flag, you can modify the sources in tree to fix the
+build, then when it works, copy the modified sources into your checked out copy
+of the package source repository and use `git format-patch` to generate the
+patch.
+
+For very complicated builds, we also have a mechanism for repeating from the
+replay stage of the build. If the build is failing during the replay stage, you
+will see lines like `[line 766 of 1156]` labeling which command is being
+replayed. `--continue=replay` will start over from the begining of the replay
+stage, `--continue=replay:766` will start from step 766 of the replay stage.
 
 In general, it is recommended to look into how other similar packages are built
 in Pyodide. If you still encounter difficulties in building your package, open a

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -84,7 +84,8 @@ If there are errors you might need to
 - patch the package by adding `.patch` files to `packages/<package-name>/patches`
 - add the patch files to the `source/patches` field in the `meta.yaml` file
 
-then re-start the build. If the package is on github, the easiest way to make patches is:
+then re-start the build. If the package is on github, the easiest way to make
+patches is:
 1. Clone the package from github. You might want to use the options `--depth 1
    --branch v1.7.2`. Replace the branch with the appropriate tag given the
    version of the package you are trying to modify.

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -132,8 +132,14 @@ async function runPythonAsync(code, globals) {
   packages set `PYODIDE_PACKAGES='*'` In addition, `make minimal` was removed,
   since it is now equivalent to `make` without extra arguments. {pr}`1801`
 
-- It is now possible to use `pyodide-build buildall` and `pyodide-build buildpkg` directly.
-  {pr}`2063`
+- {{Enhancement}} It is now possible to use `pyodide-build buildall` and
+  `pyodide-build buildpkg` directly. {pr}`2063`
+
+- {{Enhancement}} Added a `--force-rebuild` to `buildall` and `buildpkg` which
+  rebuilds the package even if it looks like it doesn't need to be rebuilt.
+  Added `--continue` flag which keeps the same source tree for the package and
+  can continue from the middle of a build.
+  {pr}`2069`
 
 - {{Enhancement}} Changes to environment variables in the build script are now
   seen in the compile and post build scripts.
@@ -148,6 +154,7 @@ async function runPythonAsync(code, globals) {
 - {{Fix}} Fix compile error `wasm-ld: error: unknown argument: --sort-common`
   and `wasm-ld: error: unknown argument: --as-needed` in ArchLinux.
   {pr}`1965`
+
 
 ### micropip
 

--- a/packages/libxslt/meta.yaml
+++ b/packages/libxslt/meta.yaml
@@ -18,7 +18,7 @@ build:
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-libxml-src="$PYODIDE_ROOT/packages/libxml/build/libxml2-2.9.10" \
+        --with-libxml-src="$PYODIDE_ROOT/packages/libxml/build/libxml-2.9.10" \
         --without-crypto
     emmake make -j ${PYODIDE_JOBS:-3}
     chmod 755 xslt-config

--- a/packages/lxml/meta.yaml
+++ b/packages/lxml/meta.yaml
@@ -6,16 +6,16 @@ source:
   url: https://files.pythonhosted.org/packages/c4/43/3f1e7d742e2a7925be180b6af5e0f67d38de2f37560365ac1a0b9a04c015/lxml-4.4.1.tar.gz
 build:
   script: |
-    export WITH_XML2_CONFIG=$PYODIDE_ROOT/packages/libxml/build/libxml2-2.9.10/xml2-config
+    export WITH_XML2_CONFIG=$PYODIDE_ROOT/packages/libxml/build/libxml-2.9.10/xml2-config
     export WITH_XSLT_CONFIG=$PYODIDE_ROOT/packages/libxslt/build/libxslt-1.1.33/xslt-config
   cflags: |
-    -I$(PYODIDE_ROOT)/packages/libxml/build/libxml2-2.9.10/include
+    -I$(PYODIDE_ROOT)/packages/libxml/build/libxml-2.9.10/include
     -I$(PYODIDE_ROOT)/packages/libxslt/build/libxslt-1.1.33/
     -L$(PYODIDE_ROOT)/packages/zlib/build/zlib-1.2.11/include
     -I$(PYODIDE_ROOT)/packages/libiconv/build/libiconv-1.16/include
     -Wno-implicit-function-declaration
   ldflags: |
-    -L$(PYODIDE_ROOT)/packages/libxml/build/libxml2-2.9.10/.libs/
+    -L$(PYODIDE_ROOT)/packages/libxml/build/libxml-2.9.10/.libs/
     -L$(PYODIDE_ROOT)/packages/libxslt/build/libxslt-1.1.33/libxslt/.libs/
     -L$(PYODIDE_ROOT)/packages/libxslt/build/libxslt-1.1.33/libexslt/.libs/
     -L$(PYODIDE_ROOT)/packages/zlib/build/zlib-1.2.11/lib/

--- a/packages/sharedlib-test-py/meta.yaml
+++ b/packages/sharedlib-test-py/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: src
 build:
   cflags: |
-    -I$(PYODIDE_ROOT)/packages/sharedlib-test/build/sharedlib-test-1.0/include
+    -I$(PYODIDE_ROOT)/packages/sharedlib-test/src/include
 test:
   imports:
     - sharedlib_test

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -252,6 +252,14 @@ def get_progress_line(package_set):
 
 
 def format_name_list(l):
+    """
+    >>> format_name_list(["regex"])
+    'regex'
+    >>> format_name_list(["regex", "parso"])
+    'regex and parso'
+    >>> format_name_list(["regex", "parso", "jedi"])
+    'regex, parso, and jedi'
+    """
     if len(l) == 1:
         return l
     most = l[:-1]

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -251,7 +251,7 @@ def get_progress_line(package_set):
     return f"In progress: " + ", ".join(package_set.keys())
 
 
-def format_name_list(l : List[str]) -> str:
+def format_name_list(l: List[str]) -> str:
     """
     >>> format_name_list(["regex"])
     'regex'

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -280,11 +280,12 @@ def mark_package_needs_build(
         if dep not in needs_build:
             mark_package_needs_build(pkg_map, pkg_map[dep], needs_build)
 
+
 def generate_needs_build_set(pkg_map):
     """
-    Generate the set of packages that need to be rebuilt. 
+    Generate the set of packages that need to be rebuilt.
 
-    This consists of: 
+    This consists of:
     1. packages whose source files have changed since they were last built
        according to needs_rebuild, and
     2. packages which depend on case 1 packages.
@@ -295,6 +296,7 @@ def generate_needs_build_set(pkg_map):
         if needs_rebuild(pkg.pkgdir, pkg.pkgdir / "build", pkg.meta):
             mark_package_needs_build(pkg_map, pkg, needs_build)
     return needs_build
+
 
 def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> None:
     """
@@ -324,7 +326,6 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
         already_built = set()
     else:
         needs_build = generate_needs_build_set(pkg_map)
-
 
     # We won't rebuild the complement of the packages that we will build.
     already_built = set(pkg_map.keys()).difference(needs_build)

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -326,7 +326,7 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     t0 = perf_counter()
     for pkg_name in needs_build:
         pkg = pkg_map[pkg_name]
-        if len(pkg.dependencies) == 0:
+        if len(pkg.unbuilt_dependencies) == 0:
             build_queue.put((job_priority(pkg), pkg))
 
     built_queue: Queue = Queue()

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -20,6 +20,7 @@ import os
 from . import common
 from .io import parse_package_config
 from .common import UNVENDORED_STDLIB_MODULES
+from .buildpkg import needs_rebuild
 
 
 class BasePackage:
@@ -73,12 +74,15 @@ class Package(BasePackage):
         self.meta = parse_package_config(pkgpath)
         self.name = self.meta["package"]["name"]
         self.version = self.meta["package"]["version"]
-        self.library = self.meta.get("build", {}).get("library", False)
-        self.shared_library = self.meta.get("build", {}).get("sharedlibrary", False)
+        self.meta["build"] = self.meta.get("build", {})
+        self.meta["requirements"] = self.meta.get("requirements", {})
+
+        self.library = self.meta["build"].get("library", False)
+        self.shared_library = self.meta["build"].get("sharedlibrary", False)
 
         assert self.name == pkgdir.stem
 
-        self.dependencies = self.meta.get("requirements", {}).get("run", [])
+        self.dependencies = self.meta["requirements"].get("run", [])
         self.unbuilt_dependencies = set(self.dependencies)
         self.dependents = set()
 
@@ -242,6 +246,23 @@ def get_progress_line(package_set):
     return f"In progress: " + ", ".join(package_set.keys())
 
 
+def format_name_list(l):
+    if len(l) == 1:
+        return l
+    most = l[:-1]
+    if len(most) > 1:
+        most = [x + "," for x in most]
+    return " ".join(most) + " and " + l[-1]
+
+
+def mark_package_needs_build(
+    pkg_map: Dict[str, BasePackage], pkg: BasePackage, needs_build: Set[str]
+):
+    needs_build.add(pkg.name)
+    for dep in pkg.dependents:
+        mark_package_needs_build(pkg_map, pkg_map[dep], needs_build)
+
+
 def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> None:
     """
     This builds packages in pkg_map in parallel, building at most args.n_jobs
@@ -264,9 +285,42 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     # dependents, because the ordering ought not to change after insertion.
     build_queue: PriorityQueue = PriorityQueue()
 
-    print("Building the following packages: " + ", ".join(sorted(pkg_map.keys())))
+    if args.force:
+        # If "force" is set, just rebuild everything
+        needs_build = set(pkg_map.keys())
+        already_built = set()
+    else:
+        needs_build = set()
+
+        for pkg in pkg_map.values():
+            # Otherwise, rebuild packages that have been updated and their dependents.
+            if needs_rebuild(pkg.pkgdir, pkg.pkgdir / "build", pkg.meta):
+                mark_package_needs_build(pkg_map, pkg, needs_build)
+
+        # We won't rebuild the complement of the packages that we will build.
+        already_built = set(pkg_map.keys()).difference(needs_build)
+        for pkg_name in already_built:
+            # Hacky way to prevent these from being rebuilt: add a dependency
+            # that won't ever be satisfied
+            pkg_map[pkg_name].unbuilt_dependencies.add("!don't build this")
+
+        # Remove the packages we've already built from the dependency sets of
+        # the remaining ones
+        for pkg_name in needs_build:
+            pkg_map[pkg_name].unbuilt_dependencies.difference_update(already_built)
+
+    if already_built:
+        print(
+            f"The following packages are already built: {format_name_list(sorted(already_built))}\n"
+        )
+    if not needs_build:
+        print("All packages already built. Quitting.")
+        return
+    print(f"Building the following packages: {format_name_list(sorted(needs_build))}")
+
     t0 = perf_counter()
-    for pkg in pkg_map.values():
+    for pkg_name in needs_build:
+        pkg = pkg_map[pkg_name]
         if len(pkg.dependencies) == 0:
             build_queue.put((job_priority(pkg), pkg))
 
@@ -283,7 +337,7 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
                 pkg._queue_idx = queue_idx
                 queue_idx += 1
             package_set[pkg.name] = None
-            msg = f"[{pkg._queue_idx}/{len(pkg_map)}] (thread {n}) building {pkg.name}"
+            msg = f"[{pkg._queue_idx}/{len(needs_build)}] (thread {n}) building {pkg.name}"
             print_with_progress_line(msg, get_progress_line(package_set))
             t0 = perf_counter()
             success = True
@@ -297,7 +351,7 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
                 del package_set[pkg.name]
                 status = "built" if success else "failed"
                 msg = (
-                    f"[{pkg._queue_idx}/{len(pkg_map)}] (thread {n}) "
+                    f"[{pkg._queue_idx}/{len(needs_build)}] (thread {n}) "
                     f"{status} {pkg.name} in {perf_counter() - t0:.2f} s"
                 )
                 print_with_progress_line(msg, get_progress_line(package_set))
@@ -308,7 +362,7 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     for n in range(0, args.n_jobs):
         Thread(target=builder, args=(n + 1,), daemon=True).start()
 
-    num_built = 0
+    num_built = len(already_built)
     while num_built < len(pkg_map):
         pkg = built_queue.get()
         if isinstance(pkg, Exception):
@@ -469,6 +523,13 @@ def make_parser(parser):
         nargs="?",
         default=None,
         help=("Only build the specified packages, provided as a comma-separated list"),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Force rebuild of all packages regardless of whether they appear to have been updated"
+        ),
     )
     parser.add_argument(
         "--n-jobs",

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -323,7 +323,6 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     if args.force_rebuild:
         # If "force_rebuild" is set, just rebuild everything
         needs_build = set(pkg_map.keys())
-        already_built = set()
     else:
         needs_build = generate_needs_build_set(pkg_map)
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -109,7 +109,7 @@ class Package(BasePackage):
                     # matter, or this package is dependent on a package that has
                     # been updated and should be rebuilt even though its own
                     # files haven't been updated.
-                    "--force",
+                    "--force-rebuild",
                 ],
                 check=False,
                 stdout=f,
@@ -320,8 +320,8 @@ def build_from_graph(pkg_map: Dict[str, BasePackage], outputdir: Path, args) -> 
     # dependents, because the ordering ought not to change after insertion.
     build_queue: PriorityQueue = PriorityQueue()
 
-    if args.force:
-        # If "force" is set, just rebuild everything
+    if args.force_rebuild:
+        # If "force_rebuild" is set, just rebuild everything
         needs_build = set(pkg_map.keys())
         already_built = set()
     else:
@@ -551,7 +551,7 @@ def make_parser(parser):
         help=("Only build the specified packages, provided as a comma-separated list"),
     )
     parser.add_argument(
-        "--force",
+        "--force-rebuild",
         action="store_true",
         help=(
             "Force rebuild of all packages regardless of whether they appear to have been updated"

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -251,7 +251,7 @@ def get_progress_line(package_set):
     return f"In progress: " + ", ".join(package_set.keys())
 
 
-def format_name_list(l):
+def format_name_list(l : List[str]) -> str:
     """
     >>> format_name_list(["regex"])
     'regex'
@@ -261,7 +261,7 @@ def format_name_list(l):
     'regex, parso, and jedi'
     """
     if len(l) == 1:
-        return l
+        return l[0]
     most = l[:-1]
     if len(most) > 1:
         most = [x + "," for x in most]

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -105,6 +105,11 @@ class Package(BasePackage):
                     args.target_install_dir,
                     "--host-install-dir",
                     args.host_install_dir,
+                    # Either this package has been updated and this doesn't
+                    # matter, or this package is dependent on a package that has
+                    # been updated and should be rebuilt even though its own
+                    # files haven't been updated.
+                    "--force",
                 ],
                 check=False,
                 stdout=f,

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -209,6 +209,7 @@ def download_and_extract(buildpath: Path, srcpath: Path, src_metadata: Dict[str,
     extract_dir_name = src_metadata.get("extract_dir")
     if not extract_dir_name:
         extract_dir_name = trim_archive_extension(tarballname)
+    print(srcpath)
     shutil.move(buildpath / extract_dir_name, srcpath)
 
 
@@ -260,30 +261,6 @@ def prepare_source(
         raise ValueError(f"path={srcdir} must point to a directory that exists")
 
     shutil.copytree(srcdir, srcpath)
-
-
-def get_source_path(
-    pkg_root: Path, pkg_metadata: Dict[str, Any], src_metadata: Dict[str, Any]
-) -> Path:
-    """
-    Get the source path. It's either "build/<pkg_version>" if a url is provided
-    or the path provided if it's an in-tree package. Raises an error if neither
-    a url nor a path is provided.
-    """
-    src_dir_name: str = f"{pkg_metadata['name']}-{pkg_metadata['version']}"
-    if "url" in src_metadata:
-        return pkg_root / "build" / src_dir_name
-    if "path" not in src_metadata:
-        raise ValueError(
-            "Incorrect source provided. Either a url or a path must be provided."
-        )
-
-    srcdir = Path(src_metadata["path"]).resolve()
-
-    if not srcdir.is_dir():
-        raise ValueError(f"path={srcdir} must point to a directory that exists")
-
-    return srcdir
 
 
 def patch(pkg_root: Path, srcpath: Path, src_metadata: Dict[str, Any]):

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -663,7 +663,10 @@ def build_package(
 
     with chdir(pkg_root), get_bash_runner() as bash_runner:
         if not should_prepare_source and not srcpath.exists():
-            raise IOError(f"Cannot find source for rebuild. Expected to find the source directory at the path {srcpath}, but that path does not exist.")
+            raise IOError(
+                "Cannot find source for rebuild. Expected to find the source"
+                f"directory at the path {srcpath}, but that path does not exist."
+            )
         else:
             if source_metadata:
                 if build_dir.resolve().is_dir():

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -209,6 +209,7 @@ def download_and_extract(buildpath: Path, srcpath: Path, src_metadata: Dict[str,
     extract_dir_name = src_metadata.get("extract_dir")
     if not extract_dir_name:
         extract_dir_name = trim_archive_extension(tarballname)
+    shutil.move(buildpath / extract_dir_name, srcpath)
 
 
 def prepare_source(

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -168,7 +168,7 @@ def trim_archive_extension(tarballname):
 
 def download_and_extract(
     buildpath: Path, srcpath: Path, src_metadata: Dict[str, Any]
-) -> Path:
+):
     """
     Download the source from specified in the meta data, then checksum it, then
     extract the archive into srcpath.
@@ -215,7 +215,7 @@ def download_and_extract(
 
 def prepare_source(
     pkg_root: Path, buildpath: Path, srcpath: Path, src_metadata: Dict[str, Any]
-) -> Path:
+):
     """
     Figure out from the "source" key in the package metadata where to get the source
     from, then get the source into srcpath (or somewhere else, if it goes somewhere
@@ -245,15 +245,15 @@ def prepare_source(
     if buildpath.resolve().is_dir():
         shutil.rmtree(buildpath)
     os.makedirs(buildpath)
-    if "url" in src_metadata:
-        download_and_extract(buildpath, srcpath, src_metadata)
-        patch(pkg_root, srcpath, src_metadata)
+    if "url" not in src_metadata:
         return
+    download_and_extract(buildpath, srcpath, src_metadata)
+    patch(pkg_root, srcpath, src_metadata)
 
 
 def get_source_path(
-    build_dir: str, pkg_metadata: Dict[str, Any], src_metadata: Dict[str, Any]
-) -> str:
+    build_dir: Path, pkg_metadata: Dict[str, Any], src_metadata: Dict[str, Any]
+) -> Path:
     """
     Get the source path. It's either "build/<pkg_version>" if a url is provided
     or the path provided if it's an in-tree package. Raises an error if neither

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -250,7 +250,7 @@ def prepare_source(
 
 
 def get_source_path(
-    build_dir: Path, pkg_metadata: Dict[str, Any], src_metadata: Dict[str, Any]
+    pkg_root: Path, pkg_metadata: Dict[str, Any], src_metadata: Dict[str, Any]
 ) -> Path:
     """
     Get the source path. It's either "build/<pkg_version>" if a url is provided
@@ -259,13 +259,14 @@ def get_source_path(
     """
     src_dir_name: str = f"{pkg_metadata['name']}-{pkg_metadata['version']}"
     if "url" in src_metadata:
-        return build_dir / src_dir_name
+        return pkg_root / "build" / src_dir_name
     if "path" not in src_metadata:
         raise ValueError(
             "Incorrect source provided. Either a url or a path must be provided."
         )
-
-    srcdir = Path(src_metadata["path"])
+    
+    with chdir(pkg_root):
+        srcdir = Path(src_metadata["path"]).resolve()
 
     if not srcdir.is_dir():
         raise ValueError(f"path={srcdir} must point to a directory that exists")
@@ -665,7 +666,7 @@ def build_package(
     build_metadata = pkg["build"]
     name = pkg_metadata["name"]
     build_dir = pkg_root / "build"
-    srcpath = get_source_path(build_dir, pkg_metadata, source_metadata)
+    srcpath = get_source_path(pkg_root, pkg_metadata, source_metadata)
 
     if not force_rebuild and not needs_rebuild(pkg_root, build_dir, source_metadata):
         return

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -211,7 +211,6 @@ def download_and_extract(
     extract_dir_name = src_metadata.get("extract_dir")
     if not extract_dir_name:
         extract_dir_name = trim_archive_extension(tarballname)
-    shutil.move(buildpath / extract_dir_name, srcpath)
 
 
 def prepare_source(

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -691,10 +691,13 @@ def build_package(
             replay_from=replay_from,
         )
 
+        should_unvendor_tests = build_metadata.get("unvendor-tests", True)
         package_files(
-            pkg_root,
-            pkg,
-            compress_package=args.compress_package,
+            name,
+            build_dir,
+            srcpath,
+            should_unvendor_tests=should_unvendor_tests,
+            compress=compress_package,
         )
         create_packaged_token(build_dir)
 
@@ -759,6 +762,7 @@ def make_parser(parser: argparse.ArgumentParser):
         type=str,
         nargs="?",
         dest="continue_from",
+        default="None",
         const="script",
         help=(
             dedent(
@@ -787,10 +791,10 @@ def make_parser(parser: argparse.ArgumentParser):
     return parser
 
 
-def parse_continue_arg(continue_from: Optional[str]) -> Dict[str, Any]:
+def parse_continue_arg(continue_from: str) -> Dict[str, Any]:
     from itertools import accumulate
 
-    is_none = continue_from is None
+    is_none = continue_from == "None"
     is_script = continue_from == "script"
     is_capture = continue_from == "capture"
     is_replay = continue_from == "replay" or re.fullmatch(
@@ -815,7 +819,7 @@ def parse_continue_arg(continue_from: Optional[str]) -> Dict[str, Any]:
     result["should_capture_compile"] = not should_capture_compile
     result["should_replay_compile"] = should_replay_compile
     result["replay_from"] = 1
-    if continue_from and continue_from.startswith("replay:"):
+    if continue_from.startswith("replay:"):
         result["replay_from"] = int(continue_from.removeprefix("replay:"))
     return result
 

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -251,7 +251,10 @@ def prepare_source(
         patch(pkg_root, srcpath, src_metadata)
         return
 
-def get_source_path(build_dir : str, pkg_metadata : Dict[str, Any], src_metadata : Dict[str, Any]) -> str:
+
+def get_source_path(
+    build_dir: str, pkg_metadata: Dict[str, Any], src_metadata: Dict[str, Any]
+) -> str:
     """
     Get the source path. It's either "build/<pkg_version>" if a url is provided
     or the path provided if it's an in-tree package. Raises an error if neither
@@ -805,7 +808,9 @@ def parse_continue_arg(continue_from: Optional[str]) -> Dict[str, Any]:
         or continue_from == "capture"
         or re.fullmatch(r"replay(:[0-9]+)?", continue_from)
     ):
-        raise IOError(f"Unexpected --continue argument '{continue_from}', should have been 'capture', 'replay', or 'replay:##'")
+        raise IOError(
+            f"Unexpected --continue argument '{continue_from}', should have been 'capture', 'replay', or 'replay:##'"
+        )
     result: Dict[str, Any] = {}
     result["should_prepare_source"] = not continue_from
     result["should_capture_compile"] = (

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -211,7 +211,7 @@ def download_and_extract(
     extract_dir_name = src_metadata.get("extract_dir")
     if not extract_dir_name:
         extract_dir_name = trim_archive_extension(tarballname)
-    return buildpath / extract_dir_name
+    shutil.move(buildpath / extract_dir_name, srcpath)
 
 
 def prepare_source(
@@ -244,9 +244,9 @@ def prepare_source(
         The location where the source ended up.
     """
     if "url" in src_metadata:
-        srcpath = download_and_extract(buildpath, srcpath, src_metadata)
+        download_and_extract(buildpath, srcpath, src_metadata)
         patch(pkg_root, srcpath, src_metadata)
-        return srcpath
+        return
 
     if "path" not in src_metadata:
         raise ValueError(
@@ -258,10 +258,7 @@ def prepare_source(
     if not srcdir.is_dir():
         raise ValueError(f"path={srcdir} must point to a directory that exists")
 
-    if not srcpath.is_dir():
-        shutil.copytree(srcdir, srcpath)
-
-    return srcpath
+    return
 
 
 def patch(pkg_root: Path, srcpath: Path, src_metadata: Dict[str, Any]):
@@ -673,9 +670,7 @@ def build_package(
                     shutil.rmtree(build_dir)
                 os.makedirs(build_dir)
 
-            # TODO: figure out why srcpath needs to change sometimes.
-            # Until we fix this, --continue won't work on some packages.
-            srcpath = prepare_source(pkg_root, build_dir, srcpath, source_metadata)
+            prepare_source(pkg_root, build_dir, srcpath, source_metadata)
             if build_metadata.get("script"):
                 run_script(build_dir, srcpath, build_metadata, bash_runner)
             if build_metadata.get("library"):

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -434,6 +434,7 @@ def unvendor_tests(install_prefix: Path, test_install_prefix: Path) -> int:
     """
     n_moved = 0
     out_files = []
+    shutil.rmtree(test_install_prefix, ignore_errors=True)
     for root, dirs, files in os.walk(install_prefix):
         root_rel = Path(root).relative_to(install_prefix)
         if root_rel.name == "__pycache__" or root_rel.name.endswith(".egg_info"):

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -166,9 +166,7 @@ def trim_archive_extension(tarballname):
     return tarballname
 
 
-def download_and_extract(
-    buildpath: Path, srcpath: Path, src_metadata: Dict[str, Any]
-):
+def download_and_extract(buildpath: Path, srcpath: Path, src_metadata: Dict[str, Any]):
     """
     Download the source from specified in the meta data, then checksum it, then
     extract the archive into srcpath.

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -661,7 +661,7 @@ def build_package(
     with chdir(pkg_root), get_bash_runner() as bash_runner:
         if not should_prepare_source and not srcpath.exists():
             raise IOError(
-                "Cannot find source for rebuild. Expected to find the source"
+                "Cannot find source for rebuild. Expected to find the source "
                 f"directory at the path {srcpath}, but that path does not exist."
             )
         else:
@@ -760,7 +760,7 @@ def make_parser(parser: argparse.ArgumentParser):
     )
     parser.add_argument(
         "--continue",
-        type=int,
+        type=str,
         nargs="?",
         dest="continue_from",
         const="capture",
@@ -793,11 +793,12 @@ def make_parser(parser: argparse.ArgumentParser):
 
 
 def parse_continue_arg(continue_from: Optional[str]) -> Dict[str, Any]:
-    assert (
+    if not (
         continue_from is None
         or continue_from == "capture"
-        or re.fullmatch("replay(:[0-9]*)?", continue_from)
-    )
+        or re.fullmatch(r"replay(:[0-9]+)?", continue_from)
+    ):
+        raise IOError(f"Unexpected --continue argument '{continue_from}', should have been 'capture', 'replay', or 'replay:##'")
     result: Dict[str, Any] = {}
     result["should_prepare_source"] = not continue_from
     result["should_capture_compile"] = (

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -662,8 +662,8 @@ def build_package(
         return
 
     with chdir(pkg_root), get_bash_runner() as bash_runner:
-        if not should_prepare_source:
-            assert srcpath.exists()
+        if not should_prepare_source and not srcpath.exists():
+            raise IOError(f"Cannot find source for rebuild. Expected to find the source directory at the path {srcpath}, but that path does not exist.")
         else:
             if source_metadata:
                 if build_dir.resolve().is_dir():

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -89,7 +89,7 @@ def get_bash_runner():
     if "PYODIDE_JOBS" in os.environ:
         env["PYODIDE_JOBS"] = os.environ["PYODIDE_JOBS"]
     b = BashRunnerWithSharedEnvironment(env=env)
-    b.run(f"source {PYODIDE_ROOT}/emsdk/emsdk/emsdk_env.sh")
+    b.run(f"source {PYODIDE_ROOT}/emsdk/emsdk/emsdk_env.sh", stderr=subprocess.DEVNULL)
     try:
         yield b
     finally:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -769,17 +769,18 @@ def make_parser(parser: argparse.ArgumentParser):
         help=(
             dedent(
                 """
-            Continue a build from the middle. For debugging. Implies "--force".
-            Possible arguments:
+                Continue a build from the middle. For debugging. Implies "--force".
+                Possible arguments:
 
-                'capture' : redo capture step and replay step (but don't prepare
-                            sources again, use existing source directory). Good for debug
-                            builds with hand-modified sources. This is the default.
+                    'capture' : redo capture step and replay step (but don't prepare
+                                sources again, use existing source directory). Good for debug
+                                builds with hand-modified sources. `--continue` with no argument
+                                has the same effect.
 
-                'replay' : Don't redo the capture step but redo the replay step.
+                    'replay' : Don't redo the capture step but redo the replay step.
 
-                'replay:15' : replay the capture step starting with the 15th compile command (any integer works)
-            """
+                    'replay:15' : replay the capture step starting with the 15th compile command (any integer works)
+                """
             ).strip()
         ),
     )
@@ -817,6 +818,8 @@ def main(args):
             "Terser is required to compress packages. Try `npm install -g terser` to install terser."
         )
     step_controls = parse_continue_arg(args.continue_from)
+    # --continue implies --force
+    force = args.force or not not args.continue_from
 
     meta_file = Path(args.package[0]).resolve()
 
@@ -845,7 +848,7 @@ def main(args):
             target_install_dir=args.target_install_dir,
             host_install_dir=args.host_install_dir,
             compress_package=args.compress_package,
-            force=args.force,
+            force=force,
             **step_controls,
         )
     except:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -264,7 +264,7 @@ def get_source_path(
         raise ValueError(
             "Incorrect source provided. Either a url or a path must be provided."
         )
-    
+
     with chdir(pkg_root):
         srcdir = Path(src_metadata["path"]).resolve()
 

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -740,6 +740,13 @@ def make_parser(parser: argparse.ArgumentParser):
         ),
     )
     parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Force rebuild of package regardless of whether it appears to have been updated"
+        ),
+    )
+    parser.add_argument(
         "--continue-from",
         type=int,
         nargs="?",

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -6,20 +6,21 @@ Builds a Pyodide package.
 
 import argparse
 import cgi
-from datetime import datetime
 import hashlib
 import json
 import os
-from pathlib import Path
 import re
 import shutil
 import subprocess
 import sys
+import fnmatch
+
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict
 from urllib import request
-import fnmatch
-from contextlib import contextmanager
 
 from . import pywasmcross
 

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -623,7 +623,7 @@ def build_package(
     target_install_dir: str,
     host_install_dir: str,
     compress_package: bool,
-    force: bool,
+    force_rebuild: bool,
     should_prepare_source: bool,
     should_capture_compile: bool,
     should_replay_compile: bool,
@@ -655,7 +655,7 @@ def build_package(
     source_metadata = pkg["source"]
     build_metadata = pkg["build"]
 
-    if not force and not needs_rebuild(pkg_root, build_dir, source_metadata):
+    if not force_rebuild and not needs_rebuild(pkg_root, build_dir, source_metadata):
         return
 
     with chdir(pkg_root), get_bash_runner() as bash_runner:
@@ -752,7 +752,7 @@ def make_parser(parser: argparse.ArgumentParser):
         ),
     )
     parser.add_argument(
-        "--force",
+        "--force-rebuild",
         action="store_true",
         help=(
             "Force rebuild of package regardless of whether it appears to have been updated"
@@ -767,7 +767,7 @@ def make_parser(parser: argparse.ArgumentParser):
         help=(
             dedent(
                 """
-                Continue a build from the middle. For debugging. Implies "--force".
+                Continue a build from the middle. For debugging. Implies "--force-rebuild".
                 Possible arguments:
 
                     'capture' : redo capture step and replay step (but don't prepare
@@ -817,8 +817,8 @@ def main(args):
             "Terser is required to compress packages. Try `npm install -g terser` to install terser."
         )
     step_controls = parse_continue_arg(args.continue_from)
-    # --continue implies --force
-    force = args.force or not not args.continue_from
+    # --continue implies --force-rebuild
+    force_rebuild = args.force_rebuild or not not args.continue_from
 
     meta_file = Path(args.package[0]).resolve()
 
@@ -847,7 +847,7 @@ def main(args):
             target_install_dir=args.target_install_dir,
             host_install_dir=args.host_install_dir,
             compress_package=args.compress_package,
-            force=force,
+            force_rebuild=force_rebuild,
             **step_controls,
         )
     except:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -16,7 +16,7 @@ import shutil
 import subprocess
 import sys
 from textwrap import dedent
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 from urllib import request
 import fnmatch
 from contextlib import contextmanager

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -23,7 +23,7 @@ from . import pywasmcross
 
 
 @contextmanager
-def chdir(new_dir: "os.PathLike[str]"):
+def chdir(new_dir: Path):
     orig_dir = Path.cwd()
     try:
         os.chdir(new_dir)
@@ -85,6 +85,7 @@ def get_bash_runner():
         "PYODIDE_ROOT": PYODIDE_ROOT,
         "PYTHONINCLUDE": os.environ["PYTHONINCLUDE"],
         "NUMPY_LIB": os.environ["NUMPY_LIB"],
+        "PYODIDE": "1",
     }
     if "PYODIDE_JOBS" in os.environ:
         env["PYODIDE_JOBS"] = os.environ["PYODIDE_JOBS"]

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -817,7 +817,7 @@ def parse_continue_arg(continue_from: str) -> Dict[str, Any]:
     result: Dict[str, Any] = {}
     result["should_prepare_source"] = should_prepare_source
     result["should_run_script"] = should_run_script
-    result["should_capture_compile"] = not should_capture_compile
+    result["should_capture_compile"] = should_capture_compile
     result["should_replay_compile"] = should_replay_compile
     result["replay_from"] = 1
     if continue_from.startswith("replay:"):

--- a/pyodide-build/pyodide_build/io.py
+++ b/pyodide-build/pyodide_build/io.py
@@ -26,6 +26,7 @@ PACKAGE_CONFIG_SPEC: Dict[str, Dict[str, Any]] = {
         "library": bool,
         "sharedlibrary": bool,
         "script": str,
+        "prereplay": str,
         "post": str,
         "replace-libs": list,
         "unvendor-tests": bool,

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -587,6 +587,7 @@ def replay_compile(
     host_install_dir: str,
     target_install_dir: str,
     replace_libs: str,
+    continue_from: int = 0,
 ):
     ...
 
@@ -596,7 +597,7 @@ def replay_compile(*, _this_is_just_here_to_appease_mypy: str):
     ...
 
 
-def replay_compile(**kwargs):
+def replay_compile(continue_from: int = 0, **kwargs):
     args = ReplayArgs(**environment_substitute_args(kwargs))
     # If pure Python, there will be no build.log file, which is fine -- just do
     # nothing
@@ -614,6 +615,8 @@ def replay_compile(**kwargs):
         num_lines = sum(1 for _1 in fd)  # type: ignore
         fd.seek(0)
         for idx, line_str in enumerate(fd):
+            if idx < continue_from - 1:
+                continue
             line = json.loads(line_str)
             print(f"[line {idx + 1} of {num_lines}]")
             replay_command(line, args)

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -587,7 +587,7 @@ def replay_compile(
     host_install_dir: str,
     target_install_dir: str,
     replace_libs: str,
-    continue_from: int = 0,
+    replay_from: int = 1,
 ):
     ...
 
@@ -597,7 +597,7 @@ def replay_compile(*, _this_is_just_here_to_appease_mypy: str):
     ...
 
 
-def replay_compile(continue_from: int = 0, **kwargs):
+def replay_compile(replay_from: int = 1, **kwargs):
     args = ReplayArgs(**environment_substitute_args(kwargs))
     # If pure Python, there will be no build.log file, which is fine -- just do
     # nothing
@@ -615,7 +615,7 @@ def replay_compile(continue_from: int = 0, **kwargs):
         num_lines = sum(1 for _1 in fd)  # type: ignore
         fd.seek(0)
         for idx, line_str in enumerate(fd):
-            if idx < continue_from - 1:
+            if idx < replay_from - 1:
                 continue
             line = json.loads(line_str)
             print(f"[line {idx + 1} of {num_lines}]")

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -143,8 +143,8 @@ def capture_make_command_wrapper_symlinks(env: Dict[str, str]):
 
 def capture_compile(*, host_install_dir: str, skip_host: bool, env: Dict[str, str]):
     TOOLSDIR = Path(common.get_make_flag("TOOLSDIR"))
-    env["PYODIDE"] = "1"
-    env["PATH"] = str(TOOLSDIR) + ":" + os.environ["PATH"]
+    env = dict(env)
+    env["PATH"] = str(TOOLSDIR) + ":" + env["PATH"]
     capture_make_command_wrapper_symlinks(env)
 
     cmd = [sys.executable, "setup.py", "install"]
@@ -429,7 +429,7 @@ def replay_command_generate_args(
         if any(arg.endswith((".cpp", ".cc")) for arg in line):
             new_args = ["em++"]
     else:
-        assert False, f"Unexpected command {line[0]}"
+        raise AssertionError(f"Unexpected command {line[0]}")
 
     if is_link_command:
         new_args.extend(args.ldflags.split())

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -60,7 +60,9 @@ def test_build_dependencies(n_jobs, monkeypatch):
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml", "micropip"})
 
     Args = namedtuple("args", ["n_jobs", "force_rebuild"])
-    buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=True))
+    buildall.build_from_graph(
+        pkg_map, Path("."), Args(n_jobs=n_jobs, force_rebuild=True)
+    )
 
     assert set(build_list) == {
         "packaging",
@@ -101,7 +103,9 @@ def test_build_all_dependencies(n_jobs, monkeypatch):
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, packages={"*"})
 
     Args = namedtuple("args", ["n_jobs", "force_rebuild"])
-    buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=False))
+    buildall.build_from_graph(
+        pkg_map, Path("."), Args(n_jobs=n_jobs, force_rebuild=False)
+    )
 
 
 @pytest.mark.parametrize("n_jobs", [1, 4])
@@ -118,4 +122,6 @@ def test_build_error(n_jobs, monkeypatch):
 
     with pytest.raises(ValueError, match="Failed build"):
         Args = namedtuple("args", ["n_jobs", "force_rebuild"])
-        buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=True))
+        buildall.build_from_graph(
+            pkg_map, Path("."), Args(n_jobs=n_jobs, force_rebuild=True)
+        )

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -59,8 +59,8 @@ def test_build_dependencies(n_jobs, monkeypatch):
 
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml", "micropip"})
 
-    Args = namedtuple("args", ["n_jobs"])
-    buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs))
+    Args = namedtuple("args", ["n_jobs", "force"])
+    buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=True))
 
     assert set(build_list) == {
         "packaging",
@@ -100,8 +100,8 @@ def test_build_all_dependencies(n_jobs, monkeypatch):
 
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, packages={"*"})
 
-    Args = namedtuple("args", ["n_jobs"])
-    buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs))
+    Args = namedtuple("args", ["n_jobs", "force"])
+    buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=False))
 
 
 @pytest.mark.parametrize("n_jobs", [1, 4])
@@ -117,5 +117,5 @@ def test_build_error(n_jobs, monkeypatch):
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml"})
 
     with pytest.raises(ValueError, match="Failed build"):
-        Args = namedtuple("args", ["n_jobs"])
-        buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs))
+        Args = namedtuple("args", ["n_jobs", "force"])
+        buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=True))

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -59,7 +59,7 @@ def test_build_dependencies(n_jobs, monkeypatch):
 
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml", "micropip"})
 
-    Args = namedtuple("args", ["n_jobs", "force"])
+    Args = namedtuple("args", ["n_jobs", "force_rebuild"])
     buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=True))
 
     assert set(build_list) == {
@@ -100,7 +100,7 @@ def test_build_all_dependencies(n_jobs, monkeypatch):
 
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, packages={"*"})
 
-    Args = namedtuple("args", ["n_jobs", "force"])
+    Args = namedtuple("args", ["n_jobs", "force_rebuild"])
     buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=False))
 
 
@@ -117,5 +117,5 @@ def test_build_error(n_jobs, monkeypatch):
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"lxml"})
 
     with pytest.raises(ValueError, match="Failed build"):
-        Args = namedtuple("args", ["n_jobs", "force"])
+        Args = namedtuple("args", ["n_jobs", "force_rebuild"])
         buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=n_jobs, force=True))

--- a/pyodide-build/pyodide_build/tests/test_buildpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_buildpkg.py
@@ -64,7 +64,7 @@ def test_prepare_source(monkeypatch):
         pkg_root = Path(pkg["package"]["name"])
         buildpath = pkg_root / "build"
         src_metadata = pkg["source"]
-        srcpath = buildpath / source_dir_name 
+        srcpath = buildpath / source_dir_name
         buildpkg.prepare_source(pkg_root, buildpath, srcpath, src_metadata)
 
 

--- a/pyodide-build/pyodide_build/tests/test_buildpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_buildpkg.py
@@ -38,6 +38,7 @@ def test_prepare_source(monkeypatch):
     monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: True)
     monkeypatch.setattr(buildpkg, "check_checksum", lambda *args, **kwargs: True)
     monkeypatch.setattr(shutil, "unpack_archive", lambda *args, **kwargs: True)
+    monkeypatch.setattr(shutil, "move", lambda *args, **kwargs: True)
 
     test_pkgs = []
 
@@ -63,10 +64,8 @@ def test_prepare_source(monkeypatch):
         pkg_root = Path(pkg["package"]["name"])
         buildpath = pkg_root / "build"
         src_metadata = pkg["source"]
-        srcpath = buildpkg.get_source_path(buildpath, pkg["package"], src_metadata)
+        srcpath = buildpath / source_dir_name 
         buildpkg.prepare_source(pkg_root, buildpath, srcpath, src_metadata)
-
-        assert srcpath.name.lower().endswith(source_dir_name.lower())
 
 
 @pytest.mark.parametrize("is_library", [True, False])

--- a/pyodide-build/pyodide_build/tests/test_buildpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_buildpkg.py
@@ -62,11 +62,9 @@ def test_prepare_source(monkeypatch):
         source_dir_name = pkg["package"]["name"] + "-" + pkg["package"]["version"]
         pkg_root = Path(pkg["package"]["name"])
         buildpath = pkg_root / "build"
-        source_path = buildpath / source_dir_name
         src_metadata = pkg["source"]
-        srcpath = buildpkg.prepare_source(
-            pkg_root, buildpath, source_path, src_metadata
-        )
+        srcpath = buildpkg.get_source_path(buildpath, pkg["package"], src_metadata)
+        buildpkg.prepare_source(pkg_root, buildpath, srcpath, src_metadata)
 
         assert srcpath.name.lower().endswith(source_dir_name.lower())
 


### PR DESCRIPTION
### Description

More improvements to pyodide-build. This includes:
1. some tuneups to pywasmcross extracted from #2065
2. a `--continue` flag that allows skipping parts of the package build in `buildpkg` for debugging the build
3. better handling of skipping already built packages in buildall -- in particular, it will now rebuild a package if a package that it depends on is being rebuilt, and the messages printed are a bit clearer.
4. a `--force` flag to force a rebuild

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Update documentation