### PR TITLE
CI Deploy pyodide-build to PyPi on releases

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -18,12 +18,16 @@ jobs:
           python-version: "3.9"
 
       - name: Install dependencies
-        run: python -m pip install build
+        run: python -m pip install build twine
 
       - name: Build wheel
         run: |
           cd pyodide-build/
           python -m build .
+
+      - name: Check wheel
+        run: |
+          twine check pyodide-build/dist/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,9 +1,8 @@
 name: deploy-release
-on: push
-# on:
-#   push:
-#     tags:
-#       - "*.*.*"
+on:
+  push:
+    tags:
+      - "*.*.*"
 jobs:
   deploy-pyodide-build-pypi:
     runs-on: ubuntu-latest
@@ -33,6 +32,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: pyodide-build/dist/

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,0 +1,34 @@
+name: deploy-release
+on: push
+# on:
+#   push:
+#     tags:
+#       - "*.*.*"
+jobs:
+  deploy-pyodide-build-pypi:
+    runs-on: ubuntu-latest
+    environment: PyPi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: python -m pip install build
+
+      - name: Build wheel
+        run: |
+          cd pyodide-build/
+          python -m build .
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: pyodide-build/dist/

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -39,33 +39,22 @@ the latest release branch named `stable` (due to ReadTheDocs constraints).
    ```
 5. Create a tag `X.Y.Z` (without leading `v`) and push
    it to upstream,
+
    ```bash
    git tag X.Y.Z
    git push upstream X.Y.Z
    ```
+
    Create a new `stable` branch from this tag,
+
    ```bash
    git checkout -b stable
    git push upstream stable --force
    ```
+
    Wait for the CI to pass and create the release on GitHub.
-6. Release the `pyodide-build` package and `pyodide` package:
-   ```bash
-   pip install twine build
-   cd pyodide-build/
-   python -m build .
-   ls dist/   # check the produced files
-   twine check dist/*X.Y.Z*
-   twine upload dist/*X.Y.Z*
-   ```
-   And to release the `pyodide` package:
-   ```bash
-   cd src/py/
-   python -m build .
-   twine check dist/*X.Y.Z*
-   twine upload dist/*X.Y.Z*
-   ```
-7. Release the Pyodide JavaScript package:
+
+6. Release the Pyodide JavaScript package:
 
    ```bash
    cd src/js
@@ -73,7 +62,7 @@ the latest release branch named `stable` (due to ReadTheDocs constraints).
    npm dist-tag add pyodide@a.b.c next # Label this release as also the latest unstable release
    ```
 
-8. Revert Step 1. and increment the version in `src/py/pyodide/__init__.py` to
+7. Revert Step 1. and increment the version in `src/py/pyodide/__init__.py` to
    the next version specified by Semantic Versioning.
 
 ### Making a minor release


### PR DESCRIPTION
Aims to simplify the release process a bit by auto-deploying pyodide-build to PyPi on git tags.

(Done from an upstream branch to be able to test it and pass secrets) 