### PR TITLE
Add _multiprocessing stub

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ norecursedirs =
 addopts =
     --doctest-modules
     --ignore="packages/matplotlib/src"
+    --ignore="src/py/lib/"
 markers =
     skip_refcount_check: Dont run refcount checks
     skip_pyproxy_check: Dont run pyproxy allocation checks

--- a/src/py/lib/_multiprocessing.py
+++ b/src/py/lib/_multiprocessing.py
@@ -1,0 +1,20 @@
+# mypy: ignore-errors
+import sys
+
+IN_BROWSER = False
+if "pyodide" in sys.modules:
+    from pyodide import IN_BROWSER
+
+if not IN_BROWSER:
+    raise Exception("This shouldn't happen!")
+
+# Prevent microprocessing.synchronize from raising an error at import time.
+def SemLock(*args, **kwargs):
+    raise OSError("Not implemented")
+
+
+SemLock.SEM_VALUE_MAX = 0
+
+
+def sem_unlink(*args, **kwargs):
+    raise OSError("Not implemented")

--- a/src/tests/python_tests.txt
+++ b/src/tests/python_tests.txt
@@ -132,7 +132,7 @@ test_compare
 test_compile	crash
 test_compileall	multiprocessing
 test_complex
-test_concurrent_futures
+test_concurrent_futures multiprocessing
 test_configparser
 test_contains
 test_context
@@ -351,10 +351,10 @@ test_module
 test_modulefinder
 test_msilib
 test_multibytecodec
-test_multiprocessing_fork
-test_multiprocessing_forkserver
-test_multiprocessing_main_handling
-test_multiprocessing_spawn
+test_multiprocessing_fork multiprocessing
+test_multiprocessing_forkserver multiprocessing
+test_multiprocessing_main_handling multiprocessing
+test_multiprocessing_spawn multiprocessing
 test_named_expressions
 test_netrc
 test_nis


### PR DESCRIPTION
Different systems feature detect `multiprocessing` in different ways. There are three different behaviors:
1. Packages that just import at top level and make no attempt to feature detect
2. Packages that feature detect by looking for an import error
3. Packages that feature detect by looking for an import error or a runtime error

The type 3 systems that detect runtime errors are the best behaved (e.g., `joblib`). Most packages seem to be type 1 (fearless top level imports). We can't simultaneously support both 1 and 2. The only type 2 system is the core Python multiprocessing tests. My thought was it is better to manually xfail the core multiprocessing tests than to patch all type 1 packages. 

It might be a good idea to try to convince some of the type 1 packages to do something a bit smarter, or to get rid of the top level import.