### PR TITLE
Fix CI Pre-build docker image not deploying on tags

### DIFF
--- a/.github/workflows/prebuilt_docker_image.yml
+++ b/.github/workflows/prebuilt_docker_image.yml
@@ -1,8 +1,7 @@
 name: prebuilt-docker-image
 on:
-  push:
-    tags:
-      - "*.*.*"
+  release:
+    types: [published]
 env:
   GHCR_REGISTRY: ghcr.io
   IMAGE_NAME: pyodide/pyodide

--- a/.github/workflows/prebuilt_docker_image.yml
+++ b/.github/workflows/prebuilt_docker_image.yml
@@ -33,7 +33,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ env.PYODIDE_ENV_VERSION }}
-          tags: ${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}
@@ -61,7 +61,7 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ env.PYODIDE_ENV_VERSION }}
-          tags: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.version }}
+          tags: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Fix bug issue #2101 introduced while implementing PR #1995.
NOTE: I am 99% sure this is the fix, but since `${{ github.event.release.tag_name }}` is available only precisely with the workflow triggered by a new release, real life testing is only the way to verify (https://github.community/t/how-to-get-just-the-tag-name/16241/28). I just need confirmation that this should be triggered on release, not just a tag.

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
