### PR TITLE
MAINT Refactor of load-pyodide (reduces diff to wheels PR)

### DIFF
--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -377,6 +377,7 @@ export async function loadPackage(names, messageCallback, errorCallback) {
     return;
   }
 
+  let releaseLock = await acquirePackageLock();
   for (let [pkg, uri] of [...toLoad, ...toLoadShared]) {
     let loaded = loadedPackages[pkg];
     if (loaded === undefined) {
@@ -398,7 +399,6 @@ export async function loadPackage(names, messageCallback, errorCallback) {
   }
 
   const packageNames = [...toLoad.keys(), ...toLoadShared.keys()].join(", ");
-  let releaseLock = await acquirePackageLock();
   try {
     messageCallback(`Loading ${packageNames}`);
     let scriptPromises = [];

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -78,7 +78,7 @@ export async function initializePackageIndex(indexURL) {
  * @returns An ArrayBuffer containing the binary data
  * @private
  */
- async function node_loadBinaryFile(indexURL, path) {
+async function node_loadBinaryFile(indexURL, path) {
   if (path.includes("://")) {
     let response = await nodeFetch(path);
     if (!response.ok) {
@@ -100,7 +100,7 @@ export async function initializePackageIndex(indexURL) {
  * @returns An ArrayBuffer containing the binary data
  * @private
  */
- async function browser_loadBinaryFile(indexURL, path) {
+async function browser_loadBinaryFile(indexURL, path) {
   const base = new URL(indexURL, location);
   const url = new URL(path, base);
   let response = await fetch(url);

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -73,7 +73,7 @@ export async function initializePackageIndex(indexURL) {
 
 export async function _fetchBinaryFile(indexURL, path) {
   if (IN_NODE) {
-    const tar_buffer = await fsPromisesMod.readFile(`${indexURL}${path}`);
+    const tar_buffer = await nodeFsPromisesMod.readFile(`${indexURL}${path}`);
     return tar_buffer.buffer;
   } else {
     let response = await fetch(`${indexURL}${path}`);
@@ -89,8 +89,6 @@ export async function _fetchBinaryFile(indexURL, path) {
 async function nodeLoadScript(url) {
   if (url.includes("://")) {
     // If it's a url, have to load it with fetch and then eval it.
-    const fetch = await fetchPromise;
-    const vm = await vmPromise;
     nodeVmMod.runInThisContext(await (await nodeFetch(url)).text());
   } else {
     // Otherwise, hopefully it is a relative path we can load from the file

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -155,7 +155,6 @@ if (globalThis.document) {
   throw new Error("Cannot determine runtime environment");
 }
 
-
 //
 // Dependency resolution
 //
@@ -459,7 +458,7 @@ export async function loadPackage(names, messageCallback, errorCallback) {
     } finally {
       delete Module.monitorRunDependencies;
     }
-    
+
     Module.reportUndefinedSymbols();
     if (loaded.length > 0) {
       const successNames = loaded.join(", ");

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -74,10 +74,11 @@ export async function initializePackageIndex(indexURL) {
 export async function _fetchBinaryFile(indexURL, path) {
   if (IN_NODE) {
     const tar_buffer = await nodeFsPromisesMod.readFile(`${indexURL}${path}`);
-    return tar_buffer.buffer;
+    return new Uint8Array(tar_buffer.buffer, tar_buffer.byteOffset, tar_buffer.byteLength);
   } else {
     let response = await fetch(`${indexURL}${path}`);
-    return await response.arrayBuffer();
+    let buffer = await response.arrayBuffer();
+    return new Uint8Array(buffer);
   }
 }
 

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -406,6 +406,7 @@ export async function loadPackage(names, messageCallback, errorCallback) {
     const failed = {};
 
     useSharedLibraryWasmPlugin();
+    Module.locateFile_packagesToLoad = toLoadShared;
     for (const [pkg, uri] of toLoadShared) {
       const pkgname =
         (Module.packages[pkg] && Module.packages[pkg].name) || pkg;
@@ -435,6 +436,7 @@ export async function loadPackage(names, messageCallback, errorCallback) {
     restoreOrigWasmPlugin();
 
     scriptPromises = [];
+    Module.locateFile_packagesToLoad = toLoad;
     for (const [pkg, uri] of toLoad) {
       const pkgname =
         (Module.packages[pkg] && Module.packages[pkg].name) || pkg;

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -414,9 +414,9 @@ export async function loadPackage(names, messageCallback, errorCallback) {
       messageCallback(`Loading ${pkg} from ${scriptSrc}`);
       scriptPromises.push(
         loadScript(scriptSrc)
-          .then((name) => {
-            loaded.push(name);
-            loadedPackages[name] = uri;
+          .then(() => {
+            loaded.push(pkg);
+            loadedPackages[pkg] = uri;
           })
           .catch((e) => {
             failed[pkg] = e;
@@ -443,9 +443,9 @@ export async function loadPackage(names, messageCallback, errorCallback) {
       messageCallback(`Loading ${pkg} from ${scriptSrc}`);
       scriptPromises.push(
         loadScript(scriptSrc)
-          .then((name) => {
-            loaded.push(name);
-            loadedPackages[name] = uri;
+          .then(() => {
+            loaded.push(pkg);
+            loadedPackages[pkg] = uri;
           })
           .catch((e) => {
             failed[pkg] = e;

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -70,11 +70,14 @@ export async function initializePackageIndex(indexURL) {
   }
 }
 
-
 export async function _fetchBinaryFile(indexURL, path) {
   if (IN_NODE) {
     const tar_buffer = await nodeFsPromisesMod.readFile(`${indexURL}${path}`);
-    return new Uint8Array(tar_buffer.buffer, tar_buffer.byteOffset, tar_buffer.byteLength);
+    return new Uint8Array(
+      tar_buffer.buffer,
+      tar_buffer.byteOffset,
+      tar_buffer.byteLength
+    );
   } else {
     let response = await fetch(`${indexURL}${path}`);
     let buffer = await response.arrayBuffer();

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -377,7 +377,7 @@ export async function loadPackage(names, messageCallback, errorCallback) {
     return;
   }
 
-  for (let [pkg, uri] of toLoadAll) {
+  for (let [pkg, uri] of [...toLoad, ...toLoadShared]) {
     let loaded = loadedPackages[pkg];
     if (loaded === undefined) {
       continue;

--- a/src/js/load-pyodide.js
+++ b/src/js/load-pyodide.js
@@ -133,20 +133,6 @@ async function nodeLoadScript(url) {
   }
 }
 
-////////////////////////////////////////////////////////////
-// Package loading
-const DEFAULT_CHANNEL = "default channel";
-
-// Regexp for validating package name and URI
-const package_uri_regexp = /^.*?([^\/]*)\.js$/;
-
-function _uri_to_package_name(package_uri) {
-  let match = package_uri_regexp.exec(package_uri);
-  if (match) {
-    return match[1].toLowerCase();
-  }
-}
-
 /**
  * @param {string) url
  * @async
@@ -169,6 +155,30 @@ if (globalThis.document) {
   throw new Error("Cannot determine runtime environment");
 }
 
+
+//
+// Dependency resolution
+//
+const DEFAULT_CHANNEL = "default channel";
+
+// Regexp for validating package name and URI
+const package_uri_regexp = /^.*?([^\/]*)\.js$/;
+
+function _uri_to_package_name(package_uri) {
+  let match = package_uri_regexp.exec(package_uri);
+  if (match) {
+    return match[1].toLowerCase();
+  }
+}
+
+/**
+ * Recursively add a package and its dependencies to toLoad and toLoadShared.
+ * A helper function for recursiveDependencies.
+ * @param {str} name The package to add
+ * @param {Set} toLoad The set of names of packages to load
+ * @param {Set} toLoadShared The set of names of shared libraries to load
+ * @private
+ */
 function addPackageToLoad(name, toLoad, toLoadShared) {
   name = name.toLowerCase();
   if (toLoad.has(name)) {

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -145,7 +145,7 @@ function unpackPyodidePy(pyodide_py_tar) {
   let stream = Module.FS.open(fileName, "w");
   Module.FS.write(
     stream,
-    new Uint8Array(pyodide_py_tar),
+    pyodide_py_tar,
     0,
     pyodide_py_tar.byteLength,
     undefined,

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -5,7 +5,7 @@ import { Module, setStandardStreams, setHomeDirectory } from "./module.js";
 import {
   loadScript,
   initializePackageIndex,
-  _fetchBinaryFile,
+  _loadBinaryFile,
   loadPackage,
   initNodeModules,
 } from "./load-pyodide.js";
@@ -266,7 +266,7 @@ export async function loadPyodide(config) {
   Module.indexURL = config.indexURL;
   await initNodeModules();
   let packageIndexReady = initializePackageIndex(config.indexURL);
-  let pyodide_py_tar_promise = _fetchBinaryFile(
+  let pyodide_py_tar_promise = _loadBinaryFile(
     config.indexURL,
     "pyodide_py.tar"
   );

--- a/src/js/pyodide.js
+++ b/src/js/pyodide.js
@@ -7,6 +7,7 @@ import {
   initializePackageIndex,
   _fetchBinaryFile,
   loadPackage,
+  initNodeModules,
 } from "./load-pyodide.js";
 import { makePublicAPI, registerJsModule } from "./api.js";
 import "./pyproxy.gen.js";
@@ -263,6 +264,7 @@ export async function loadPyodide(config) {
     config.indexURL += "/";
   }
   Module.indexURL = config.indexURL;
+  await initNodeModules();
   let packageIndexReady = initializePackageIndex(config.indexURL);
   let pyodide_py_tar_promise = _fetchBinaryFile(
     config.indexURL,


### PR DESCRIPTION
This simplifies handling of node modules in load-pyodide a bit. Eventually we could split this off into a separate compatibility file or something.

This also fixes a significant bug, which is that `readFile` is allowed to return a `Buffer` whose backing data is shared with other buffers. When we convert to `Uint8Array`, we have to keep track of which part of the buffer we are supposed to be looking at.

I also rearranged the `loadPackage` internals to prepare for #2027. I changed the error handling behavior a bit, so in some circumstances where `loadPackage` would have logged an error, it now throws an error.

This is split off from #2027.