### PR TITLE
fix js syntax typo in switch statement

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -75,9 +75,9 @@
             switch (fut.syntax_check) {
               case "syntax-error":
                 term.error(fut.formatted_error.trimEnd());
-                continue;
+                break;
               case "incomplete":
-                continue;
+                break;
               case "complete":
                 break;
               default:


### PR DESCRIPTION
The `continue` keyword in js has no effect in switch statements
