### PR TITLE
FIX scipy Templated_PyUFunc

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -12,6 +12,13 @@ substitutions:
 
 # Change Log
 
+## Unreleased
+
+### Uncategorized
+
+- {{Fix}} A fatal error in `scipy.stats.binom.ppf` has been fixed.
+  {pr}`2109`
+
 ## Version 0.19.0
 
 _January 10, 2021_

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -28,6 +28,7 @@ source:
     - patches/sasum-returns-double-not-float.patch
     - patches/skip-fortran-fails-to-link.patch
     - patches/rename-_page_trend_test.patch
+    - patches/USE_CPP14-branch-doesn-t-work-for-wasm.patch
 
 build:
   # set linker and C flags to error on anything to do with function declarations being wrong.

--- a/packages/scipy/patches/USE_CPP14-branch-doesn-t-work-for-wasm.patch
+++ b/packages/scipy/patches/USE_CPP14-branch-doesn-t-work-for-wasm.patch
@@ -1,0 +1,25 @@
+From 035d57cd137a4da176d9803bf80437d93f72e9f3 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Fri, 14 Jan 2022 12:02:32 -0800
+Subject: [PATCH] USE_CPP14 branch doesn't work for wasm
+
+---
+ scipy/stats/_boost/include/Templated_PyUFunc.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scipy/stats/_boost/include/Templated_PyUFunc.hpp b/scipy/stats/_boost/include/Templated_PyUFunc.hpp
+index 7e37688d3..a048d05aa 100644
+--- a/scipy/stats/_boost/include/Templated_PyUFunc.hpp
++++ b/scipy/stats/_boost/include/Templated_PyUFunc.hpp
+@@ -7,7 +7,7 @@
+ // TODO: remove C++11 implementation when SciPy supports C++14 on all platforms
+ #define USE_CPP14 (__cplusplus >= 201402L)
+ 
+-#if USE_CPP14
++#if USE_CPP14 && !defined(__wasm32__) && !defined(__wasm64__)
+ 
+ #include <type_traits>
+ #include <utility>
+-- 
+2.25.1
+

--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -40,7 +40,9 @@ def test_dlamch():
 
     lapack.dlamch("Epsilon-Machine")
 
+
 @run_in_pyodide
 def test_binom_ppf():
     from scipy.stats import binom
+
     assert binom.ppf(0.9, 1000, 0.1) == 112

--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -1,52 +1,46 @@
 import pytest
 from conftest import selenium_context_manager
+from pyodide_build import testing
+
+run_in_pyodide = testing.run_in_pyodide(
+    module_scope=True,
+    packages=["scipy"],
+    xfail_browsers={"chrome": "Times out in chrome"},
+    driver_timeout=40,
+)
 
 
-@pytest.mark.driver_timeout(40)
-def test_scipy_linalg(selenium_module_scope):
-    if selenium_module_scope.browser == "chrome":
-        pytest.xfail("Times out in chrome")
-    with selenium_context_manager(selenium_module_scope) as selenium:
-        selenium.load_package("scipy")
-        selenium.run(
-            r"""
-            import numpy as np
-            import scipy as sp
-            import scipy.linalg
-            from numpy.testing import assert_allclose
+@run_in_pyodide
+def test_scipy_linalg():
+    import numpy as np
+    import scipy as sp
+    import scipy.linalg
+    from numpy.testing import assert_allclose
 
-            N = 10
-            X = np.random.RandomState(42).rand(N, N)
+    N = 10
+    X = np.random.RandomState(42).rand(N, N)
 
-            X_inv = scipy.linalg.inv(X)
+    X_inv = scipy.linalg.inv(X)
 
-            res = X.dot(X_inv)
+    res = X.dot(X_inv)
 
-            assert_allclose(res, np.identity(N),
-                            rtol=1e-07, atol=1e-9)
-            """
-        )
+    assert_allclose(res, np.identity(N), rtol=1e-07, atol=1e-9)
 
 
-@pytest.mark.driver_timeout(40)
-def test_brentq(selenium_module_scope):
-    with selenium_context_manager(selenium_module_scope) as selenium:
-        selenium.load_package("scipy")
-        selenium.run(
-            """
-            from scipy.optimize import brentq
-            brentq(lambda x: x, -1, 1)
-            """
-        )
+@run_in_pyodide
+def test_brentq():
+    from scipy.optimize import brentq
+
+    brentq(lambda x: x, -1, 1)
 
 
-@pytest.mark.driver_timeout(40)
-def test_dlamch(selenium_module_scope):
-    with selenium_context_manager(selenium_module_scope) as selenium:
-        selenium.load_package("scipy")
-        selenium.run(
-            """
-            from scipy.linalg import lapack
-            lapack.dlamch('Epsilon-Machine')
-            """
-        )
+@run_in_pyodide
+def test_dlamch():
+    from scipy.linalg import lapack
+
+    lapack.dlamch("Epsilon-Machine")
+
+@run_in_pyodide
+def test_binom_ppf():
+    from scipy.stats import binom
+    assert binom.ppf(0.9, 1000, 0.1) == 112


### PR DESCRIPTION
Fixes #2108. I also made an upstream PR here: https://github.com/scipy/scipy/pull/15416

The problematic code looks like:
```C
double func(double, double, double);
typedef double (*variadic_func)(...);

double bad_func(double a, double b, double c){
   variadic_func f = (variadic_func)func;
   return f(a, b, c);
}
```
but it's hidden behind an `#ifdef`. The `#else` clause works correctly.