### PR TITLE
Fix numpy comparator functions

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -19,6 +19,9 @@ substitutions:
 - {{Fix}} A fatal error in `scipy.stats.binom.ppf` has been fixed.
   {pr}`2109`
 
+- {{Fix}} Type signature mismatches in some numpy comparators have been fixed.
+  {pr}`2110`
+
 ## Version 0.19.0
 
 _January 10, 2021_

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -22,6 +22,7 @@ source:
     - patches/not-build-lapack-lite-as-64-bit.patch
     - patches/fix-invalid-asm-instruction.patch
     - patches/fix-removed-decorators-module.patch
+    - patches/fix-comparator-function-signatures.patch
 
 build:
   skip_host: False

--- a/packages/numpy/patches/fix-comparator-function-signatures.patch
+++ b/packages/numpy/patches/fix-comparator-function-signatures.patch
@@ -1,0 +1,54 @@
+From 072253d217502f27e575beed75db83b8216e5b90 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Sun, 16 Jan 2022 09:38:29 -0800
+Subject: [PATCH] BUG: Fix comparator function signatures
+
+The comparator functions are expected to have signature int f(void *, void*, PyArrayObject *).
+Some of the comparators drop the third argument because they don't use them. Because the
+comparators are unused, with most architectures this works fine. However, calling a function
+pointer that has been cast to have a different number of arguments is undefined in the C
+specification. With web assembly targets, it crashes at runtime.
+
+This fixes the comparators defined in arraytypes.c.src to all take three arguments.
+
+See also related work:
+258ce2523ffad99be69afbd421d540086cb6bf61
+23c05e6f1b392f80f749dbb4668b5e7b52aef014
+---
+ numpy/core/src/multiarray/arraytypes.c.src | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/numpy/core/src/multiarray/arraytypes.c.src b/numpy/core/src/multiarray/arraytypes.c.src
+index 71808cc48..71401c60e 100644
+--- a/numpy/core/src/multiarray/arraytypes.c.src
++++ b/numpy/core/src/multiarray/arraytypes.c.src
+@@ -2849,7 +2849,7 @@ static int
+ #define LT(a,b) ((a) < (b) || ((b) != (b) && (a) ==(a)))
+ 
+ static int
+-@TYPE@_compare(@type@ *pa, @type@ *pb)
++@TYPE@_compare(@type@ *pa, @type@ *pb, PyArrayObject *NPY_UNUSED(ap))
+ {
+     const @type@ a = *pa;
+     const @type@ b = *pb;
+@@ -2869,7 +2869,7 @@ static int
+ 
+ 
+ static int
+-C@TYPE@_compare(@type@ *pa, @type@ *pb)
++C@TYPE@_compare(@type@ *pa, @type@ *pb, PyArrayObject *NPY_UNUSED(ap))
+ {
+     const @type@ ar = pa[0];
+     const @type@ ai = pa[1];
+@@ -2924,7 +2924,7 @@ C@TYPE@_compare(@type@ *pa, @type@ *pb)
+  */
+ 
+ static int
+-@TYPE@_compare(@type@ *pa, @type@ *pb)
++@TYPE@_compare(@type@ *pa, @type@ *pb, PyArrayObject *NPY_UNUSED(ap))
+ {
+     const @type@ a = *pa;
+     const @type@ b = *pb;
+-- 
+2.25.1
+

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -1,8 +1,10 @@
 import pytest
 from pyodide_build.testing import run_in_pyodide as run_in_pyodide_orig
 
+
 def run_in_pyodide(**kwargs):
     return run_in_pyodide_orig(module_scope=True, packages=["numpy"])
+
 
 def test_numpy(selenium):
     selenium.load_package("numpy")
@@ -359,8 +361,10 @@ def test_fft(selenium):
         """
     )
 
+
 @run_in_pyodide
 def test_np_unique():
     """Numpy comparator functions formerly had a fatal error, see PR #2110"""
     import numpy as np
+
     np.unique(np.array([1.1, 1.1]), axis=-1)

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -362,7 +362,7 @@ def test_fft(selenium):
     )
 
 
-@run_in_pyodide
+@run_in_pyodide()
 def test_np_unique():
     """Numpy comparator functions formerly had a fatal error, see PR #2110"""
     import numpy as np

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -361,6 +361,6 @@ def test_fft(selenium):
 
 @run_in_pyodide
 def test_np_unique():
-    """"""
+    """Numpy comparator functions formerly had a fatal error, see PR #2110"""
     import numpy as np
     np.unique(np.array([1.1, 1.1]), axis=-1)

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -1,5 +1,8 @@
 import pytest
+from pyodide_build.testing import run_in_pyodide as run_in_pyodide_orig
 
+def run_in_pyodide(**kwargs):
+    return run_in_pyodide_orig(module_scope=True, packages=["numpy"])
 
 def test_numpy(selenium):
     selenium.load_package("numpy")
@@ -355,3 +358,9 @@ def test_fft(selenium):
         `);
         """
     )
+
+@run_in_pyodide
+def test_np_unique():
+    """"""
+    import numpy as np
+    np.unique(np.array([1.1, 1.1]), axis=-1)


### PR DESCRIPTION
This creates fatal errors when used with e.g., `numpy.unique`, see added test.

My upstream PR https://github.com/numpy/numpy/pull/20833 with this patch was accepted.