### PR TITLE
Drop ruamel.yaml dependency

### DIFF
--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Dict, Any, Optional
 import warnings
+import yaml
 
 from .io import parse_package_config
 
@@ -61,27 +62,12 @@ def _get_metadata(package: str, version: Optional[str] = None) -> Dict:
     return pypi_metadata
 
 
-def _import_ruamel_yaml():
-    """Import ruamel.yaml with a better error message is not installed."""
-    try:
-        from ruamel.yaml import YAML
-    except ImportError as err:
-        raise ImportError(
-            "No module named 'ruamel'. "
-            "It can be installed with pip install ruamel.yaml"
-        ) from err
-    return YAML
-
-
 def make_package(package: str, version: Optional[str] = None):
     """
     Creates a template that will work for most pure Python packages,
     but will have to be edited for more complex things.
     """
     print(f"Creating meta.yaml package for {package}")
-    YAML = _import_ruamel_yaml()
-
-    yaml = YAML()
 
     pypi_metadata = _get_metadata(package, version)
     sdist_metadata = _extract_sdist(pypi_metadata)
@@ -111,7 +97,7 @@ def make_package(package: str, version: Optional[str] = None):
         os.makedirs(PACKAGES_ROOT / package)
     out_path = PACKAGES_ROOT / package / "meta.yaml"
     with open(out_path, "w") as fd:
-        yaml.dump(yaml_content, fd)
+        yaml.dump(yaml_content, fd, default_flow_style=False, sort_keys=False)
     success(f"Output written to {out_path}")
 
 
@@ -141,11 +127,6 @@ def success(msg):
 
 
 def update_package(package: str, update_patched: bool = True):
-
-    YAML = _import_ruamel_yaml()
-
-    yaml = YAML()
-
     meta_path = PACKAGES_ROOT / package / "meta.yaml"
     try:
         yaml_content = parse_package_config(meta_path)
@@ -193,7 +174,7 @@ def update_package(package: str, update_patched: bool = True):
     yaml_content["source"]["sha256"] = sdist_metadata["digests"]["sha256"]
     yaml_content["package"]["version"] = pypi_metadata["info"]["version"]
     with open(PACKAGES_ROOT / package / "meta.yaml", "w") as fd:
-        yaml.dump(yaml_content, fd)
+        yaml.dump(yaml_content, fd, default_flow_style=False, sort_keys=False)
     success(f"Updated {package} from {local_ver} to {pypi_ver}.")
 
 

--- a/pyodide-build/pyodide_build/tests/test_mkpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_mkpkg.py
@@ -32,7 +32,6 @@ def test_mkpkg(tmpdir, monkeypatch, capsys):
 
 
 def test_mkpkg_update(tmpdir, monkeypatch):
-    pytest.importorskip("ruamel")
     base_dir = Path(str(tmpdir))
     monkeypatch.setattr(pyodide_build.mkpkg, "PACKAGES_ROOT", base_dir)
 

--- a/pyodide-build/pyodide_build/tests/test_mkpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_mkpkg.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-import pytest
 
 import yaml
 from pkg_resources import parse_version

--- a/pyodide-build/setup.cfg
+++ b/pyodide-build/setup.cfg
@@ -20,7 +20,7 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    pyyaml
+    pyyaml>=5.1
     cython<3.0
 [options.entry_points]
 console_scripts =

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
   cython<3.0
   packaging
   pyyaml
-  ruamel.yaml
   # lint
   black
   flake8


### PR DESCRIPTION
`ruamel.yaml` was introduced at https://github.com/pyodide/pyodide/pull/1465 to prevent `mkpkg` command from reordering keys in meta.yaml.
But it seems like `pyyaml.dump(..., sort_keys=False)` does the same thing we want. So I think it's fine to remove the dependency.

__Checklists__

- [x] Add / update tests
