### PR TITLE
Improve error message when a destroyed pyproxy is used

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -26,8 +26,10 @@ substitutions:
 - {{Fix}} Type signature mismatches in some numpy comparators have been fixed.
   {pr}`2110`
 
-- {{Fix}} The error message that occurs when a destroyed `PyProxy` is used has 
-  been improved with some context information.
+- {{Fix}} The "PyProxy has already been destroyed" error message has been
+  improved with some context information.
+  {pr}`2121`
+
 
 ## Version 0.19.0
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -26,6 +26,9 @@ substitutions:
 - {{Fix}} Type signature mismatches in some numpy comparators have been fixed.
   {pr}`2110`
 
+- {{Fix}} The error message that occurs when a destroyed `PyProxy` is used has 
+  been improved with some context information.
+
 ## Version 0.19.0
 
 _January 10, 2021_

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -30,7 +30,6 @@ substitutions:
   improved with some context information.
   {pr}`2121`
 
-
 ## Version 0.19.0
 
 _January 10, 2021_

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -129,9 +129,7 @@ Module.pyproxy_new = function (ptrobj, cache) {
 function _getPtr(jsobj) {
   let ptr = jsobj.$$.ptr;
   if (ptr === null) {
-    throw new Error(
-      jsobj.$$.destroyed_msg
-    );
+    throw new Error(jsobj.$$.destroyed_msg);
   }
   return ptr;
 }
@@ -219,8 +217,8 @@ Module.pyproxy_destroy = function (proxy, destroyed_msg) {
   let proxy_repr;
   try {
     proxy_repr = proxy.toString();
-  } catch(e) {
-    if(e.pyodide_fatal_error){
+  } catch (e) {
+    if (e.pyodide_fatal_error) {
       throw e;
     }
   }
@@ -229,12 +227,12 @@ Module.pyproxy_destroy = function (proxy, destroyed_msg) {
   // just in case!
   proxy.$$.ptr = null;
   destroyed_msg += "\n" + `The object was of type ${proxy_type} and `;
-  if(proxy_repr){
+  if (proxy_repr) {
     destroyed_msg += `had repr ${proxy_repr}`;
   } else {
     destroyed_msg += "an error was raised when trying to generate its repr";
   }
-  proxy.$$.destroyed_msg = destroyed_msg
+  proxy.$$.destroyed_msg = destroyed_msg;
   pyproxy_decref_cache(proxy.$$.cache);
   try {
     Module._Py_DecRef(ptrobj);

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -226,9 +226,9 @@ Module.pyproxy_destroy = function (proxy, destroyed_msg) {
   // to use this proxy. Mark it deleted before decrementing reference count
   // just in case!
   proxy.$$.ptr = null;
-  destroyed_msg += "\n" + `The object was of type ${proxy_type} and `;
+  destroyed_msg += "\n" + `The object was of type "${proxy_type}" and `;
   if (proxy_repr) {
-    destroyed_msg += `had repr ${proxy_repr}`;
+    destroyed_msg += `had repr "${proxy_repr}"`;
   } else {
     destroyed_msg += "an error was raised when trying to generate its repr";
   }

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -130,7 +130,7 @@ function _getPtr(jsobj) {
   let ptr = jsobj.$$.ptr;
   if (ptr === null) {
     throw new Error(
-      jsobj.$$.destroyed_msg || "Object has already been destroyed"
+      jsobj.$$.destroyed_msg
     );
   }
   return ptr;
@@ -214,11 +214,27 @@ Module.pyproxy_destroy = function (proxy, destroyed_msg) {
   }
   let ptrobj = _getPtr(proxy);
   Module.finalizationRegistry.unregister(proxy);
+  destroyed_msg ||= "Object has already been destroyed";
+  let proxy_type = proxy.type;
+  let proxy_repr;
+  try {
+    proxy_repr = proxy.toString();
+  } catch(e) {
+    if(e.pyodide_fatal_error){
+      throw e;
+    }
+  }
   // Maybe the destructor will call JavaScript code that will somehow try
   // to use this proxy. Mark it deleted before decrementing reference count
   // just in case!
   proxy.$$.ptr = null;
-  proxy.$$.destroyed_msg = destroyed_msg;
+  destroyed_msg += "\n" + `The object was of type ${proxy_type} and `;
+  if(proxy_repr){
+    destroyed_msg += `had repr ${proxy_repr}`;
+  } else {
+    destroyed_msg += "an error was raised when trying to generate its repr";
+  }
+  proxy.$$.destroyed_msg = destroyed_msg
   pyproxy_decref_cache(proxy.$$.cache);
   try {
     Module._Py_DecRef(ptrobj);

--- a/src/core/pyproxy.js
+++ b/src/core/pyproxy.js
@@ -212,7 +212,7 @@ Module.pyproxy_destroy = function (proxy, destroyed_msg) {
   }
   let ptrobj = _getPtr(proxy);
   Module.finalizationRegistry.unregister(proxy);
-  destroyed_msg ||= "Object has already been destroyed";
+  destroyed_msg = destroyed_msg || "Object has already been destroyed";
   let proxy_type = proxy.type;
   let proxy_repr;
   try {

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -347,7 +347,7 @@ def test_call_pyproxy_destroy_args(selenium):
             f({})
             f([])
         `);
-        assertThrows(() => y.length, "Error", 
+        assertThrows(() => y.length, "Error",
             "This borrowed proxy was automatically destroyed\n" +
             "The object was of type list and had repr []"
         );

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -348,7 +348,7 @@ def test_call_pyproxy_destroy_args(selenium):
             f([])
         `);
         assertThrows(() => y.length, "Error",
-            "This borrowed proxy was automatically destroyed\n" +
+            "This borrowed proxy was automatically destroyed at the end of a function call.*" +
             "The object was of type list and had repr []"
         );
         """

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -349,7 +349,7 @@ def test_call_pyproxy_destroy_args(selenium):
         `);
         assertThrows(() => y.length, "Error",
             "This borrowed proxy was automatically destroyed at the end of a function call.*" +
-            "The object was of type list and had repr []"
+            'The object was of type "list" and had repr "[]"'
         );
         """
     )

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -347,7 +347,10 @@ def test_call_pyproxy_destroy_args(selenium):
             f({})
             f([])
         `);
-        assertThrows(() => y.length, "Error", "This borrowed proxy was automatically destroyed");
+        assertThrows(() => y.length, "Error", 
+            "This borrowed proxy was automatically destroyed\n" +
+            "The object was of type list and had repr []"
+        );
         """
     )
 

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -339,7 +339,7 @@ def test_jsproxy_call_meth_js_kwargs(selenium):
 
 def test_call_pyproxy_destroy_args(selenium):
     selenium.run_js(
-        """
+        r"""
         let y;
         self.f = function(x){ y = x; }
         pyodide.runPython(`

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -349,7 +349,7 @@ def test_call_pyproxy_destroy_args(selenium):
         `);
         assertThrows(() => y.length, "Error",
             "This borrowed proxy was automatically destroyed at the end of a function call.*\n" +
-            'The object was of type "list" and had repr "[]"'
+            'The object was of type "list" and had repr "\\[\\]"'
         );
         """
     )

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -348,7 +348,7 @@ def test_call_pyproxy_destroy_args(selenium):
             f([])
         `);
         assertThrows(() => y.length, "Error",
-            "This borrowed proxy was automatically destroyed at the end of a function call.*" +
+            "This borrowed proxy was automatically destroyed at the end of a function call.*\n" +
             'The object was of type "list" and had repr "[]"'
         );
         """

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -604,7 +604,7 @@ def test_create_proxy(selenium):
 
 def test_return_destroyed_value(selenium):
     selenium.run_js(
-        """
+        r"""
         self.f = function(x){ return x };
         pyodide.runPython(`
             from pyodide import create_proxy, JsException

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -616,7 +616,7 @@ def test_return_destroyed_value(selenium):
             except JsException as e:
                 assert str(e) == (
                     "Error: Object has already been destroyed\n"
-                    "The object was of type list and had repr []"
+                    'The object was of type "list" and had repr "[]"'
                 )
         `);
         """

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -614,8 +614,7 @@ def test_return_destroyed_value(selenium):
             try:
                 f(p)
             except JsException as e:
-                assert str(e) ==
-                (
+                assert str(e) == (
                     "Error: Object has already been destroyed\n"
                     "The object was of type list and had repr []"
                 )

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -614,7 +614,7 @@ def test_return_destroyed_value(selenium):
             try:
                 f(p)
             except JsException as e:
-                assert str(e) == 
+                assert str(e) ==
                 (
                     "Error: Object has already been destroyed\n"
                     "The object was of type list and had repr []"
@@ -623,7 +623,7 @@ def test_return_destroyed_value(selenium):
         """
     )
 
-g
+
 def test_docstrings_a():
     from _pyodide.docstring import get_cmeth_docstring, dedent_docstring
     from pyodide import JsProxy

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -614,12 +614,16 @@ def test_return_destroyed_value(selenium):
             try:
                 f(p)
             except JsException as e:
-                assert str(e) == "Error: Object has already been destroyed"
+                assert str(e) == 
+                (
+                    "Error: Object has already been destroyed\n"
+                    "The object was of type list and had repr []"
+                )
         `);
         """
     )
 
-
+g
 def test_docstrings_a():
     from _pyodide.docstring import get_cmeth_docstring, dedent_docstring
     from pyodide import JsProxy

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -615,7 +615,7 @@ def test_return_destroyed_value(selenium):
                 f(p)
             except JsException as e:
                 assert str(e) == (
-                    "Error: Object has already been destroyed\n"
+                    "Error: Object has already been destroyed\\n"
                     'The object was of type "list" and had repr "[]"'
                 )
         `);

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -762,6 +762,11 @@ def test_errors(selenium):
         assertThrowsAsync(async () => await t, "PythonError", "");
         assertThrows(() => t.toString(), "PythonError", "");
         assertThrows(() => Array.from(t), "PythonError", "");
+        t.destroy();
+        assertThrows(() => t.type, "Error",
+            "Uncaught Error: Object has already been destroyed\n" +
+            "The object was of type Temp and an error was raised when trying to generate its repr"
+        )
         """
     )
 

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -759,14 +759,14 @@ def test_errors(selenium):
         assertThrows(() => t.delete(1), "PythonError", "");
         assertThrows(() => t.has(1), "PythonError", "");
         assertThrows(() => t.length, "PythonError", "");
-        assertThrowsAsync(async () => await t, "PythonError", "");
         assertThrows(() => t.toString(), "PythonError", "");
         assertThrows(() => Array.from(t), "PythonError", "");
+        await assertThrowsAsync(async () => await t, "PythonError", "");
         t.destroy();
         assertThrows(() => t.type, "Error",
             "Object has already been destroyed\n" +
             'The object was of type "Temp" and an error was raised when trying to generate its repr'
-        )
+        );
         """
     )
 

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -765,7 +765,7 @@ def test_errors(selenium):
         t.destroy();
         assertThrows(() => t.type, "Error",
             "Object has already been destroyed\n" +
-            "The object was of type Temp and an error was raised when trying to generate its repr"
+            'The object was of type "Temp" and an error was raised when trying to generate its repr'
         )
         """
     )

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -729,7 +729,7 @@ def test_pyproxy_implicit_copy(selenium):
 @pytest.mark.skip_pyproxy_check
 def test_errors(selenium):
     selenium.run_js(
-        """
+        r"""
         let t = pyodide.runPython(`
             def te(self, *args, **kwargs):
                 raise Exception(repr(args))
@@ -764,7 +764,7 @@ def test_errors(selenium):
         assertThrows(() => Array.from(t), "PythonError", "");
         t.destroy();
         assertThrows(() => t.type, "Error",
-            "Uncaught Error: Object has already been destroyed\n" +
+            "Object has already been destroyed\n" +
             "The object was of type Temp and an error was raised when trying to generate its repr"
         )
         """


### PR DESCRIPTION
As discussed in https://github.com/pyodide/pyodide-blog/pull/13, the error messages generated when someone attempts to use an already-destroyed pyproxy aren't that great. This adds some extra context which should hopefully improve the situation significantly.

With this PR the error message includes the type and repr of the destroyed object (if possible)
```
Error: Object has already been destroyed
The object was of type list and had repr []
```

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
