### PR TITLE
FIX REPL tab at beginning of line should indent not complete

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -30,6 +30,9 @@ substitutions:
   improved with some context information.
   {pr}`2121`
 
+- {{Enhancement}} Pressing TAB in REPL no longer triggers completion when input
+  is whitespace. {pr}`2125`
+
 ## Version 0.19.0
 
 _January 10, 2021_

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -133,6 +133,15 @@
               term.set_command("");
               term.set_prompt(ps1);
             },
+            "TAB": (event, original) => {
+              const command = term.before_cursor();
+              // Disable completion for whitespaces.
+              if (command.trim() === "") {
+                term.insert("\t");
+                return false;
+              }
+              return original(event);
+            }
           },
         });
         window.term = term;


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->
In pyodide REPL, if you type
```py
for i in range(3):  # with a '\n'
```
then press tab, you get completion suggestions. But in normal REPL, a '\t' should be entered.
This PR checks the command and determines whether entering '\t' or falling back to completion.
### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry