### PR TITLE
Fix numpy fatal error: incorrect random_float_fill return type

### DIFF
--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -23,6 +23,7 @@ source:
     - patches/fix-invalid-asm-instruction.patch
     - patches/fix-removed-decorators-module.patch
     - patches/fix-comparator-function-signatures.patch
+    - patches/fix-random_float_fill-return-type.patch
 
 build:
   skip_host: False

--- a/packages/numpy/patches/fix-random_float_fill-return-type.patch
+++ b/packages/numpy/patches/fix-random_float_fill-return-type.patch
@@ -1,0 +1,33 @@
+From 575e6b726adcd2c1bef5ca0185aa2b2178cea20e Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Wed, 26 Jan 2022 18:59:47 -0800
+Subject: [PATCH] BUG: Fix the return type of random_float_fill
+
+The `random_float_fill` function type is declared with return type `double` but
+I think this is a typo. The actual implementation of `random_float_fill` is
+`random_standard_uniform_fill_f` which has return type `void`:
+
+void random_standard_uniform_fill_f(bitgen_t *bitgen_state, npy_intp cnt, float *out)
+
+Also, `random_double_fill` is declared with return type `void`. This fixes the
+return type of `random_float_fill` to match.
+---
+ numpy/random/_common.pxd | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/numpy/random/_common.pxd b/numpy/random/_common.pxd
+index 9f2e8c3ca..3625634cd 100644
+--- a/numpy/random/_common.pxd
++++ b/numpy/random/_common.pxd
+@@ -45,7 +45,7 @@
+ ctypedef double (*random_double_2)(void *state, double a, double b) nogil
+ ctypedef double (*random_double_3)(void *state, double a, double b, double c) nogil
+ 
+-ctypedef double (*random_float_fill)(bitgen_t *state, np.npy_intp count, float* out) nogil
++ctypedef void (*random_float_fill)(bitgen_t *state, np.npy_intp count, float* out) nogil
+ ctypedef float (*random_float_0)(bitgen_t *state) nogil
+ ctypedef float (*random_float_1)(bitgen_t *state, float a) nogil
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
This fixes the last fatal error in the numpy test suite. With this PR, the numpy test suite runs to completion:
```
181 failed, 14413 passed
```