### PR TITLE
MAINT Reorder make lint to typecheck first before running formatters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,11 +138,6 @@ update_base_url: \
 lint: node_modules/.installed
 	# check for unused imports, the rest is done by black
 	flake8 --select=F401 src tools pyodide-build benchmark conftest.py docs packages/matplotlib/src/
-	find src -type f -regex '.*\.\(c\|h\)' \
-		| xargs clang-format-6.0 -output-replacements-xml \
-		| (! grep '<replacement ')
-	npx prettier --check .
-	black --check .
 	mypy --ignore-missing-imports    \
 		pyodide-build/pyodide_build/ \
 		src/ 					     \
@@ -156,6 +151,12 @@ lint: node_modules/.installed
 	mypy --ignore-missing-imports    \
 		packages/micropip/src/
 
+	# Format checks
+	find src -type f -regex '.*\.\(c\|h\)' \
+		| xargs clang-format-6.0 -output-replacements-xml \
+		| (! grep '<replacement ')
+	npx prettier --check .
+	black --check .
 
 
 benchmark: all


### PR DESCRIPTION
We should run mypy before black. Fixing mypy type errors can mess up formatting, but fixing formatting can't mess up type errors. The current process looks like:
1. format error, run formatter
2. type errors, fix type errors
3. fixing type errors introduced new format errors, run formatter again

If we check types first then the process looks instead like:
1. type errors, fix type errors
2. format errors, run formatter