### PR TITLE
Add default_converter argument to to_py

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -46,6 +46,11 @@ substitutions:
 - {{Enhancement}} The Javascript package was migrated to Typescript.
   {pr}`2130` and {pr}`2133`
 
+- {{Enhancement}} Added a `default_converter` argument to {any}`JsProxy.to_py`
+  and {any}`pyodide.toPy` which is used to process any object that doesn't have
+  a built-in conversion to Python.
+  {pr}`2170`
+
 ## Version 0.19.0
 
 _January 10, 2021_

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -57,8 +57,9 @@ EM_JS_REF(PyObject*, js2python, (JsRef id), {
  * Convert a JavaScript object to Python to a given depth. This is the
  * implementation of `toJs`.
  */
-EM_JS_REF(PyObject*, js2python_convert, (JsRef id, int depth), {
-  return Module.js2python_convert(id, depth);
+EM_JS_REF(PyObject*, js2python_convert, (JsRef id, int depth, JsRef default_converter), {
+  let defaultConverter = default_converter ? Module.hiwire.get_value(default_converter) : undefined;
+  return Module.js2python_convert(id, {depth, defaultConverter});
 });
 
 #include "include_js_file.h"

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -57,10 +57,14 @@ EM_JS_REF(PyObject*, js2python, (JsRef id), {
  * Convert a JavaScript object to Python to a given depth. This is the
  * implementation of `toJs`.
  */
+// clang-format off
 EM_JS_REF(PyObject*, js2python_convert, (JsRef id, int depth, JsRef default_converter), {
-  let defaultConverter = default_converter ? Module.hiwire.get_value(default_converter) : undefined;
-  return Module.js2python_convert(id, {depth, defaultConverter});
+  let defaultConverter = default_converter
+    ? Module.hiwire.get_value(default_converter)
+    : undefined;
+  return Module.js2python_convert(id, { depth, defaultConverter });
 });
+// clang-format on
 
 #include "include_js_file.h"
 #include "js2python.js"

--- a/src/core/js2python.h
+++ b/src/core/js2python.h
@@ -18,7 +18,7 @@ PyObject*
 js2python(JsRef x);
 
 PyObject*
-js2python_convert(JsRef x, int depth);
+js2python_convert(JsRef x, int depth, JsRef defaultConverter);
 
 /** Initialize any global variables used by this module. */
 int

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -322,9 +322,10 @@ JS_FILE(js2python_init, () => {
       if (result !== undefined) {
         return result;
       }
-      throw new Error(
-        "defaultConverter returned invalid object. It must return a PyProxy, number, bigint, boolean, null, or undefined."
-      );
+      let result_id = Module.hiwire.new_value(result_js);
+      result = _JsProxy_create(result_id);
+      Module.hiwire.decref(result_id);
+      return result;
     } finally {
       context.depth++;
     }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -716,7 +716,10 @@ JsProxy_toPy(PyObject* self,
   if(default_converter != NULL){
     default_converter_js = python2js(default_converter);
   }
-  return js2python_convert(GET_JSREF(self), depth, default_converter_js);
+  PyObject* result = js2python_convert(GET_JSREF(self), depth, default_converter_js);
+  destroy_proxy(default_converter_js, NULL);
+  hiwire_CLEAR(default_converter_js);
+  return result;
 }
 
 static PyMethodDef JsProxy_toPy_MethodDef = {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -704,14 +704,19 @@ JsProxy_toPy(PyObject* self,
              Py_ssize_t nargs,
              PyObject* kwnames)
 {
-  static const char* const _keywords[] = { "depth", 0 };
-  static struct _PyArg_Parser _parser = { "|$i:toPy", _keywords, 0 };
+  static const char* const _keywords[] = { "depth", "default_converter", 0 };
+  static struct _PyArg_Parser _parser = { "|$iO:toPy", _keywords, 0 };
   int depth = -1;
+  PyObject *default_converter = NULL;
   if (kwnames != NULL &&
-      !_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser, &depth)) {
+      !_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser, &depth, &default_converter)) {
     return NULL;
   }
-  return js2python_convert(GET_JSREF(self), depth);
+  JsRef default_converter_js = NULL;
+  if(default_converter != NULL){
+    default_converter_js = python2js(default_converter);
+  }
+  return js2python_convert(GET_JSREF(self), depth, default_converter_js);
 }
 
 static PyMethodDef JsProxy_toPy_MethodDef = {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -707,16 +707,18 @@ JsProxy_toPy(PyObject* self,
   static const char* const _keywords[] = { "depth", "default_converter", 0 };
   static struct _PyArg_Parser _parser = { "|$iO:toPy", _keywords, 0 };
   int depth = -1;
-  PyObject *default_converter = NULL;
+  PyObject* default_converter = NULL;
   if (kwnames != NULL &&
-      !_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser, &depth, &default_converter)) {
+      !_PyArg_ParseStackAndKeywords(
+        args, nargs, kwnames, &_parser, &depth, &default_converter)) {
     return NULL;
   }
   JsRef default_converter_js = NULL;
-  if(default_converter != NULL){
+  if (default_converter != NULL) {
     default_converter_js = python2js(default_converter);
   }
-  PyObject* result = js2python_convert(GET_JSREF(self), depth, default_converter_js);
+  PyObject* result =
+    js2python_convert(GET_JSREF(self), depth, default_converter_js);
   destroy_proxy(default_converter_js, NULL);
   hiwire_CLEAR(default_converter_js);
   return result;

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -719,8 +719,10 @@ JsProxy_toPy(PyObject* self,
   }
   PyObject* result =
     js2python_convert(GET_JSREF(self), depth, default_converter_js);
-  destroy_proxy(default_converter_js, NULL);
-  hiwire_CLEAR(default_converter_js);
+  if(default_converter_js != NULL){
+    destroy_proxy(default_converter_js, NULL);
+    hiwire_CLEAR(default_converter_js);
+  }
   return result;
 }
 

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -719,7 +719,7 @@ JsProxy_toPy(PyObject* self,
   }
   PyObject* result =
     js2python_convert(GET_JSREF(self), depth, default_converter_js);
-  if(default_converter_js != NULL){
+  if (default_converter_js != NULL) {
     destroy_proxy(default_converter_js, NULL);
     hiwire_CLEAR(default_converter_js);
   }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -721,7 +721,7 @@ JsProxy_toPy(PyObject* self,
     js2python_convert(GET_JSREF(self), depth, default_converter_js);
   if (default_converter_js != NULL) {
     destroy_proxy(default_converter_js, NULL);
-    hiwire_CLEAR(default_converter_js);
+    hiwire_decref(default_converter_js);
   }
   return result;
 }

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -36,6 +36,14 @@ EM_JS(void, destroy_proxies, (JsRef proxies_id, char* msg_ptr), {
   }
 });
 
+EM_JS(void, destroy_proxy, (JsRef proxy_id, char* msg_ptr), {
+  let msg = undefined;
+  if (msg_ptr) {
+    msg = UTF8ToString(msg_ptr);
+  }
+  Module.pyproxy_destroy(Module.hiwire.get_value(proxy_id), msg);
+});
+
 static PyObject* asyncio;
 
 // Flags controlling presence or absence of many small mixins depending on which

--- a/src/core/pyproxy.h
+++ b/src/core/pyproxy.h
@@ -25,10 +25,16 @@ int
 pyproxy_Check(JsRef x);
 
 /**
- * Destroy a list of PyProxies. Steals the reference to the list.
+ * Destroy a list of PyProxies.
  */
 void
 destroy_proxies(JsRef proxies_id, char* msg);
+
+/**
+ * Destroy a PyProxy.
+ */
+void
+destroy_proxy(JsRef proxy, char* msg);
 
 /**
  * Wrap a Python callable in a JavaScript function that can be called once.

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -201,7 +201,7 @@ export function unregisterJsModule(name: string) {
  */
 export function toPy(
   obj: any,
-  { depth }: { depth: number } = { depth: -1 }
+  { depth, defaultConverter }: { depth: number, defaultConverter? : (value: any, converter : (value : any) => any) => any } = { depth: -1 }
 ): Py2JsResult {
   // No point in converting these, it'd be dumb to proxy them so they'd just
   // get converted back by `js2python` at the end
@@ -222,7 +222,7 @@ export function toPy(
   try {
     obj_id = Module.hiwire.new_value(obj);
     try {
-      py_result = Module.js2python_convert(obj_id, depth);
+      py_result = Module.js2python_convert(obj_id, {depth, defaultConverter});
     } catch (e) {
       if (e instanceof Module._PropagatePythonError) {
         Module._pythonexc2js();

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -208,8 +208,8 @@ export function toPy(
      */
     depth: number;
     /**
-     * Optional argument to convert objects with no
-     * default conversion. See the documentation of :any:`JsProxy.to_py`.
+     * Optional argument to convert objects with no default conversion. See the
+     * documentation of :any:`JsProxy.to_py`.
      */
     defaultConverter?: (
       value: any,

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -195,8 +195,9 @@ export function unregisterJsModule(name: string) {
  *
  * @param obj
  * @param options
- * @param options.depth Optional argument to limit the depth of the
- * conversion.
+ * @param options.depth Optional argument to limit the depth of the conversion.
+ * @param options.default_converter Optional argument to convert objects with no
+ * default conversion. See the documentation of :any:`JsProxy.to_py`.
  * @returns The object converted to Python.
  */
 export function toPy(

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -201,7 +201,17 @@ export function unregisterJsModule(name: string) {
  */
 export function toPy(
   obj: any,
-  { depth, defaultConverter }: { depth: number, defaultConverter? : (value: any, converter : (value : any) => any) => any } = { depth: -1 }
+  {
+    depth,
+    defaultConverter,
+  }: {
+    depth: number;
+    defaultConverter?: (
+      value: any,
+      converter: (value: any) => any,
+      cacheConversion: (input: any, output: any) => any
+    ) => any;
+  } = { depth: -1 }
 ): Py2JsResult {
   // No point in converting these, it'd be dumb to proxy them so they'd just
   // get converted back by `js2python` at the end
@@ -222,7 +232,7 @@ export function toPy(
   try {
     obj_id = Module.hiwire.new_value(obj);
     try {
-      py_result = Module.js2python_convert(obj_id, {depth, defaultConverter});
+      py_result = Module.js2python_convert(obj_id, { depth, defaultConverter });
     } catch (e) {
       if (e instanceof Module._PropagatePythonError) {
         Module._pythonexc2js();

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -195,9 +195,6 @@ export function unregisterJsModule(name: string) {
  *
  * @param obj
  * @param options
- * @param options.depth Optional argument to limit the depth of the conversion.
- * @param options.default_converter Optional argument to convert objects with no
- * default conversion. See the documentation of :any:`JsProxy.to_py`.
  * @returns The object converted to Python.
  */
 export function toPy(
@@ -206,7 +203,14 @@ export function toPy(
     depth,
     defaultConverter,
   }: {
+    /**
+     *  Optional argument to limit the depth of the conversion.
+     */
     depth: number;
+    /**
+     * Optional argument to convert objects with no
+     * default conversion. See the documentation of :any:`JsProxy.to_py`.
+     */
     defaultConverter?: (
       value: any,
       converter: (value: any) => any,

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -53,7 +53,7 @@ class JsProxy:
         *,
         depth: int = -1,
         default_converter: Callable[
-            ["JsProxy", Callable[["JsProxy"], Any], Callable[["JsProxy", Any]]], Any
+            ["JsProxy", Callable[["JsProxy"], Any], Callable[["JsProxy", Any], None]], Any
         ] = None,
     ) -> Any:
         """Convert the :class:`JsProxy` to a native Python object as best as

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -65,12 +65,11 @@ class JsProxy:
         :ref:`type-translations-jsproxy-to-py` for more information.
 
         ``default_converter`` if present will be invoked whenever Pyodide does
-        not have some built in conversion for the object. If
-        ``default_converter`` returns ``None``, then the object will be proxied.
+        not have some built in conversion for the object.
         If ``default_converter`` raises an error, the error will be allowed to
-        propagate. In other cases, the object returned will be used as the
+        propagate. Otherwise, the object returned will be used as the
         conversion. ``default_converter`` takes three arguments. The first
-        argument is the value to be converted:
+        argument is the value to be converted.
 
         Here are a couple examples of converter functions. In addition to the
         normal conversions, convert ``Date`` to ``datetime``:
@@ -81,6 +80,7 @@ class JsProxy:
             def default_converter(value, _ignored1, _ignored2):
                 if value.constructor.name == "Date":
                     return datetime.fromtimestamp(d.valueOf()/1000)
+                return value
 
         Don't create any JsProxies, require a complete conversion or raise an error:
 
@@ -111,7 +111,7 @@ class JsProxy:
 
             def default_converter(value, convert, cache):
                 if value.constructor.name != "Pair":
-                    return None
+                    return value
                 result = []
                 cache(value, result);
                 result.append(convert(value.first))

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -53,7 +53,8 @@ class JsProxy:
         *,
         depth: int = -1,
         default_converter: Callable[
-            ["JsProxy", Callable[["JsProxy"], Any], Callable[["JsProxy", Any], None]], Any
+            ["JsProxy", Callable[["JsProxy"], Any], Callable[["JsProxy", Any], None]],
+            Any,
         ] = None,
     ) -> Any:
         """Convert the :class:`JsProxy` to a native Python object as best as

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -185,7 +185,7 @@ class JsProxy:
         """
 
     def to_memoryview(self) -> memoryview:
-        """Convert the buffer to a memoryview.
+        """Convert a buffer to a memoryview.
 
         Copies the data once. This currently has the same effect as :any:`to_py`.
         Present only if the wrapped Javascript object is an ArrayBuffer or
@@ -193,7 +193,7 @@ class JsProxy:
         """
 
     def to_bytes(self) -> bytes:
-        """Convert the buffer to a bytes object.
+        """Convert a buffer to a bytes object.
 
         Copies the data once.
         Present only if the wrapped Javascript object is an ArrayBuffer or
@@ -201,7 +201,7 @@ class JsProxy:
         """
 
     def to_file(self, file: IOBase):
-        """Writes the entire buffer to a file.
+        """Writes a buffer to a file.
 
         Will write the entire contents of the buffer to the current position of
         the file.
@@ -225,7 +225,7 @@ class JsProxy:
         """
 
     def from_file(self, file: IOBase):
-        """Reads from a file into the buffer.
+        """Reads from a file into a buffer.
 
         Will try to read a chunk of data the same size as the buffer from
         the current position of the file.
@@ -251,7 +251,7 @@ class JsProxy:
         """
 
     def _into_file(self, file: IOBase):
-        """Will write the entire contents of the buffer into a file using
+        """Will write the entire contents of a buffer into a file using
         ``canOwn : true`` without any copy. After this, the buffer cannot be
         used again.
 
@@ -279,7 +279,7 @@ class JsProxy:
         """
 
     def to_string(self, encoding=None) -> str:
-        """Convert the buffer to a string object.
+        """Convert a buffer to a string object.
 
         Copies the data twice.
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -53,7 +53,7 @@ class JsProxy:
         *,
         depth: int = -1,
         default_converter: Callable[
-            [JsProxy, Callable[[JsProxy], Any], Callable[[JsProxy, Any]]], Any
+            ["JsProxy", Callable[["JsProxy"], Any], Callable[["JsProxy", Any]]], Any
         ] = None,
     ) -> Any:
         """Convert the :class:`JsProxy` to a native Python object as best as

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1136,6 +1136,85 @@ def test_to_py(selenium):
         )
 
 
+def test_to_py_default_converter(selenium):
+    selenium.run_js(
+        """
+        class Pair {
+            constructor(first, second){
+                this.first = first;
+                this.second = second;
+            }
+        }
+        l = [1,2,3];
+        self.p = new Pair(l, [l]);
+        const opts = {defaultConverter(value, converter, cache){
+            if(p.constructor.name === "Pair"){
+                let list = pyodide.globals.get("list");
+                l = list();
+                list.destroy();
+                cache(value, l);
+                const first = converter(value.first);
+                const second = converter(value.second);
+                l.append(first);
+                l.append(second);
+                first.destroy();
+                second.destroy();
+                return l;
+            }
+        }};
+        self.r = pyodide.toPy(p, opts);
+        pyodide.runPython(`
+            from js import r
+            assert isinstance(r, list)
+            assert r[0] is r[1][0]
+            assert r[0] == [1,2,3]
+        `);
+        r.destroy();
+        self.p.first = p;
+        self.r = pyodide.toPy(p, opts);
+        pyodide.runPython(`
+            from js import r
+            assert r[0] is r
+        `);
+        r.destroy();
+        """
+    )
+
+
+def test_to_py_default_converter2(selenium):
+    selenium.run_js(
+        """
+        class Pair {
+            constructor(first, second){
+                this.first = first;
+                this.second = second;
+            }
+        }
+        l = [1,2,3];
+        self.p = new Pair(l, [l]);
+        pyodide.runPython(`
+            from js import p
+            def default_converter(value, converter, cache):
+               l = []
+               cache(value, l)
+               l.append(converter(value.first))
+               l.append(converter(value.second))
+               return l
+            r = p.to_py(default_converter=default_converter)
+            assert isinstance(r, list)
+            assert r[0] is r[1][0]
+            assert r[0] == [1,2,3]
+        `);
+        self.p.first = p;
+        pyodide.runPython(`
+            r = p.to_py(default_converter=default_converter)
+            assert r[0] is r
+            del r
+        `);
+        """
+    )
+
+
 def test_buffer_format_string(selenium):
     errors = [
         ["aaa", "Expected format string to have length <= 2, got 'aaa'"],

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1196,7 +1196,7 @@ def test_to_py_default_converter2(selenium):
         pyodide.runPython(`
             from js import p
             def default_converter(value, converter, cache):
-                if value.constructor.name != "Pair:
+                if value.constructor.name != "Pair":
                     return value
                 l = []
                 cache(value, l)

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1148,19 +1148,20 @@ def test_to_py_default_converter(selenium):
         l = [1,2,3];
         self.p = new Pair(l, [l]);
         const opts = {defaultConverter(value, converter, cache){
-            if(p.constructor.name === "Pair"){
-                let list = pyodide.globals.get("list");
-                l = list();
-                list.destroy();
-                cache(value, l);
-                const first = converter(value.first);
-                const second = converter(value.second);
-                l.append(first);
-                l.append(second);
-                first.destroy();
-                second.destroy();
-                return l;
+            if(p.constructor.name !== "Pair"){
+                return value;
             }
+            let list = pyodide.globals.get("list");
+            l = list();
+            list.destroy();
+            cache(value, l);
+            const first = converter(value.first);
+            const second = converter(value.second);
+            l.append(first);
+            l.append(second);
+            first.destroy();
+            second.destroy();
+            return l;
         }};
         self.r = pyodide.toPy(p, opts);
         pyodide.runPython(`
@@ -1195,11 +1196,13 @@ def test_to_py_default_converter2(selenium):
         pyodide.runPython(`
             from js import p
             def default_converter(value, converter, cache):
-               l = []
-               cache(value, l)
-               l.append(converter(value.first))
-               l.append(converter(value.second))
-               return l
+                if value.constructor.name != "Pair:
+                    return value
+                l = []
+                cache(value, l)
+                l.append(converter(value.first))
+                l.append(converter(value.second))
+                return l
             r = p.to_py(default_converter=default_converter)
             assert isinstance(r, list)
             assert r[0] is r[1][0]


### PR DESCRIPTION
See the discussion with @oeway here: #2067.

This adds a new `default_converter` argument to `JsProxy.to_py` and `pyodide.toPy` which can be used to control the conversion of objects with no standard conversion. It can be used for instance to ensure that no `JsProxy`s are left over in the converted object, by just raising an error:
```py
def default_converter(_value, _ignored1, _ignored2):
    raise Exception("Object was not completely converted")
some_jsproxy.to_py(default_converter=default_converter)
```
If `default_converter` returns `None`, then `value` will be proxied. If you want to convert `Date` to `datetime` that can be done as follows:
```py
from datetime import datetime
def default_converter(value, _ignored1, _ignored2):
    if value.constructor.name == "Date":
        return datetime.fromtimestamp(d.valueOf()/1000)
```
If we have a pair class:
```js
class Pair {
    constructor(first, second){
        this.first = first;
        this.second = second;
    }
}
```
we can convert that as follows:
```py
def default_converter(value, convert, cache):
    if value.constructor.name != "Pair":
        return None
    result = []
    cache(value, result);
    result.append(convert(value.first))
    result.append(convert(value.second))
    return result
```
Note that this will handle self referential pairs correctly:
```js
const p = new Pair(0,0);
p.first = p;
```
will be converted to a list like:
```py
l = [0,0]
l[0] = l
```

### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
