### PR TITLE
MAINT Add Hiwire to top level namespace

### DIFF
--- a/docs/development/core.md
+++ b/docs/development/core.md
@@ -13,7 +13,7 @@ The primary purpose of `core` is to implement {ref}`type translations <type-tran
 
 ### Backend utilities
 
-- `hiwire` -- A helper framework. It is impossible for wasm to directly hold owning references to JavaScript objects. The primary purpose of hiwire is to act as a surrogate owner for JavaScript references by holding the references in a JavaScript `Map`. `hiwire` also defines a wide variety of `EM_JS` helper functions to do JavaScript operations on the held objects. The primary type that hiwire exports is `JsRef`. References are created with `Module.hiwire.new_value` (only can be done from JavaScript) and must be destroyed from C with `hiwire_decref` or `hiwire_CLEAR`, or from JavaScript with `Module.hiwire.decref`.
+- `hiwire` -- A helper framework. It is impossible for wasm to directly hold owning references to JavaScript objects. The primary purpose of hiwire is to act as a surrogate owner for JavaScript references by holding the references in a JavaScript `Map`. `hiwire` also defines a wide variety of `EM_JS` helper functions to do JavaScript operations on the held objects. The primary type that hiwire exports is `JsRef`. References are created with `Hiwire.new_value` (only can be done from JavaScript) and must be destroyed from C with `hiwire_decref` or `hiwire_CLEAR`, or from JavaScript with `Hiwire.decref`.
 - `error_handling` -- defines macros useful for error propagation and for adapting JavaScript functions to the CPython calling convention. See more in the {ref}`error_handling_macros` section.
 
 ### Type conversion from JavaScript to Python
@@ -89,9 +89,9 @@ Use `EM_JS_REF` when return value is a `JsRef`:
 
 ```javascript
 EM_JS_REF(JsRef, hiwire_call, (JsRef idfunc, JsRef idargs), {
-  let jsfunc = Module.hiwire.get_value(idfunc);
-  let jsargs = Module.hiwire.get_value(idargs);
-  return Module.hiwire.new_value(jsfunc(... jsargs));
+  let jsfunc = Hiwire.get_value(idfunc);
+  let jsargs = Hiwire.get_value(idargs);
+  return Hiwire.new_value(jsfunc(... jsargs));
 });
 ```
 
@@ -107,7 +107,7 @@ If the function returns `void`, use `EM_JS_NUM` with return type `errcode`. `err
 
 ```javascript
 EM_JS_NUM(errcode, hiwire_set_member_int, (JsRef idobj, int idx, JsRef idval), {
-  Module.hiwire.get_value(idobj)[idx] = Module.hiwire.get_value(idval);
+  Hiwire.get_value(idobj)[idx] = Hiwire.get_value(idval);
 });
 ```
 
@@ -115,7 +115,7 @@ If the function returns `int` or `bool` use `EM_JS_NUM`:
 
 ```javascript
 EM_JS_NUM(int, hiwire_get_length, (JsRef idobj), {
-  return Module.hiwire.get_value(idobj).length;
+  return Hiwire.get_value(idobj).length;
 });
 ```
 

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -22,7 +22,7 @@ EM_JS(void, console_error, (char* msg), {
 // Right now this is dead code (probably), please don't remove it.
 // Intended for debugging purposes.
 EM_JS(void, console_error_obj, (JsRef obj), {
-  console.error(Module.hiwire.get_value(obj));
+  console.error(Hiwire.get_value(obj));
 });
 
 /**
@@ -46,7 +46,7 @@ set_error(PyObject* err)
  * err - The error object
  */
 EM_JS_REF(JsRef, new_error, (const char* msg, PyObject* err), {
-  return Module.hiwire.new_value(new API.PythonError(UTF8ToString(msg), err));
+  return Hiwire.new_value(new API.PythonError(UTF8ToString(msg), err));
 });
 
 /**
@@ -213,7 +213,7 @@ EM_JS(void, log_python_error, (JsRef jserror), {
   // If a js error occurs in here, it's a weird edge case. This will probably
   // never happen, but for maximum paranoia let's double check.
   try {
-    let msg = Module.hiwire.get_value(jserror).message;
+    let msg = Hiwire.get_value(jserror).message;
     console.warn("Python exception:\n" + msg + "\n");
   } catch (e) {
     API.fatal_error(e);

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -1,5 +1,5 @@
 import ErrorStackParser from "error-stack-parser";
-import { Module, API } from "./module.js";
+import { Module, API, Hiwire } from "./module.js";
 
 function isPyodideFrame(frame: ErrorStackParser.StackFrame): boolean {
   const fileName = frame.fileName || "";
@@ -48,11 +48,11 @@ Module.handle_js_error = function (e: any) {
   }
   if (!restored_error) {
     // Wrap the JavaScript error
-    let eidx = Module.hiwire.new_value(e);
+    let eidx = Hiwire.new_value(e);
     let err = Module._JsProxy_create(eidx);
     Module._set_error(err);
     Module._Py_DecRef(err);
-    Module.hiwire.decref(eidx);
+    Hiwire.decref(eidx);
   }
   let stack = ErrorStackParser.parse(e);
   if (isErrorStart(stack[0])) {

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -25,7 +25,7 @@ hiwire_from_bool(bool boolean)
 }
 
 EM_JS(bool, hiwire_to_bool, (JsRef val), {
-  return !!Module.hiwire.get_value(val);
+  return !!Hiwire.get_value(val);
 });
 
 EM_JS_NUM(int, hiwire_init, (), {
@@ -43,24 +43,24 @@ EM_JS_NUM(int, hiwire_init, (), {
     // conventions.
     counter : new Uint32Array([1])
   };
-  Module.hiwire = {};
-  Module.hiwire.UNDEFINED = DEREF_U8(_Js_undefined, 0);
-  Module.hiwire.JSNULL = DEREF_U8(_Js_null, 0);
-  Module.hiwire.TRUE = DEREF_U8(_Js_true, 0);
-  Module.hiwire.FALSE = DEREF_U8(_Js_false, 0);
+  Hiwire = {};
+  Hiwire.UNDEFINED = DEREF_U8(_Js_undefined, 0);
+  Hiwire.JSNULL = DEREF_U8(_Js_null, 0);
+  Hiwire.TRUE = DEREF_U8(_Js_true, 0);
+  Hiwire.FALSE = DEREF_U8(_Js_false, 0);
 
-  _hiwire.objects.set(Module.hiwire.UNDEFINED, [ undefined, -1 ]);
-  _hiwire.objects.set(Module.hiwire.JSNULL, [ null, -1 ]);
-  _hiwire.objects.set(Module.hiwire.TRUE, [ true, -1 ]);
-  _hiwire.objects.set(Module.hiwire.FALSE, [ false, -1 ]);
-  let hiwire_next_permanent = Module.hiwire.FALSE + 2;
+  _hiwire.objects.set(Hiwire.UNDEFINED, [ undefined, -1 ]);
+  _hiwire.objects.set(Hiwire.JSNULL, [ null, -1 ]);
+  _hiwire.objects.set(Hiwire.TRUE, [ true, -1 ]);
+  _hiwire.objects.set(Hiwire.FALSE, [ false, -1 ]);
+  let hiwire_next_permanent = Hiwire.FALSE + 2;
 
 #ifdef DEBUG_F
-  Module.hiwire._hiwire = _hiwire;
+  Hiwire._hiwire = _hiwire;
   let many_objects_warning_threshold = 200;
 #endif
 
-  Module.hiwire.new_value = function(jsval)
+  Hiwire.new_value = function(jsval)
   {
     // Should we guard against duplicating standard values?
     // Probably not worth it for performance: it's harmless to ocassionally
@@ -88,7 +88,7 @@ EM_JS_NUM(int, hiwire_init, (), {
     return idval;
   };
 
-  Module.hiwire.intern_object = function(obj)
+  Hiwire.intern_object = function(obj)
   {
     let id = hiwire_next_permanent;
     hiwire_next_permanent += 2;
@@ -97,13 +97,13 @@ EM_JS_NUM(int, hiwire_init, (), {
   };
 
   // for testing purposes.
-  Module.hiwire.num_keys = function(){
+  Hiwire.num_keys = function(){
     // clang-format off
     return Array.from(_hiwire.objects.keys()).filter((x) => x % 2).length
     // clang-format on
   };
 
-  Module.hiwire.get_value = function(idval)
+  Hiwire.get_value = function(idval)
   {
     if (!idval) {
       API.fail_test = true;
@@ -113,7 +113,7 @@ EM_JS_NUM(int, hiwire_init, (), {
       if (_PyErr_Occurred()) {
         // This will lead to a more helpful error message.
         let exc = _wrap_exception();
-        let e = Module.hiwire.pop_value(exc);
+        let e = Hiwire.pop_value(exc);
         console.error(
           `Internal error: Argument '${idval}' to hiwire.get_value is falsy. ` +
           "This was probably because the Python error indicator was set when get_value was called. " +
@@ -142,7 +142,7 @@ EM_JS_NUM(int, hiwire_init, (), {
     return _hiwire.objects.get(idval)[0];
   };
 
-  Module.hiwire.decref = function(idval)
+  Hiwire.decref = function(idval)
   {
     // clang-format off
     if ((idval & 1) === 0) {
@@ -157,17 +157,17 @@ EM_JS_NUM(int, hiwire_init, (), {
     // clang-format on
   };
 
-  Module.hiwire.incref = function(idval) { _hiwire.objects.get(idval)[1]++; };
+  Hiwire.incref = function(idval) { _hiwire.objects.get(idval)[1]++; };
 
-  Module.hiwire.pop_value = function(idval)
+  Hiwire.pop_value = function(idval)
   {
-    let result = Module.hiwire.get_value(idval);
-    Module.hiwire.decref(idval);
+    let result = Hiwire.get_value(idval);
+    Hiwire.decref(idval);
     return result;
   };
 
   // This is factored out primarily for testing purposes.
-  Module.hiwire.isPromise = function(obj)
+  Hiwire.isPromise = function(obj)
   {
     try {
       // clang-format off
@@ -247,7 +247,7 @@ EM_JS_NUM(int, hiwire_init, (), {
 
 EM_JS_REF(JsRef, JsString_InternFromCString, (const char* str), {
   let jsstring = UTF8ToString(str);
-  return Module.hiwire.intern_object(jsstring);
+  return Hiwire.intern_object(jsstring);
 })
 
 JsRef
@@ -263,15 +263,15 @@ EM_JS(JsRef, hiwire_incref, (JsRef idval), {
   if (idval & 1) {
     // least significant bit unset ==> idval is a singleton.
     // We don't reference count singletons.
-    Module.hiwire.incref(idval);
+    Hiwire.incref(idval);
   }
   return idval;
 });
 
-EM_JS(void, hiwire_decref, (JsRef idval), { Module.hiwire.decref(idval); });
+EM_JS(void, hiwire_decref, (JsRef idval), { Hiwire.decref(idval); });
 
 EM_JS_REF(JsRef, hiwire_int, (int val), {
-  return Module.hiwire.new_value(val);
+  return Hiwire.new_value(val);
 });
 
 // clang-format off
@@ -286,12 +286,12 @@ hiwire_int_from_digits, (const unsigned int* digits, size_t ndigits), {
   if (-Number.MAX_SAFE_INTEGER < result && result < Number.MAX_SAFE_INTEGER) {
     result = Number(result);
   }
-  return Module.hiwire.new_value(result);
+  return Hiwire.new_value(result);
 })
 // clang-format on
 
 EM_JS_REF(JsRef, hiwire_double, (double val), {
-  return Module.hiwire.new_value(val);
+  return Hiwire.new_value(val);
 });
 
 EM_JS_REF(JsRef, hiwire_string_ucs4, (const char* ptr, int len), {
@@ -299,7 +299,7 @@ EM_JS_REF(JsRef, hiwire_string_ucs4, (const char* ptr, int len), {
   for (let i = 0; i < len; ++i) {
     jsstr += String.fromCodePoint(DEREF_U32(ptr, i));
   }
-  return Module.hiwire.new_value(jsstr);
+  return Hiwire.new_value(jsstr);
 });
 
 EM_JS_REF(JsRef, hiwire_string_ucs2, (const char* ptr, int len), {
@@ -307,7 +307,7 @@ EM_JS_REF(JsRef, hiwire_string_ucs2, (const char* ptr, int len), {
   for (let i = 0; i < len; ++i) {
     jsstr += String.fromCharCode(DEREF_U16(ptr, i));
   }
-  return Module.hiwire.new_value(jsstr);
+  return Hiwire.new_value(jsstr);
 });
 
 EM_JS_REF(JsRef, hiwire_string_ucs1, (const char* ptr, int len), {
@@ -315,23 +315,23 @@ EM_JS_REF(JsRef, hiwire_string_ucs1, (const char* ptr, int len), {
   for (let i = 0; i < len; ++i) {
     jsstr += String.fromCharCode(DEREF_U8(ptr, i));
   }
-  return Module.hiwire.new_value(jsstr);
+  return Hiwire.new_value(jsstr);
 });
 
 EM_JS_REF(JsRef, hiwire_string_utf8, (const char* ptr), {
-  return Module.hiwire.new_value(UTF8ToString(ptr));
+  return Hiwire.new_value(UTF8ToString(ptr));
 });
 
 EM_JS_REF(JsRef, hiwire_string_ascii, (const char* ptr), {
-  return Module.hiwire.new_value(AsciiToString(ptr));
+  return Hiwire.new_value(AsciiToString(ptr));
 });
 
 EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
-  throw Module.hiwire.pop_value(iderr);
+  throw Hiwire.pop_value(iderr);
 });
 
 EM_JS(bool, JsArray_Check, (JsRef idobj), {
-  let obj = Module.hiwire.get_value(idobj);
+  let obj = Hiwire.get_value(idobj);
   if (Array.isArray(obj)) {
     return true;
   }
@@ -351,20 +351,20 @@ EM_JS(bool, JsArray_Check, (JsRef idobj), {
   return false;
 });
 
-EM_JS_REF(JsRef, JsArray_New, (), { return Module.hiwire.new_value([]); });
+EM_JS_REF(JsRef, JsArray_New, (), { return Hiwire.new_value([]); });
 
 EM_JS_NUM(errcode, JsArray_Push, (JsRef idarr, JsRef idval), {
-  Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
+  Hiwire.get_value(idarr).push(Hiwire.get_value(idval));
 });
 
 EM_JS(void, JsArray_Push_unchecked, (JsRef idarr, JsRef idval), {
-  Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
+  Hiwire.get_value(idarr).push(Hiwire.get_value(idval));
 });
 
-EM_JS_REF(JsRef, JsObject_New, (), { return Module.hiwire.new_value({}); });
+EM_JS_REF(JsRef, JsObject_New, (), { return Hiwire.new_value({}); });
 
 EM_JS_REF(JsRef, JsObject_GetString, (JsRef idobj, const char* ptrkey), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let jskey = UTF8ToString(ptrkey);
   let result = jsobj[jskey];
   // clang-format off
@@ -372,7 +372,7 @@ EM_JS_REF(JsRef, JsObject_GetString, (JsRef idobj, const char* ptrkey), {
     // clang-format on
     return ERROR_REF;
   }
-  return Module.hiwire.new_value(result);
+  return Hiwire.new_value(result);
 });
 
 // clang-format off
@@ -381,9 +381,9 @@ errcode,
 JsObject_SetString,
 (JsRef idobj, const char* ptrkey, JsRef idval),
 {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let jskey = UTF8ToString(ptrkey);
-  let jsval = Module.hiwire.get_value(idval);
+  let jsval = Hiwire.get_value(idval);
   jsobj[jskey] = jsval;
 });
 
@@ -392,29 +392,29 @@ errcode,
 JsObject_DeleteString,
 (JsRef idobj, const char* ptrkey),
 {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let jskey = UTF8ToString(ptrkey);
   delete jsobj[jskey];
 });
 // clang-format on
 
 EM_JS_REF(JsRef, JsArray_Get, (JsRef idobj, int idx), {
-  let obj = Module.hiwire.get_value(idobj);
+  let obj = Hiwire.get_value(idobj);
   let result = obj[idx];
   // clang-format off
   if (result === undefined && !(idx in obj)) {
     // clang-format on
     return ERROR_REF;
   }
-  return Module.hiwire.new_value(result);
+  return Hiwire.new_value(result);
 });
 
 EM_JS_NUM(errcode, JsArray_Set, (JsRef idobj, int idx, JsRef idval), {
-  Module.hiwire.get_value(idobj)[idx] = Module.hiwire.get_value(idval);
+  Hiwire.get_value(idobj)[idx] = Hiwire.get_value(idval);
 });
 
 EM_JS_NUM(errcode, JsArray_Delete, (JsRef idobj, int idx), {
-  let obj = Module.hiwire.get_value(idobj);
+  let obj = Hiwire.get_value(idobj);
   // Weird edge case: allow deleting an empty entry, but we raise a key error if
   // access is attempted.
   if (idx < 0 || idx >= obj.length) {
@@ -424,7 +424,7 @@ EM_JS_NUM(errcode, JsArray_Delete, (JsRef idobj, int idx), {
 });
 
 EM_JS_REF(JsRef, JsObject_Dir, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let result = [];
   do {
     // clang-format off
@@ -436,7 +436,7 @@ EM_JS_REF(JsRef, JsObject_Dir, (JsRef idobj), {
     ));
     // clang-format on
   } while (jsobj = Object.getPrototypeOf(jsobj));
-  return Module.hiwire.new_value(result);
+  return Hiwire.new_value(result);
 });
 
 static JsRef
@@ -455,9 +455,9 @@ convert_va_args(va_list args)
 }
 
 EM_JS_REF(JsRef, hiwire_call, (JsRef idfunc, JsRef idargs), {
-  let jsfunc = Module.hiwire.get_value(idfunc);
-  let jsargs = Module.hiwire.get_value(idargs);
-  return Module.hiwire.new_value(jsfunc(... jsargs));
+  let jsfunc = Hiwire.get_value(idfunc);
+  let jsargs = Hiwire.get_value(idargs);
+  return Hiwire.new_value(jsfunc(... jsargs));
 });
 
 JsRef
@@ -472,9 +472,9 @@ hiwire_call_va(JsRef idobj, ...)
 }
 
 EM_JS_REF(JsRef, hiwire_call_OneArg, (JsRef idfunc, JsRef idarg), {
-  let jsfunc = Module.hiwire.get_value(idfunc);
-  let jsarg = Module.hiwire.get_value(idarg);
-  return Module.hiwire.new_value(jsfunc(jsarg));
+  let jsfunc = Hiwire.get_value(idfunc);
+  let jsarg = Hiwire.get_value(idarg);
+  return Hiwire.new_value(jsfunc(jsarg));
 });
 
 // clang-format off
@@ -482,22 +482,22 @@ EM_JS_REF(JsRef,
 hiwire_call_bound,
 (JsRef idfunc, JsRef idthis, JsRef idargs),
 {
-  let func = Module.hiwire.get_value(idfunc);
+  let func = Hiwire.get_value(idfunc);
   let this_;
   if (idthis === 0) {
     this_ = null;
   } else {
-    this_ = Module.hiwire.get_value(idthis);
+    this_ = Hiwire.get_value(idthis);
   }
-  let args = Module.hiwire.get_value(idargs);
-  return Module.hiwire.new_value(func.apply(this_, args));
+  let args = Hiwire.get_value(idargs);
+  return Hiwire.new_value(func.apply(this_, args));
 });
 // clang-format on
 
 EM_JS(bool, hiwire_HasMethod, (JsRef obj_id, JsRef name), {
   // clang-format off
-  let obj = Module.hiwire.get_value(obj_id);
-  return obj && typeof obj[Module.hiwire.get_value(name)] === "function";
+  let obj = Hiwire.get_value(obj_id);
+  return obj && typeof obj[Hiwire.get_value(name)] === "function";
   // clang-format on
 })
 
@@ -513,18 +513,18 @@ JsRef,
 hiwire_CallMethodString,
 (JsRef idobj, const char* name, JsRef idargs),
 {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let jsname = UTF8ToString(name);
-  let jsargs = Module.hiwire.get_value(idargs);
-  return Module.hiwire.new_value(jsobj[jsname](...jsargs));
+  let jsargs = Hiwire.get_value(idargs);
+  return Hiwire.new_value(jsobj[jsname](...jsargs));
 });
 // clang-format on
 
 EM_JS_REF(JsRef, hiwire_CallMethod, (JsRef idobj, JsRef name, JsRef idargs), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  let jsname = Module.hiwire.get_value(name);
-  let jsargs = Module.hiwire.get_value(idargs);
-  return Module.hiwire.new_value(jsobj[jsname](... jsargs));
+  let jsobj = Hiwire.get_value(idobj);
+  let jsname = Hiwire.get_value(name);
+  let jsargs = Hiwire.get_value(idargs);
+  return Hiwire.new_value(jsobj[jsname](... jsargs));
 });
 
 // clang-format off
@@ -533,10 +533,10 @@ JsRef,
 hiwire_CallMethod_OneArg,
 (JsRef idobj, JsRef name, JsRef idarg),
 {
-  let jsobj = Module.hiwire.get_value(idobj);
-  let jsname = Module.hiwire.get_value(name);
-  let jsarg = Module.hiwire.get_value(idarg);
-  return Module.hiwire.new_value(jsobj[jsname](jsarg));
+  let jsobj = Hiwire.get_value(idobj);
+  let jsname = Hiwire.get_value(name);
+  let jsarg = Hiwire.get_value(idarg);
+  return Hiwire.new_value(jsobj[jsname](jsarg));
 });
 // clang-format on
 
@@ -583,13 +583,13 @@ hiwire_CallMethodId_OneArg(JsRef obj, Js_Identifier* name, JsRef arg)
 }
 
 EM_JS_REF(JsRef, hiwire_construct, (JsRef idobj, JsRef idargs), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  let jsargs = Module.hiwire.get_value(idargs);
-  return Module.hiwire.new_value(Reflect.construct(jsobj, jsargs));
+  let jsobj = Hiwire.get_value(idobj);
+  let jsargs = Hiwire.get_value(idargs);
+  return Hiwire.new_value(Reflect.construct(jsobj, jsargs));
 });
 
 EM_JS(bool, hiwire_has_length, (JsRef idobj), {
-  let val = Module.hiwire.get_value(idobj);
+  let val = Hiwire.get_value(idobj);
   // clang-format off
   return (typeof val.size === "number") ||
          (typeof val.length === "number" && typeof val !== "function");
@@ -597,7 +597,7 @@ EM_JS(bool, hiwire_has_length, (JsRef idobj), {
 });
 
 EM_JS_NUM(int, hiwire_get_length, (JsRef idobj), {
-  let val = Module.hiwire.get_value(idobj);
+  let val = Hiwire.get_value(idobj);
   // clang-format off
   if (typeof val.size === "number") {
     return val.size;
@@ -610,7 +610,7 @@ EM_JS_NUM(int, hiwire_get_length, (JsRef idobj), {
 });
 
 EM_JS(bool, hiwire_get_bool, (JsRef idobj), {
-  let val = Module.hiwire.get_value(idobj);
+  let val = Hiwire.get_value(idobj);
   // clang-format off
   if (!val) {
     return false;
@@ -627,23 +627,23 @@ EM_JS(bool, hiwire_get_bool, (JsRef idobj), {
 });
 
 EM_JS(bool, hiwire_is_pyproxy, (JsRef idobj), {
-  return API.isPyProxy(Module.hiwire.get_value(idobj));
+  return API.isPyProxy(Hiwire.get_value(idobj));
 });
 
 EM_JS(bool, hiwire_is_function, (JsRef idobj), {
   // clang-format off
-  return typeof Module.hiwire.get_value(idobj) === 'function';
+  return typeof Hiwire.get_value(idobj) === 'function';
   // clang-format on
 });
 
 EM_JS(bool, hiwire_is_comlink_proxy, (JsRef idobj), {
-  let value = Module.hiwire.get_value(idobj);
+  let value = Hiwire.get_value(idobj);
   return !!(API.Comlink && value[API.Comlink.createEndpoint]);
 });
 
 EM_JS(bool, hiwire_is_error, (JsRef idobj), {
   // From https://stackoverflow.com/a/45496068
-  let value = Module.hiwire.get_value(idobj);
+  let value = Hiwire.get_value(idobj);
   // clang-format off
   return !!(value && typeof value.stack === "string" &&
             typeof value.message === "string");
@@ -652,34 +652,34 @@ EM_JS(bool, hiwire_is_error, (JsRef idobj), {
 
 EM_JS(bool, hiwire_is_promise, (JsRef idobj), {
   // clang-format off
-  let obj = Module.hiwire.get_value(idobj);
-  return Module.hiwire.isPromise(obj);
+  let obj = Hiwire.get_value(idobj);
+  return Hiwire.isPromise(obj);
   // clang-format on
 });
 
 EM_JS_REF(JsRef, hiwire_resolve_promise, (JsRef idobj), {
   // clang-format off
-  let obj = Module.hiwire.get_value(idobj);
+  let obj = Hiwire.get_value(idobj);
   let result = Promise.resolve(obj);
-  return Module.hiwire.new_value(result);
+  return Hiwire.new_value(result);
   // clang-format on
 });
 
 EM_JS_REF(JsRef, hiwire_to_string, (JsRef idobj), {
-  return Module.hiwire.new_value(Module.hiwire.get_value(idobj).toString());
+  return Hiwire.new_value(Hiwire.get_value(idobj).toString());
 });
 
 EM_JS_REF(JsRef, hiwire_typeof, (JsRef idobj), {
-  return Module.hiwire.new_value(typeof Module.hiwire.get_value(idobj));
+  return Hiwire.new_value(typeof Hiwire.get_value(idobj));
 });
 
 EM_JS_REF(char*, hiwire_constructor_name, (JsRef idobj), {
-  return stringToNewUTF8(Module.hiwire.get_value(idobj).constructor.name);
+  return stringToNewUTF8(Hiwire.get_value(idobj).constructor.name);
 });
 
 #define MAKE_OPERATOR(name, op)                                                \
   EM_JS(bool, hiwire_##name, (JsRef ida, JsRef idb), {                         \
-    return !!(Module.hiwire.get_value(ida) op Module.hiwire.get_value(idb));   \
+    return !!(Hiwire.get_value(ida) op Hiwire.get_value(idb));                 \
   })
 
 MAKE_OPERATOR(less_than, <);
@@ -692,83 +692,83 @@ MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
 EM_JS(bool, hiwire_is_iterator, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   // clang-format off
   return typeof jsobj.next === 'function';
   // clang-format on
 });
 
 EM_JS_NUM(int, hiwire_next, (JsRef idobj, JsRef* result_ptr), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   // clang-format off
   let { done, value } = jsobj.next();
   // clang-format on
-  let result_id = Module.hiwire.new_value(value);
+  let result_id = Hiwire.new_value(value);
   DEREF_U32(result_ptr, 0) = result_id;
   return done;
 });
 
 EM_JS(bool, hiwire_is_iterable, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   // clang-format off
   return typeof jsobj[Symbol.iterator] === 'function';
   // clang-format on
 });
 
 EM_JS_REF(JsRef, hiwire_get_iterator, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  return Module.hiwire.new_value(jsobj[Symbol.iterator]());
+  let jsobj = Hiwire.get_value(idobj);
+  return Hiwire.new_value(jsobj[Symbol.iterator]());
 })
 
 EM_JS_REF(JsRef, JsObject_Entries, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  return Module.hiwire.new_value(Object.entries(jsobj));
+  let jsobj = Hiwire.get_value(idobj);
+  return Hiwire.new_value(Object.entries(jsobj));
 });
 
 EM_JS_REF(JsRef, JsObject_Keys, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  return Module.hiwire.new_value(Object.keys(jsobj));
+  let jsobj = Hiwire.get_value(idobj);
+  return Hiwire.new_value(Object.keys(jsobj));
 });
 
 EM_JS_REF(JsRef, JsObject_Values, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  return Module.hiwire.new_value(Object.values(jsobj));
+  let jsobj = Hiwire.get_value(idobj);
+  return Hiwire.new_value(Object.values(jsobj));
 });
 
 EM_JS(bool, hiwire_is_typedarray, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   // clang-format off
   return ArrayBuffer.isView(jsobj) || jsobj.constructor.name === "ArrayBuffer";
   // clang-format on
 });
 
 EM_JS_NUM(errcode, hiwire_assign_to_ptr, (JsRef idobj, void* ptr), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   Module.HEAPU8.set(Module.typedArrayAsUint8Array(jsobj), ptr);
 });
 
 EM_JS_NUM(errcode, hiwire_assign_from_ptr, (JsRef idobj, void* ptr), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   Module.typedArrayAsUint8Array(jsobj).set(
     Module.HEAPU8.subarray(ptr, ptr + jsobj.byteLength));
 });
 
 EM_JS_NUM(errcode, hiwire_read_from_file, (JsRef idobj, int fd), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let uint8_buffer = Module.typedArrayAsUint8Array(jsobj);
   let stream = Module.FS.streams[fd];
   Module.FS.read(stream, uint8_buffer, 0, uint8_buffer.byteLength);
 });
 
 EM_JS_NUM(errcode, hiwire_write_to_file, (JsRef idobj, int fd), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let uint8_buffer = Module.typedArrayAsUint8Array(jsobj);
   let stream = Module.FS.streams[fd];
   Module.FS.write(stream, uint8_buffer, 0, uint8_buffer.byteLength);
 });
 
 EM_JS_NUM(errcode, hiwire_into_file, (JsRef idobj, int fd), {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let uint8_buffer = Module.typedArrayAsUint8Array(jsobj);
   let stream = Module.FS.streams[fd];
   // set canOwn param to true, leave position undefined.
@@ -782,7 +782,7 @@ void,
 hiwire_get_buffer_info,
 (JsRef idobj, Py_ssize_t* byteLength_ptr, char** format_ptr, Py_ssize_t* size_ptr, bool* checked_ptr),
 {
-  let jsobj = Module.hiwire.get_value(idobj);
+  let jsobj = Hiwire.get_value(idobj);
   let byteLength = jsobj.byteLength;
   let [format_utf8, size, checked] = Module.get_buffer_datatype(jsobj);
   // Store results into arguments
@@ -794,24 +794,24 @@ hiwire_get_buffer_info,
 // clang-format on
 
 EM_JS_REF(JsRef, hiwire_subarray, (JsRef idarr, int start, int end), {
-  let jsarr = Module.hiwire.get_value(idarr);
+  let jsarr = Hiwire.get_value(idarr);
   let jssub = jsarr.subarray(start, end);
-  return Module.hiwire.new_value(jssub);
+  return Hiwire.new_value(jssub);
 });
 
-EM_JS_REF(JsRef, JsMap_New, (), { return Module.hiwire.new_value(new Map()); })
+EM_JS_REF(JsRef, JsMap_New, (), { return Hiwire.new_value(new Map()); })
 
 EM_JS_NUM(errcode, JsMap_Set, (JsRef mapid, JsRef keyid, JsRef valueid), {
-  let map = Module.hiwire.get_value(mapid);
-  let key = Module.hiwire.get_value(keyid);
-  let value = Module.hiwire.get_value(valueid);
+  let map = Hiwire.get_value(mapid);
+  let key = Hiwire.get_value(keyid);
+  let value = Hiwire.get_value(valueid);
   map.set(key, value);
 })
 
-EM_JS_REF(JsRef, JsSet_New, (), { return Module.hiwire.new_value(new Set()); })
+EM_JS_REF(JsRef, JsSet_New, (), { return Hiwire.new_value(new Set()); })
 
 EM_JS_NUM(errcode, JsSet_Add, (JsRef mapid, JsRef keyid), {
-  let set = Module.hiwire.get_value(mapid);
-  let key = Module.hiwire.get_value(keyid);
+  let set = Hiwire.get_value(mapid);
+  let key = Hiwire.get_value(keyid);
   set.add(key);
 })

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -45,7 +45,6 @@ EM_JS_NUM(int, hiwire_init, (), {
     // conventions.
     counter : new Uint32Array([1])
   };
-  Hiwire = {};
   Hiwire.UNDEFINED = DEREF_U8(_Js_undefined, 0);
   Hiwire.JSNULL = DEREF_U8(_Js_null, 0);
   Hiwire.TRUE = DEREF_U8(_Js_true, 0);

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -24,9 +24,11 @@ hiwire_from_bool(bool boolean)
   return boolean ? Js_true : Js_false;
 }
 
+// clang-format off
 EM_JS(bool, hiwire_to_bool, (JsRef val), {
   return !!Hiwire.get_value(val);
 });
+// clang-format on
 
 EM_JS_NUM(int, hiwire_init, (), {
   let _hiwire = {
@@ -268,11 +270,17 @@ EM_JS(JsRef, hiwire_incref, (JsRef idval), {
   return idval;
 });
 
-EM_JS(void, hiwire_decref, (JsRef idval), { Hiwire.decref(idval); });
+// clang-format off
+EM_JS(void, hiwire_decref, (JsRef idval), {
+  Hiwire.decref(idval);
+});
+// clang-format on
 
+// clang-format off
 EM_JS_REF(JsRef, hiwire_int, (int val), {
   return Hiwire.new_value(val);
 });
+// clang-format on
 
 // clang-format off
 EM_JS_REF(JsRef,
@@ -351,7 +359,11 @@ EM_JS(bool, JsArray_Check, (JsRef idobj), {
   return false;
 });
 
-EM_JS_REF(JsRef, JsArray_New, (), { return Hiwire.new_value([]); });
+// clang-format off
+EM_JS_REF(JsRef, JsArray_New, (), {
+  return Hiwire.new_value([]);
+});
+// clang-format on
 
 EM_JS_NUM(errcode, JsArray_Push, (JsRef idarr, JsRef idval), {
   Hiwire.get_value(idarr).push(Hiwire.get_value(idval));
@@ -361,7 +373,11 @@ EM_JS(void, JsArray_Push_unchecked, (JsRef idarr, JsRef idval), {
   Hiwire.get_value(idarr).push(Hiwire.get_value(idval));
 });
 
-EM_JS_REF(JsRef, JsObject_New, (), { return Hiwire.new_value({}); });
+// clang-format off
+EM_JS_REF(JsRef, JsObject_New, (), {
+  return Hiwire.new_value({});
+});
+// clang-format on
 
 EM_JS_REF(JsRef, JsObject_GetString, (JsRef idobj, const char* ptrkey), {
   let jsobj = Hiwire.get_value(idobj);
@@ -376,27 +392,22 @@ EM_JS_REF(JsRef, JsObject_GetString, (JsRef idobj, const char* ptrkey), {
 });
 
 // clang-format off
-EM_JS_NUM(
-errcode,
-JsObject_SetString,
-(JsRef idobj, const char* ptrkey, JsRef idval),
+EM_JS_NUM(errcode,
+          JsObject_SetString,
+          (JsRef idobj, const char* ptrkey, JsRef idval),
 {
   let jsobj = Hiwire.get_value(idobj);
   let jskey = UTF8ToString(ptrkey);
   let jsval = Hiwire.get_value(idval);
   jsobj[jskey] = jsval;
 });
+// clang-format on
 
-EM_JS_NUM(
-errcode,
-JsObject_DeleteString,
-(JsRef idobj, const char* ptrkey),
-{
+EM_JS_NUM(errcode, JsObject_DeleteString, (JsRef idobj, const char* ptrkey), {
   let jsobj = Hiwire.get_value(idobj);
   let jskey = UTF8ToString(ptrkey);
   delete jsobj[jskey];
 });
-// clang-format on
 
 EM_JS_REF(JsRef, JsArray_Get, (JsRef idobj, int idx), {
   let obj = Hiwire.get_value(idobj);
@@ -479,8 +490,8 @@ EM_JS_REF(JsRef, hiwire_call_OneArg, (JsRef idfunc, JsRef idarg), {
 
 // clang-format off
 EM_JS_REF(JsRef,
-hiwire_call_bound,
-(JsRef idfunc, JsRef idthis, JsRef idargs),
+          hiwire_call_bound,
+          (JsRef idfunc, JsRef idthis, JsRef idargs),
 {
   let func = Hiwire.get_value(idfunc);
   let this_;
@@ -508,10 +519,9 @@ hiwire_HasMethodId(JsRef obj, Js_Identifier* name)
 }
 
 // clang-format off
-EM_JS_REF(
-JsRef,
-hiwire_CallMethodString,
-(JsRef idobj, const char* name, JsRef idargs),
+EM_JS_REF(JsRef,
+          hiwire_CallMethodString,
+          (JsRef idobj, const char* name, JsRef idargs),
 {
   let jsobj = Hiwire.get_value(idobj);
   let jsname = UTF8ToString(name);
@@ -528,10 +538,9 @@ EM_JS_REF(JsRef, hiwire_CallMethod, (JsRef idobj, JsRef name, JsRef idargs), {
 });
 
 // clang-format off
-EM_JS_REF(
-JsRef,
-hiwire_CallMethod_OneArg,
-(JsRef idobj, JsRef name, JsRef idarg),
+EM_JS_REF(JsRef,
+          hiwire_CallMethod_OneArg,
+          (JsRef idobj, JsRef name, JsRef idarg),
 {
   let jsobj = Hiwire.get_value(idobj);
   let jsname = Hiwire.get_value(name);
@@ -779,8 +788,11 @@ EM_JS_NUM(errcode, hiwire_into_file, (JsRef idobj, int fd), {
 // clang-format off
 EM_JS_UNCHECKED(
 void,
-hiwire_get_buffer_info,
-(JsRef idobj, Py_ssize_t* byteLength_ptr, char** format_ptr, Py_ssize_t* size_ptr, bool* checked_ptr),
+hiwire_get_buffer_info, (JsRef idobj,
+                         Py_ssize_t* byteLength_ptr,
+                         char** format_ptr,
+                         Py_ssize_t* size_ptr,
+                         bool* checked_ptr),
 {
   let jsobj = Hiwire.get_value(idobj);
   let byteLength = jsobj.byteLength;
@@ -799,7 +811,11 @@ EM_JS_REF(JsRef, hiwire_subarray, (JsRef idarr, int start, int end), {
   return Hiwire.new_value(jssub);
 });
 
-EM_JS_REF(JsRef, JsMap_New, (), { return Hiwire.new_value(new Map()); })
+// clang-format off
+EM_JS_REF(JsRef, JsMap_New, (), {
+  return Hiwire.new_value(new Map());
+})
+// clang-format on
 
 EM_JS_NUM(errcode, JsMap_Set, (JsRef mapid, JsRef keyid, JsRef valueid), {
   let map = Hiwire.get_value(mapid);
@@ -808,7 +824,11 @@ EM_JS_NUM(errcode, JsMap_Set, (JsRef mapid, JsRef keyid, JsRef valueid), {
   map.set(key, value);
 })
 
-EM_JS_REF(JsRef, JsSet_New, (), { return Hiwire.new_value(new Set()); })
+// clang-format off
+EM_JS_REF(JsRef, JsSet_New, (), {
+  return Hiwire.new_value(new Set());
+})
+// clang-format on
 
 EM_JS_NUM(errcode, JsSet_Add, (JsRef mapid, JsRef keyid), {
   let set = Hiwire.get_value(mapid);

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -43,7 +43,7 @@ _js2python_pyproxy(PyObject* val)
 }
 
 EM_JS_REF(PyObject*, js2python, (JsRef id), {
-  let value = Module.hiwire.get_value(id);
+  let value = Hiwire.get_value(id);
   let result = Module.js2python_convertImmutable(value);
   // clang-format off
   if (result !== undefined) {

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -129,20 +129,20 @@ JS_FILE(js2python_init, () => {
     try {
       context.cache.set(obj, list);
       for (let i = 0; i < obj.length; i++) {
-        entryid = Module.hiwire.new_value(obj[i]);
+        entryid = Hiwire.new_value(obj[i]);
         item = js2python_convert_with_context(entryid, context);
         // PyList_SetItem steals a reference to item no matter what
         _Py_IncRef(item);
         if (_PyList_SetItem(list, i, item) === -1) {
           throw new PropagateError();
         }
-        Module.hiwire.decref(entryid);
+        Hiwire.decref(entryid);
         entryid = 0;
         _Py_DecRef(item);
         item = 0;
       }
     } catch (e) {
-      Module.hiwire.decref(entryid);
+      Hiwire.decref(entryid);
       _Py_DecRef(item);
       _Py_DecRef(list);
       throw e;
@@ -170,7 +170,7 @@ JS_FILE(js2python_init, () => {
             `Cannot use key of type ${key_type} as a key to a Python dict`
           );
         }
-        value_id = Module.hiwire.new_value(value_js);
+        value_id = Hiwire.new_value(value_js);
         value_py = js2python_convert_with_context(value_id, context);
 
         if (_PyDict_SetItem(dict, key_py, value_py) === -1) {
@@ -178,14 +178,14 @@ JS_FILE(js2python_init, () => {
         }
         _Py_DecRef(key_py);
         key_py = 0;
-        Module.hiwire.decref(value_id);
+        Hiwire.decref(value_id);
         value_id = 0;
         _Py_DecRef(value_py);
         value_py = 0;
       }
     } catch (e) {
       _Py_DecRef(key_py);
-      Module.hiwire.decref(value_id);
+      Hiwire.decref(value_id);
       _Py_DecRef(value_py);
       _Py_DecRef(dict);
       throw e;
@@ -285,7 +285,7 @@ JS_FILE(js2python_init, () => {
    * Convert a JavaScript object to Python to a given depth.
    */
   function js2python_convert_with_context(id, context) {
-    let value = Module.hiwire.get_value(id);
+    let value = Hiwire.get_value(id);
     let result;
     result = js2python_convertImmutable(value);
     if (result !== undefined) {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -497,8 +497,8 @@ finally:
 
 // A helper method for jsproxy_subscript.
 EM_JS_REF(JsRef, JsProxy_subscript_js, (JsRef idobj, JsRef idkey), {
-  let obj = Module.hiwire.get_value(idobj);
-  let key = Module.hiwire.get_value(idkey);
+  let obj = Hiwire.get_value(idobj);
+  let key = Hiwire.get_value(idkey);
   let result = obj.get(key);
   // clang-format off
   if (result === undefined) {
@@ -511,7 +511,7 @@ EM_JS_REF(JsRef, JsProxy_subscript_js, (JsRef idobj, JsRef idkey), {
     }
   }
   // clang-format on
-  return Module.hiwire.new_value(result);
+  return Hiwire.new_value(result);
 });
 
 /**
@@ -1168,8 +1168,8 @@ finally:
  * destroys them and the result of the Promise.
  */
 EM_JS_REF(JsRef, get_async_js_call_done_callback, (JsRef proxies_id), {
-  let proxies = Module.hiwire.get_value(proxies_id);
-  return Module.hiwire.new_value(function(result) {
+  let proxies = Hiwire.get_value(proxies_id);
+  return Hiwire.new_value(function(result) {
     let msg = "This borrowed proxy was automatically destroyed " +
               "at the end of an asynchronous function call. Try " +
               "using create_proxy or create_once_callable.";
@@ -1581,7 +1581,7 @@ EM_JS_REF(JsRef,
 JsBuffer_DecodeString_js,
 (JsRef jsbuffer_id, char* encoding),
 {
-  let buffer = Module.hiwire.get_value(jsbuffer_id);
+  let buffer = Hiwire.get_value(jsbuffer_id);
   let encoding_js;
   if (encoding) {
     encoding_js = UTF8ToString(encoding);
@@ -1597,7 +1597,7 @@ JsBuffer_DecodeString_js,
     }
     throw e;
   }
-  return Module.hiwire.new_value(res);
+  return Hiwire.new_value(res);
 })
 // clang-format on
 

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -158,7 +158,7 @@ pyodide_init(void)
   if (_pyodide_proxy == NULL) {
     FATAL_ERROR("Failed to create _pyodide proxy.");
   }
-  EM_ASM({ API._pyodide = Module.hiwire.pop_value($0); }, _pyodide_proxy);
+  EM_ASM({ API._pyodide = Hiwire.pop_value($0); }, _pyodide_proxy);
 
   Py_CLEAR(_pyodide);
   Py_CLEAR(core_module);

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -1,2 +1,2 @@
-let API = Module.API;
-let Hiwire = Module.hiwire;
+const API = Module.API;
+const Hiwire = Module.hiwire;

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -1,1 +1,2 @@
 let API = Module.API;
+let Hiwire = Module.hiwire;

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -21,7 +21,7 @@ EM_JS(int, pyproxy_Check, (JsRef x), {
   if (x == 0) {
     return false;
   }
-  let val = Module.hiwire.get_value(x);
+  let val = Hiwire.get_value(x);
   return API.isPyProxy(val);
 });
 
@@ -30,7 +30,7 @@ EM_JS(void, destroy_proxies, (JsRef proxies_id, char* msg_ptr), {
   if (msg_ptr) {
     msg = UTF8ToString(msg_ptr);
   }
-  let proxies = Module.hiwire.get_value(proxies_id);
+  let proxies = Hiwire.get_value(proxies_id);
   for (let px of proxies) {
     Module.pyproxy_destroy(px, msg);
   }
@@ -236,18 +236,18 @@ int
 _PyObject_GetMethod(PyObject* obj, PyObject* name, PyObject** method);
 
 EM_JS(JsRef, proxy_cache_get, (JsRef proxyCacheId, PyObject* descr), {
-  let proxyCache = Module.hiwire.get_value(proxyCacheId);
+  let proxyCache = Hiwire.get_value(proxyCacheId);
   let proxyId = proxyCache.get(descr);
   if (!proxyId) {
     return undefined;
   }
   // Okay found a proxy. Is it alive?
-  if (Module.hiwire.get_value(proxyId).$$.ptr) {
+  if (Hiwire.get_value(proxyId).$$.ptr) {
     return proxyId;
   } else {
     // It's dead, tidy up
     proxyCache.delete(descr);
-    Module.hiwire.decref(proxyId);
+    Hiwire.decref(proxyId);
     return undefined;
   }
 })
@@ -256,7 +256,7 @@ EM_JS(JsRef, proxy_cache_get, (JsRef proxyCacheId, PyObject* descr), {
 EM_JS(void,
 proxy_cache_set,
 (JsRef proxyCacheId, PyObject* descr, JsRef proxy), {
-  let proxyCache = Module.hiwire.get_value(proxyCacheId);
+  let proxyCache = Hiwire.get_value(proxyCacheId);
   proxyCache.set(descr, proxy);
 })
 // clang-format on
@@ -805,7 +805,7 @@ size_t py_buffer_shape_offset = offsetof(Py_buffer, shape);
  * Convert a C array of Py_ssize_t to JavaScript.
  */
 EM_JS_REF(JsRef, array_to_js, (Py_ssize_t * array, int len), {
-  return Module.hiwire.new_value(
+  return Hiwire.new_value(
     Array.from(HEAP32.subarray(array / 4, array / 4 + len)));
 })
 
@@ -937,7 +937,7 @@ finally:
 }
 
 EM_JS_REF(JsRef, pyproxy_new, (PyObject * ptrobj), {
-  return Module.hiwire.new_value(Module.pyproxy_new(ptrobj));
+  return Hiwire.new_value(Module.pyproxy_new(ptrobj));
 });
 
 /**
@@ -970,7 +970,7 @@ EM_JS_REF(JsRef, create_once_callable, (PyObject * obj), {
     _Py_DecRef(obj);
   };
   Module.finalizationRegistry.register(wrapper, [ obj, undefined ], wrapper);
-  return Module.hiwire.new_value(wrapper);
+  return Hiwire.new_value(wrapper);
 });
 
 static PyObject*
@@ -1021,7 +1021,7 @@ EM_JS_REF(JsRef, create_promise_handles, (
   }
   let done_callback = (x) => {};
   if(done_callback_id){
-    done_callback = Module.hiwire.get_value(done_callback_id);
+    done_callback = Hiwire.get_value(done_callback_id);
   }
   let used = false;
   function checkUsed(){
@@ -1063,7 +1063,7 @@ EM_JS_REF(JsRef, create_promise_handles, (
   }
   onFulfilled.destroy = destroy;
   onRejected.destroy = destroy;
-  return Module.hiwire.new_value(
+  return Hiwire.new_value(
     [onFulfilled, onRejected]
   );
 })

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -140,7 +140,7 @@ Module.pyproxy_new = function (ptrobj: number, cache?: PyProxyCache) {
   if (!cache) {
     // The cache needs to be accessed primarily from the C function
     // _pyproxy_getattr so we make a hiwire id.
-    let cacheId = Module.hiwire.new_value(new Map());
+    let cacheId = Hiwire.new_value(new Map());
     cache = { cacheId, refcnt: 0 };
   }
   cache.refcnt++;
@@ -225,9 +225,9 @@ function pyproxy_decref_cache(cache: PyProxyCache) {
   }
   cache.refcnt--;
   if (cache.refcnt === 0) {
-    let cache_map = Module.hiwire.pop_value(cache.cacheId);
+    let cache_map = Hiwire.pop_value(cache.cacheId);
     for (let proxy_id of cache_map.values()) {
-      const cache_entry = Module.hiwire.pop_value(proxy_id);
+      const cache_entry = Hiwire.pop_value(proxy_id);
       if (!cache.leaked) {
         Module.pyproxy_destroy(cache_entry, pyproxy_cache_destroyed_msg);
       }
@@ -284,8 +284,8 @@ Module.callPyObjectKwargs = function (ptrobj: number, ...jsargs: any) {
   let num_kwargs = kwargs_names.length;
   jsargs.push(...kwargs_values);
 
-  let idargs = Module.hiwire.new_value(jsargs);
-  let idkwnames = Module.hiwire.new_value(kwargs_names);
+  let idargs = Hiwire.new_value(jsargs);
+  let idkwnames = Hiwire.new_value(kwargs_names);
   let idresult;
   try {
     idresult = Module.__pyproxy_apply(
@@ -298,13 +298,13 @@ Module.callPyObjectKwargs = function (ptrobj: number, ...jsargs: any) {
   } catch (e) {
     API.fatal_error(e);
   } finally {
-    Module.hiwire.decref(idargs);
-    Module.hiwire.decref(idkwnames);
+    Hiwire.decref(idargs);
+    Hiwire.decref(idkwnames);
   }
   if (idresult === 0) {
     Module._pythonexc2js();
   }
-  return Module.hiwire.pop_value(idresult);
+  return Hiwire.pop_value(idresult);
 };
 
 Module.callPyObject = function (ptrobj: number, ...jsargs: any) {
@@ -349,7 +349,7 @@ export class PyProxyClass {
    */
   get type(): string {
     let ptrobj = _getPtr(this);
-    return Module.hiwire.pop_value(Module.__pyproxy_type(ptrobj));
+    return Hiwire.pop_value(Module.__pyproxy_type(ptrobj));
   }
   toString(): string {
     let ptrobj = _getPtr(this);
@@ -362,7 +362,7 @@ export class PyProxyClass {
     if (jsref_repr === 0) {
       Module._pythonexc2js();
     }
-    return Module.hiwire.pop_value(jsref_repr);
+    return Hiwire.pop_value(jsref_repr);
   }
   /**
    * Destroy the ``PyProxy``. This will release the memory. Any further attempt
@@ -433,12 +433,12 @@ export class PyProxyClass {
     if (!create_pyproxies) {
       proxies_id = 0;
     } else if (pyproxies) {
-      proxies_id = Module.hiwire.new_value(pyproxies);
+      proxies_id = Hiwire.new_value(pyproxies);
     } else {
-      proxies_id = Module.hiwire.new_value([]);
+      proxies_id = Hiwire.new_value([]);
     }
     if (dict_converter) {
-      dict_converter_id = Module.hiwire.new_value(dict_converter);
+      dict_converter_id = Hiwire.new_value(dict_converter);
     }
     try {
       idresult = Module._python2js_custom_dict_converter(
@@ -450,13 +450,13 @@ export class PyProxyClass {
     } catch (e) {
       API.fatal_error(e);
     } finally {
-      Module.hiwire.decref(proxies_id);
-      Module.hiwire.decref(dict_converter_id);
+      Hiwire.decref(proxies_id);
+      Hiwire.decref(dict_converter_id);
     }
     if (idresult === 0) {
       Module._pythonexc2js();
     }
-    return Module.hiwire.pop_value(idresult);
+    return Hiwire.pop_value(idresult);
   }
   /**
    * Check whether the :any:`PyProxy.length` getter is available on this PyProxy. A
@@ -564,14 +564,14 @@ export class PyProxyGetItemMethods {
    */
   get(key: any): Py2JsResult {
     let ptrobj = _getPtr(this);
-    let idkey = Module.hiwire.new_value(key);
+    let idkey = Hiwire.new_value(key);
     let idresult;
     try {
       idresult = Module.__pyproxy_getitem(ptrobj, idkey);
     } catch (e) {
       API.fatal_error(e);
     } finally {
-      Module.hiwire.decref(idkey);
+      Hiwire.decref(idkey);
     }
     if (idresult === 0) {
       if (Module._PyErr_Occurred()) {
@@ -580,7 +580,7 @@ export class PyProxyGetItemMethods {
         return undefined;
       }
     }
-    return Module.hiwire.pop_value(idresult);
+    return Hiwire.pop_value(idresult);
   }
 }
 
@@ -598,16 +598,16 @@ export class PyProxySetItemMethods {
    */
   set(key: any, value: any) {
     let ptrobj = _getPtr(this);
-    let idkey = Module.hiwire.new_value(key);
-    let idval = Module.hiwire.new_value(value);
+    let idkey = Hiwire.new_value(key);
+    let idval = Hiwire.new_value(value);
     let errcode;
     try {
       errcode = Module.__pyproxy_setitem(ptrobj, idkey, idval);
     } catch (e) {
       API.fatal_error(e);
     } finally {
-      Module.hiwire.decref(idkey);
-      Module.hiwire.decref(idval);
+      Hiwire.decref(idkey);
+      Hiwire.decref(idval);
     }
     if (errcode === -1) {
       Module._pythonexc2js();
@@ -622,14 +622,14 @@ export class PyProxySetItemMethods {
    */
   delete(key: any) {
     let ptrobj = _getPtr(this);
-    let idkey = Module.hiwire.new_value(key);
+    let idkey = Hiwire.new_value(key);
     let errcode;
     try {
       errcode = Module.__pyproxy_delitem(ptrobj, idkey);
     } catch (e) {
       API.fatal_error(e);
     } finally {
-      Module.hiwire.decref(idkey);
+      Hiwire.decref(idkey);
     }
     if (errcode === -1) {
       Module._pythonexc2js();
@@ -652,14 +652,14 @@ export class PyProxyContainsMethods {
    */
   has(key: any): boolean {
     let ptrobj = _getPtr(this);
-    let idkey = Module.hiwire.new_value(key);
+    let idkey = Hiwire.new_value(key);
     let result;
     try {
       result = Module.__pyproxy_contains(ptrobj, idkey);
     } catch (e) {
       API.fatal_error(e);
     } finally {
-      Module.hiwire.decref(idkey);
+      Hiwire.decref(idkey);
     }
     if (result === -1) {
       Module._pythonexc2js();
@@ -688,7 +688,7 @@ function* iter_helper(iterptr: number, token: {}): Generator<Py2JsResult> {
   try {
     let item;
     while ((item = Module.__pyproxy_iter_next(iterptr))) {
-      yield Module.hiwire.pop_value(item);
+      yield Hiwire.pop_value(item);
     }
   } catch (e) {
     API.fatal_error(e);
@@ -768,7 +768,7 @@ export class PyProxyIteratorMethods {
     let idresult;
     // Note: arg is optional, if arg is not supplied, it will be undefined
     // which gets converted to "Py_None". This is as intended.
-    let idarg = Module.hiwire.new_value(arg);
+    let idarg = Hiwire.new_value(arg);
     let done;
     try {
       idresult = Module.__pyproxyGen_Send(_getPtr(this), idarg);
@@ -779,12 +779,12 @@ export class PyProxyIteratorMethods {
     } catch (e) {
       API.fatal_error(e);
     } finally {
-      Module.hiwire.decref(idarg);
+      Hiwire.decref(idarg);
     }
     if (done && idresult === 0) {
       Module._pythonexc2js();
     }
-    let value = Module.hiwire.pop_value(idresult);
+    let value = Hiwire.pop_value(idresult);
     return { done, value };
   }
 }
@@ -795,14 +795,14 @@ export class PyProxyIteratorMethods {
 // invariants, and to deal with the mro
 function python_hasattr(jsobj: PyProxyClass, jskey: any) {
   let ptrobj = _getPtr(jsobj);
-  let idkey = Module.hiwire.new_value(jskey);
+  let idkey = Hiwire.new_value(jskey);
   let result;
   try {
     result = Module.__pyproxy_hasattr(ptrobj, idkey);
   } catch (e) {
     API.fatal_error(e);
   } finally {
-    Module.hiwire.decref(idkey);
+    Hiwire.decref(idkey);
   }
   if (result === -1) {
     Module._pythonexc2js();
@@ -815,7 +815,7 @@ function python_hasattr(jsobj: PyProxyClass, jskey: any) {
 // Js_undefined).
 function python_getattr(jsobj: PyProxyClass, jskey: any) {
   let ptrobj = _getPtr(jsobj);
-  let idkey = Module.hiwire.new_value(jskey);
+  let idkey = Hiwire.new_value(jskey);
   let idresult;
   let cacheId = jsobj.$$.cache.cacheId;
   try {
@@ -823,7 +823,7 @@ function python_getattr(jsobj: PyProxyClass, jskey: any) {
   } catch (e) {
     API.fatal_error(e);
   } finally {
-    Module.hiwire.decref(idkey);
+    Hiwire.decref(idkey);
   }
   if (idresult === 0) {
     if (Module._PyErr_Occurred()) {
@@ -835,16 +835,16 @@ function python_getattr(jsobj: PyProxyClass, jskey: any) {
 
 function python_setattr(jsobj: PyProxyClass, jskey: any, jsval: any) {
   let ptrobj = _getPtr(jsobj);
-  let idkey = Module.hiwire.new_value(jskey);
-  let idval = Module.hiwire.new_value(jsval);
+  let idkey = Hiwire.new_value(jskey);
+  let idval = Hiwire.new_value(jsval);
   let errcode;
   try {
     errcode = Module.__pyproxy_setattr(ptrobj, idkey, idval);
   } catch (e) {
     API.fatal_error(e);
   } finally {
-    Module.hiwire.decref(idkey);
-    Module.hiwire.decref(idval);
+    Hiwire.decref(idkey);
+    Hiwire.decref(idval);
   }
   if (errcode === -1) {
     Module._pythonexc2js();
@@ -853,14 +853,14 @@ function python_setattr(jsobj: PyProxyClass, jskey: any, jsval: any) {
 
 function python_delattr(jsobj: PyProxyClass, jskey: any) {
   let ptrobj = _getPtr(jsobj);
-  let idkey = Module.hiwire.new_value(jskey);
+  let idkey = Hiwire.new_value(jskey);
   let errcode;
   try {
     errcode = Module.__pyproxy_delattr(ptrobj, idkey);
   } catch (e) {
     API.fatal_error(e);
   } finally {
-    Module.hiwire.decref(idkey);
+    Hiwire.decref(idkey);
   }
   if (errcode === -1) {
     Module._pythonexc2js();
@@ -907,7 +907,7 @@ let PyProxyHandlers = {
     // 2. The result of getattr
     let idresult = python_getattr(jsobj, jskey);
     if (idresult !== 0) {
-      return Module.hiwire.pop_value(idresult);
+      return Hiwire.pop_value(idresult);
     }
   },
   set(jsobj: PyProxyClass, jskey: any, jsval: any) {
@@ -952,7 +952,7 @@ let PyProxyHandlers = {
     if (idresult === 0) {
       Module._pythonexc2js();
     }
-    let result = Module.hiwire.pop_value(idresult);
+    let result = Hiwire.pop_value(idresult);
     result.push(...Reflect.ownKeys(jsobj));
     return result;
   },
@@ -986,8 +986,8 @@ export class PyProxyAwaitableMethods {
       resolveHandle = resolve;
       rejectHandle = reject;
     });
-    let resolve_handle_id = Module.hiwire.new_value(resolveHandle);
-    let reject_handle_id = Module.hiwire.new_value(rejectHandle);
+    let resolve_handle_id = Hiwire.new_value(resolveHandle);
+    let reject_handle_id = Hiwire.new_value(rejectHandle);
     let errcode;
     try {
       errcode = Module.__pyproxy_ensure_future(
@@ -998,8 +998,8 @@ export class PyProxyAwaitableMethods {
     } catch (e) {
       API.fatal_error(e);
     } finally {
-      Module.hiwire.decref(reject_handle_id);
-      Module.hiwire.decref(resolve_handle_id);
+      Hiwire.decref(reject_handle_id);
+      Hiwire.decref(resolve_handle_id);
     }
     if (errcode === -1) {
       Module._pythonexc2js();
@@ -1197,8 +1197,8 @@ export class PyProxyBufferMethods {
     let readonly = !!DEREF_U32(buffer_struct_ptr, 3);
     let format_ptr = DEREF_U32(buffer_struct_ptr, 4);
     let itemsize = DEREF_U32(buffer_struct_ptr, 5);
-    let shape = Module.hiwire.pop_value(DEREF_U32(buffer_struct_ptr, 6));
-    let strides = Module.hiwire.pop_value(DEREF_U32(buffer_struct_ptr, 7));
+    let shape = Hiwire.pop_value(DEREF_U32(buffer_struct_ptr, 6));
+    let strides = Hiwire.pop_value(DEREF_U32(buffer_struct_ptr, 7));
 
     let view_ptr = DEREF_U32(buffer_struct_ptr, 8);
     let c_contiguous = !!DEREF_U32(buffer_struct_ptr, 9);

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -14,7 +14,7 @@
  * See Makefile recipe for src/js/pyproxy.gen.ts
  */
 
-import { Module, API } from "./module.js";
+import { Module, API, Hiwire } from "./module.js";
 
 // pyodide-skip
 

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -554,7 +554,7 @@ _JsArray_PushEntry(ConversionContext context,
 
 EM_JS_REF(JsRef, _JsArray_PostProcess_helper, (JsRef jscontext, JsRef array), {
   return Hiwire.new_value(
-    Hiwire.get_value(jscontext).dict_converter(Hiwire.get_value(array)));`
+    Hiwire.get_value(jscontext).dict_converter(Hiwire.get_value(array)));
 })
 
 static JsRef

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -554,8 +554,7 @@ _JsArray_PushEntry(ConversionContext context,
 
 EM_JS_REF(JsRef, _JsArray_PostProcess_helper, (JsRef jscontext, JsRef array), {
   return Hiwire.new_value(
-    Hiwire.get_value(jscontext).dict_converter(
-      Hiwire.get_value(array)));
+    Hiwire.get_value(jscontext).dict_converter(Hiwire.get_value(array)));`
 })
 
 static JsRef
@@ -579,12 +578,14 @@ python2js_custom_dict_converter(PyObject* x,
     // No custom converter provided, go back to default convertion to Map.
     return python2js_with_depth(x, depth, proxies);
   }
+  // clang-format off
   JsRef jscontext = (JsRef)EM_ASM_INT(
     {
       return Hiwire.new_value(
         { dict_converter : Hiwire.get_value($0) });
     },
     dict_converter);
+  // clang-format on
   ConversionContext context = {
     .depth = depth,
     .proxies = proxies,

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -539,8 +539,8 @@ EM_JS_NUM(int,
           _JsArray_PushEntry_helper,
           (JsRef array, JsRef key, JsRef value),
           {
-            Module.hiwire.get_value(array).push(
-              [ Module.hiwire.get_value(key), Module.hiwire.get_value(value) ]);
+            Hiwire.get_value(array).push(
+              [ Hiwire.get_value(key), Hiwire.get_value(value) ]);
           })
 
 static int
@@ -553,9 +553,9 @@ _JsArray_PushEntry(ConversionContext context,
 }
 
 EM_JS_REF(JsRef, _JsArray_PostProcess_helper, (JsRef jscontext, JsRef array), {
-  return Module.hiwire.new_value(
-    Module.hiwire.get_value(jscontext).dict_converter(
-      Module.hiwire.get_value(array)));
+  return Hiwire.new_value(
+    Hiwire.get_value(jscontext).dict_converter(
+      Hiwire.get_value(array)));
 })
 
 static JsRef
@@ -581,8 +581,8 @@ python2js_custom_dict_converter(PyObject* x,
   }
   JsRef jscontext = (JsRef)EM_ASM_INT(
     {
-      return Module.hiwire.new_value(
-        { dict_converter : Module.hiwire.get_value($0) });
+      return Hiwire.new_value(
+        { dict_converter : Hiwire.get_value($0) });
     },
     dict_converter);
   ConversionContext context = {
@@ -686,7 +686,7 @@ finally:
 }
 
 EM_JS_NUM(errcode, destroy_proxies_js, (JsRef proxies_id), {
-  for (let proxy of Module.hiwire.get_value(proxies_id)) {
+  for (let proxy of Hiwire.get_value(proxies_id)) {
     proxy.destroy();
   }
 })

--- a/src/core/python2js_buffer.c
+++ b/src/core/python2js_buffer.c
@@ -42,7 +42,7 @@ EM_JS_REF(JsRef, _python2js_buffer_inner, (
     suboffsets,
     converter,
   });
-  return Module.hiwire.new_value(result);
+  return Hiwire.new_value(result);
 });
 // clang-format on
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -1,4 +1,4 @@
-import { Module, API } from "./module.js";
+import { Module, API, Hiwire } from "./module";
 import { loadPackage, loadedPackages } from "./load-package";
 import {
   isPyProxy,
@@ -220,7 +220,7 @@ export function toPy(
   let py_result = 0;
   let result = 0;
   try {
-    obj_id = Module.hiwire.new_value(obj);
+    obj_id = Hiwire.new_value(obj);
     try {
       py_result = Module.js2python_convert(obj_id, depth);
     } catch (e) {
@@ -239,10 +239,10 @@ export function toPy(
       Module._pythonexc2js();
     }
   } finally {
-    Module.hiwire.decref(obj_id);
+    Hiwire.decref(obj_id);
     Module._Py_DecRef(py_result);
   }
-  return Module.hiwire.pop_value(result);
+  return Hiwire.pop_value(result);
 }
 
 /**

--- a/src/js/module.ts
+++ b/src/js/module.ts
@@ -12,6 +12,8 @@ Module.preRun = [];
 
 export let API: any = {};
 Module.API = API;
+export let Hiwire: any = {};
+Module.hiwire = Hiwire;
 
 /**
  *


### PR DESCRIPTION
We use `Module.hiwire` a total of 232 times, this switches all those to just `Hiwire`.