### PR TITLE
ENH Show informative error message when fetching wheel fails

### DIFF
--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -113,11 +113,17 @@ be the case if the wheels is made using standard Python tools (`pip wheel`,
 All required dependencies must have been previously installed with {mod}`micropip`
 or {any}`pyodide.loadPackage`.
 
-If the file is on a remote server, the server must set Cross-Origin Resource Sharing
-(CORS) headers to allow access. Otherwise, you can prepend a CORS proxy to the
+```{admonition} Cross-Origin Resource Sharing (CORS)
+:class: info
+
+If the file is on a remote server, the server must set
+[Cross-Origin Resource Sharing (CORS) headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+to allow access. Otherwise, you can prepend a CORS proxy to the
 URL. Note however that using third-party CORS proxies has security implications,
 particularly since we are not able to check the file integrity, unlike with
 installs from PyPI.
+```
+
 
 ## Example
 

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -124,7 +124,6 @@ particularly since we are not able to check the file integrity, unlike with
 installs from PyPI.
 ```
 
-
 ## Example
 
 ```html

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -305,7 +305,7 @@ class _PackageManager:
                 raise ValueError(
                     f"Couldn't fetch wheel from '{wheel['url']}'."
                     "One common reason for this is when the server blocks "
-                    "Cross-Origin Requests Sharing (CORS)."
+                    "Cross-Origin Resource Sharing (CORS)."
                     "Check if the server is sending the correct 'Access-Control-Allow-Origin' header."
                 ) from e
 

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -304,7 +304,8 @@ class _PackageManager:
             else:
                 raise ValueError(
                     f"Couldn't fetch wheel from '{wheel['url']}'."
-                    "One common reason of this is when the server blocks cross-origin requests."
+                    "One common reason for this is when the server blocks "
+                    "Cross-Origin Requests Sharing (CORS)."
                     "Check if the server is sending the correct 'Access-Control-Allow-Origin' header."
                 ) from e
 

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -295,7 +295,19 @@ class _PackageManager:
 
     async def add_wheel(self, name, wheel, version, extras, ctx, transaction):
         transaction["locked"][name] = PackageMetadata(name=name, version=version)
-        wheel_bytes = await fetch_bytes(wheel["url"])
+
+        try:
+            wheel_bytes = await fetch_bytes(wheel["url"])
+        except Exception as e:
+            if wheel["url"].startswith("https://files.pythonhosted.org/"):
+                raise e
+            else:
+                raise ValueError(
+                    f"Couldn't fetch wheel from '{wheel['url']}'."
+                    "One common reason of this is when the server blocks cross-origin requests."
+                    "Check if the server is sending the correct 'Access-Control-Allow-Origin' header."
+                ) from e
+
         wheel["wheel_bytes"] = wheel_bytes
 
         with ZipFile(io.BytesIO(wheel_bytes)) as zip_file:  # type: ignore

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -345,6 +345,22 @@ def test_install_keep_going(monkeypatch):
         )
 
 
+def test_fetch_wheel_fail(monkeypatch):
+    pytest.importorskip("packaging")
+    from micropip import _micropip
+
+    def _mock_fetch_bytes(*args, **kwargs):
+        raise Exception("Failed to fetch")
+
+    monkeypatch.setattr(_micropip, "fetch_bytes", _mock_fetch_bytes)
+
+    msg = "Access-Control-Allow-Origin"
+    with pytest.raises(ValueError, match=msg):
+        asyncio.get_event_loop().run_until_complete(
+            _micropip.install("htps://x.com/xxx-1.0.0-py3-none-any.whl")
+        )
+
+
 def test_list_pypi_package(monkeypatch):
     pytest.importorskip("packaging")
     from micropip import _micropip


### PR DESCRIPTION
### Description

We sometimes receive issues about failure in `micropip.install` due to cross-origin requests (#2166).
The current error message (`JsException: TypeError: failed to fetch`) is not very informative. This adds a more informative error message. 

Note that AFAIK it is not possible to detect the CORS error, we could just know that the fetch has been failed. But I think it's worth to inform about CORS error because it's very common reason for the micropip fetch error.

### Checklists

- [x] Add / update tests

Close #2166