### PR TITLE
fix(mkpkg): arguments were incorrect

### DIFF
--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -288,16 +288,12 @@ def main(args):
     try:
         package = args.package[0]
         if args.update:
-            update_package(
-                package, update_patched=True, wheel=args.wheel, sdist=args.sdist
-            )
+            update_package(package, update_patched=True, source_fmt=args.source_format)
             return
         if args.update_if_not_patched:
-            update_package(
-                package, update_patched=False, wheel=args.wheel, sdist=args.sdist
-            )
+            update_package(package, update_patched=False, source_fmt=args.source_format)
             return
-        make_package(package, args.version, wheel=args.wheel, sdist=args.sdist)
+        make_package(package, args.version, source_fmt=args.source_format)
     except MkpkgFailedException as e:
         # This produces two types of error messages:
         #


### PR DESCRIPTION

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

mkpkg was broken after #2126.

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation

Ideally mypy should catch this, but it seems `pre-commit` is not being run/checked, quite a few things fail:

```console
$ pre-commit run -a
Check Yaml...............................................................Failed
- hook id: check-yaml
- exit code: 1

expected a single document in the stream
  in ".clang-format", line 2, column 1
but found another document
  in ".clang-format", line 110, column 1

Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Failed
- hook id: trailing-whitespace
- exit code: 1
- files were modified by this hook

Fixing packages/CLAPACK/make.inc
Fixing packages/micropip/src/micropip/package.py
Fixing src/py/_pyodide/console.py
Fixing .prettierignore

black....................................................................Failed
- hook id: black
- exit code: 123
- files were modified by this hook

reformatted /Users/henryschreiner/git/software/pyodide/benchmark/benchmarks/log_likelihood.py
reformatted /Users/henryschreiner/git/software/pyodide/benchmark/benchmarks/vibr_energy.py
reformatted /Users/henryschreiner/git/software/pyodide/benchmark/benchmarks/lstsqr.py
reformatted /Users/henryschreiner/git/software/pyodide/packages/cloudpickle/test_cloudpickle.py
reformatted /Users/henryschreiner/git/software/pyodide/packages/sympy/test_sympy.py
reformatted /Users/henryschreiner/git/software/pyodide/benchmark/benchmarks/periodic_dist.py
reformatted /Users/henryschreiner/git/software/pyodide/packages/nlopt/test_nlopt.py
reformatted /Users/henryschreiner/git/software/pyodide/benchmark/benchmarks/wave.py
error: cannot format /Users/henryschreiner/git/software/pyodide/pyodide-build/pyodide_build/_f2c_fixes.py: INTERNAL ERROR: Black produced code that is not equivalent to the source.  Please report a bug on https://github.com/psf/black/issues.  This diff might be helpful: /var/folders/_8/xtbws09n017fbzdx9dmgnyyr0000gn/T/blk_fewlf2sd.log
reformatted /Users/henryschreiner/git/software/pyodide/packages/numcodecs/test_numcodecs.py
reformatted /Users/henryschreiner/git/software/pyodide/pyodide-build/pyodide_build/mkpkg.py
reformatted /Users/henryschreiner/git/software/pyodide/packages/micropip/src/micropip/_micropip.py
reformatted /Users/henryschreiner/git/software/pyodide/src/tests/test_console.py
reformatted /Users/henryschreiner/git/software/pyodide/src/tests/test_typeconversions.py
Oh no! 💥 💔 💥
13 files reformatted, 144 files left unchanged, 1 file failed to reformat.

flake8...................................................................Failed
- hook id: flake8
- exit code: 1

packages/joblib/test_joblib.py:1:1: F401 'pytest' imported but unused
packages/scipy/test_scipy.py:1:1: F401 'pytest' imported but unused
packages/scipy/test_scipy.py:2:1: F401 'conftest.selenium_context_manager' imported but unused
packages/scipy/test_scipy.py:16:5: F401 'scipy as sp' imported but unused
packages/micropip/src/micropip/package.py:2:1: F401 'dataclasses.field' imported but unused
packages/micropip/src/micropip/package.py:3:1: F401 'pathlib.Path' imported but unused
packages/micropip/src/micropip/package.py:4:1: F401 'typing.Dict' imported but unused
packages/msgpack/test_pack.py:6:5: F401 'msgpack.Unpacker' imported but unused
packages/msgpack/test_pack.py:6:5: F401 'msgpack.Packer' imported but unused
packages/msgpack/test_pack.py:6:5: F401 'msgpack.pack' imported but unused
packages/test_packages_common.py:3:1: F401 'pathlib.Path' imported but unused
packages/test_packages_common.py:6:1: F401 'json' imported but unused

mypy.....................................................................Failed
- hook id: mypy
- exit code: 2

pyodide-build/setup.py: error: Duplicate module named 'setup' (also at 'packages/sharedlib-test-py/src/setup.py')
pyodide-build/setup.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
Found 1 error in 1 file (errors prevented further checking)

clang-format-6.0.........................................................Passed
prettier.................................................................Passed
```

I would _highly_ recommend you use the clang-format wheel & pre-commit mirror for the clang-format job! See https://scikit-hep.org/developer/style for other recommendations.

```yaml
- repo: https://github.com/pre-commit/mirrors-clang-format
  rev: "v13.0.0"
  hooks:
  - id: clang-format
```
