### PR TITLE
Strip whitespace from micropip.list() output

### DIFF
--- a/packages/micropip/src/micropip/package.py
+++ b/packages/micropip/src/micropip/package.py
@@ -7,21 +7,19 @@ __all__ = ["PackageDict"]
 
 
 def _format_table(headers: List[str], table: List[Iterable]) -> str:
-    # fmt: off
     """
     Returns a minimal formatted table
 
     >>> print(_format_table(["Header1", "Header2"], [["val1", "val2"], ["val3", "val4"]]))
     Header1 | Header2
     ------- | -------
-    val1    | val2   
-    val3    | val4   
+    val1    | val2
+    val3    | val4
     """
-    # fmt: on
 
     def format_row(values, widths, filler=""):
         row = " | ".join(f"{x:{filler}<{w}}" for x, w in zip(values, widths))
-        return row
+        return row.rstrip()
 
     col_width = [max(len(x) for x in col) for col in zip(headers, *table)]
     rows = []


### PR DESCRIPTION
This would make `pre-commit` and `black` stop complaining about the trailing whitespaces