### PR TITLE
DOC Pin markupsafe version

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -10,3 +10,4 @@ sphinx-issues==2.0.0
 sphinx-js==3.1
 sphinx-version-warning~=1.1.2
 sphinx-panels
+markupsafe<2.1.0


### PR DESCRIPTION
Building documentation is failing due to the markupsafe version update.

The reason it fails is:
- `markupsafe` 2.1.0 dropped the old api `soft_unicode`
- `Jinja` < 3 relies on the old api.
- `sphinx-js` pinned the version of `Jinja` to < 3

This PR is a hotfix, pinning the version of markupsafe to < 2.1.0.
But for a long term solution, I think we should fix `sphinx-js` (maybe fork it or find an alternative?), since it is critial plugin for our documentation but it's not updated quite a while. 

