### PR TITLE
Add ruamel.yaml to the mandatory dependency of pyodide-build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 # -- Project information -----------------------------------------------------
 
@@ -53,6 +54,9 @@ versionwarning_body_selector = "#main-content > div"
 
 autosummary_generate = True
 autodoc_default_flags = ["members", "inherited-members"]
+
+# Add modules to be mocked.
+mock_modules = ["ruamel.yaml"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -183,3 +187,6 @@ if IN_SPHINX:
     delete_attrs(pyodide.webloop.WebLoop)
     delete_attrs(pyodide.webloop.WebLoopPolicy)
     delete_attrs(pyodide.console.PyodideConsole)
+
+    for module in mock_modules:
+        sys.modules[module] = mock.Mock()

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -12,6 +12,8 @@ import warnings
 from pathlib import Path
 from typing import Any, Literal, Optional
 
+from ruamel.yaml import YAML
+
 PACKAGES_ROOT = Path(__file__).parents[2] / "packages"
 
 
@@ -89,18 +91,6 @@ def _get_metadata(package: str, version: Optional[str] = None) -> dict:
     return pypi_metadata
 
 
-def _import_ruamel_yaml():
-    """Import ruamel.yaml with a better error message is not installed."""
-    try:
-        from ruamel.yaml import YAML
-    except ImportError as err:
-        raise ImportError(
-            "No module named 'ruamel'. "
-            "It can be installed with pip install ruamel.yaml"
-        ) from err
-    return YAML
-
-
 def run_prettier(meta_path):
     subprocess.run(["npx", "prettier", "-w", meta_path])
 
@@ -115,7 +105,6 @@ def make_package(
     but will have to be edited for more complex things.
     """
     print(f"Creating meta.yaml package for {package}")
-    YAML = _import_ruamel_yaml()
 
     yaml = YAML()
 
@@ -188,8 +177,6 @@ def update_package(
     update_patched: bool = True,
     source_fmt: Optional[Literal["wheel", "sdist"]] = None,
 ):
-
-    YAML = _import_ruamel_yaml()
     yaml = YAML()
 
     meta_path = PACKAGES_ROOT / package / "meta.yaml"

--- a/pyodide-build/pyodide_build/tests/test_mkpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_mkpkg.py
@@ -15,7 +15,6 @@ from pyodide_build.io import parse_package_config
 
 @pytest.mark.parametrize("source_fmt", ["wheel", "sdist"])
 def test_mkpkg(tmpdir, monkeypatch, capsys, source_fmt):
-    pytest.importorskip("ruamel")
     assert pyodide_build.mkpkg.PACKAGES_ROOT.exists()
     base_dir = Path(str(tmpdir))
     monkeypatch.setattr(pyodide_build.mkpkg, "PACKAGES_ROOT", base_dir)
@@ -39,7 +38,6 @@ def test_mkpkg(tmpdir, monkeypatch, capsys, source_fmt):
 @pytest.mark.parametrize("old_dist_type", ["wheel", "sdist"])
 @pytest.mark.parametrize("new_dist_type", ["wheel", "sdist", "same"])
 def test_mkpkg_update(tmpdir, monkeypatch, old_dist_type, new_dist_type):
-    pytest.importorskip("ruamel")
     base_dir = Path(str(tmpdir))
     monkeypatch.setattr(pyodide_build.mkpkg, "PACKAGES_ROOT", base_dir)
 

--- a/pyodide-build/setup.cfg
+++ b/pyodide-build/setup.cfg
@@ -22,6 +22,7 @@ python_requires = >=3.8
 install_requires =
     pyyaml
     cython<3.0
+    ruamel.yaml
 [options.entry_points]
 console_scripts =
     pyodide-build = pyodide_build.__main__:main

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
   cython<3.0
   packaging
   pyyaml
-  ruamel.yaml
   # lint
   pre-commit
   # testing


### PR DESCRIPTION
### Description

Adds `ruamel.yaml` to the dependency of pyodide-build, so that one doesn't need to additionally install it to run `pyodide-build mkpkg`