### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -107,6 +107,4 @@ SpacesInSquareBrackets: false
 Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
----
-Language: JavaScript
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         args: ["--py39-plus"]
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: "v1.1.0"
+    rev: "v1.2.0"
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]
@@ -67,9 +67,10 @@ repos:
         additional_dependencies: *mypy-deps
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v13.0.0"
+    rev: "v13.0.1"
     hooks:
       - id: clang-format
+        types_or: [c++, c, cuda]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.5.1"


### PR DESCRIPTION
- chore: update pre-commit hooks
- style: run pre-commit -a, javascript now included

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

This bumps the pre-commit hooks. This was to avoid running into https://github.com/pre-commit/mirrors-clang-format/pull/10, but I noticed that you include JavaScript in .clang-format, so I'm guessing that's supposed to be included? It was missed in the original pre-commit runs. Assuming JSON should not be included? Or would that count under JavaScript?