### PR TITLE
chore: enable the rest of flake8 & bugbear

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-extend-ignore = E203, E402, E501, E731, E741
-select = C,E,F,W
+extend-ignore = E203, E402, E501, E731, E741, B950
+select = C,E,F,W,B,B9

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+extend-ignore = E203, E402, E501, E731, E741
+select = C,E,F,W

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     rev: "4.0.1"
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,9 @@ repos:
       - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: "4.0.1"
     hooks:
       - id: flake8
-        types: [file, python]
-        # only check for unused imports, as the rest is done by black
-        args: [--select=F401]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931

--- a/benchmark/benchmarks/check_mask.py
+++ b/benchmark/benchmarks/check_mask.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 
-def check_mask(db, mask=[1, 0, 1]):
+def check_mask(db, mask=(1, 0, 1)):
     out = np.zeros(db.shape[0], dtype=bool)
     for idx, line in enumerate(db):
         target, vector = line[0], line[1:]

--- a/benchmark/benchmarks/diffusion.py
+++ b/benchmark/benchmarks/diffusion.py
@@ -10,7 +10,7 @@ def diffusion(u, tempU, iterNum):
     """
     mu = 0.1
 
-    for n in range(iterNum):
+    for _ in range(iterNum):
         tempU[1:-1, 1:-1] = u[1:-1, 1:-1] + mu * (
             u[2:, 1:-1]
             - 2 * u[1:-1, 1:-1]

--- a/benchmark/benchmarks/fdtd.py
+++ b/benchmark/benchmarks/fdtd.py
@@ -14,7 +14,7 @@ def fdtd(input_grid, steps):
     l_x = grid.shape[0]
     l_y = grid.shape[1]
 
-    for i in range(steps):
+    for _ in range(steps):
         np.copyto(previous_grid, old_grid)
         np.copyto(old_grid, grid)
 

--- a/benchmark/benchmarks/grayscott.py
+++ b/benchmark/benchmarks/grayscott.py
@@ -19,7 +19,7 @@ def grayscott(counts, Du, Dv, F, k):
     u += 0.15 * np.random.random((n, n))
     v += 0.15 * np.random.random((n, n))
 
-    for i in range(counts):
+    for _ in range(counts):
         Lu = (
             U[0:-2, 1:-1]
             + U[1:-1, 0:-2]

--- a/conftest.py
+++ b/conftest.py
@@ -434,7 +434,7 @@ class NodeWrapper(SeleniumWrapper):
         self.p.expect_exact(f"{cmd_id}:UUID\r\n")
         if self.p.before:
             self._logs.append(self.p.before.decode()[:-2].replace("\r", ""))
-        self.p.expect(f"[01]\r\n")
+        self.p.expect("[01]\r\n")
         success = int(self.p.match[0].decode()[0]) == 0
         self.p.expect_exact(f"\r\n{cmd_id}:UUID\r\n")
         if success:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ def delete_attrs(cls):
         if not name.startswith("_"):
             try:
                 delattr(cls, name)
-            except:
+            except Exception:
                 pass
 
 

--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -51,7 +51,7 @@ def destructure_param(param: dict[str, Any]) -> list[dict[str, Any]]:
     result = []
     for child in decl["children"]:
         child = dict(child)
-        if not "type" in child:
+        if "type" not in child:
             if "signatures" in child:
                 child["comment"] = child["signatures"][0]["comment"]
                 child["type"] = {

--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -59,7 +59,7 @@ def destructure_param(param: dict[str, Any]) -> list[dict[str, Any]]:
                     "declaration": dict(child),
                 }
             else:
-                assert False, "Didn't expect to get here..."
+                raise AssertionError("Didn't expect to get here...")
         child["name"] = param["name"] + "." + child["name"]
         result.append(child)
     return result
@@ -185,7 +185,7 @@ def _type_name(self, type):
         return f"boolean (typeguard for {self._type_name(type['targetType'])})"
     if type_of_type == "reflection":
         return reflection_type_name(self, type)
-    assert False
+    raise AssertionError()
 
 
 TsAnalyzer._type_name = _type_name
@@ -353,12 +353,13 @@ def get_jsdoc_content_directive(app):
                 rst = self.add_async_option_to_rst(rst)
             return rst
 
-        def add_async_option_to_rst(self, rst):
+        def add_async_option_to_rst(self, rst: str) -> str:
             rst_lines = rst.split("\n")
-            for i, line in enumerate(rst_lines):
-                if line.startswith(".."):
-                    break
-            rst_lines.insert(i + 1, "   :async:")
+            try:
+                index = next(i for i, ln in enumerate(rst_lines) if ln.startswith(".."))
+            except StopIteration:
+                index = len(rst_lines) - 1
+            rst_lines.insert(index + 1, "   :async:")
             return "\n".join(rst_lines)
 
         def get_rst_for_group(self, objects):

--- a/docs/sphinx_pyodide/sphinx_pyodide/packages.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/packages.py
@@ -83,7 +83,7 @@ def get_packages_summary_directive(app):
             group += thead
 
             rows = []
-            for name, pkg_info in packages.items():
+            for pkg_info in packages.values():
                 row = nodes.row()
                 rows.append(row)
                 for column in columns:

--- a/packages/matplotlib/src/browser_backend.py
+++ b/packages/matplotlib/src/browser_backend.py
@@ -430,7 +430,7 @@ class NavigationToolbar2Wasm(NavigationToolbar2):
             span.textContent = "\u00a0"
             div.appendChild(span)
 
-        for text, tooltip_text, image_file, name_of_method in self.toolitems:
+        for _text, _tooltip_text, image_file, name_of_method in self.toolitems:
             if image_file in _FONTAWESOME_ICONS:
                 if image_file is None:
                     add_spacer()
@@ -442,7 +442,7 @@ class NavigationToolbar2Wasm(NavigationToolbar2):
                     button.addEventListener("click", getattr(self, name_of_method))
                     div.appendChild(button)
 
-        for format, mimetype in sorted(list(FILE_TYPES.items())):
+        for format, _mimetype in sorted(list(FILE_TYPES.items())):
             button = document.createElement("button")
             button.classList.add("fa")
             button.textContent = format

--- a/packages/matplotlib/src/wasm_backend.py
+++ b/packages/matplotlib/src/wasm_backend.py
@@ -71,7 +71,7 @@ class NavigationToolbar2AggWasm(NavigationToolbar2Wasm):
         data = io.BytesIO()
         try:
             self.canvas.figure.savefig(data, format=format)
-        except Exception as e:
+        except Exception:
             raise
         element.setAttribute(
             "href",

--- a/packages/scikit-image/test_skimage.py
+++ b/packages/scikit-image/test_skimage.py
@@ -50,4 +50,4 @@ def test_skimage():
     assert len(np.unique(segments_fz)) == 194
     assert len(np.unique(segments_slic)) == 196
     assert len(np.unique(segments_quick)) == 695
-    assert len(np.unique(segments_watershed)) > 0  # TODO: some number, perhaps?
+    assert len(np.unique(segments_watershed)) == 256

--- a/packages/scikit-image/test_skimage.py
+++ b/packages/scikit-image/test_skimage.py
@@ -50,3 +50,4 @@ def test_skimage():
     assert len(np.unique(segments_fz)) == 194
     assert len(np.unique(segments_slic)) == 196
     assert len(np.unique(segments_quick)) == 695
+    assert len(np.unique(segments_watershed)) > 0  # TODO: some number, perhaps?

--- a/packages/sympy/test_sympy.py
+++ b/packages/sympy/test_sympy.py
@@ -8,4 +8,4 @@ def test_sympy():
     a, b = sympy.symbols("a,b")
     c = sympy.sqrt(a**2 + b**2)
 
-    c.subs({a: 3, b: 4}) == 5
+    assert c.subs({a: 3, b: 4}) == 5

--- a/packages/wrapt/test_wrapt.py
+++ b/packages/wrapt/test_wrapt.py
@@ -53,10 +53,6 @@ def test_wrapt():
             function1d_argspec = inspect.getargspec(function1d)
             self.assertEqual(function1o_argspec, function1d_argspec)
 
-        def test_getmembers(self):
-            inspect.getmembers(function1o)
-            inspect.getmembers(function1d)
-
         def test_isinstance(self):
             # Test preservation of isinstance() checks.
 

--- a/packages/wrapt/test_wrapt.py
+++ b/packages/wrapt/test_wrapt.py
@@ -54,8 +54,8 @@ def test_wrapt():
             self.assertEqual(function1o_argspec, function1d_argspec)
 
         def test_getmembers(self):
-            function1o_members = inspect.getmembers(function1o)
-            function1d_members = inspect.getmembers(function1d)
+            inspect.getmembers(function1o)
+            inspect.getmembers(function1d)
 
         def test_isinstance(self):
             # Test preservation of isinstance() checks.

--- a/pyodide-build/pyodide_build/_f2c_fixes.py
+++ b/pyodide-build/pyodide_build/_f2c_fixes.py
@@ -20,7 +20,7 @@ def fix_f2c_output(f2c_output_path: str):
             [
                 "patch",
                 str(f2c_output_path),
-                f"../../patches/fix-implicit-cast-args-from-newer-lapack.patch",
+                "../../patches/fix-implicit-cast-args-from-newer-lapack.patch",
             ]
         )
 
@@ -145,7 +145,7 @@ def regroup_lines(lines: Iterable[str]) -> Iterator[str]:
     """
     line_iter = iter(lines)
     for line in line_iter:
-        if not "/* Subroutine */" in line:
+        if "/* Subroutine */" not in line:
             yield line
             continue
 
@@ -222,7 +222,7 @@ def fix_inconsistent_decls(lines: list[str]) -> list[str]:
         func_types[func_name] = types
 
     for idx, line in enumerate(lines):
-        if not "extern /* Subroutine */" in line:
+        if "extern /* Subroutine */" not in line:
             continue
         decls = line.split(")")[:-1]
         for decl in decls:

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -264,7 +264,7 @@ def print_with_progress_line(str, progress_line):
 def get_progress_line(package_set):
     if not package_set:
         return None
-    return f"In progress: " + ", ".join(package_set.keys())
+    return "In progress: " + ", ".join(package_set.keys())
 
 
 def format_name_list(l: list[str]) -> str:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -829,7 +829,7 @@ def main(args):
             **step_controls,
         )
 
-    except:
+    except Exception:
         success = False
         raise
     finally:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -490,7 +490,7 @@ def unvendor_tests(install_prefix: Path, test_install_prefix: Path) -> int:
     n_moved = 0
     out_files = []
     shutil.rmtree(test_install_prefix, ignore_errors=True)
-    for root, dirs, files in os.walk(install_prefix):
+    for root, _dirs, files in os.walk(install_prefix):
         root_rel = Path(root).relative_to(install_prefix)
         if root_rel.name == "__pycache__" or root_rel.name.endswith(".egg_info"):
             continue

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -631,7 +631,7 @@ def replay_compile(replay_from: int = 1, **kwargs):
 
 
 def clean_out_native_artifacts():
-    for root, dirs, files in os.walk("."):
+    for root, _dirs, files in os.walk("."):
         for file in files:
             path = Path(root) / file
             if path.suffix in (".o", ".so", ".a"):

--- a/pyodide-build/pyodide_build/testing.py
+++ b/pyodide-build/pyodide_build/testing.py
@@ -1,7 +1,7 @@
 import contextlib
 import inspect
 from base64 import b64encode
-from typing import Callable, Optional
+from typing import Callable, Collection, Optional
 
 import pytest
 
@@ -31,8 +31,8 @@ def run_in_pyodide(
     *,
     standalone: bool = False,
     module_scope: bool = False,
-    packages: list[str] = [],
-    xfail_browsers: dict[str, str] = {},
+    packages: Collection[str] = (),
+    xfail_browsers: Optional[dict[str, str]] = None,
     driver_timeout: Optional[float] = None,
 ) -> Callable:
     """
@@ -53,10 +53,12 @@ def run_in_pyodide(
         selenium driver timeout (in seconds)
     """
 
+    xfail_browsers_local = xfail_browsers or {}
+
     def decorator(f):
         def inner(selenium):
-            if selenium.browser in xfail_browsers:
-                xfail_message = xfail_browsers[selenium.browser]
+            if selenium.browser in xfail_browsers_local:
+                xfail_message = xfail_browsers_local[selenium.browser]
                 pytest.xfail(xfail_message)
             with set_webdriver_script_timeout(selenium, driver_timeout):
                 if len(packages) > 0:

--- a/src/py/_pyodide/_base.py
+++ b/src/py/_pyodide/_base.py
@@ -251,7 +251,7 @@ class CodeRunner:
             # generator must return, which raises StopIteration
             self.code = e.value
         else:
-            assert False
+            raise AssertionError()
         return self
 
     def run(self, globals: dict[str, Any] = None, locals: dict[str, Any] = None):

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Iterable
 _save_name = __name__
 __name__ = "pyodide"
 
+
 # From jsproxy.c
 class JsException(Exception):
     """

--- a/src/py/_pyodide/console.py
+++ b/src/py/_pyodide/console.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Literal, Optional, Union
 
 from _pyodide._base import CodeRunner, should_quiet
 
-__all__ = ["repr_shorten", "BANNER", "Console", "PyodideConsole", "ConsoleFuture"]
+__all__ = ["repr_shorten", "BANNER", "Console", "ConsoleFuture"]
 
 BANNER = f"""
 Python {python_version()} ({', '.join(python_build())}) on WebAssembly VM

--- a/src/py/pyodide/console.py
+++ b/src/py/pyodide/console.py
@@ -4,7 +4,7 @@ from _pyodide.console import Console, ConsoleFuture, repr_shorten
 BANNER = _pyodide.console.BANNER
 from _pyodide._base import CodeRunner
 
-__all__ = ["Console", "PyodideConsole", "Banner", "repr_shorten", "ConsoleFuture"]
+__all__ = ["Console", "PyodideConsole", "BANNER", "repr_shorten", "ConsoleFuture"]
 
 
 class PyodideConsole(Console):

--- a/src/tests/make_test_list.py
+++ b/src/tests/make_test_list.py
@@ -74,7 +74,7 @@ def collect_tests(base_dir):
     # collection.
     tests = []
 
-    for root, dirs, files in os.walk(base_dir):
+    for root, _dirs, files in os.walk(base_dir):
         root = Path(root).relative_to(base_dir)
 
         if str(root) == ".":

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -67,11 +67,11 @@ def test_completion():
             "assert ",
             "async ",
             "await ",
+            "a_variable",
             "abs(",
             "all(",
             "any(",
             "ascii(",
-            "a_variable",
         ],
         0,
     )

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -60,7 +60,7 @@ def test_repr():
 
 def test_completion():
     shell = Console({"a_variable": 7})
-    shell.complete("a") == (
+    assert shell.complete("a") == (
         [
             "and ",
             "as ",

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -99,13 +99,13 @@ def test_interactive_console():
         return await res
 
     async def test():
-        assert await get_result("x = 5") == None
+        assert await get_result("x = 5") is None
         assert await get_result("x") == 5
         assert await get_result("x ** 2") == 25
 
         assert_incomplete("def f(x):")
         assert_incomplete("    return x*x + 1")
-        assert await get_result("") == None
+        assert await get_result("") is None
         assert await get_result("[f(x) for x in range(5)]") == [1, 2, 5, 10, 17]
 
         assert_incomplete("def factorial(n):")
@@ -113,10 +113,10 @@ def test_interactive_console():
         assert_incomplete("        return 1")
         assert_incomplete("    else:")
         assert_incomplete("        return n * factorial(n - 1)")
-        assert await get_result("") == None
+        assert await get_result("") is None
         assert await get_result("factorial(10)") == 3628800
 
-        assert await get_result("import pytz") == None
+        assert await get_result("import pytz") is None
         assert await get_result("pytz.utc.zone") == "UTC"
 
         fut = shell.push("1+")
@@ -130,7 +130,7 @@ def test_interactive_console():
         fut = shell.push("raise Exception('hi')")
         try:
             await fut
-        except:
+        except Exception:
             assert (
                 fut.formatted_error
                 == 'Traceback (most recent call last):\n  File "<console>", line 1, in <module>\nException: hi\n'
@@ -201,10 +201,10 @@ def test_persistent_redirection(safe_sys_redirections):
         return await res
 
     async def test():
-        assert await get_result("print('foobar')") == None
+        assert await get_result("print('foobar')") is None
         assert my_stdout == "foo\nfoobar\n"
 
-        assert await get_result("print('foobar')") == None
+        assert await get_result("print('foobar')") is None
         assert my_stdout == "foo\nfoobar\nfoobar\n"
 
         assert await get_result("1+1") == 2
@@ -256,17 +256,17 @@ def test_nonpersistent_redirection(safe_sys_redirections):
     assert my_stdout == ""
 
     async def test():
-        assert await get_result("print('foobar')") == None
+        assert await get_result("print('foobar')") is None
         assert my_stdout == "foobar\n"
 
         print("bar")
         assert my_stdout == "foobar\n"
 
-        assert await get_result("print('foobar')") == None
+        assert await get_result("print('foobar')") is None
         assert my_stdout == "foobar\nfoobar\n"
 
-        assert await get_result("import sys") == None
-        assert await get_result("print('foobar', file=sys.stderr)") == None
+        assert await get_result("import sys") is None
+        assert await get_result("print('foobar', file=sys.stderr)") is None
         assert my_stderr == "foobar\n"
 
         assert await get_result("1+1") == 2
@@ -290,7 +290,7 @@ async def test_console_imports():
         assert res.syntax_check == "complete"
         return await res
 
-    assert await get_result("import pytz") == None
+    assert await get_result("import pytz") is None
     assert await get_result("pytz.utc.zone") == "UTC"
 
 
@@ -330,7 +330,7 @@ def test_console_html(console_html_fixture):
 
     def get_result():
         return selenium.run_js(
-            f"""
+            """
             await term.ready;
             return term.get_output().trim();
             """

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -730,7 +730,7 @@ def test_object_entries_keys_values(selenium):
 
 
 def test_mixins_feature_presence(selenium):
-    result = selenium.run_js(
+    selenium.run_js(
         """
         let fields = [
             [{ [Symbol.iterator](){} }, "__iter__"],
@@ -1082,7 +1082,7 @@ def test_buffer_assign_back(selenium):
 
 def test_buffer_conversions(selenium):
     selenium.run_js(
-        f"""
+        """
         self.s = "abcဴ";
         self.jsbytes = new TextEncoder().encode(s);
         pyodide.runPython(`

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -159,9 +159,6 @@ def test_load_failure_retry(selenium_standalone):
 
 
 def test_load_package_unknown(selenium_standalone):
-    selenium_standalone.server_hostname
-    selenium_standalone.server_port
-
     build_dir = Path(__file__).parents[2] / "build"
     pyparsing_wheel_name = get_pyparsing_wheel_name()
     shutil.copyfile(

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -159,8 +159,8 @@ def test_load_failure_retry(selenium_standalone):
 
 
 def test_load_package_unknown(selenium_standalone):
-    url = selenium_standalone.server_hostname
-    port = selenium_standalone.server_port
+    selenium_standalone.server_hostname
+    selenium_standalone.server_port
 
     build_dir = Path(__file__).parents[2] / "build"
     pyparsing_wheel_name = get_pyparsing_wheel_name()
@@ -170,7 +170,7 @@ def test_load_package_unknown(selenium_standalone):
     )
 
     try:
-        selenium_standalone.load_package(f"./pyparsing-custom-3.0.6-py3-none-any.whl")
+        selenium_standalone.load_package("./pyparsing-custom-3.0.6-py3-none-any.whl")
     finally:
         (build_dir / "pyparsing-custom-3.0.6-py3-none-any.whl").unlink()
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -197,7 +197,7 @@ def test_dup_temp_file():
 
     tf = TemporaryFile(buffering=0)
     fd1 = os.dup(tf.fileno())
-    fd2 = os.dup2(tf.fileno(), 50)
+    os.dup2(tf.fileno(), 50)
     s = b"hello there!"
     tf.write(s)
     tf2 = open(fd1, "w+")
@@ -290,7 +290,7 @@ def test_hiwire_is_promise(selenium):
 
     if not selenium.browser == "node":
         assert selenium.run_js(
-            f"return pyodide._module.hiwire.isPromise(document.all) === false;"
+            "return pyodide._module.hiwire.isPromise(document.all) === false;"
         )
 
     assert selenium.run_js(

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -22,7 +22,7 @@ def test_string_conversion(selenium_module_scope, s):
             pyodide.runPython('spy = bytes({sbytes}).decode()');
             """
         )
-        assert selenium.run_js(f"""return pyodide.runPython('spy') === sjs;""")
+        assert selenium.run_js("""return pyodide.runPython('spy') === sjs;""")
         assert selenium.run(
             """
             from js import sjs
@@ -79,7 +79,7 @@ def test_number_conversions(selenium_module_scope, n):
             `);
             """
         )
-        assert selenium.run_js(f"""return pyodide.runPython('x_py') === x_js;""")
+        assert selenium.run_js("""return pyodide.runPython('x_py') === x_js;""")
         assert selenium.run(
             """
             from js import x_js
@@ -162,11 +162,11 @@ def test_hyp_py2js2py(selenium_module_scope, obj):
         # have to defend against them here.
         try:
             assume(obj == obj)
-        except:
+        except Exception:
             assume(False)
         try:
             obj_bytes = list(pickle.dumps(obj))
-        except:
+        except Exception:
             assume(False)
         selenium.run(
             f"""
@@ -224,7 +224,7 @@ def test_hyp_tojs_no_crash(selenium_module_scope, obj):
 
         try:
             obj_bytes = list(pickle.dumps(obj))
-        except:
+        except Exception:
             assume(False)
         selenium.run(
             f"""


### PR DESCRIPTION
- chore: enable the rest of flake8
- chore: enable flake8-bugbear

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

You can see exactly what was part of each change by looking at the separate comments. I might not have always chosen the best way to silence the warning, so please check. I assume you were never really trying to catch BaseException, and used Exception, but that can be changed to BaseException if you really meant to catch out of memory, control-C, etc. I removed variables that were unused, though sometimes maybe they were supposed to be checked or used somewhere. Etc.


There's an unofficial trick to put flake8 config into pyproject.toml, I can use that if you prefer. I didn't place it in setup.cfg, as I assume that's going away.

---

<details>
<summary>Flake8 report:</summary>

```
packages/wrapt/test_wrapt.py:57:13: F841 local variable 'function1o_members' is assigned to but never used
packages/wrapt/test_wrapt.py:58:13: F841 local variable 'function1d_members' is assigned to but never used
docs/conf.py:113:13: E722 do not use bare 'except'
packages/scikit-image/test_skimage.py:48:5: F841 local variable 'segments_watershed' is assigned to but never used
pyodide-build/pyodide_build/_f2c_fixes.py:23:17: F541 f-string is missing placeholders
pyodide-build/pyodide_build/_f2c_fixes.py:148:12: E713 test for membership should be 'not in'
pyodide-build/pyodide_build/_f2c_fixes.py:225:12: E713 test for membership should be 'not in'
pyodide-build/pyodide_build/buildpkg.py:832:5: E722 do not use bare 'except'
docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py:54:12: E713 test for membership should be 'not in'
packages/matplotlib/src/wasm_backend.py:74:9: F841 local variable 'e' is assigned to but never used
src/tests/test_package_loading.py:162:5: F841 local variable 'url' is assigned to but never used
src/tests/test_package_loading.py:163:5: F841 local variable 'port' is assigned to but never used
src/tests/test_package_loading.py:173:42: F541 f-string is missing placeholders
conftest.py:437:23: F541 f-string is missing placeholders
src/tests/test_console.py:102:42: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:108:37: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:116:37: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:119:48: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:133:9: E722 do not use bare 'except'
src/tests/test_console.py:204:52: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:207:52: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:259:52: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:265:52: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:268:47: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:269:69: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:293:44: E711 comparison to None should be 'if cond is None:'
src/tests/test_console.py:333:13: F541 f-string is missing placeholders
src/tests/test_jsproxy.py:733:5: F841 local variable 'result' is assigned to but never used
src/tests/test_jsproxy.py:1085:9: F541 f-string is missing placeholders
src/py/pyodide/console.py:7:1: F822 undefined name 'Banner' in __all__
src/tests/test_pyodide.py:200:5: F841 local variable 'fd2' is assigned to but never used
src/tests/test_pyodide.py:293:13: F541 f-string is missing placeholders
src/tests/test_typeconversions.py:25:32: F541 f-string is missing placeholders
src/tests/test_typeconversions.py:82:32: F541 f-string is missing placeholders
src/tests/test_typeconversions.py:165:9: E722 do not use bare 'except'
src/tests/test_typeconversions.py:169:9: E722 do not use bare 'except'
src/tests/test_typeconversions.py:227:9: E722 do not use bare 'except'
pyodide-build/pyodide_build/buildall.py:267:12: F541 f-string is missing placeholders
src/py/_pyodide/console.py:16:1: F822 undefined name 'PyodideConsole' in __all__
src/py/_pyodide/_core_docs.py:14:1: E302 expected 2 blank lines, found 1
```

</details>

<details>
<summary>Bugbear report:</summary>

```
benchmark/benchmarks/diffusion.py:13:9: B007 Loop control variable 'n' not used within the loop body. If this is intended, start the name with an underscore.
packages/sympy/test_sympy.py:11:5: B015 Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
docs/sphinx_pyodide/sphinx_pyodide/packages.py:86:17: B007 Loop control variable 'name' not used within the loop body. If this is intended, start the name with an underscore.
benchmark/benchmarks/grayscott.py:22:9: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
src/py/_pyodide/_base.py:254:13: B011 Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().
benchmark/benchmarks/fdtd.py:17:9: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
pyodide-build/pyodide_build/buildpkg.py:493:15: B007 Loop control variable 'dirs' not used within the loop body. If this is intended, start the name with an underscore.
docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py:62:17: B011 Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().
docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py:188:5: B011 Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().
docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py:358:17: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
src/tests/test_console.py:63:5: B015 Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
benchmark/benchmarks/check_mask.py:10:25: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
pyodide-build/pyodide_build/pywasmcross.py:634:15: B007 Loop control variable 'dirs' not used within the loop body. If this is intended, start the name with an underscore.
packages/matplotlib/src/browser_backend.py:433:13: B007 Loop control variable 'text' not used within the loop body. If this is intended, start the name with an underscore.
packages/matplotlib/src/browser_backend.py:433:19: B007 Loop control variable 'tooltip_text' not used within the loop body. If this is intended, start the name with an underscore.
packages/matplotlib/src/browser_backend.py:445:21: B007 Loop control variable 'mimetype' not used within the loop body. If this is intended, start the name with an underscore.
pyodide-build/pyodide_build/testing.py:34:27: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
pyodide-build/pyodide_build/testing.py:35:38: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
src/tests/make_test_list.py:77:15: B007 Loop control variable 'dirs' not used within the loop body. If this is intended, start the name with an underscore.
```

</details>

