### PR TITLE
chore: some package updates

### DIFF
--- a/packages/MarkupSafe/meta.yaml
+++ b/packages/MarkupSafe/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: MarkupSafe
-  version: 2.0.1
+  version: 2.1.0
 source:
-  sha256: 594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a
-  url: https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz
+  sha256: 80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f
+  url: https://files.pythonhosted.org/packages/62/0f/52c009332fdadd484e898dc8f2acca0663c1031b3517070fd34ad9c1b64e/MarkupSafe-2.1.0.tar.gz
 test:
   imports:
     - markupsafe

--- a/packages/astropy/meta.yaml
+++ b/packages/astropy/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: astropy
-  version: "5.0"
+  version: 5.0.1
 source:
-  url: https://files.pythonhosted.org/packages/82/f0/fc3f6f250bb9d5e5aaa890469fb27c4edee66cf0e2ea4f8b0b287260c6f8/astropy-5.0.tar.gz
-  sha256: 70203e151e13292586a817b4069ce1aad4643567aff38b1d191c173bc54f3927
+  url: https://files.pythonhosted.org/packages/91/a8/619de6e60fe461e3c7e908ec6fa04333b91249e7877a42485b2df981fdcb/astropy-5.0.1.tar.gz
+  sha256: 6382cde6a205aa0b16a0d5e61c0c0131ebd4f0174d6c73e2964f4bee132a9027
 build:
   script: |
     pip install extension-helpers

--- a/packages/cffi/meta.yaml
+++ b/packages/cffi/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: cffi
-  version: 1.14.6
+  version: 1.15.0
 requirements:
   run:
     - pycparser
 source:
-  url: https://files.pythonhosted.org/packages/2e/92/87bb61538d7e60da8a7ec247dc048f7671afe17016cd0008b3b710012804/cffi-1.14.6.tar.gz
-  sha256: c9a875ce9d7fe32887784274dd533c57909b7b1dcadcc128a2ac21331a9765dd
+  url: https://files.pythonhosted.org/packages/00/9e/92de7e1217ccc3d5f352ba21e52398372525765b2e0c4530e6eb2ba9282a/cffi-1.15.0.tar.gz
+  sha256: 920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954
   patches:
     - patches/libffi-config.patch
 test:

--- a/packages/imageio/meta.yaml
+++ b/packages/imageio/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: imageio
-  version: 2.14.0
+  version: 2.16.1
 source:
-  sha256: af6c7c89947ee9d81eab2caee3726f61e1a0d861e87e856904868d0fe7c0aa15
-  url: https://files.pythonhosted.org/packages/88/1e/62f8088805f7eb9cc9ce2b8ae7528a4083014f223c4e55d268dc48ac06c6/imageio-2.14.0-py3-none-any.whl
+  sha256: d8d17c59b6f5f3b350bbbe346e7cb7dda0399b1881d93ad01cb29b5acdb24c42
+  url: https://files.pythonhosted.org/packages/29/24/a3a7aa7f1e7f1c3a5c9fe2ff3fec8d9d17e10741eafb710f06705744b35f/imageio-2.16.1-py3-none-any.whl
 requirements:
   run:
     - numpy

--- a/packages/logbook/meta.yaml
+++ b/packages/logbook/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: logbook
-  version: 1.5.2
+  version: 1.5.3
 
 source:
-  url: https://github.com/getlogbook/logbook/archive/refs/tags/1.5.2.tar.gz
-  sha256: 3eebcb13a41636004a2d03d875bc1c2ccc4afb02dc13f45320b147fee79c9739
+  url: https://files.pythonhosted.org/packages/2f/d9/16ac346f7c0102835814cc9e5b684aaadea101560bb932a2403bd26b2320/Logbook-1.5.3.tar.gz
+  sha256: 66f454ada0f56eae43066f604a222b09893f98c1adc18df169710761b8f32fe8
 
 requirements:
   run:

--- a/packages/pyrsistent/meta.yaml
+++ b/packages/pyrsistent/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: pyrsistent
-  version: 0.18.0
+  version: 0.18.1
 source:
-  url: https://files.pythonhosted.org/packages/f4/d7/0fa558c4fb00f15aabc6d42d365fcca7a15fcc1091cd0f5784a14f390b7f/pyrsistent-0.18.0.tar.gz
-  sha256: 773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b
+  url: https://files.pythonhosted.org/packages/42/ac/455fdc7294acc4d4154b904e80d964cc9aae75b087bbf486be04df9f2abd/pyrsistent-0.18.1.tar.gz
+  sha256: d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96
 test:
   imports:
     - pyrsistent

--- a/packages/pytest/meta.yaml
+++ b/packages/pytest/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: pytest
-  version: 6.2.5
+  version: 7.0.1
 source:
-  url: https://files.pythonhosted.org/packages/40/76/86f886e750b81a4357b6ed606b2bcf0ce6d6c27ad3c09ebf63ed674fc86e/pytest-6.2.5-py3-none-any.whl
-  sha256: 7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134
+  url: https://files.pythonhosted.org/packages/38/93/c7c0bd1e932b287fb948eb9ce5a3d6307c9fc619db1e199f8c8bc5dad95f/pytest-7.0.1-py3-none-any.whl
+  sha256: 9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db
 requirements:
   run:
     - atomicwrites

--- a/packages/regex/meta.yaml
+++ b/packages/regex/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: regex
-  version: 2021.7.6
+  version: 2022.1.18
 source:
-  sha256: 8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d
-  url: https://files.pythonhosted.org/packages/c0/d1/ad6afa6000ab869f6af2c85985d40558ffb298d9fcb2ab04c0648436008f/regex-2021.7.6.tar.gz
+  sha256: 97f32dc03a8054a4c4a5ab5d761ed4861e828b2c200febd4e46857069a483916
+  url: https://files.pythonhosted.org/packages/4c/75/b5b60055897d78882da8bc4c94609067cf531a42726df2e44ce69e8ec7a9/regex-2022.1.18.tar.gz
 test:
   imports:
     - regex

--- a/packages/setuptools/meta.yaml
+++ b/packages/setuptools/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: setuptools
-  version: 60.5.0
+  version: 60.9.3
 source:
-  url: https://files.pythonhosted.org/packages/eb/53/0dd4c7960579da8be13fa9b2c2591643d37f323e3d79f8bc8b1b6c8e6217/setuptools-60.5.0-py3-none-any.whl
-  sha256: 68eb94073fc486091447fcb0501efd6560a0e5a1839ba249e5ff3c4c93f05f90
+  url: https://files.pythonhosted.org/packages/3b/02/8d4d27b1cacaac2d129a27d17a22d92a2a5eedcb7817d4ed8ab0d4daf5c4/setuptools-60.9.3-py3-none-any.whl
+  sha256: e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b
 build:
   post: |
     find build/setuptools-*/dist -name '*.exe' -delete

--- a/packages/sqlalchemy/meta.yaml
+++ b/packages/sqlalchemy/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: sqlalchemy
-  version: 1.4.29
+  version: 1.4.31
 source:
-  url: https://files.pythonhosted.org/packages/80/7c/ab3470159bab67fcb28bc4038c55751d6b333a59b70af8943a95e470f8ab/SQLAlchemy-1.4.29.tar.gz
-  sha256: fa2bad14e1474ba649cfc969c1d2ec915dd3e79677f346bbfe08e93ef9020b39
+  url: https://files.pythonhosted.org/packages/0f/80/d8883f12689a55e333d221bb9a56c727e976f5a8e9dc862efeac9f40d296/SQLAlchemy-1.4.31.tar.gz
+  sha256: 582b59d1e5780a447aada22b461e50b404a9dc05768da1d87368ad8190468418
 test:
   imports:
     - sqlalchemy

--- a/packages/threadpoolctl/meta.yaml
+++ b/packages/threadpoolctl/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: threadpoolctl
-  version: 3.0.0
+  version: 3.1.0
 
 source:
-  url: https://files.pythonhosted.org/packages/ff/fe/8aaca2a0db7fd80f0b2cf8a16a034d3eea8102d58ff9331d2aaf1f06766a/threadpoolctl-3.0.0-py3-none-any.whl
-  sha256: 4fade5b3b48ae4b1c30f200b28f39180371104fccc642e039e0f2435ec8cc211
+  url: https://files.pythonhosted.org/packages/61/cf/6e354304bcb9c6413c4e02a747b600061c21d38ba51e7e544ac7bc66aecc/threadpoolctl-3.1.0-py3-none-any.whl
+  sha256: 8b99adda265feb6773280df41eece7b2e6561b772d21ffd52e372f999024907b

--- a/packages/typing-extensions/meta.yaml
+++ b/packages/typing-extensions/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: typing-extensions
-  version: 4.0.1
+  version: 4.1.1
 source:
-  url: https://files.pythonhosted.org/packages/05/e4/baf0031e39cf545f0c9edd5b1a2ea12609b7fcba2d58e118b11753d68cf0/typing_extensions-4.0.1-py3-none-any.whl
-  sha256: 7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b
+  url: https://files.pythonhosted.org/packages/45/6b/44f7f8f1e110027cf88956b59f2fad776cca7e1704396d043f89effd3a0e/typing_extensions-4.1.1-py3-none-any.whl
+  sha256: 21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
 
 test:
   imports:


### PR DESCRIPTION
I've updated the following packages:


- ~~chore: update lxml to 4.8.0~~
- chore: update MarkupSafe to 2.1.0
- chore: update astropy to 5.0.1
- chore: update logbook to 1.5.3
- chore: update regex to 2022.1.18
- chore: update sqlalchemy to 1.4.31
- chore: updated cffi to 1.15.0
- chore: updated imageio to 2.16.1
- chore: updated setuptools to 60.9.3
- chore: updated pytest to 7.0.1
- chore: updated typing-extensions to 4.1.1
- chore: updated pyrsistent to 0.18.1
- chore: updated threadpoolctl to 3.1.0

I wasn't sure how caching was done (if I update numpy, etc. all at once will
that blow up the CI build time?), and I'm hoping to avoid failures, so I left
the big or patched ones alone. Was after lxml (see #2225), but thought I'd get a couple other ones while at it. Removed it, having an issue so will be bumped separately.

* matplotlib 3.3.3 ❌ -> 3.5.1
* nltk 3.6.7 ❌ -> 3.7
* numpy 1.21.4 ❌ -> 1.22.2
* pandas 1.3.5 ❌ -> 1.4.1
* pillow 9.0.0 ❌ -> 9.0.1
* pyrsistent 0.18.0 ❌ -> 0.18.1
* python-sat 0.1.7.dev15 ❌ -> 0.1.7.dev16
* scikit-image 0.19.1 ❌ -> 0.19.2
* scipy 1.7.3 ❌ -> 1.8.0
* statsmodels 0.13.1 ❌ -> 0.13.2
* swiglpk 5.0.3 ❌ -> 5.0.4
* yt 3.6.1 ❌ -> 4.0.2
* zarr 2.10.3 ❌ -> 2.11.0
