### PR TITLE
upgrade to jquery.terminal 2.32.0

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.23.0/js/jquery.terminal.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.32.0/js/jquery.terminal.min.js"></script>
     <link
-      href="https://cdn.jsdelivr.net/npm/jquery.terminal@2.23.0/css/jquery.terminal.min.css"
+      href="https://cdn.jsdelivr.net/npm/jquery.terminal@2.32.0/css/jquery.terminal.min.css"
       rel="stylesheet"
     />
     <script src="{{ PYODIDE_BASE_URL }}pyodide.js"></script>
@@ -128,7 +128,7 @@
           keymap: {
             "CTRL+C": async function (event, original) {
               clear_console();
-              term.echo_command();
+              term.enter();
               term.echo("KeyboardInterrupt");
               term.set_command("");
               term.set_prompt(ps1);


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->
Upgrade to jquery.terminal 2.32.0 to fix https://github.com/jcubic/jquery.terminal/pull/741
`echo_command` should be replaced by `enter`, see https://github.com/jcubic/jquery.terminal/blob/master/CHANGELOG.md#2310
### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->
