### PR TITLE
Fix bug in loadDynlib

### DIFF
--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -223,7 +223,15 @@ const acquireDynlibLock = createLock();
  * @private
  */
 async function loadDynlib(lib: string, shared: boolean) {
-  const byteArray = Module.FS.lookupPath(lib).node.contents;
+  const node = Module.FS.lookupPath(lib).node;
+  let byteArray;
+  if (node.mount.type == Module.FS.filesystems.MEMFS) {
+    byteArray = Module.FS.filesystems.MEMFS.getFileDataAsTypedArray(
+      Module.FS.lookupPath(lib).node
+    );
+  } else {
+    byteArray = Module.FS.readFile(lib);
+  }
   const releaseDynlibLock = await acquireDynlibLock();
   try {
     const module = await Module.loadWebAssemblyModule(byteArray, {


### PR DESCRIPTION
Split off from #2225. 

Fix loadDynlib to handle files with length < capacity.
We also update it to handle .so files that are not in the MEMFS.
(In this case we have to copy the file into memory before loading it.)