### PR TITLE
Add patches to make astropy work more fully

### DIFF
--- a/packages/astropy/meta.yaml
+++ b/packages/astropy/meta.yaml
@@ -4,6 +4,9 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/82/f0/fc3f6f250bb9d5e5aaa890469fb27c4edee66cf0e2ea4f8b0b287260c6f8/astropy-5.0.tar.gz
   sha256: 70203e151e13292586a817b4069ce1aad4643567aff38b1d191c173bc54f3927
+  patches:
+    - patches/0001-Move-ssl-import-into-functions-to-avoid-import-error.patch
+    - patches/0002-Move-concurrent.futures-import-into-function-to-avoi.patch
 build:
   script: |
     pip install extension-helpers
@@ -16,6 +19,26 @@ requirements:
     - packaging
     - numpy
     - pyerfa
+    - pyyaml
 test:
   imports:
     - astropy
+    - astropy.config
+    - astropy.constants
+    - astropy.convolution
+    - astropy.coordinates
+    - astropy.cosmology
+    - astropy.extern
+    - astropy.io
+    - astropy.modeling
+    - astropy.nddata
+    - astropy.samp
+    - astropy.stats
+    - astropy.table
+    - astropy.time
+    - astropy.timeseries
+    - astropy.uncertainty
+    - astropy.units
+    - astropy.utils
+    - astropy.visualization
+    - astropy.wcs

--- a/packages/astropy/patches/0001-Move-ssl-import-into-functions-to-avoid-import-error.patch
+++ b/packages/astropy/patches/0001-Move-ssl-import-into-functions-to-avoid-import-error.patch
@@ -1,0 +1,40 @@
+From 4e4f12d0052cb9c9fc8ac550266889a0c39af8ec Mon Sep 17 00:00:00 2001
+From: Jo Bovy <bovy@astro.utoronto.ca>
+Date: Mon, 28 Feb 2022 20:43:45 -0500
+Subject: [PATCH] Move ssl import into functions to avoid import error
+
+---
+ astropy/utils/data.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/astropy/utils/data.py b/astropy/utils/data.py
+index 0dde5b293..25c758be2 100644
+--- a/astropy/utils/data.py
++++ b/astropy/utils/data.py
+@@ -13,7 +13,6 @@ import io
+ import re
+ import shutil
+ import socket
+-import ssl
+ import sys
+ import urllib.request
+ import urllib.error
+@@ -1048,6 +1047,7 @@ def _build_urlopener(ftp_tls=False, ssl_context=None, allow_insecure=False):
+     """
+     Helper for building a `urllib.request.build_opener` which handles TLS/SSL.
+     """
++    import ssl
+ 
+     ssl_context = dict(it for it in ssl_context) if ssl_context else {}
+     cert_chain = {}
+@@ -1087,6 +1087,7 @@ def _build_urlopener(ftp_tls=False, ssl_context=None, allow_insecure=False):
+ def _try_url_open(source_url, timeout=None, http_headers=None, ftp_tls=False,
+                   ssl_context=None, allow_insecure=False):
+     """Helper for opening a URL while handling TLS/SSL verification issues."""
++    import ssl
+ 
+     # Always try first with a secure connection
+     # _build_urlopener uses lru_cache, so the ssl_context argument must be
+-- 
+2.32.0 (Apple Git-132)
+

--- a/packages/astropy/patches/0002-Move-concurrent.futures-import-into-function-to-avoi.patch
+++ b/packages/astropy/patches/0002-Move-concurrent.futures-import-into-function-to-avoi.patch
@@ -1,0 +1,35 @@
+From 77517841878c92eb29ea2e29cb4c37f2ff7d0f43 Mon Sep 17 00:00:00 2001
+From: Jo Bovy <bovy@astro.utoronto.ca>
+Date: Tue, 1 Mar 2022 21:19:17 -0500
+Subject: [PATCH] Move concurrent.futures import into function to avoid import
+ error
+
+---
+ astropy/utils/console.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/astropy/utils/console.py b/astropy/utils/console.py
+index f2bd22a24..5db50e0f9 100644
+--- a/astropy/utils/console.py
++++ b/astropy/utils/console.py
+@@ -14,7 +14,6 @@ import struct
+ import sys
+ import threading
+ import time
+-from concurrent.futures import ProcessPoolExecutor, as_completed
+ 
+ try:
+     import fcntl
+@@ -805,7 +804,8 @@ class ProgressBar:
+             else:
+                 ctx = multiprocessing.get_context(multiprocessing_start_method)
+                 kwargs = dict(mp_context=ctx)
+-
++                
++                from concurrent.futures import ProcessPoolExecutor, as_completed
+                 with ProcessPoolExecutor(
+                         max_workers=(int(multiprocess)
+                                      if multiprocess is not True
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This PR updates the `astropy` package in `pyodide` to:
1. Apply patches to avoid crippling import errors due to the lack of `import _ssl` and full multiprocessing support in `pyodide`
2. Add a missing dependency `pyyaml` (see https://github.com/astropy/astropy/blob/v5.0.1/setup.cfg#L30)
3. Add import tests for all `astropy` sub-packages.

Without these packages, much of `astropy` doesn't work in `pyodide` even though most of `astropy` doesn't require SSL or multiprocessing (but these are imported in utility modules used throughout `astropy`). As you can see, the patches are very small and simple (just moving the imports into the functions that use them, causing the error to occur there).

With these patches, everything I've tried to run in `astropy` that I think should be able to run in a browser works. But I haven't tried running a test suite more systematically.

I will try to get these patches (or some version of them) accepted upstream so they would hopefully not be necessary for the next `astropy` release.

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [x] Add / update tests
