### PR TITLE
fix: better error messages, fewer tracebacks

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -297,9 +297,13 @@ def patch(pkg_root: Path, srcpath: Path, src_metadata: dict[str, Any]):
     # Apply all the patches
     with chdir(srcpath):
         for patch in patches:
-            subprocess.run(
-                ["patch", "-p1", "--binary", "-i", pkg_root / patch], check=True
+            result = subprocess.run(
+                ["patch", "-p1", "--binary", "--verbose", "-i", pkg_root / patch],
+                check=False,
             )
+            if result.returncode != 0:
+                print(f"ERROR: Patch {pkg_root/patch} failed")
+                raise SystemExit(result.returncode)
 
     # Add any extra files
     for src, dst in extras:

--- a/pyodide-build/pyodide_build/tests/test_buildpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_buildpkg.py
@@ -10,27 +10,27 @@ from pyodide_build.io import parse_package_config
 
 
 def test_subprocess_with_shared_env():
-    p = buildpkg.BashRunnerWithSharedEnvironment()
-    p.env.pop("A", None)
+    with buildpkg.BashRunnerWithSharedEnvironment() as p:
+        p.env.pop("A", None)
 
-    res = p.run("A=6; echo $A", stdout=subprocess.PIPE)
-    assert res.stdout == b"6\n"
-    assert p.env.get("A", None) is None
+        res = p.run("A=6; echo $A", stdout=subprocess.PIPE)
+        assert res.stdout == b"6\n"
+        assert p.env.get("A", None) is None
 
-    p.run("export A=2")
-    assert p.env["A"] == "2"
+        p.run("export A=2")
+        assert p.env["A"] == "2"
 
-    res = p.run("echo $A", stdout=subprocess.PIPE)
-    assert res.stdout == b"2\n"
+        res = p.run("echo $A", stdout=subprocess.PIPE)
+        assert res.stdout == b"2\n"
 
-    res = p.run("A=6; echo $A", stdout=subprocess.PIPE)
-    assert res.stdout == b"6\n"
-    assert p.env.get("A", None) == "6"
+        res = p.run("A=6; echo $A", stdout=subprocess.PIPE)
+        assert res.stdout == b"6\n"
+        assert p.env.get("A", None) == "6"
 
-    p.env["A"] = "7"
-    res = p.run("echo $A", stdout=subprocess.PIPE)
-    assert res.stdout == b"7\n"
-    assert p.env["A"] == "7"
+        p.env["A"] = "7"
+        res = p.run("echo $A", stdout=subprocess.PIPE)
+        assert res.stdout == b"7\n"
+        assert p.env["A"] == "7"
 
 
 def test_prepare_source(monkeypatch):
@@ -73,9 +73,9 @@ def test_run_script(is_library, tmpdir):
     src_dir = Path(tmpdir.mkdir("build/package_name"))
     script = "touch out.txt"
     build_metadata = {"script": script, "library": is_library}
-    shared_env = buildpkg.BashRunnerWithSharedEnvironment()
-    buildpkg.run_script(build_dir, src_dir, build_metadata, shared_env)
-    assert (src_dir / "out.txt").exists()
+    with buildpkg.BashRunnerWithSharedEnvironment() as shared_env:
+        buildpkg.run_script(build_dir, src_dir, build_metadata, shared_env)
+        assert (src_dir / "out.txt").exists()
 
 
 def test_run_script_environment(tmpdir):
@@ -83,10 +83,10 @@ def test_run_script_environment(tmpdir):
     src_dir = Path(tmpdir.mkdir("build/package_name"))
     script = "export A=2"
     build_metadata = {"script": script, "library": False}
-    shared_env = buildpkg.BashRunnerWithSharedEnvironment()
-    shared_env.env.pop("A", None)
-    buildpkg.run_script(build_dir, src_dir, build_metadata, shared_env)
-    assert shared_env.env["A"] == "2"
+    with buildpkg.BashRunnerWithSharedEnvironment() as shared_env:
+        shared_env.env.pop("A", None)
+        buildpkg.run_script(build_dir, src_dir, build_metadata, shared_env)
+        assert shared_env.env["A"] == "2"
 
 
 def test_unvendor_tests(tmpdir):


### PR DESCRIPTION
This reduces the text output when an error is hit, removing the tracebacks for known errors. Tracebacks are for unknown/unexpected errors - if you expect an error, it's better to print out an actual error message. I've also made the patch applying a bit more verbose in case it helps, as it sometimes does.

Example after the changes:

```
Building the following packages: yt
[1/1] (thread 1) building yt
Error building yt. Printing build logs.
Hmm...  Looks like a unified diff to me...
The text leading up to this was:
--------------------------
|diff --git a/setupext.py b/setupext.py
|index 92c456bab..ce2c5fbad 100644
|--- a/setupext.py
|+++ b/setupext.py
--------------------------
patching file setupext.py
Using Plan A...
Hunk #1 FAILED at 57.
1 out of 1 hunk FAILED -- saving rejects to file setupext.py.rej
done
[2022-03-02 17:35:58] Building package yt...
ERROR: Patch /src/packages/yt/patches/skip-openmp.patch failed
[2022-03-02 17:36:14] Succeeded building package yt in 16.5 seconds.
ERROR: cancelling buildall
[1/1] (thread 1) failed yt in 16.76 s
make[1]: *** [Makefile:12: all] Error 1
make[1]: Leaving directory '/src/packages'
make: *** [Makefile:187: build/packages.json] Error 2
```
