### PR TITLE
MAINT Improve circleci cache rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,13 @@ jobs:
 
       - restore_cache:
           keys:
-            - -core-{{ checksum "Makefile.envs" }}-{{ checksum "cpython/Makefile" }}-v20210910-
+            - -core-v20220303-{{ checksum "cpython/Makefile" }}-{{ checksum "Makefile.envs" }}
+            - -core-v20220303-{{ checksum "cpython/Makefile" }}
+            - -core-v20220303
 
       - run:
           name: build emsdk
-          no_output_timeout: 1200
+          no_output_timeout: 20m
           command: |
             # This is necessary to use the ccache from emsdk
             source pyodide_env.sh
@@ -55,7 +57,7 @@ jobs:
 
       - run:
           name: build cpython
-          no_output_timeout: 1200
+          no_output_timeout: 20m
           command: |
             # This is necessary to use the ccache from emsdk
             source pyodide_env.sh
@@ -66,7 +68,7 @@ jobs:
 
       - run:
           name: build pyodide core
-          no_output_timeout: 1200
+          no_output_timeout: 20m
           command: |
             # This is necessary to use the ccache from emsdk
             source pyodide_env.sh
@@ -82,7 +84,7 @@ jobs:
       - save_cache:
           paths:
             - /root/.ccache
-          key: -core-{{ checksum "Makefile.envs" }}-{{ checksum "cpython/Makefile" }}-v20210910-
+          key: -core-v20220303-{{ checksum "cpython/Makefile" }}-{{ checksum "Makefile.envs" }}
 
       - run:
           name: Clean up workspace
@@ -121,11 +123,12 @@ jobs:
 
       - restore_cache:
           keys:
-            - -pkg-{{ checksum "Makefile.envs" }}-v20210911-
+            - -pkg1-v20220303-{{ checksum "Makefile.envs" }}
+            - -pkg1-v20220303
 
       - run:
           name: build packages
-          no_output_timeout: 1800
+          no_output_timeout: 30m
           command: |
             source pyodide_env.sh
 
@@ -145,7 +148,7 @@ jobs:
       - save_cache:
           paths:
             - /root/.ccache
-          key: -pkg-{{ checksum "Makefile.envs" }}-v20210911-
+          key: -pkg1-v20220303-{{ checksum "Makefile.envs" }}
 
       - persist_to_workspace:
           root: .
@@ -184,11 +187,12 @@ jobs:
 
       - restore_cache:
           keys:
-            - -pkg-{{ checksum "Makefile.envs" }}-v20210911-
+            - -pkg2-v20220303-{{ checksum "Makefile.envs" }}
+            - -pkg2-v20220303
 
       - run:
           name: build packages
-          no_output_timeout: 1800
+          no_output_timeout: 30m
           command: |
             source pyodide_env.sh
 
@@ -208,7 +212,7 @@ jobs:
       - save_cache:
           paths:
             - /root/.ccache
-          key: -pkg-{{ checksum "Makefile.envs" }}-v20210911-
+          key: -pkg2-v20220303-{{ checksum "Makefile.envs" }}
 
       - run:
           name: Zip build directory


### PR DESCRIPTION
CI caches should have names like `type-version-hash1-hash2-...` where ideally the components are sorted in descending order of how often they are changed. Then we can use fallbacks that change less often.

Also, each CI step needs its own separate cache so that fallbacks work as well as possible.

I also replaced some timeouts specified in seconds with timeouts specified in minutes since that is easier to read.