### PR TITLE
Fix word splitting on run_docker script

### DIFF
--- a/run_docker
+++ b/run_docker
@@ -17,7 +17,7 @@ USER_GID="$(id -g)"
 USER_COMMENT_FIELD="${USER_NAME} pyodide user alias"
 USER_INTERPRETER="/sbin/nologin"
 USER_ACCOUNT_INFO="${USER_NAME}:${USER_PASS}:${USER_ID}:${USER_GID}:${USER_COMMENT_FIELD}:${USER_HOME}:${USER_INTERPRETER}"
-USER_FLAG="--user $USER_ID:$USER_GID"
+USER_FLAG=("--user" "$USER_ID:$USER_GID")
 
 set -eo pipefail
 
@@ -83,7 +83,7 @@ do
         shift
       ;;
       --root)
-        USER_FLAG=""
+        USER_FLAG=()
         shift
       ;;
       -*)
@@ -104,14 +104,14 @@ PYODIDE_DOCKER_IMAGE=${PYODIDE_DOCKER_IMAGE:-${DEFAULT_PYODIDE_DOCKER_IMAGE}}
 # in case the port is not a number, do not bind the port
 case $PYODIDE_SYSTEM_PORT in
   none)
-  PORT_CONFIGURATION_LINE=""
+  PORT_CONFIGURATION_LINE=()
   ;;
   ''|*[!0-9]*) # contains a non-digit character, therefore it is not a number
   echo "WARNING: Invalid port argument '$PYODIDE_SYSTEM_PORT'. Port binding disabled."
-  PORT_CONFIGURATION_LINE=""
+  PORT_CONFIGURATION_LINE=()
   ;;
   *)
-  PORT_CONFIGURATION_LINE="-p $PYODIDE_SYSTEM_PORT:$PYODIDE_DOCKER_PORT"
+  PORT_CONFIGURATION_LINE=("-p" "$PYODIDE_SYSTEM_PORT:$PYODIDE_DOCKER_PORT")
   ;;
 esac
 
@@ -119,10 +119,9 @@ mkdir -p .docker_home
 
 # Start a detached container as root, add the host uname and uid to /etc/passwd,
 # then run forever
-# shellcheck disable=2086 # Intended splitting
 CONTAINER=$(\
   docker run \
-    $PORT_CONFIGURATION_LINE \
+    "${PORT_CONFIGURATION_LINE[@]}" \
     -d --rm \
     -v "$PWD":/src \
     --user root \
@@ -136,10 +135,9 @@ CONTAINER=$(\
 
 EXIT_STATUS=0
 # Execute the provided command as the host user with HOME=/src
-# shellcheck disable=2086 # Intended splitting
 docker exec \
   "$DOCKER_INTERACTIVE" --tty \
-  $USER_FLAG \
+  "${USER_FLAG[@]}" \
   "$CONTAINER" \
   /bin/bash -c "${DOCKER_COMMAND}" || EXIT_STATUS=$?
 

--- a/run_docker
+++ b/run_docker
@@ -119,9 +119,10 @@ mkdir -p .docker_home
 
 # Start a detached container as root, add the host uname and uid to /etc/passwd,
 # then run forever
+# shellcheck disable=2086 # Intended splitting
 CONTAINER=$(\
   docker run \
-    "$PORT_CONFIGURATION_LINE" \
+    $PORT_CONFIGURATION_LINE \
     -d --rm \
     -v "$PWD":/src \
     --user root \
@@ -135,9 +136,10 @@ CONTAINER=$(\
 
 EXIT_STATUS=0
 # Execute the provided command as the host user with HOME=/src
+# shellcheck disable=2086 # Intended splitting
 docker exec \
   "$DOCKER_INTERACTIVE" --tty \
-  "$USER_FLAG" \
+  $USER_FLAG \
   "$CONTAINER" \
   /bin/bash -c "${DOCKER_COMMAND}" || EXIT_STATUS=$?
 


### PR DESCRIPTION
#2257 added a double quote on every bash variable, but there was an error because we have some intended word-splitting stuff.