### PR TITLE
Fix typo in docs [skip ci]

### DIFF
--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -437,7 +437,7 @@ from pyodide import create_proxy
 from js import document
 def my_callback():
     print("hi")
-proxy = document.create_proxy(my_callback)
+proxy = pyodide.create_proxy(my_callback)
 document.body.addEventListener("click", proxy)
 # ...
 # make sure to hold on to proxy


### PR DESCRIPTION
document.create_proxy ==> pyodide.create_proxy
Resolves #2261