### PR TITLE
chore: isort avoid local build confusion, bump pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,13 +22,13 @@ repos:
       - id: isort
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: "v2.31.0"
+    rev: "v2.31.1"
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: "v1.2.0"
+    rev: "v1.2.5"
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]
@@ -39,14 +39,14 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: "4.0.1"
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.931"
+    rev: "v0.940"
     hooks:
       - id: mypy
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ known_first_party = [
   "pyodide_build",
   "_pyodide",
 ]
+known_third_party = [
+  "build",
+]


### PR DESCRIPTION

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Quick update of pre-commit files, fixing URL of flake8, and making sure `build` doesn't trigger as a local directory in isort (#2272).
