### PR TITLE
Implement more accurate wheel finding using the packaging tags module

### DIFF
--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -19,7 +19,7 @@ from typing import Any, ClassVar, Optional
 
 from . import common
 from .buildpkg import needs_rebuild
-from .common import UNVENDORED_STDLIB_MODULES
+from .common import UNVENDORED_STDLIB_MODULES, find_matching_wheels
 from .io import parse_package_config
 
 
@@ -106,14 +106,12 @@ class Package(BasePackage):
 
     def wheel_path(self) -> Path:
         dist_dir = self.pkgdir / "dist"
-        wheels = list(dist_dir.glob("*emscripten_wasm32.whl")) + list(
-            dist_dir.glob("*py3-none-any.whl")
-        )
-        if len(wheels) != 1:
+        wheel, *rest = find_matching_wheels(dist_dir.glob("*.whl"))
+        if rest:
             raise Exception(
-                f"Unexpected number of wheels {len(wheels)} when building {self.name}"
+                f"Unexpected number of wheels {len(rest) + 1} when building {self.name}"
             )
-        return wheels[0]
+        return wheel
 
     def tests_path(self) -> Optional[Path]:
         tests = list((self.pkgdir / "dist").glob("*-tests.tar"))

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -23,6 +23,7 @@ from typing import Any, NoReturn, Optional, TextIO
 from urllib import request
 
 from . import pywasmcross
+from .common import find_matching_wheels
 
 
 @contextmanager
@@ -466,11 +467,15 @@ def package_wheel(
         return
 
     distdir = srcpath / "dist"
-    wheel_paths = list(distdir.glob("*.whl"))
-    assert len(wheel_paths) == 1
-    unpack_wheel(wheel_paths[0])
-    wheel_paths[0].unlink()
-    wheel_dir = next(p for p in distdir.glob("*") if p.is_dir())
+    wheel, *rest = find_matching_wheels(distdir.glob("*.whl"))
+    if rest:
+        raise Exception(
+            f"Unexpected number of wheels {len(rest) + 1} when building {pkg_name}"
+        )
+    unpack_wheel(wheel)
+    wheel.unlink()
+    wheel_dir_name = "-".join(wheel.stem.split("-", 2)[:-1])
+    wheel_dir = distdir / wheel_dir_name
 
     post = build_metadata.get("post")
     if post:

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -10,10 +10,9 @@ PLATFORM = "emscripten_wasm32"
 
 def pyodide_tags() -> Iterator[Tag]:
     """
-    Returns the sequence of tag triples for the running interpreter.
+    Returns the sequence of tag triples for the Pyodide interpreter.
 
-    The order of the sequence corresponds to priority order for the
-    interpreter, from most to least important.
+    The sequence is ordered in decreasing specificity.
     """
 
     yield from cpython_tags(platforms=[PLATFORM])
@@ -21,6 +20,18 @@ def pyodide_tags() -> Iterator[Tag]:
 
 
 def find_matching_wheels(wheel_paths: Iterable[Path]) -> Iterator[Path]:
+    """
+    Returns the sequence wheels whose tags match the Pyodide interpreter.
+
+    Parameters
+    ----------
+    wheel_paths
+        A list of paths to wheels
+
+    Returns
+    -------
+    The subset of wheel_paths that have tags that match the Pyodide interpreter.
+    """
     wheel_tags_list: list[tuple[Path, frozenset[Tag]]] = [
         (wheel, parse_tag(wheel.stem.split("-", 2)[-1])) for wheel in wheel_paths
     ]

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -131,7 +131,7 @@ def compile(env, **kwargs):
     make_command_wrapper_symlinks(env)
     args["builddir"] = str(Path(".").absolute())
     env["PYWASMCROSS_ARGS"] = json.dumps(args)
-    env["_PYTHON_HOST_PLATFORM"] = "emscripten_wasm32"
+    env["_PYTHON_HOST_PLATFORM"] = common.PLATFORM
 
     try:
         subprocess.check_call([sys.executable, "setup.py", "bdist_wheel"], env=env)

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -1,4 +1,4 @@
-from pyodide_build.common import (
+from pyodide_build.common import (  # type: ignore[import]
     ALWAYS_PACKAGES,
     CORE_PACKAGES,
     CORE_SCIPY_PACKAGES,
@@ -85,27 +85,29 @@ def test_wheel_paths():
 
     old_version = "cp38"
     current_version = "cp39"
-    strings = [
-        "threadpoolctl-3.1.0-py3-none-any.whl",
-        "parso-0.8.3-py2.py3-none-any.whl",
-        "distlib-0.3.4-py2-none-any.whl",
-        "bcrypt-3.2.0-cp36-abi3-manylinux2010_x86_64.whl",
-        "bcrypt-3.2.0-cp36-abi3-emscripten_wasm32.whl",
-    ]
+    future_version = "cp317"
+    strings = []
 
-    for arch in ["emscripten_wasm32", "linux_x86_64", "none"]:
-        strings.extend(
-            [
-                f"wrapt-1.13.3-{old_version}-{old_version}-{arch}.whl",
-                f"wrapt-1.13.3-{old_version}-abi3-{arch}.whl",
-                f"wrapt-1.13.3-{current_version}-{current_version}-{arch}.whl",
-            ]
-        )
+    for interp in [
+        old_version,
+        current_version,
+        future_version,
+        "py3",
+        "py2",
+        "py2.py3",
+    ]:
+        for abi in [interp, "abi3", "none"]:
+            for arch in ["emscripten_wasm32", "linux_x86_64", "any"]:
+                strings.append(f"wrapt-1.13.3-{interp}-{abi}-{arch}.whl")
+
     paths = [Path(x) for x in strings]
-    assert [x.name for x in find_matching_wheels(paths)] == [
-        "wrapt-1.13.3-cp39-cp39-emscripten_wasm32.whl",
-        "wrapt-1.13.3-cp38-abi3-emscripten_wasm32.whl",
-        "bcrypt-3.2.0-cp36-abi3-emscripten_wasm32.whl",
-        "threadpoolctl-3.1.0-py3-none-any.whl",
-        "parso-0.8.3-py2.py3-none-any.whl",
+    assert [x.stem.split("-", 2)[-1] for x in find_matching_wheels(paths)] == [
+        "cp39-cp39-emscripten_wasm32",
+        "cp39-abi3-emscripten_wasm32",
+        "cp39-none-emscripten_wasm32",
+        "cp38-abi3-emscripten_wasm32",
+        "py3-none-emscripten_wasm32",
+        "py2.py3-none-emscripten_wasm32",
+        "py3-none-any",
+        "py2.py3-none-any",
     ]

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -4,6 +4,7 @@ from pyodide_build.common import (
     CORE_SCIPY_PACKAGES,
     UNVENDORED_STDLIB_MODULES,
     _parse_package_subset,
+    find_matching_wheels,
     get_make_environment_vars,
     get_make_flag,
 )
@@ -77,3 +78,34 @@ def test_get_make_environment_vars():
     assert "SIDE_MODULE_CFLAGS" in vars
     assert "SIDE_MODULE_CXXFLAGS" in vars
     assert "TOOLSDIR" in vars
+
+
+def test_wheel_paths():
+    from pathlib import Path
+
+    old_version = "cp38"
+    current_version = "cp39"
+    strings = [
+        "threadpoolctl-3.1.0-py3-none-any.whl",
+        "parso-0.8.3-py2.py3-none-any.whl",
+        "distlib-0.3.4-py2-none-any.whl",
+        "bcrypt-3.2.0-cp36-abi3-manylinux2010_x86_64.whl",
+        "bcrypt-3.2.0-cp36-abi3-emscripten_wasm32.whl",
+    ]
+
+    for arch in ["emscripten_wasm32", "linux_x86_64", "none"]:
+        strings.extend(
+            [
+                f"wrapt-1.13.3-{old_version}-{old_version}-{arch}.whl",
+                f"wrapt-1.13.3-{old_version}-abi3-{arch}.whl",
+                f"wrapt-1.13.3-{current_version}-{current_version}-{arch}.whl",
+            ]
+        )
+    paths = [Path(x) for x in strings]
+    assert [x.name for x in find_matching_wheels(paths)] == [
+        "wrapt-1.13.3-cp39-cp39-emscripten_wasm32.whl",
+        "wrapt-1.13.3-cp38-abi3-emscripten_wasm32.whl",
+        "bcrypt-3.2.0-cp36-abi3-emscripten_wasm32.whl",
+        "threadpoolctl-3.1.0-py3-none-any.whl",
+        "parso-0.8.3-py2.py3-none-any.whl",
+    ]


### PR DESCRIPTION
### Description

This adds a `find_matching_wheels` function that correctly determines which wheels the Pyodide interpreter supports according to the platform compatibility tags spec. This should fix problems with extra host platform wheels lying around or wheels built for different versions of Python (e.g., cp39 vs cp310).

### Checklists

- [x] Add / update tests
