### PR TITLE
Remove Py2JsResult

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -63,6 +63,11 @@ substitutions:
 - {{Breaking}} Removed the `skip-host` key from the `meta.yaml` format. If
   needed, install a host copy of the package with pip instead. {pr}`2256`
 
+- {{Fix}} The type `Py2JsResult` has been replaced with `any` which is more
+  accurate. For backwards compatibility, we still export `Py2JsResult` as an
+  alias for `any`.
+  {pr}`2277`
+
 _February 19, 2022_
 
 ## Version 0.19.1

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -316,14 +316,7 @@ Module.callPyObject = function (ptrobj: number, ...jsargs: any) {
   return Module.callPyObjectKwargs(ptrobj, ...jsargs, {});
 };
 
-export type Py2JsResult =
-  | PyProxy
-  | number
-  | bigint
-  | string
-  | boolean
-  | undefined;
-export type PyProxy = PyProxyClass & { [x: string]: Py2JsResult };
+export type PyProxy = PyProxyClass & { [x: string]: any };
 
 export class PyProxyClass {
   $$: { ptr: number; cache: PyProxyCache; destroyed_msg?: string };
@@ -583,7 +576,7 @@ export class PyProxyGetItemMethods {
    * @param key The key to look up.
    * @returns The corresponding value.
    */
-  get(key: any): Py2JsResult {
+  get(key: any): any {
     let ptrobj = _getPtr(this);
     let idkey = Hiwire.new_value(key);
     let idresult;
@@ -705,7 +698,7 @@ export class PyProxyContainsMethods {
  *
  * @private
  */
-function* iter_helper(iterptr: number, token: {}): Generator<Py2JsResult> {
+function* iter_helper(iterptr: number, token: {}): Generator<any> {
   try {
     let item;
     while ((item = Module.__pyproxy_iter_next(iterptr))) {
@@ -739,7 +732,7 @@ export class PyProxyIterableMethods {
    *
    * This will be used implicitly by ``for(let x of proxy){}``.
    */
-  [Symbol.iterator](): Iterator<Py2JsResult, Py2JsResult, Py2JsResult> {
+  [Symbol.iterator](): Iterator<any, any, any> {
     let ptrobj = _getPtr(this);
     let token = {};
     let iterptr;
@@ -785,7 +778,7 @@ export class PyProxyIteratorMethods {
    * some_value}``. When the generator raises a ``StopIteration(result_value)``
    * exception, ``next`` returns ``{done : true, value : result_value}``.
    */
-  next(arg: any = undefined): IteratorResult<Py2JsResult, Py2JsResult> {
+  next(arg: any = undefined): IteratorResult<any, any> {
     let idresult;
     // Note: arg is optional, if arg is not supplied, it will be undefined
     // which gets converted to "Py_None". This is as intended.
@@ -982,7 +975,7 @@ let PyProxyHandlers = {
   },
 };
 
-export type PyProxyAwaitable = PyProxy & Promise<Py2JsResult>;
+export type PyProxyAwaitable = PyProxy & Promise<any>;
 
 /**
  * The Promise / JavaScript awaitable API.
@@ -1101,7 +1094,7 @@ export class PyProxyAwaitableMethods {
 
 export type PyProxyCallable = PyProxy &
   PyProxyCallableMethods &
-  ((...args: any[]) => Py2JsResult);
+  ((...args: any[]) => any);
 
 export class PyProxyCallableMethods {
   apply(jsthis: PyProxyClass, jsargs: any) {

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -1,11 +1,6 @@
 import { Module, API, Hiwire } from "./module";
 import { loadPackage, loadedPackages } from "./load-package";
-import {
-  isPyProxy,
-  PyBuffer,
-  PyProxy,
-  TypedArray,
-} from "./pyproxy.gen";
+import { isPyProxy, PyBuffer, PyProxy, TypedArray } from "./pyproxy.gen";
 import { PythonError } from "./error_handling.gen";
 export { loadPackage, loadedPackages, isPyProxy };
 
@@ -49,10 +44,7 @@ export let version: string = ""; // actually defined in loadPyodide (see pyodide
  * @returns The result of the Python code translated to JavaScript. See the
  *          documentation for :any:`pyodide.eval_code` for more info.
  */
-export function runPython(
-  code: string,
-  globals: PyProxy = API.globals
-): any {
+export function runPython(code: string, globals: PyProxy = API.globals): any {
   return API.pyodide_py.eval_code(code, globals);
 }
 API.runPython = runPython;

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -4,7 +4,6 @@ import {
   isPyProxy,
   PyBuffer,
   PyProxy,
-  Py2JsResult,
   TypedArray,
 } from "./pyproxy.gen";
 import { PythonError } from "./error_handling.gen";
@@ -53,7 +52,7 @@ export let version: string = ""; // actually defined in loadPyodide (see pyodide
 export function runPython(
   code: string,
   globals: PyProxy = API.globals
-): Py2JsResult {
+): any {
   return API.pyodide_py.eval_code(code, globals);
 }
 API.runPython = runPython;
@@ -141,7 +140,7 @@ export async function loadPackagesFromImports(
 export async function runPythonAsync(
   code: string,
   globals: PyProxy = API.globals
-): Promise<Py2JsResult> {
+): Promise<any> {
   return await API.pyodide_py.eval_code_async(code, globals);
 }
 API.runPythonAsync = runPythonAsync;
@@ -217,7 +216,7 @@ export function toPy(
       cacheConversion: (input: any, output: any) => any
     ) => any;
   } = { depth: -1 }
-): Py2JsResult {
+): any {
   // No point in converting these, it'd be dumb to proxy them so they'd just
   // get converted back by `js2python` at the end
   switch (typeof obj) {

--- a/src/js/index.test-d.ts
+++ b/src/js/index.test-d.ts
@@ -38,7 +38,7 @@ async function main() {
   if (pyodide.isPyProxy(x)) {
     expectType<PyProxy>(x);
   } else {
-    expectType<number | string | boolean | bigint | undefined>(x);
+    expectType<any>(x);
   }
 
   let px: PyProxy = <PyProxy>{};

--- a/src/js/index.test-d.ts
+++ b/src/js/index.test-d.ts
@@ -1,7 +1,6 @@
 import { expectType, expectAssignable } from "tsd";
 import {
   loadPyodide,
-  Py2JsResult,
   PyProxy,
   PyProxyWithLength,
   PyProxyWithGet,
@@ -34,7 +33,7 @@ async function main() {
 
   expectType<PyProxy>(pyodide.globals);
 
-  let x: Py2JsResult;
+  let x: any;
   expectType<boolean>(pyodide.isPyProxy(x));
   if (pyodide.isPyProxy(x)) {
     expectType<PyProxy>(x);
@@ -44,8 +43,8 @@ async function main() {
 
   let px: PyProxy = <PyProxy>{};
 
-  expectType<Py2JsResult>(pyodide.runPython("1+1"));
-  expectType<Py2JsResult>(pyodide.runPython("1+1", px));
+  expectType<any>(pyodide.runPython("1+1"));
+  expectType<any>(pyodide.runPython("1+1", px));
 
   expectType<Promise<void>>(pyodide.loadPackagesFromImports("import some_pkg"));
   expectType<Promise<void>>(
@@ -80,10 +79,10 @@ async function main() {
   expectType<void>(pyodide.unregisterJsModule("blah"));
 
   pyodide.setInterruptBuffer(new Int32Array(1));
-  expectType<Py2JsResult>(pyodide.toPy({}));
+  expectType<any>(pyodide.toPy({}));
   expectType<string>(pyodide.version);
 
-  expectType<Py2JsResult>(px.x);
+  expectType<any>(px.x);
   expectType<PyProxy>(px.copy());
   expectType<void>(px.destroy("blah"));
   expectType<void>(px.destroy());
@@ -98,7 +97,7 @@ async function main() {
 
   if (px.supportsGet()) {
     expectType<PyProxyWithGet>(px);
-    expectType<(x: any) => Py2JsResult>(px.get);
+    expectType<(x: any) => any>(px.get);
   }
 
   if (px.supportsHas()) {
@@ -118,7 +117,7 @@ async function main() {
 
   if (px.isAwaitable()) {
     expectType<PyProxyAwaitable>(px);
-    expectType<Py2JsResult>(await px);
+    expectType<any>(await px);
   }
 
   if (px.isBuffer()) {
@@ -141,22 +140,22 @@ async function main() {
 
   if (px.isCallable()) {
     expectType<PyProxyCallable>(px);
-    expectType<Py2JsResult>(px(1, 2, 3));
-    expectAssignable<(...args: any[]) => Py2JsResult>(px);
+    expectType<any>(px(1, 2, 3));
+    expectAssignable<(...args: any[]) => any>(px);
   }
 
   if (px.isIterable()) {
     expectType<PyProxyIterable>(px);
     for (let x of px) {
-      expectType<Py2JsResult>(x);
+      expectType<any>(x);
     }
     let it = px[Symbol.iterator]();
-    expectAssignable<{ done?: Py2JsResult; value: Py2JsResult }>(it.next());
+    expectAssignable<{ done?: any; value: any }>(it.next());
   }
 
   if (px.isIterator()) {
     expectType<PyProxyIterator>(px);
-    expectAssignable<{ done?: Py2JsResult; value: Py2JsResult }>(px.next());
-    expectAssignable<{ done?: Py2JsResult; value: Py2JsResult }>(px.next(22));
+    expectAssignable<{ done?: any; value: any }>(px.next());
+    expectAssignable<{ done?: any; value: any }>(px.next(22));
   }
 }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -7,7 +7,7 @@ import { initializePackageIndex, loadPackage } from "./load-package.js";
 import { makePublicAPI, PyodideInterface } from "./api.js";
 import "./error_handling.gen.js";
 
-import { PyProxy, PyProxyDict, Py2JsResult } from "./pyproxy.gen";
+import { PyProxy, PyProxyDict } from "./pyproxy.gen";
 
 export {
   PyProxy,
@@ -21,10 +21,11 @@ export {
   PyProxyAwaitable,
   PyProxyBuffer,
   PyProxyCallable,
-  Py2JsResult,
   TypedArray,
   PyBuffer,
 } from "./pyproxy.gen";
+
+export type Py2JsResult = any;
 
 let runPythonInternal_dict: PyProxy; // Initialized in finalizeBootstrap
 /**
@@ -32,7 +33,7 @@ let runPythonInternal_dict: PyProxy; // Initialized in finalizeBootstrap
  * `eval_code` from `_pyodide` so that it can work before `pyodide` is imported.
  * @private
  */
-API.runPythonInternal = function (code: string): Py2JsResult {
+API.runPythonInternal = function (code: string): any {
   return API._pyodide._base.eval_code(code, runPythonInternal_dict);
 };
 


### PR DESCRIPTION
The Py2JsResult type is incorrect, it should actually be `any`. Strictly
speaking, `any` except it won't be `null`. But I am not sure
that "anything except for null" provides extra value of "any" .

For backwards compatibility, we still `export type Py2JsResult = any;`