### PR TITLE
Move making archive of shared libraries to buildpkg

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -8,11 +8,10 @@ endif
 
 
 all: .artifacts/bin/pyodide-build
-	mkdir -p build-logs
 	PYTHONPATH="$(PYODIDE_ROOT)/pyodide-build/"\
 		python -m pyodide_build buildall . ../build \
 		$(ONLY_PACKAGES) --n-jobs $${PYODIDE_JOBS:-4} \
-		--log-dir=build-logs
+		--log-dir=./build-logs
 
 .artifacts/bin/pyodide-build: ../pyodide-build/pyodide_build/**
 	mkdir -p $(HOSTINSTALLDIR)

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -169,6 +169,7 @@ class Package(BasePackage):
         if rebuilt:
             shutil.move(self.pkgdir / "build.log.tmp", self.pkgdir / "build.log")
             if log_dir and (self.pkgdir / "build.log").exists():
+                log_dir.mkdir(exist_ok=True, parents=True)
                 shutil.copy(
                     self.pkgdir / "build.log",
                     log_dir / f"{self.name}.log",

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from queue import PriorityQueue, Queue
 from threading import Lock, Thread
 from time import perf_counter, sleep
-from typing import Any, ClassVar, Optional
+from typing import Any, Optional
 
 from . import common
 from .buildpkg import needs_rebuild
@@ -79,9 +79,6 @@ class StdLibPackage(BasePackage):
 
 @total_ordering
 class Package(BasePackage):
-    # If the CWD matters, hold this lock
-    cwd_lock: ClassVar[Lock] = Lock()
-
     def __init__(self, pkgdir: Path):
         self.pkgdir = pkgdir
 
@@ -123,8 +120,6 @@ class Package(BasePackage):
         return None
 
     def build(self, outputdir: Path, args) -> None:
-        with self.__class__.cwd_lock:
-            log_dir = Path(args.log_dir).resolve() if args.log_dir else None
 
         with open(self.pkgdir / "build.log.tmp", "w") as f:
             p = subprocess.run(
@@ -168,6 +163,8 @@ class Package(BasePackage):
 
         if rebuilt:
             shutil.move(self.pkgdir / "build.log.tmp", self.pkgdir / "build.log")
+            log_dir = Path(args.log_dir).resolve() if args.log_dir else None
+
             if log_dir and (self.pkgdir / "build.log").exists():
                 log_dir.mkdir(exist_ok=True, parents=True)
                 shutil.copy(
@@ -189,13 +186,11 @@ class Package(BasePackage):
         if self.library:
             return
         if self.shared_library:
-            with self.__class__.cwd_lock:
-                file_path = shutil.make_archive(
-                    f"{self.name}-{self.version}", "zip", self.pkgdir / "dist"
-                )
-                shutil.copy(file_path, outputdir)
-                Path(file_path).unlink()
+            file_path = Path(self.pkgdir / f"{self.name}-{self.version}.zip")
+            shutil.copy(file_path, outputdir)
+            file_path.unlink()
             return
+
         shutil.copy(self.wheel_path(), outputdir)
         test_path = self.tests_path()
         if test_path:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -706,6 +706,9 @@ def build_package(
         shutil.rmtree(pkg_root / "dist", ignore_errors=True)
         shutil.copytree(srcpath / "dist", pkg_root / "dist")
 
+        if build_metadata.get("sharedlibrary"):
+            shutil.make_archive(f"{name}-{version}", "zip", pkg_root / "dist")
+
         create_packaged_token(build_dir)
 
 


### PR DESCRIPTION
### Description

Moves the logic of generating zip archive of a shared library from `buildall` to `buildpkg` so that thread-unsafe `shutil.make_archive` won't bother us anymore.
