### PR TITLE
Dockerfile update for Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:14.16.1-buster-slim AS node-image
-FROM python:3.9.5-slim-buster
+FROM python:3.10.2-slim-buster
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -8,7 +8,7 @@ RUN apt-get update \
         patch pkg-config swig unzip wget xz-utils \
         autoconf autotools-dev automake texinfo dejagnu \
         build-essential prelink autoconf libtool libltdl-dev \
-        gnupg2 libdbus-glib-1-2
+        gnupg2 libdbus-glib-1-2 sudo
 
 ADD docs/requirements-doc.txt requirements.txt /
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
   packaging
   pyyaml
   ruamel.yaml
+  build==0.7.0
   # lint
   pre-commit
   # testing


### PR DESCRIPTION
I also added `sudo` and the Python `build` package. The `build` package is in preparation for #2272. The point of adding `sudo` is that it is annoying not to have any way to install more packages. In the future, we can update `run_docker` to add the current user to sudoers (I think I have this on a local branch somewhere) and that will make experimenting with the docker image easier.