### PR TITLE
ENH Calculate indexURL from error stack trace

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -155,7 +155,7 @@ class SeleniumWrapper:
     def load_pyodide(self):
         self.run_js(
             """
-            let pyodide = await loadPyodide({ indexURL : './', fullStdLib: false, jsglobals : self });
+            let pyodide = await loadPyodide({ fullStdLib: false, jsglobals : self });
             self.pyodide = pyodide;
             globalThis.pyodide = pyodide;
             pyodide._api.inTestHoist = true; // improve some error messages for tests

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -71,6 +71,10 @@ substitutions:
   alias for `any`.
   {pr}`2277`
 
+- {{Enhancement}} It is no longer necessary to provide `indexURL` to
+  `loadPyodide`.
+  {pr}`2292`
+
 _February 19, 2022_
 
 ## Version 0.19.1

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -268,7 +268,7 @@ you say
 
 ```
 loadPyodide({
-  ..., stdin: stdin_func, stdout: stdout_func, stderr: stderr_func
+  stdin: stdin_func, stdout: stdout_func, stderr: stderr_func
 });
 ```
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -17,9 +17,7 @@ Pyodide with {any}`loadPyodide <globalThis.loadPyodide>` specifying an index URL
   <body>
     <script type="text/javascript">
       async function main(){
-        let pyodide = await loadPyodide({
-          indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/"
-        });
+        let pyodide = await loadPyodide();
         console.log(pyodide.runPython("1 + 2"));
       }
       main();
@@ -100,9 +98,7 @@ Then you can load Pyodide in Node.js as follows,
 ```js
 let pyodide_pkg = await import("pyodide/pyodide.js");
 
-let pyodide = await pyodide_pkg.loadPyodide({
-  indexURL: "<pyodide artifacts folder>",
-});
+let pyodide = await pyodide_pkg.loadPyodide();
 
 await pyodide.runPythonAsync("1+1");
 ```

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -59,7 +59,7 @@ packages are finished loading:
 ```javascript
 let pyodide;
 async function main() {
-  pyodide = await loadPyodide({ indexURL: "<some-url>" });
+  pyodide = await loadPyodide();
   await pyodide.loadPackage("matplotlib");
   // matplotlib is now available
 }
@@ -138,9 +138,7 @@ installs from PyPI.
     ></script>
     <script type="text/javascript">
       async function main() {
-        let pyodide = await loadPyodide({
-          indexURL: "https://cdn.jsdelivr.net/pyodide/dev/full/",
-        });
+        let pyodide = await loadPyodide();
         await pyodide.loadPackage("micropip");
         await pyodide.runPythonAsync(`
         import micropip

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -24,7 +24,7 @@ and returns {js:mod}`the Pyodide top level namespace <pyodide>`.
 
 ```pyodide
 async function main() {
-  let pyodide = await loadPyodide({ indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/" });
+  let pyodide = await loadPyodide();
   // Pyodide is now ready to use...
   console.log(pyodide.runPython(`
     import sys
@@ -67,9 +67,7 @@ Create and save a test `index.html` page with the following contents:
     Open your browser console to see Pyodide output
     <script type="text/javascript">
       async function main(){
-        let pyodide = await loadPyodide({
-          indexURL : "https://cdn.jsdelivr.net/pyodide/dev/full/"
-        });
+        let pyodide = await loadPyodide();
         console.log(pyodide.runPython(`
             import sys
             sys.version
@@ -114,9 +112,7 @@ Create and save a test `index.html` page with the following contents:
       output.value = "Initializing...\n";
       // init Pyodide
       async function main() {
-        let pyodide = await loadPyodide({
-          indexURL: "https://cdn.jsdelivr.net/pyodide/dev/full/",
-        });
+        let pyodide = await loadPyodide();
         output.value += "Ready!\n";
         return pyodide;
       }

--- a/docs/usage/wasm-constraints.md
+++ b/docs/usage/wasm-constraints.md
@@ -11,7 +11,7 @@ or via [patches](https://github.com/pyodide/pyodide/tree/main/cpython/patches).
 ### Optional modules
 
 The following stdlib modules are included by default, however
-they can be excluded with `loadPyodide({..., fullStdLib = false })`.
+they can be excluded with `loadPyodide({ fullStdLib : false })`.
 Individual modules can then be loaded as necessary using
 {any}`pyodide.loadPackage`,
 

--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -108,9 +108,7 @@ shown below:
 importScripts("https://cdn.jsdelivr.net/pyodide/dev/full/pyodide.js");
 
 async function loadPyodideAndPackages() {
-  self.pyodide = await loadPyodide({
-    indexURL: "https://cdn.jsdelivr.net/pyodide/dev/full/",
-  });
+  self.pyodide = await loadPyodide();
   await self.pyodide.loadPackage(["numpy", "pytz"]);
 }
 let pyodideReadyPromise = loadPyodideAndPackages();

--- a/src/js/index.test-d.ts
+++ b/src/js/index.test-d.ts
@@ -16,10 +16,9 @@ import {
 } from "./pyodide";
 
 async function main() {
-  let pyodide = await loadPyodide({ indexURL: "blah" });
-  expectType<Promise<typeof pyodide>>(
-    loadPyodide({ indexURL: "blah", fullStdLib: true })
-  );
+  let pyodide = await loadPyodide();
+  expectType<Promise<typeof pyodide>>(loadPyodide({ indexURL: "blah" }));
+  expectType<Promise<typeof pyodide>>(loadPyodide({ fullStdLib: true }));
 
   expectType<Promise<typeof pyodide>>(
     loadPyodide({

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -209,7 +209,11 @@ type ConfigType = {
 export async function loadPyodide(
   options: {
     /**
-     * The URL from which Pyodide will load packages
+     * The URL from which Pyodide will load the main Pyodide runtime and
+     * packages. Defaults to the url that pyodide is loaded from with the file
+     * name (pyodide.js or pyodide.mjs) removed. It is recommended that you
+     * leave this undefined, providing an incorrect value can cause broken
+     * behavior.
      */
     indexURL?: string;
 

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -151,6 +151,35 @@ function finalizeBootstrap(config: ConfigType) {
 declare function _createPyodideModule(Module: any): Promise<void>;
 
 /**
+ *  If indexURL isn't provided, throw an error and catch it and then parse our
+ *  file name out from the stack trace.
+ *
+ *  Question: But getting the URL from error stack trace is well... really
+ *  hacky. Can't we use
+ *  [`document.currentScript`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
+ *  or
+ *  [`import.meta.url`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta)
+ *  instead?
+ *
+ *  Answer: `document.currentScript` works for the browser main thread.
+ *  `import.meta` works for es6 modules. In a classic webworker, I think there
+ *  is no approach that works. Also we would need some third approach for node
+ *  when loading a commonjs module using `require`. On the other hand, this
+ *  stack trace approach works for every case without any feature detection
+ *  code.
+ */
+function calculateIndexURL(): string {
+  let err;
+  try {
+    throw new Error();
+  } catch (e) {
+    err = e;
+  }
+  const fileName = ErrorStackParser.parse(err)[0].fileName!;
+  return fileName.slice(0, fileName.lastIndexOf("/"));
+}
+
+/**
  * See documentation for loadPyodide.
  * @private
  */
@@ -177,50 +206,45 @@ type ConfigType = {
  * @memberof globalThis
  * @async
  */
-export async function loadPyodide(options: {
-  /**
-   * The URL from which Pyodide will load packages
-   */
-  indexURL?: string;
+export async function loadPyodide(
+  options: {
+    /**
+     * The URL from which Pyodide will load packages
+     */
+    indexURL?: string;
 
-  /**
-   * The home directory which Pyodide will use inside virtual file system. Default: "/home/pyodide"
-   */
-  homedir?: string;
+    /**
+     * The home directory which Pyodide will use inside virtual file system. Default: "/home/pyodide"
+     */
+    homedir?: string;
 
-  /** Load the full Python standard library.
-   * Setting this to false excludes following modules: distutils.
-   * Default: true
-   */
-  fullStdLib?: boolean;
-  /**
-   * Override the standard input callback. Should ask the user for one line of input.
-   */
-  stdin?: () => string;
-  /**
-   * Override the standard output callback.
-   * Default: undefined
-   */
-  stdout?: (msg: string) => void;
-  /**
-   * Override the standard error output callback.
-   * Default: undefined
-   */
-  stderr?: (msg: string) => void;
-  jsglobals?: object;
-}): Promise<PyodideInterface> {
+    /** Load the full Python standard library.
+     * Setting this to false excludes following modules: distutils.
+     * Default: true
+     */
+    fullStdLib?: boolean;
+    /**
+     * Override the standard input callback. Should ask the user for one line of input.
+     */
+    stdin?: () => string;
+    /**
+     * Override the standard output callback.
+     * Default: undefined
+     */
+    stdout?: (msg: string) => void;
+    /**
+     * Override the standard error output callback.
+     * Default: undefined
+     */
+    stderr?: (msg: string) => void;
+    jsglobals?: object;
+  } = {}
+): Promise<PyodideInterface> {
   if ((loadPyodide as any).inProgress) {
     throw new Error("Pyodide is already loading.");
   }
   if (!options.indexURL) {
-    let err;
-    try {
-      throw new Error();
-    } catch (e) {
-      err = e;
-    }
-    const fileName = ErrorStackParser.parse(err)[0].fileName!;
-    options.indexURL = fileName.slice(0, fileName.lastIndexOf("/"));
+    options.indexURL = calculateIndexURL();
   }
   (loadPyodide as any).inProgress = true;
 

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -155,7 +155,7 @@ declare function _createPyodideModule(Module: any): Promise<void>;
  * @private
  */
 type ConfigType = {
-  indexURL: string;
+  indexURL?: string;
   homedir?: string;
   fullStdLib?: boolean;
   stdin?: () => string;
@@ -269,6 +269,7 @@ export async function loadPyodide(config: {
   unpackPyodidePy(pyodide_py_tar);
   Module._pyodide_init();
 
+  config.indexURL!;
   let pyodide = finalizeBootstrap(config);
   // Module.runPython works starting here.
 

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -1,6 +1,7 @@
 /**
  * The main bootstrap code for loading pyodide.
  */
+import ErrorStackParser from "error-stack-parser";
 import { Module, setStandardStreams, setHomeDirectory, API } from "./module.js";
 import { loadScript, _loadBinaryFile, initNodeModules } from "./compat.js";
 import { initializePackageIndex, loadPackage } from "./load-package.js";
@@ -180,7 +181,7 @@ export async function loadPyodide(config: {
   /**
    * The URL from which Pyodide will load packages
    */
-  indexURL: string;
+  indexURL?: string;
 
   /**
    * The home directory which Pyodide will use inside virtual file system. Default: "/home/pyodide"
@@ -212,7 +213,14 @@ export async function loadPyodide(config: {
     throw new Error("Pyodide is already loading.");
   }
   if (!config.indexURL) {
-    throw new Error("Please provide indexURL parameter to loadPyodide");
+    let err;
+    try {
+      throw new Error();
+    } catch (e) {
+      err = e;
+    }
+    const fileName = ErrorStackParser.parse(err)[0].fileName;
+    config.indexURL = fileName.slice(0, fileName.lastIndexOf("/"));
   }
   (loadPyodide as any).inProgress = true;
 

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -155,8 +155,8 @@ declare function _createPyodideModule(Module: any): Promise<void>;
  * @private
  */
 type ConfigType = {
-  indexURL?: string;
-  homedir?: string;
+  indexURL: string;
+  homedir: string;
   fullStdLib?: boolean;
   stdin?: () => string;
   stdout?: (msg: string) => void;
@@ -177,7 +177,7 @@ type ConfigType = {
  * @memberof globalThis
  * @async
  */
-export async function loadPyodide(config: {
+export async function loadPyodide(options: {
   /**
    * The URL from which Pyodide will load packages
    */
@@ -212,15 +212,15 @@ export async function loadPyodide(config: {
   if ((loadPyodide as any).inProgress) {
     throw new Error("Pyodide is already loading.");
   }
-  if (!config.indexURL) {
+  if (!options.indexURL) {
     let err;
     try {
       throw new Error();
     } catch (e) {
       err = e;
     }
-    const fileName = ErrorStackParser.parse(err)[0].fileName;
-    config.indexURL = fileName.slice(0, fileName.lastIndexOf("/"));
+    const fileName = ErrorStackParser.parse(err)[0].fileName!;
+    options.indexURL = fileName.slice(0, fileName.lastIndexOf("/"));
   }
   (loadPyodide as any).inProgress = true;
 
@@ -230,7 +230,7 @@ export async function loadPyodide(config: {
     stdin: globalThis.prompt ? globalThis.prompt : undefined,
     homedir: "/home/pyodide",
   };
-  config = Object.assign(default_config, config);
+  let config = Object.assign(default_config, options) as ConfigType;
   if (!config.indexURL.endsWith("/")) {
     config.indexURL += "/";
   }
@@ -242,7 +242,7 @@ export async function loadPyodide(config: {
   );
 
   setStandardStreams(config.stdin, config.stdout, config.stderr);
-  setHomeDirectory(config.homedir!);
+  setHomeDirectory(config.homedir);
 
   let moduleLoaded = new Promise((r) => (Module.postRun = r));
 
@@ -269,7 +269,6 @@ export async function loadPyodide(config: {
   unpackPyodidePy(pyodide_py_tar);
   Module._pyodide_init();
 
-  config.indexURL!;
   let pyodide = finalizeBootstrap(config);
   // Module.runPython works starting here.
 

--- a/src/js/test/conftest.js
+++ b/src/js/test/conftest.js
@@ -3,5 +3,5 @@ import path from "path";
 globalThis.path = path;
 
 before(async () => {
-  globalThis.pyodide = await loadPyodide({ indexURL: "../../build/" });
+  globalThis.pyodide = await loadPyodide();
 });

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -24,9 +24,7 @@
       }
 
       async function main() {
-        globalThis.pyodide = await loadPyodide({
-          indexURL: "{{ PYODIDE_BASE_URL }}",
-        });
+        globalThis.pyodide = await loadPyodide({});
         let namespace = pyodide.globals.get("dict")();
         pyodide.runPython(
           `

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -24,7 +24,7 @@
       }
 
       async function main() {
-        globalThis.pyodide = await loadPyodide({});
+        globalThis.pyodide = await loadPyodide();
         let namespace = pyodide.globals.get("dict")();
         pyodide.runPython(
           `

--- a/src/templates/module_webworker.js
+++ b/src/templates/module_webworker.js
@@ -12,7 +12,7 @@ onmessage = async function (e) {
     }
 
     if (!loadPyodide.inProgress) {
-      self.pyodide = await loadPyodide({ indexURL: "{{ PYODIDE_BASE_URL }}" });
+      self.pyodide = await loadPyodide({});
     }
     await self.pyodide.loadPackagesFromImports(data.python);
     let results = await self.pyodide.runPythonAsync(data.python);

--- a/src/templates/module_webworker.js
+++ b/src/templates/module_webworker.js
@@ -12,7 +12,7 @@ onmessage = async function (e) {
     }
 
     if (!loadPyodide.inProgress) {
-      self.pyodide = await loadPyodide({});
+      self.pyodide = await loadPyodide();
     }
     await self.pyodide.loadPackagesFromImports(data.python);
     let results = await self.pyodide.runPythonAsync(data.python);

--- a/src/templates/webworker.js
+++ b/src/templates/webworker.js
@@ -12,7 +12,7 @@ onmessage = async function (e) {
     }
 
     if (!loadPyodide.inProgress) {
-      self.pyodide = await loadPyodide({ indexURL: "{{ PYODIDE_BASE_URL }}" });
+      self.pyodide = await loadPyodide({});
     }
     await self.pyodide.loadPackagesFromImports(data.python);
     let results = await self.pyodide.runPythonAsync(data.python);

--- a/src/templates/webworker.js
+++ b/src/templates/webworker.js
@@ -12,7 +12,7 @@ onmessage = async function (e) {
     }
 
     if (!loadPyodide.inProgress) {
-      self.pyodide = await loadPyodide({});
+      self.pyodide = await loadPyodide();
     }
     await self.pyodide.loadPackagesFromImports(data.python);
     let results = await self.pyodide.runPythonAsync(data.python);


### PR DESCRIPTION
If no indexURL is provided, we throw and catch an error and
then use ErrorStackParser to calculate where pyodide.js has
been loaded from. Resolves #2290.