### PR TITLE
MAINT Use tee to pipe stdout to build.log from buildpkg

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -693,7 +693,7 @@ def build_package(
         if not continue_:
             prepare_source(pkg_root, build_dir, srcpath, source_metadata)
 
-            run_script(build_dir, srcpath, build_metadata, bash_runner)
+        run_script(build_dir, srcpath, build_metadata, bash_runner)
 
         if build_metadata.get("library"):
             create_packaged_token(build_dir)


### PR DESCRIPTION
This makes it so that buildpkg generates build.log on its own
even when it isn't run from buildall. This is helpful because
when working on a specific package it is nicer to run buildpkg
directly so you can see the build on the console. However, it
is frustrating when you want to grep the build log for instance
that there isn't a build log.

This tees stdout into a build log from insidde buildpkg. It also
fixes the issue with overwriting build.log when nothing needs to
be done (though that issue I think was also fixed in December by
calling needs_build from buildall). Now buildall can just redirect
the subprocess output to /dev/null.