### PR TITLE
Add handling and tests for weird Javascript errors

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -71,6 +71,12 @@ substitutions:
   alias for `any`.
   {pr}`2277`
 
+- {{ Enhancement }} Added robust handling for non-`Error` objects thrown by
+  Javascript code. This mostly should never happen since well behaved Javascript
+  code ought to throw errors. But it's better not to completely crash if it
+  throws something else.
+  {pr}`2294`
+
 _February 19, 2022_
 
 ## Version 0.19.1

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -239,6 +239,9 @@ trigger_fatal_error(PyObject* mod, PyObject* _args)
   Py_UNREACHABLE();
 }
 
+/**
+ * This is for testing fatal errors in test_pyodide
+ */
 PyObject*
 raw_call(PyObject* mod, PyObject* jsproxy)
 {

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -239,12 +239,21 @@ trigger_fatal_error(PyObject* mod, PyObject* _args)
   Py_UNREACHABLE();
 }
 
+PyObject*
+raw_call(PyObject* mod, PyObject* jsproxy)
+{
+  JsRef func = JsProxy_AsJs(jsproxy);
+  EM_ASM(Hiwire.get_value($0)(), func);
+  Py_RETURN_NONE;
+}
+
 static PyMethodDef methods[] = {
   {
     "trigger_fatal_error",
     trigger_fatal_error,
     METH_NOARGS,
   },
+  { "raw_call", raw_call, METH_O },
   { NULL } /* Sentinel */
 };
 

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -235,7 +235,7 @@ Module.handle_js_error = function (e: any) {
     // Try to restore the original Python exception.
     restored_error = Module._restore_sys_last_exception(e.__error_address);
   }
-  let stack;
+  let stack: any;
   let weirdCatch;
   try {
     stack = ErrorStackParser.parse(e);

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -11,6 +11,38 @@ API.dump_traceback = function () {
   Module.__Py_DumpTraceback(fd_stdout, Module._PyGILState_GetThisThreadState());
 };
 
+function ensureCaughtObjectIsError(e: any) {
+  if (typeof e === "string") {
+    // Sometimes emscripten throws a raw string...
+    e = new Error(e);
+  } else if (
+    typeof e !== "object" ||
+    e === null ||
+    typeof e.stack !== "string" ||
+    typeof e.message !== "string"
+  ) {
+    // We caught something really weird. Be brave!
+    let msg = `A value of type ${typeof e} with tag ${Object.prototype.toString.call(
+      e
+    )} was thrown as an error!`;
+    try {
+      msg += `\nString interpolation of the thrown value gives """${e}""".`;
+    } catch (e) {
+      msg += `\nString interpolation of the thrown value fails.`;
+    }
+    try {
+      msg += `\nThe thrown value's toString method returns """${e.toString()}""".`;
+    } catch (e) {
+      msg += `\nThe thrown value's toString method fails.`;
+    }
+    e = new Error(msg);
+  }
+  // Post conditions:
+  // 1. typeof e is object
+  // 2. hiwire_is_error(e) returns true
+  return e;
+}
+
 let fatal_error_occurred = false;
 /**
  * Signal a fatal error.
@@ -25,7 +57,7 @@ let fatal_error_occurred = false;
  * @private
  */
 API.fatal_error = function (e: any) {
-  if (e.pyodide_fatal_error) {
+  if (e && e.pyodide_fatal_error) {
     return;
   }
   if (fatal_error_occurred) {
@@ -34,14 +66,10 @@ API.fatal_error = function (e: any) {
     return;
   }
   if (typeof e === "number") {
-    // A C++ exception. Have to do some conversion work.
+    // Hopefully a C++ exception? Have to do some conversion work.
     e = convertCppException(e);
-  } else if (typeof e === "string") {
-    e = new Error(e);
-  } else if (typeof e !== "object") {
-    e = new Error(
-      `An object of type ${typeof e} was thrown as an error. toString returns ${e.toString()}`
-    );
+  } else {
+    e = ensureCaughtObjectIsError(e);
   }
   // Mark e so we know not to handle it later in EM_JS wrappers
   e.pyodide_fatal_error = true;
@@ -193,7 +221,7 @@ function isErrorStart(frame: ErrorStackParser.StackFrame): boolean {
 }
 
 Module.handle_js_error = function (e: any) {
-  if (e.pyodide_fatal_error) {
+  if (e && e.pyodide_fatal_error) {
     throw e;
   }
   if (e instanceof Module._PropagatePythonError) {
@@ -207,6 +235,16 @@ Module.handle_js_error = function (e: any) {
     // Try to restore the original Python exception.
     restored_error = Module._restore_sys_last_exception(e.__error_address);
   }
+  let stack;
+  let weirdCatch;
+  try {
+    stack = ErrorStackParser.parse(e);
+  } catch (e) {
+    weirdCatch = true;
+  }
+  if (weirdCatch) {
+    e = ensureCaughtObjectIsError(e);
+  }
   if (!restored_error) {
     // Wrap the JavaScript error
     let eidx = Hiwire.new_value(e);
@@ -215,7 +253,10 @@ Module.handle_js_error = function (e: any) {
     Module._Py_DecRef(err);
     Hiwire.decref(eidx);
   }
-  let stack = ErrorStackParser.parse(e);
+  if (weirdCatch) {
+    // In this case we have no stack frames so we can quit
+    return;
+  }
   if (isErrorStart(stack[0])) {
     while (isPyodideFrame(stack[0])) {
       stack.shift();

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -239,7 +239,7 @@ Module.handle_js_error = function (e: any) {
   let weirdCatch;
   try {
     stack = ErrorStackParser.parse(e);
-  } catch (e) {
+  } catch (_) {
     weirdCatch = true;
   }
   if (weirdCatch) {

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -886,6 +886,77 @@ def test_reentrant_fatal(selenium_standalone):
     )
 
 
+def test_weird_throws(selenium):
+    """Throw strange Javascript garbage and make sure we survive."""
+    selenium.run_js(
+        '''
+        self.funcs = {
+            null(){ throw null; },
+            undefined(){ throw undefined; },
+            obj(){ throw {}; },
+            obj_null_proto(){ throw Object.create(null); },
+            string(){ throw "abc"; },
+            func(){ throw self.funcs.func; },
+            number(){ throw 12; },
+            bigint(){ throw 12n; },
+        };
+        pyodide.runPython(`
+            from js import funcs
+            from unittest import TestCase
+            from pyodide import JsException
+            raises = TestCase().assertRaisesRegex
+            msgs = {
+                "null" : ['type object .* tag .object Null.', '"""null"""',  'fails'],
+                "undefined" : ['type undefined .* tag .object Undefined.', '"""undefined"""',  'fails'],
+                "obj" : ['type object .* tag .object Object.', '""".object Object."""',  '""".object Object."""'],
+                "obj_null_proto" : ['type object .* tag .object Object.', 'fails',  'fails'],
+                "string" : ["Error: abc"],
+                "func" : ['type function .* tag .object Function.', 'throw self.funcs.func',  'throw self.funcs.func'],
+                "number" : ['type number .* tag .object Number.'],
+                "bigint" : ['type bigint .* tag .object BigInt.'],
+            }
+            for name, f in funcs.object_entries():
+                msg = '.*\\\\n.*'.join(msgs.get(name, ["xx"]))
+                with raises(JsException, msg):
+                    f()
+        `);
+        '''
+    )
+
+
+@pytest.mark.skip_refcount_check
+@pytest.mark.skip_pyproxy_check
+@pytest.mark.parametrize(
+    "to_throw", ["Object.create(null);", "'Some message'", "null", "undefined"]
+)
+def test_weird_fatals(selenium_standalone, to_throw):
+    expected_message = {
+        "Object.create(null);": "Error: A value of type object with tag [object Object] was thrown as an error!",
+        "'Some message'": "Error: Some message",
+        "null": "Error: A value of type object with tag [object Null] was thrown as an error!",
+        "undefined": "Error: A value of type undefined with tag [object Undefined] was thrown as an error!",
+    }[to_throw]
+    msg = selenium_standalone.run_js(
+        f"""
+        self.f = function(){{ throw {to_throw} }};
+        """
+        """
+        try {
+            pyodide.runPython(`
+                from _pyodide_core import raw_call
+                from js import f
+                raw_call(f)
+            `);
+        } catch(e){
+            return e.toString();
+        }
+        """
+    )
+    print("msg", msg[: len(expected_message)])
+    print("expected_message", expected_message)
+    assert msg[: len(expected_message)] == expected_message
+
+
 def test_restore_error(selenium):
     # See PR #1816.
     selenium.run_js(

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -926,15 +926,12 @@ def test_weird_throws(selenium):
 
 @pytest.mark.skip_refcount_check
 @pytest.mark.skip_pyproxy_check
-@pytest.mark.parametrize(
-    "to_throw", ["Object.create(null);", "'Some message'", "null", "undefined"]
-)
+@pytest.mark.parametrize("to_throw", ["Object.create(null);", "'Some message'", "null"])
 def test_weird_fatals(selenium_standalone, to_throw):
     expected_message = {
         "Object.create(null);": "Error: A value of type object with tag [object Object] was thrown as an error!",
         "'Some message'": "Error: Some message",
         "null": "Error: A value of type object with tag [object Null] was thrown as an error!",
-        "undefined": "Error: A value of type undefined with tag [object Undefined] was thrown as an error!",
     }[to_throw]
     msg = selenium_standalone.run_js(
         f"""


### PR DESCRIPTION
On rare occasions, a Javascript object that isn't an error gets thrown.
This PR ensures that we are handling this situation without anything going
too far astray.

This is a followup to #2236.