### PR TITLE
Set PLATFORM_TRIPLET, include platform in so names, only load compatible so files

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -1,6 +1,8 @@
 export PYVERSION ?= 3.10.2
 export PYODIDE_EMSCRIPTEN_VERSION ?= 2.0.16
 
+export PLATFORM_TRIPLET=wasm32-emscripten
+
 # BASH_ENV tells bash to run pyodide_env.sh on startup, which sets various
 # environment variables. The next line instructs make to use bash to run each
 # command.

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -10,7 +10,7 @@ INSTALL=$(ROOT)/installs/python-$(PYVERSION)
 TARBALL=$(ROOT)/downloads/Python-$(PYVERSION).tgz
 URL=https://www.python.org/ftp/python/$(PYVERSION)/Python-$(PYVERSION).tgz
 LIB=libpython$(PYMAJOR).$(PYMINOR).a
-SYSCONFIG_NAME=_sysconfigdata__emscripten_
+SYSCONFIG_NAME=_sysconfigdata__emscripten_$(PLATFORM_TRIPLET)
 
 ZLIBVERSION = 1.2.11
 ZLIBTARBALL=$(ROOT)/downloads/zlib-$(ZLIBVERSION).tar.gz
@@ -140,6 +140,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.configured $(INSTALL)/lib/lib
 		  ./configure \
 			  CFLAGS="${PYTHON_CFLAGS}" \
 			  CPPFLAGS="-I$(SQLITEBUILD) -I$(BZIP2BUILD) -I$(ZLIBBUILD)" \
+			  PLATFORM_TRIPLET="$(PLATFORM_TRIPLET)" \
 			  --without-pymalloc \
 			  --disable-shared \
 			  --disable-ipv6 \

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 import textwrap
 from contextlib import contextmanager
 from datetime import datetime
@@ -431,6 +432,18 @@ def compile(
         )
 
 
+def replace_so_abi_tags(wheel_dir: Path):
+    """Replace native abi tag with emscripten abi tag in .so file names"""
+    build_soabi = sysconfig.get_config_var("SOABI")
+    assert build_soabi
+    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    assert ext_suffix
+    build_triplet = "-".join(build_soabi.split("-")[2:])
+    host_triplet = common.get_make_flag("PLATFORM_TRIPLET")
+    for file in wheel_dir.glob(f"**/*{ext_suffix}"):
+        file.rename(file.with_name(file.name.replace(build_triplet, host_triplet)))
+
+
 def package_wheel(
     pkg_name: str,
     pkg_root: Path,
@@ -478,6 +491,10 @@ def package_wheel(
     name, ver, _ = wheel.name.split("-", 2)
     wheel_dir_name = f"{name}-{ver}"
     wheel_dir = distdir / wheel_dir_name
+
+    # update so abi tags after build is complete but before running post script
+    # to maximize sanity.
+    replace_so_abi_tags(wheel_dir)
 
     post = build_metadata.get("post")
     if post:

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -21,7 +21,6 @@ if IS_MAIN:
 
     PYWASMCROSS_ARGS["pythoninclude"] = os.environ["PYTHONINCLUDE"]
 
-import importlib.machinery
 import re
 import subprocess
 from collections import namedtuple
@@ -501,8 +500,7 @@ def handle_command(
        containing ``args.cflags``, ``args.cxxflags``, and ``args.ldflags``
     """
     # some libraries have different names on wasm e.g. png16 = png
-    library_output = get_library_output(line)
-    is_link_cmd = library_output is not None
+    is_link_cmd = get_library_output(line) is not None
 
     if line[0] == "gfortran":
         if "-dumpversion" in line:
@@ -521,17 +519,6 @@ def handle_command(
     if returncode != 0:
         sys.exit(returncode)
 
-    # Emscripten .so files shouldn't have the native platform slug
-    if library_output:
-        renamed = library_output
-        for ext in importlib.machinery.EXTENSION_SUFFIXES:
-            if ext == ".so":
-                continue
-            if renamed.endswith(ext):
-                renamed = renamed[: -len(ext)] + ".so"
-                break
-        if library_output != renamed:
-            os.rename(library_output, renamed)
     sys.exit(returncode)
 
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -1,4 +1,4 @@
-import { Module, API } from "./module.js";
+import { Module, API, Tests } from "./module.js";
 import { IN_NODE, nodeFsPromisesMod, _loadBinaryFile } from "./compat.js";
 import { PyProxy, isPyProxy } from "./pyproxy.gen";
 
@@ -247,10 +247,19 @@ async function loadDynlib(lib: string, shared: boolean) {
         nodelete: true,
       });
     }
+  } catch (e) {
+    if (e.message.includes("need to see wasm magic number")) {
+      console.warn(
+        `Failed to load dynlib ${lib}. We probably just tried to load a linux .so file or something.`
+      );
+      return;
+    }
+    throw e;
   } finally {
     releaseDynlibLock();
   }
 }
+Tests.loadDynlib = loadDynlib;
 
 const acquirePackageLock = createLock();
 

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -64,6 +64,8 @@ def unpack_buffer(filename: str, buffer: JsProxy, target: str = "site") -> JsPro
 
 def should_load_dynlib(path: str):
     suffixes = Path(path).suffixes
+    if not suffixes:
+        return False
     if suffixes[-1] != ".so":
         return False
     if len(suffixes) == 1:

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -1,6 +1,8 @@
+import re
 import shutil
 import sysconfig
 import tarfile
+from importlib.machinery import EXTENSION_SUFFIXES
 from pathlib import Path
 from site import getsitepackages
 from tempfile import NamedTemporaryFile
@@ -14,6 +16,16 @@ STD_LIB = Path(sysconfig.get_path("stdlib"))
 TARGETS = {"site": SITE_PACKAGES, "lib": STD_LIB}
 ZIP_TYPES = {".whl", ".zip"}
 TAR_TYPES = {".tar", ".gz", ".bz", ".gz", ".tgz", ".bz2", ".tbz2"}
+EXTENSION_TAGS = [suffix.removesuffix(".so") for suffix in EXTENSION_SUFFIXES]
+# See PEP 3149. I think the situation has since been updated since PEP 3149 does
+# not talk about platform triples. But I could not find any newer pep discussing
+# shared library names.
+#
+# There are other interpreters but it's better to have false negatives than
+# false positives.
+PLATFORM_TAG_REGEX = re.compile(
+    r"\.(cpython|pypy|jython)-[0-9]{2,}[a-z]*(-[a-z0-9_-]*)?"
+)
 
 
 def unpack_buffer(filename: str, buffer: JsProxy, target: str = "site") -> JsProxy:
@@ -50,6 +62,22 @@ def unpack_buffer(filename: str, buffer: JsProxy, target: str = "site") -> JsPro
         return to_js(get_dynlibs(f, target_dir))
 
 
+def should_load_dynlib(path: str):
+    suffixes = Path(path).suffixes
+    if suffixes[-1] != ".so":
+        return False
+    if len(suffixes) == 1:
+        return True
+    tag = suffixes[-2]
+    if tag in EXTENSION_TAGS:
+        return True
+    # Okay probably it's not compatible now. But it might be an unrelated .so
+    # file with a name with an extra dot: `some.name.so` vs
+    # `some.cpython-39-x86_64-linux-gnu.so` Let's make a best effort here to
+    # check.
+    return not PLATFORM_TAG_REGEX.match(tag)
+
+
 def get_dynlibs(archive: IO[bytes], target_dir: Path) -> list[str]:
     """List out the paths to .so files in a zip or tar archive.
 
@@ -80,5 +108,5 @@ def get_dynlibs(archive: IO[bytes], target_dir: Path) -> list[str]:
     return [
         str((target_dir / path).resolve())
         for path in dynlib_paths_iter
-        if path.endswith(".so")
+        if should_load_dynlib(path)
     ]

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -341,6 +341,7 @@ def test_should_load_dynlib():
         f"x.{ext_suffix}",
     ]
     should_not_load = [
+        "a",
         "a.py",
         "a.txt",
         "a/b.txt",
@@ -366,6 +367,7 @@ def test_get_dynlibs():
     from pyodide._package_loader import get_dynlibs
 
     files = [
+        "a",
         "a.so",
         "a.py",
         "a.txt",

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -307,6 +307,57 @@ def test_install_archive(selenium):
         (test_dir / "test_pkg.tar.gz").unlink(missing_ok=True)
 
 
+def test_load_bad_so_file(selenium):
+    # If we load a bad so file, we should catch the error, ignore it (and log a
+    # warning)
+    selenium.run_js(
+        """
+        pyodide.FS.writeFile("/a.so", new Uint8Array(4))
+        await pyodide._api.tests.loadDynlib("/a.so");
+        """
+    )
+    assert (
+        "Failed to load dynlib /a.so. We probably just tried to load a linux .so file or something."
+        in selenium.logs
+    )
+
+
+def test_should_load_dynlib():
+    import sysconfig
+
+    from pyodide._package_loader import should_load_dynlib
+
+    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    assert ext_suffix
+    should_load = [
+        "a.so",
+        "a/b.so",
+        "b/b.so",
+        "a/b/c/d.so",
+        "a/b/c/d.abi3.so",
+        "x.abi3.so",
+        "a.b.c.so",
+        "a-weird-name.stuff-with-dashes.so",
+        f"x.{ext_suffix}",
+    ]
+    should_not_load = [
+        "a.py",
+        "a.txt",
+        "a/b.txt",
+        "a/b.py",
+        "b/a.py",
+        "q.cpython-38-x86_64-linux-gnu.so",
+        "q.cpython-38-x86_64-linux-gnu.so",
+        "q" + ext_suffix.replace("cpython", "pypy"),
+        "q.cpython-32mu.so",
+        "x.so.1",  # Any chance we'd want these at some point?
+    ]
+    for file in should_load:
+        assert should_load_dynlib(file)
+    for file in should_not_load:
+        assert not should_load_dynlib(file)
+
+
 def test_get_dynlibs():
     import tarfile
     from tempfile import NamedTemporaryFile


### PR DESCRIPTION
For reasons that are a bit beyond me, `--host` and `PLATFORM_TRIPLET`
seem to be independent, in particular we've had an empty
`PLATFORM_TRIPLET`. This is unfortunate because `PLATFORM_TRIPLET`
is used to generate the SOABI config variable which in turn is used
to decide whether a .so file is a good match for loading. We'd like
for linux Pythons not to try to import emscripten .so files (it
raises `ImportError: some_file.so: invalid ELF header`). Similarly,
we'd like to avoid attempting to load linux .so files in wasm. These
platform tags are our friends.

Anyways, this PR sets `PLATFORM_TRIPLET` and ensures that .so files
built by pywasmcross are tagged with our SOABI tag.

I moved the .so file renaming from pywasmcross to buildpkg just
before running the post script. That is a better place to put it in
case the package wants to look at the .so file after linking it. It
might be surprised that we moved it.

I also improved the error message if we try to `loadWebAssemblyModule`
something that is actually say a Linux .so file and updated get_dynlibs
to filter out .so files that have an incompatible abi tag.