### PR TITLE
Change runPython and runPythonAsync 'globals' to be passed as a named argument

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -84,6 +84,11 @@ substitutions:
   throws something else.
   {pr}`2294`
 
+- {{ Breaking }} The `globals` argument to `runPython` and `runPythonAsync` is
+  now passed as a named argument. The old usage still works with a deprecation
+  warning.
+  {pr}`2300`
+
 _February 19, 2022_
 
 ## Version 0.19.1

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -31,6 +31,7 @@ export let globals: PyProxy; // actually defined in loadPyodide (see pyodide.js)
  */
 export let version: string = ""; // actually defined in loadPyodide (see pyodide.js)
 
+let runPythonPositionalGlobalsDeprecationWarned = false;
 /**
  * Runs a string of Python code from JavaScript.
  *
@@ -38,14 +39,30 @@ export let version: string = ""; // actually defined in loadPyodide (see pyodide
  * returned.
  *
  * @param code Python code to evaluate
- * @param globals An optional Python dictionary to use as the globals. Defaults
- *        to :any:`pyodide.globals`. Uses the Python API
+ * @param options
+ * @param options.globals An optional Python dictionary to use as the globals.
+ *        Defaults to :any:`pyodide.globals`. Uses the Python API
  *        :any:`pyodide.eval_code` to evaluate the code.
  * @returns The result of the Python code translated to JavaScript. See the
  *          documentation for :any:`pyodide.eval_code` for more info.
  */
-export function runPython(code: string, globals: PyProxy = API.globals): any {
-  return API.pyodide_py.eval_code(code, globals);
+export function runPython(
+  code: string,
+  options: { globals?: PyProxy } = {}
+): any {
+  if (API.isPyProxy(options)) {
+    options = { globals: options as PyProxy };
+    if (!runPythonPositionalGlobalsDeprecationWarned) {
+      console.warn(
+        "Passing a PyProxy as the second argument to runPython is deprecated. Use 'runPython(code, {globals : some_dict})' instead."
+      );
+      runPythonPositionalGlobalsDeprecationWarned = true;
+    }
+  }
+  if (!options.globals) {
+    options.globals = API.globals;
+  }
+  return API.pyodide_py.eval_code(code, options.globals);
 }
 API.runPython = runPython;
 
@@ -102,38 +119,48 @@ export async function loadPackagesFromImports(
  * Runs Python code using `PyCF_ALLOW_TOP_LEVEL_AWAIT
  * <https://docs.python.org/3/library/ast.html?highlight=pycf_allow_top_level_await#ast.PyCF_ALLOW_TOP_LEVEL_AWAIT>`_.
  *
- * .. admonition:: Python imports
- *    :class: warning
+ * .. admonition:: Python imports :class: warning
  *
  *    Since pyodide 0.18.0, you must call :js:func:`loadPackagesFromImports` to
- *    import any python packages referenced via `import` statements in your code.
- *    This function will no longer do it for you.
+ *    import any python packages referenced via `import` statements in your
+ *    code. This function will no longer do it for you.
  *
  * For example:
  *
  * .. code-block:: pyodide
  *
- *    let result = await pyodide.runPythonAsync(`
- *        from js import fetch
- *        response = await fetch("./packages.json")
- *        packages = await response.json()
- *        # If final statement is an expression, its value is returned to JavaScript
+ *    let result = await pyodide.runPythonAsync(` from js import fetch response
+ *        = await fetch("./packages.json") packages = await response.json() # If
+ *        final statement is an expression, its value is returned to JavaScript
  *        len(packages.packages.object_keys())
  *    `);
  *    console.log(result); // 79
  *
  * @param code Python code to evaluate
- * @param globals An optional Python dictionary to use as the globals.
- *        Defaults to :any:`pyodide.globals`. Uses the Python API
- *        :any:`pyodide.eval_code_async` to evaluate the code.
+ * @param options
+ * @param options.globals An optional Python dictionary to use as the globals.
+ * Defaults to :any:`pyodide.globals`. Uses the Python API
+ * :any:`pyodide.eval_code_async` to evaluate the code.
  * @returns The result of the Python code translated to JavaScript.
  * @async
  */
 export async function runPythonAsync(
   code: string,
-  globals: PyProxy = API.globals
+  options: { globals?: PyProxy } = {}
 ): Promise<any> {
-  return await API.pyodide_py.eval_code_async(code, globals);
+  if (API.isPyProxy(options)) {
+    options = { globals: options as PyProxy };
+    if (!runPythonPositionalGlobalsDeprecationWarned) {
+      console.warn(
+        "Passing a PyProxy as the second argument to runPython is deprecated. Use 'runPython(code, {globals : some_dict})' instead."
+      );
+      runPythonPositionalGlobalsDeprecationWarned = true;
+    }
+  }
+  if (!options.globals) {
+    options.globals = API.globals;
+  }
+  return await API.pyodide_py.eval_code_async(code, options.globals);
 }
 API.runPythonAsync = runPythonAsync;
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -166,7 +166,7 @@ export async function runPythonAsync(
     options = { globals: options as PyProxy };
     if (!runPythonPositionalGlobalsDeprecationWarned) {
       console.warn(
-        "Passing a PyProxy as the second argument to runPython is deprecated. Use 'runPython(code, {globals : some_dict})' instead."
+        "Passing a PyProxy as the second argument to runPython is deprecated. Use 'runPythonAsync(code, {globals : some_dict})' instead."
       );
       runPythonPositionalGlobalsDeprecationWarned = true;
     }

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -38,6 +38,12 @@ let runPythonPositionalGlobalsDeprecationWarned = false;
  * The last part of the string may be an expression, in which case, its value is
  * returned.
  *
+ * .. admonition:: Positional globals argument :class: warning
+ *
+ *    In Pyodide v0.19, this function took the globals parameter as a
+ *    positional argument rather than as a named argument. In v0.20 this will
+ *    still work  but it is deprecated. It will be removed in v0.21.
+ *
  * @param code Python code to evaluate
  * @param options
  * @param options.globals An optional Python dictionary to use as the globals.
@@ -119,22 +125,30 @@ export async function loadPackagesFromImports(
  * Runs Python code using `PyCF_ALLOW_TOP_LEVEL_AWAIT
  * <https://docs.python.org/3/library/ast.html?highlight=pycf_allow_top_level_await#ast.PyCF_ALLOW_TOP_LEVEL_AWAIT>`_.
  *
+ * For example:
+ *
+ * .. code-block:: pyodide
+ *
+ *    let result = await pyodide.runPythonAsync(`
+ *        from js import fetch
+ *        response = await fetch("./packages.json")
+ *        packages = await response.json()
+ *        # If final statement is an expression, its value is returned to JavaScript
+ *        len(packages.packages.object_keys())
+ *    `);
+ *    console.log(result); // 79
+ *
  * .. admonition:: Python imports :class: warning
  *
  *    Since pyodide 0.18.0, you must call :js:func:`loadPackagesFromImports` to
  *    import any python packages referenced via `import` statements in your
  *    code. This function will no longer do it for you.
  *
- * For example:
+ * .. admonition:: Positional globals argument :class: warning
  *
- * .. code-block:: pyodide
- *
- *    let result = await pyodide.runPythonAsync(` from js import fetch response
- *        = await fetch("./packages.json") packages = await response.json() # If
- *        final statement is an expression, its value is returned to JavaScript
- *        len(packages.packages.object_keys())
- *    `);
- *    console.log(result); // 79
+ *    In Pyodide v0.19, this function took the globals parameter as a
+ *    positional argument rather than as a named argument. In v0.20 this will
+ *    still work  but it is deprecated. It will be removed in v0.21.
  *
  * @param code Python code to evaluate
  * @param options

--- a/src/js/index.test-d.ts
+++ b/src/js/index.test-d.ts
@@ -43,7 +43,9 @@ async function main() {
   let px: PyProxy = <PyProxy>{};
 
   expectType<any>(pyodide.runPython("1+1"));
-  expectType<any>(pyodide.runPython("1+1", px));
+  expectType<any>(pyodide.runPython("1+1", { globals: px }));
+  expectType<Promise<any>>(pyodide.runPythonAsync("1+1"));
+  expectType<Promise<any>>(pyodide.runPythonAsync("1+1", { globals: px }));
 
   expectType<Promise<void>>(pyodide.loadPackagesFromImports("import some_pkg"));
   expectType<Promise<void>>(


### PR DESCRIPTION
This is for future-proofing in case we decide to add more options at
some point. Old usage is still accepted but causes a deprecation warning.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
