### PR TITLE
ENH Automatically schedule coroutines

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -101,6 +101,11 @@ substitutions:
 - {{ Enhancement }} Updated to Emscripten 2.0.27.
   {pr}`1102`
 
+- {{ Enhancement }} Async Python functions called from Javascript now have the
+  resulting coroutine automatically scheduled. For instance, this makes it
+  possible to use an async Python function as a Javascript event handler.
+  {pr}`2319`
+
 _February 19, 2022_
 
 ## Version 0.19.1

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -313,7 +313,12 @@ Module.callPyObjectKwargs = function (ptrobj: number, ...jsargs: any) {
   if (idresult === 0) {
     Module._pythonexc2js();
   }
-  return Hiwire.pop_value(idresult);
+  let result = Hiwire.pop_value(idresult);
+  // Automatically schedule coroutines
+  if (result && result._ensure_future) {
+    result._ensure_future();
+  }
+  return result;
 };
 
 Module.callPyObject = function (ptrobj: number, ...jsargs: any) {

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -315,7 +315,7 @@ Module.callPyObjectKwargs = function (ptrobj: number, ...jsargs: any) {
   }
   let result = Hiwire.pop_value(idresult);
   // Automatically schedule coroutines
-  if (result && result._ensure_future) {
+  if (result && result.type === "coroutine" && result._ensure_future) {
     result._ensure_future();
   }
   return result;

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -913,3 +913,22 @@ def test_pyproxy_borrow(selenium):
         Tcopy.destroy();
         """
     )
+
+
+def test_coroutine_scheduling(selenium):
+    selenium.run_js(
+        """
+        let f = pyodide.runPython(`
+            x = 0
+            async def f():
+                global x
+                print('hi!')
+                x += 1
+            f
+        `);
+        setTimeout(f, 100);
+        await sleep(200);
+        assert(() => x === 1);
+        f.destroy();
+        """
+    )

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -928,7 +928,7 @@ def test_coroutine_scheduling(selenium):
         `);
         setTimeout(f, 100);
         await sleep(200);
-        assert(() => x === 1);
+        assert(() => pyodide.globals.get('x') === 1);
         f.destroy();
         """
     )


### PR DESCRIPTION
Without this PR,
```js
let f = pyodide.globals.get("some_async_function");
setTimeout(f, 100);
```
doesn't work because `setTimeout` calls `f` which returns a coroutine which is left unscheduled and so the actual work in `f` is never executed. This is surprising to people, see for instance https://github.com/pyodide/pyodide/discussions/2229. This changes the behavior to automatically schedule all coroutines created from async functions called from Javascript so that async functions can be used as Javascript event handlers.