### PR TITLE
Update documentation for passing in global namespace

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -82,9 +82,9 @@ and returns a list of packages imported.
 
 ## How can I execute code in a custom namespace?
 
-The second argument to {any}`pyodide.runPython` is an object which may include a
-`globals` element which creates a namespace for code to read from and write to.
-The namespace is a Python dictionary.
+The second argument to {any}`pyodide.runPython` is an options object which may
+include a `globals` element which is a namespace for code to read from and write
+to. The provided namespace must be a Python dictionary.
 
 ```pyodide
 let my_namespace = pyodide.globals.get("dict")();
@@ -94,7 +94,7 @@ my_namespace.get("y"); // ==> 4
 ```
 
 You can also use this approach to inject variables from JavaScript into the
-python namespace, for example:
+Python namespace, for example:
 
 ```pyodide
 let my_namespace = pyodide.toPy({ x: 2, y: [1, 2, 3] });

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -82,26 +82,27 @@ and returns a list of packages imported.
 
 ## How can I execute code in a custom namespace?
 
-The second argument to {any}`pyodide.eval_code` is an object
-which may include a `globals` element which creates a namespace for code to read from and write to.
+The second argument to {any}`pyodide.runPython` is an object which may include a
+`globals` element which creates a namespace for code to read from and write to.
 The namespace is a Python dictionary.
 
-```javascript
+```pyodide
 let my_namespace = pyodide.globals.get("dict")();
 pyodide.runPython(`x = 1 + 1`, { globals: my_namespace });
 pyodide.runPython(`y = x ** x`, { globals: my_namespace });
 my_namespace.get("y"); // ==> 4
 ```
 
-You can also use this approach to inject variables from JavaScript into the python namespace, for example:
+You can also use this approach to inject variables from JavaScript into the
+python namespace, for example:
 
-```javascript
+```pyodide
 let my_namespace = pyodide.toPy({ x: 2, y: [1, 2, 3] });
 pyodide.runPython(
   `
-	assert x == y[1]
-	z = x ** x
-`,
+  assert x == y[1]
+  z = x ** x
+  `,
   { globals: my_namespace }
 );
 my_namespace.get("z"); // ==> 4

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -82,14 +82,29 @@ and returns a list of packages imported.
 
 ## How can I execute code in a custom namespace?
 
-The second argument to {any}`pyodide.eval_code` is a global namespace to execute the code in.
+The second argument to {any}`pyodide.eval_code` is an object
+which may include a `globals` element which creates a namespace for code to read from and write to.
 The namespace is a Python dictionary.
 
 ```javascript
-let my_namespace = pyodide.globals.dict();
-pyodide.runPython(`x = 1 + 1`, my_namespace);
-pyodide.runPython(`y = x ** x`, my_namespace);
-my_namespace.y; // ==> 4
+let my_namespace = pyodide.globals.get("dict")();
+pyodide.runPython(`x = 1 + 1`, { globals: my_namespace });
+pyodide.runPython(`y = x ** x`, { globals: my_namespace });
+my_namespace.get("y"); // ==> 4
+```
+
+You can also use this approach to inject variables from JavaScript into the python namespace, for example:
+
+```javascript
+let my_namespace = pyodide.toPy({ x: 2, y: [1, 2, 3] });
+pyodide.runPython(
+  `
+	assert x == y[1]
+	z = x ** x
+`,
+  { globals: my_namespace }
+);
+my_namespace.get("z"); // ==> 4
 ```
 
 ## How to detect that code is run with Pyodide?

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -33,22 +33,22 @@ export let version: string = ""; // actually defined in loadPyodide (see pyodide
 
 let runPythonPositionalGlobalsDeprecationWarned = false;
 /**
- * Runs a string of Python code from JavaScript.
+ * Runs a string of Python code from JavaScript, using :any:`pyodide.eval_code`
+ * to evaluate the code. If the last statement in the Python code is an
+ * expression (and the code doesn't end with a semicolon), the value of the
+ * expression is returned.
  *
- * The last part of the string may be an expression, in which case, its value is
- * returned.
+ * .. admonition:: Positional globals argument
+ *    :class: warning
  *
- * .. admonition:: Positional globals argument :class: warning
- *
- *    In Pyodide v0.19, this function took the globals parameter as a
- *    positional argument rather than as a named argument. In v0.20 this will
- *    still work  but it is deprecated. It will be removed in v0.21.
+ *    In Pyodide v0.19, this function took the globals parameter as a positional
+ *    argument rather than as a named argument. In v0.20 this will still work
+ *    but it is deprecated. It will be removed in v0.21.
  *
  * @param code Python code to evaluate
  * @param options
  * @param options.globals An optional Python dictionary to use as the globals.
- *        Defaults to :any:`pyodide.globals`. Uses the Python API
- *        :any:`pyodide.eval_code` to evaluate the code.
+ *        Defaults to :any:`pyodide.globals`.
  * @returns The result of the Python code translated to JavaScript. See the
  *          documentation for :any:`pyodide.eval_code` for more info.
  */
@@ -122,8 +122,11 @@ export async function loadPackagesFromImports(
 }
 
 /**
- * Runs Python code using `PyCF_ALLOW_TOP_LEVEL_AWAIT
- * <https://docs.python.org/3/library/ast.html?highlight=pycf_allow_top_level_await#ast.PyCF_ALLOW_TOP_LEVEL_AWAIT>`_.
+ * Run a Python code string with top level await using
+ * :any:`pyodide.eval_code_async` to evaluate the code. Returns a promise which
+ * resolves when execution completes. If the last statement in the Python code
+ * is an expression (and the code doesn't end with a semicolon), the returned
+ * promise will resolve to the value of this expression.
  *
  * For example:
  *
@@ -138,13 +141,15 @@ export async function loadPackagesFromImports(
  *    `);
  *    console.log(result); // 79
  *
- * .. admonition:: Python imports :class: warning
+ * .. admonition:: Python imports
+ *    :class: warning
  *
  *    Since pyodide 0.18.0, you must call :js:func:`loadPackagesFromImports` to
  *    import any python packages referenced via `import` statements in your
  *    code. This function will no longer do it for you.
  *
- * .. admonition:: Positional globals argument :class: warning
+ * .. admonition:: Positional globals argument
+ *    :class: warning
  *
  *    In Pyodide v0.19, this function took the globals parameter as a
  *    positional argument rather than as a named argument. In v0.20 this will
@@ -153,8 +158,7 @@ export async function loadPackagesFromImports(
  * @param code Python code to evaluate
  * @param options
  * @param options.globals An optional Python dictionary to use as the globals.
- * Defaults to :any:`pyodide.globals`. Uses the Python API
- * :any:`pyodide.eval_code_async` to evaluate the code.
+ * Defaults to :any:`pyodide.globals`.
  * @returns The result of the Python code translated to JavaScript.
  * @async
  */


### PR DESCRIPTION
* Fix API call so it actually works
* Update calling convention for changes in #2300
* Provide another example of creating a namespace from an existing set
  of JavaScript variables.

This closes #2321.
