### PR TITLE
MAINT Bump zlib version

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -12,10 +12,10 @@ URL=https://www.python.org/ftp/python/$(PYVERSION)/Python-$(PYVERSION).tgz
 LIB=libpython$(PYMAJOR).$(PYMINOR).a
 SYSCONFIG_NAME=_sysconfigdata__emscripten_
 
-ZLIBVERSION = 1.2.11
+ZLIBVERSION=1.2.12
 ZLIBTARBALL=$(ROOT)/downloads/zlib-$(ZLIBVERSION).tar.gz
 ZLIBBUILD=$(ROOT)/build/zlib-$(ZLIBVERSION)
-ZLIBURL=https://zlib.net/zlib-1.2.11.tar.gz
+ZLIBURL=https://zlib.net/zlib-$(ZLIBVERSION).tar.gz
 
 SQLITETARBALL=$(ROOT)/downloads/sqlite-autoconf-3270200.tar.gz
 SQLITEBUILD=$(ROOT)/build/sqlite-autoconf-3270200


### PR DESCRIPTION
Apparently zlib v1.2.11 had an out of bounds memory access bug so
they yanked it. This bumps the version and gets the build working
again.