### PR TITLE
Switch extractDir to camelCase

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -109,7 +109,7 @@ substitutions:
 - {{ Enhancement }} Updated to Emscripten 2.0.27.
   {pr}`2295`
 
-- {{ Breaking }} The `extract_dir` argument to
+- {{ Breaking }} The `extractDir` argument to
   {any}`unpackArchive <pyodide.unpackArchive>` is now passed as a named argument.
   The old usage still works with a deprecation warning.
   {pr}`2300`

--- a/docs/project/deprecation-timeline.md
+++ b/docs/project/deprecation-timeline.md
@@ -14,7 +14,7 @@ deprecation warnings. More details about each item can often be found in the
 
 - The `globals` argument to `runPython` and `runPythonAsync` will be passed as a
   named argument only.
-- The `extract_dir` argument to `unpackArchive` will be passed as a named
+- The `extractDir` argument to `unpackArchive` will be passed as a named
   argument only.
 
 ## 0.20.0

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -344,14 +344,14 @@ let unpackArchivePositionalExtractDirDeprecationWarned = false;
  * 'tgz' are considered to be synonyms.
  *
  * @param options
- * @param options.extract_dir The directory to unpack the archive into. Defaults
+ * @param options.extractDir The directory to unpack the archive into. Defaults
  * to the working directory.
  */
 export function unpackArchive(
   buffer: TypedArray,
   format: string,
   options: {
-    extract_dir?: string;
+    extractDir?: string;
   } = {}
 ) {
   if (typeof options === "string") {
@@ -361,9 +361,9 @@ export function unpackArchive(
       );
       unpackArchivePositionalExtractDirDeprecationWarned = true;
     }
-    options = { extract_dir: options };
+    options = { extractDir: options };
   }
-  let extract_dir = options.extract_dir;
+  let extract_dir = options.extractDir;
   API.package_loader.unpack_buffer.callKwargs({
     buffer,
     format,

--- a/src/js/index.test-d.ts
+++ b/src/js/index.test-d.ts
@@ -162,6 +162,6 @@ async function main() {
 
   pyodide.unpackArchive(new Uint8Array(40), "tar");
   pyodide.unpackArchive(new Uint8Array(40), "tar", {
-    extract_dir: "/some/path",
+    extractDir: "/some/path",
   });
 }


### PR DESCRIPTION
The other key word arguments in our JavaScript apis have camelCase names. It's good to be consistent.