### PR TITLE
Enable ANSI escape codes in console

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -120,6 +120,9 @@ substitutions:
   possible to use an async Python function as a Javascript event handler.
   {pr}`2319`
 
+- {{ Enhancement }} Support ANSI escape codes in the Pyodide console.
+  {pr}`2345`
+
 ## Version 0.19.1
 
 _February 19, 2022_

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.32.0/js/jquery.terminal.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.23.0/js/unix_formatting.min.js"></script>
     <link
       href="https://cdn.jsdelivr.net/npm/jquery.terminal@2.32.0/css/jquery.terminal.min.css"
       rel="stylesheet"

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -349,7 +349,7 @@ def test_console_html(console_html_fixture):
     assert exec_and_get_result("1+1") == ">>> 1+1\n2"
     assert exec_and_get_result("1 +1") == ">>> 1 +1\n2"
     assert exec_and_get_result("1+ 1") == ">>> 1+ 1\n2"
-    assert exec_and_get_result("[1,2,3]") == ">>> &#91;1,2,3&#93;\n[1, 2, 3]"
+    assert exec_and_get_result("[1,2,3]") == ">>> [1,2,3]\n[1, 2, 3]"
     assert (
         exec_and_get_result("{'a' : 1, 'b' : 2, 'c' : 3}")
         == ">>> {'a' : 1, 'b' : 2, 'c' : 3}\n{'a': 1, 'b': 2, 'c': 3}"
@@ -359,11 +359,15 @@ def test_console_html(console_html_fixture):
     )
     assert (
         exec_and_get_result("[x*x+1 for x in range(5)]")
-        == ">>> &#91;x*x+1 for x in range(5)&#93;\n[1, 2, 5, 10, 17]"
+        == ">>> [x*x+1 for x in range(5)]\n[1, 2, 5, 10, 17]"
     )
     assert (
         exec_and_get_result("{x+1:x*x+1 for x in range(5)}")
         == ">>> {x+1:x*x+1 for x in range(5)}\n{1: 1, 2: 2, 3: 5, 4: 10, 5: 17}"
+    )
+    assert (
+        exec_and_get_result("print('\x1b[31mHello World\x1b[0m')")
+        == ">>> print('[[;#A00;]Hello World]')\n[[;#A00;]Hello World]"
     )
 
     term_exec(


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Currently, ANSI escape codes are not supported in the console:

```
Welcome to the Pyodide terminal emulator 🐍
Python 3.9.5 (default, Feb 22 2022 14:12:02) on WebAssembly VM
Type "help", "copyright", "credits" or "license" for more information.
>>> print(u"\u001b[31mHello World\u001b[0m")
[31mHello World[0m
```

This is easily fixed by adding an extra javascript file that jQuery Terminal needs to render the codes.

With this change `Hello World` is rendered in red.

The [rich](https://github.com/Textualize/rich) library also works

```
>>> import micropip
>>> await micropip.install('rich')
>>> from rich import print
>>> print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:")
Hello, World! 🧛
```

(`World` is actually rendered in magenta.)

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests