### PR TITLE
MAINT Fix JsBuffer_tobytes and JsBuffer_tomemoryview signatures

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1643,7 +1643,7 @@ finally:
 }
 
 static PyObject*
-JsBuffer_tomemoryview(PyObject* buffer)
+JsBuffer_tomemoryview(PyObject* buffer, PyObject* _ignored)
 {
   JsProxy* self = (JsProxy*)buffer;
   return JsBuffer_CopyIntoMemoryView(
@@ -1657,7 +1657,7 @@ static PyMethodDef JsBuffer_tomemoryview_MethodDef = {
 };
 
 static PyObject*
-JsBuffer_tobytes(PyObject* buffer)
+JsBuffer_tobytes(PyObject* buffer, PyObject* _ignored)
 {
   JsProxy* self = (JsProxy*)buffer;
   return JsBuffer_CopyIntoBytes(self->js, self->byteLength);


### PR DESCRIPTION
METH_NOARGS functions are supposed to take a second `PyObject*` argument which will always be `NULL`.