### PR TITLE
Fix scipy import failure #2338

### DIFF
--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -31,6 +31,7 @@ source:
     - patches/USE_CPP14-branch-doesn-t-work-for-wasm.patch
     - patches/0001-Fix-getbreak-dlamch.patch
     - patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
+    - patches/0001-loadDynamicLibrary-flapack.patch
 
 build:
   cflags: |
@@ -96,10 +97,6 @@ build:
 
     # Input error causes "duplicate symbol" linker errors. Empty out the file.
     echo "" > scipy/sparse/linalg/dsolve/SuperLU/SRC/input_error.c
-    echo 'import sys' >> scipy/__init__.py
-    echo 'if "pyodide_js" in sys.modules:'  >> scipy/__init__.py
-    echo '   from pyodide_js._module import loadDynamicLibrary' >> scipy/__init__.py
-    echo "   loadDynamicLibrary('/lib/python$PYMAJOR.$PYMINOR/site-packages/scipy/linalg/_flapack.so')" >> scipy/__init__.py
 
 requirements:
   run:

--- a/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
+++ b/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
@@ -1,6 +1,6 @@
-From 2b1c8ba0c5ee3acc2f9f221d517114c28b2c8bf9 Mon Sep 17 00:00:00 2001
+From 6e87b998a3c0073c507626a7c88963d9bda27c24 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
-Date: Sat, 2 Apr 2022 11:13:37 -0700
+Date: Sat, 2 Apr 2022 14:20:25 -0700
 Subject: [PATCH] loadDynamicLibrary flapack
 
 We are using CLAPACK for our LAPACK, but CLAPACK only supports
@@ -26,14 +26,14 @@ look them up with `dlsym`). Scipy is not loaded this way. But we
 need the `lapack_extras.f` symbols to have this global visibility.
 So we have to call loadDynamicLibrary on it, hence this patch.
 ---
- scipy/__init__.py | 7 +++++++
- 1 file changed, 7 insertions(+)
+ scipy/__init__.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
 
 diff --git a/scipy/__init__.py b/scipy/__init__.py
-index 8c23069f9..4fa852612 100644
+index 8c23069f9..f408fc0b6 100644
 --- a/scipy/__init__.py
 +++ b/scipy/__init__.py
-@@ -158,3 +158,10 @@ else:
+@@ -158,3 +158,11 @@ else:
  
      # This makes "from scipy import fft" return scipy.fft, not np.fft
      del fft
@@ -42,6 +42,7 @@ index 8c23069f9..4fa852612 100644
 +    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
 +    from pyodide_js._module import loadDynamicLibrary
 +    loadDynamicLibrary(f'/lib/python3.10/site-packages/scipy/linalg/_flapack{ext_suffix}')
++    del loadDynamicLibrary
 +    del sysconfig
 +    del ext_suffix
 -- 

--- a/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
+++ b/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
@@ -1,4 +1,4 @@
-From 6e87b998a3c0073c507626a7c88963d9bda27c24 Mon Sep 17 00:00:00 2001
+From ae58d041d3e19afdee21e1aab396aa45740368e0 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 2 Apr 2022 14:20:25 -0700
 Subject: [PATCH] loadDynamicLibrary flapack
@@ -26,25 +26,25 @@ look them up with `dlsym`). Scipy is not loaded this way. But we
 need the `lapack_extras.f` symbols to have this global visibility.
 So we have to call loadDynamicLibrary on it, hence this patch.
 ---
- scipy/__init__.py | 8 ++++++++
+ scipy/linalg/__init__.py | 8 ++++++++
  1 file changed, 8 insertions(+)
 
-diff --git a/scipy/__init__.py b/scipy/__init__.py
-index 8c23069f9..f408fc0b6 100644
---- a/scipy/__init__.py
-+++ b/scipy/__init__.py
-@@ -158,3 +158,11 @@ else:
- 
-     # This makes "from scipy import fft" return scipy.fft, not np.fft
-     del fft
+diff --git a/scipy/linalg/__init__.py b/scipy/linalg/__init__.py
+index e88479b48..586c52ba6 100644
+--- a/scipy/linalg/__init__.py
++++ b/scipy/linalg/__init__.py
+@@ -219,3 +219,11 @@ __all__ = [s for s in dir() if not s.startswith('_')]
+ from scipy._lib._testutils import PytestTester
+ test = PytestTester(__name__)
+ del PytestTester
 +
-+    import sysconfig
-+    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
-+    from pyodide_js._module import loadDynamicLibrary
-+    loadDynamicLibrary(f'/lib/python3.10/site-packages/scipy/linalg/_flapack{ext_suffix}')
-+    del loadDynamicLibrary
-+    del sysconfig
-+    del ext_suffix
++import sysconfig
++import pyodide_js
++ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
++pyodide_js._module.loadDynamicLibrary(f'/lib/python3.10/site-packages/scipy/linalg/_flapack{ext_suffix}')
++del pyodide_js
++del sysconfig
++del ext_suffix
 -- 
 2.25.1
 

--- a/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
+++ b/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
@@ -1,4 +1,4 @@
-From 841959a2833208b1739ac4d45c08245da836b8b3 Mon Sep 17 00:00:00 2001
+From d79b13dac5ab8626cf15e6ac620ea5ac6c6da047 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 2 Apr 2022 14:20:25 -0700
 Subject: [PATCH] loadDynamicLibrary flapack
@@ -26,22 +26,24 @@ look them up with `dlsym`). Scipy is not loaded this way. But we
 need the `lapack_extras.f` symbols to have this global visibility.
 So we have to call loadDynamicLibrary on it, hence this patch.
 ---
- scipy/linalg/lapack.py | 9 +++++++++
- 1 file changed, 9 insertions(+)
+ scipy/linalg/lapack.py | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
 
 diff --git a/scipy/linalg/lapack.py b/scipy/linalg/lapack.py
-index 9850d80c4..05ad527e2 100644
+index 9850d80c4..a28c3c6ca 100644
 --- a/scipy/linalg/lapack.py
 +++ b/scipy/linalg/lapack.py
-@@ -809,6 +809,15 @@ All functions
+@@ -809,6 +809,17 @@ All functions
     ilaver
  
  """
 +
 +import sysconfig
 +import pyodide_js
++from site import getsitepackages
 +ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
-+pyodide_js._module.loadDynamicLibrary(f'/lib/python3.10/site-packages/scipy/linalg/_flapack{ext_suffix}')
++pyodide_js._module.loadDynamicLibrary(f'{getsitepackages()[0]}/scipy/linalg/_flapack{ext_suffix}')
++del getsitepackages
 +del pyodide_js
 +del sysconfig
 +del ext_suffix

--- a/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
+++ b/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
@@ -1,4 +1,4 @@
-From 6a12f704bc79832925424e7325bc5cf577be81ad Mon Sep 17 00:00:00 2001
+From 2b1c8ba0c5ee3acc2f9f221d517114c28b2c8bf9 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 2 Apr 2022 11:13:37 -0700
 Subject: [PATCH] loadDynamicLibrary flapack
@@ -30,7 +30,7 @@ So we have to call loadDynamicLibrary on it, hence this patch.
  1 file changed, 7 insertions(+)
 
 diff --git a/scipy/__init__.py b/scipy/__init__.py
-index 8c23069f9..0fe6fd64f 100644
+index 8c23069f9..4fa852612 100644
 --- a/scipy/__init__.py
 +++ b/scipy/__init__.py
 @@ -158,3 +158,10 @@ else:
@@ -41,7 +41,7 @@ index 8c23069f9..0fe6fd64f 100644
 +    import sysconfig
 +    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
 +    from pyodide_js._module import loadDynamicLibrary
-+    loadDynamicLibrary(f'/lib/python3.10/site-packages/scipy/linalg/_flapack.{ext_suffix}')
++    loadDynamicLibrary(f'/lib/python3.10/site-packages/scipy/linalg/_flapack{ext_suffix}')
 +    del sysconfig
 +    del ext_suffix
 -- 

--- a/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
+++ b/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
@@ -1,0 +1,49 @@
+From 6a12f704bc79832925424e7325bc5cf577be81ad Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Sat, 2 Apr 2022 11:13:37 -0700
+Subject: [PATCH] loadDynamicLibrary flapack
+
+We are using CLAPACK for our LAPACK, but CLAPACK only supports
+LAPACK v3.2 since starting in v3.3 LAPACK started adding fortran
+code from Fortran standards more recent that 1990 and f2c only
+supports Fortran '90. Scipy uses some functions that were added
+in LAPACK v3.4, but all of these are Fortran 77 compliant and so
+we *can* f2c them. In scipy/meta.yaml we inject these into
+`lapack_extras.f` which gets built into `_flapack.so`.
+
+Why do we do it this way? It was the first thing I tried that
+worked and I was so exhausted that I didn't have the energy to be
+bothered by the hack. Ideally we would copy these into our CLAPACK
+but CLAPACK is the result of hand modified f2c output. (In fact
+this is how f2c was always intended to be used, the output is not
+good C code by itself.) We are automating the patches that are
+necessary in `_f2c_fixes.py`, but these don't get applied to CLAPACK.
+
+Anyways, the issue is that CLAPACK is loaded as a "shared library"
+which means that we call `loadDynamicLibrary` on it so that all of
+its symbols are globally scoped (as opposed to needing to manually
+look them up with `dlsym`). Scipy is not loaded this way. But we
+need the `lapack_extras.f` symbols to have this global visibility.
+So we have to call loadDynamicLibrary on it, hence this patch.
+---
+ scipy/__init__.py | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/scipy/__init__.py b/scipy/__init__.py
+index 8c23069f9..0fe6fd64f 100644
+--- a/scipy/__init__.py
++++ b/scipy/__init__.py
+@@ -158,3 +158,10 @@ else:
+ 
+     # This makes "from scipy import fft" return scipy.fft, not np.fft
+     del fft
++
++    import sysconfig
++    ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
++    from pyodide_js._module import loadDynamicLibrary
++    loadDynamicLibrary(f'/lib/python3.10/site-packages/scipy/linalg/_flapack.{ext_suffix}')
++    del sysconfig
++    del ext_suffix
+-- 
+2.25.1
+

--- a/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
+++ b/packages/scipy/patches/0001-loadDynamicLibrary-flapack.patch
@@ -1,4 +1,4 @@
-From ae58d041d3e19afdee21e1aab396aa45740368e0 Mon Sep 17 00:00:00 2001
+From 841959a2833208b1739ac4d45c08245da836b8b3 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 2 Apr 2022 14:20:25 -0700
 Subject: [PATCH] loadDynamicLibrary flapack
@@ -26,17 +26,17 @@ look them up with `dlsym`). Scipy is not loaded this way. But we
 need the `lapack_extras.f` symbols to have this global visibility.
 So we have to call loadDynamicLibrary on it, hence this patch.
 ---
- scipy/linalg/__init__.py | 8 ++++++++
- 1 file changed, 8 insertions(+)
+ scipy/linalg/lapack.py | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 
-diff --git a/scipy/linalg/__init__.py b/scipy/linalg/__init__.py
-index e88479b48..586c52ba6 100644
---- a/scipy/linalg/__init__.py
-+++ b/scipy/linalg/__init__.py
-@@ -219,3 +219,11 @@ __all__ = [s for s in dir() if not s.startswith('_')]
- from scipy._lib._testutils import PytestTester
- test = PytestTester(__name__)
- del PytestTester
+diff --git a/scipy/linalg/lapack.py b/scipy/linalg/lapack.py
+index 9850d80c4..05ad527e2 100644
+--- a/scipy/linalg/lapack.py
++++ b/scipy/linalg/lapack.py
+@@ -809,6 +809,15 @@ All functions
+    ilaver
+ 
+ """
 +
 +import sysconfig
 +import pyodide_js
@@ -45,6 +45,10 @@ index e88479b48..586c52ba6 100644
 +del pyodide_js
 +del sysconfig
 +del ext_suffix
++
+ #
+ # Author: Pearu Peterson, March 2002
+ #
 -- 
 2.25.1
 


### PR DESCRIPTION
Trying to understand this bug made me realize that I am very deeply confused about a lot of stuff. But the actual cause of it is very simple: I patched this into `__init__.py`:
```py
if "pyodide_js" in sys.modules:
   from pyodide_js._module import loadDynamicLibrary
   loadDynamicLibrary('/lib/python3.10/site-packages/scipy/linalg/_flapack.so')
```
I uh... I have no idea what the conditional is supposed to mean. As far as I can tell, `if "pyodide_js" in sys.modules:` is just total nonsense. But it does explain the strange behavior of the bug. Anyways, I added a new patch with a detailed explanation.

I still don't really understand why importing scipy ever works. But this is okay, if the tests pass then who cares why it works right??