### PR TITLE
Update changelog.md

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -139,7 +139,7 @@ _February 19, 2022_
 - {{Fix}} Type signature mismatches in some numpy comparators have been fixed.
   {pr}`2110`
 
-## Type translations
+### Type translations
 
 - {{Fix}} The "PyProxy has already been destroyed" error message has been
   improved with some context information.


### PR DESCRIPTION
Fix broken title level of `Type translations` for release 0.19.1

### Description

The changelog for release 0.19.1 rendering was broken as `Type Translations` title level was too high.

![Screenshot 2022-04-04 at 11-53-34 Change Log — Version 0 19 1](https://user-images.githubusercontent.com/243665/161520089-af069b97-82c2-48bc-80d1-f3219bb2c0c8.png)

