### PR TITLE
CI Disable log clipping in building docker images on Github Actions

### DIFF
--- a/.github/workflows/prebuilt_docker_image.yml
+++ b/.github/workflows/prebuilt_docker_image.yml
@@ -5,7 +5,7 @@ on:
 env:
   GHCR_REGISTRY: ghcr.io
   IMAGE_NAME: pyodide/pyodide
-  PYODIDE_ENV_VERSION: 20220213-chrome97-firefox96
+  PYODIDE_ENV_VERSION: 20220317-chrome99-firefox98-py310
 jobs:
   build_docker:
     runs-on: ubuntu-latest
@@ -33,6 +33,7 @@ jobs:
             VERSION=${{ env.PYODIDE_ENV_VERSION }}
           tags: ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
+          driver-opts: BUILDKIT_STEP_LOG_MAX_SIZE=-1
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}
   build_ghcr:
@@ -61,5 +62,6 @@ jobs:
             VERSION=${{ env.PYODIDE_ENV_VERSION }}
           tags: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
+          driver-opts: BUILDKIT_STEP_LOG_MAX_SIZE=-1
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}

--- a/.github/workflows/prebuilt_docker_image.yml
+++ b/.github/workflows/prebuilt_docker_image.yml
@@ -33,7 +33,7 @@ jobs:
             VERSION=${{ env.PYODIDE_ENV_VERSION }}
           tags: ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
-          driver-opts: BUILDKIT_STEP_LOG_MAX_SIZE=-1
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}
   build_ghcr:
@@ -62,6 +62,6 @@ jobs:
             VERSION=${{ env.PYODIDE_ENV_VERSION }}
           tags: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
-          driver-opts: BUILDKIT_STEP_LOG_MAX_SIZE=-1
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}

--- a/.github/workflows/prebuilt_docker_image.yml
+++ b/.github/workflows/prebuilt_docker_image.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        id: builder
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v3
@@ -33,7 +38,7 @@ jobs:
             VERSION=${{ env.PYODIDE_ENV_VERSION }}
           tags: ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
-          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
+          builder: ${{ steps.builder.outputs.name }}
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}
   build_ghcr:
@@ -47,6 +52,11 @@ jobs:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        id: builder
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v3
@@ -62,6 +72,6 @@ jobs:
             VERSION=${{ env.PYODIDE_ENV_VERSION }}
           tags: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
-          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
+          builder: ${{ steps.builder.outputs.name }}
       - name: Image digest
         run: echo ${{ steps.build.outputs.digest }}

--- a/.github/workflows/prebuilt_docker_image.yml
+++ b/.github/workflows/prebuilt_docker_image.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Log into Docker Hub registry
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         id: builder
         with:
           driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
+      - name: Log into Docker Hub registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v3
@@ -46,17 +46,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        id: builder
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
       - name: Log into registry ${{ env.GHCR_REGISTRY }}
         uses: docker/login-action@v1
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        id: builder
-        with:
-          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=-1
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v3


### PR DESCRIPTION
Disable log clipping behavior of docker buildkit.
This will help us analyze the log when `prebuilt_docker_image` action fails.
