### PR TITLE
TST Enable some skipped or xfailed tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -83,7 +83,7 @@ def built_packages() -> list[str]:
 
 
 def _package_is_built(package_name: str) -> bool:
-    return package_name in built_packages()
+    return package_name.lower() in built_packages()
 
 
 class JavascriptException(Exception):

--- a/packages/Pillow/test_pillow.py
+++ b/packages/Pillow/test_pillow.py
@@ -2,7 +2,7 @@ from pyodide_build.testing import run_in_pyodide
 
 
 @run_in_pyodide(
-    packages=["pillow"],
+    packages=["Pillow"],
 )
 def test_pillow():
     import io
@@ -38,7 +38,7 @@ def test_pillow():
 
 
 @run_in_pyodide(
-    packages=["pillow"],
+    packages=["Pillow"],
 )
 def test_jpeg_modes():
     from PIL import Image

--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from conftest import ROOT_PATH, built_packages
+from conftest import ROOT_PATH, _package_is_built
 from pyodide_build.io import parse_package_config
 from pyodide_build.testing import PYVERSION
 
@@ -43,7 +43,7 @@ def test_parse_package(name):
 @pytest.mark.driver_timeout(40)
 @pytest.mark.parametrize("name", registered_packages())
 def test_import(name, selenium_standalone):
-    if name not in built_packages():
+    if not _package_is_built(name):
         raise AssertionError(
             "Implementation error. Test for an unbuilt package "
             "should have been skipped in selenium_standalone fixture"

--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -25,8 +25,6 @@ UNSUPPORTED_PACKAGES: dict[str, list[str]] = {
     "firefox": [],
     "node": ["cmyt", "yt"],
 }
-if "CI" in os.environ:
-    UNSUPPORTED_PACKAGES["chrome"].extend(["statsmodels"])
 
 
 @pytest.mark.parametrize("name", registered_packages())


### PR DESCRIPTION
### Description

- Pillow - mistakenly skipped after #2278
- Jjinja2 - skipped due to wrong logic in `_package_is_built`.
- statsmodels - xfailed due to browser issue in older version of Chrome
