### PR TITLE
Update cryptography to v3.4.8

### DIFF
--- a/packages/cryptography/meta.yaml
+++ b/packages/cryptography/meta.yaml
@@ -1,16 +1,18 @@
 package:
   name: cryptography
-  version: 3.3.2
+  version: 3.4.8
 
 source:
-  url: https://files.pythonhosted.org/packages/d4/85/38715448253404186029c575d559879912eb8a1c5d16ad9f25d35f7c4f4c/cryptography-3.3.2.tar.gz
-  sha256: 5a60d3780149e13b7a6ff7ad6526b38846354d11a15e21068e57073e29e19bed
+  url: https://files.pythonhosted.org/packages/cc/98/8a258ab4787e6f835d350639792527d2eb7946ff9fc0caca9c3f4cf5dcfe/cryptography-3.4.8.tar.gz
+  sha256: 94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c
 build:
   cflags: |
     -I$(OPEN_SSL_ROOT)/include/
     -Wno-implicit-function-declaration
   ldflags: |
     -L$(OPEN_SSL_ROOT)/dist/
+  script: |
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1
 requirements:
   run:
     - openssl

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -185,6 +185,7 @@ def success(msg):
 
 def update_package(
     package: str,
+    version: str | None = None,
     update_patched: bool = True,
     source_fmt: Literal["wheel", "sdist"] | None = None,
 ):
@@ -213,7 +214,7 @@ def update_package(
     else:
         old_fmt = "sdist"
 
-    pypi_metadata = _get_metadata(package)
+    pypi_metadata = _get_metadata(package, version)
     pypi_ver = pypi_metadata["info"]["version"]
     local_ver = yaml_content["package"]["version"]
     already_up_to_date = pypi_ver <= local_ver and (
@@ -288,10 +289,20 @@ def main(args):
     try:
         package = args.package[0]
         if args.update:
-            update_package(package, update_patched=True, source_fmt=args.source_format)
+            update_package(
+                package,
+                args.version,
+                update_patched=True,
+                source_fmt=args.source_format,
+            )
             return
         if args.update_if_not_patched:
-            update_package(package, update_patched=False, source_fmt=args.source_format)
+            update_package(
+                package,
+                args.version,
+                update_patched=False,
+                source_fmt=args.source_format,
+            )
             return
         make_package(package, args.version, source_fmt=args.source_format)
     except MkpkgFailedException as e:

--- a/pyodide-build/pyodide_build/tests/test_mkpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_mkpkg.py
@@ -61,7 +61,7 @@ def test_mkpkg_update(tmpdir, monkeypatch, old_dist_type, new_dist_type):
     source_fmt = new_dist_type
     if new_dist_type == "same":
         source_fmt = None
-    pyodide_build.mkpkg.update_package("idna", False, source_fmt)
+    pyodide_build.mkpkg.update_package("idna", None, False, source_fmt)
 
     db = parse_package_config(meta_path)
     assert list(db.keys()) == list(db_init.keys())


### PR DESCRIPTION
As recommended here: https://github.com/pyca/cryptography/issues/7051
we can build v3.4.8 with `export CRYPTOGRAPHY_DONT_BUILD_RUST=1`.