### PR TITLE
chore: some pacage updates

### DIFF
--- a/packages/autograd/meta.yaml
+++ b/packages/autograd/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: autograd
-  version: "1.3"
+  version: "1.4"
 source:
-  sha256: a15d147577e10de037de3740ca93bfa3b5a7cdfbc34cfb9105429c3580a33ec4
-  url: https://files.pythonhosted.org/packages/23/12/b58522dc2cbbd7ab939c7b8e5542c441c9a06a8eccb00b3ecac04a739896/autograd-1.3.tar.gz
+  sha256: 383de0f537ef2e38b85ff9692593b0cfae8958c9b3bd451b52c255fd9171ffce
+  url: https://files.pythonhosted.org/packages/04/6d/63beeb8c1f1964aa7d84e59657c7f5b85f6ae009ed80f51e0d3ec78e0f97/autograd-1.4.tar.gz
 test:
   imports:
     - autograd

--- a/packages/fonttools/meta.yaml
+++ b/packages/fonttools/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: fonttools
-  version: 4.31.2
+  version: 4.32.0
 source:
-  url: https://files.pythonhosted.org/packages/b0/5c/5dd502b0e2e0cb2980fc4ed17e970089003e377115abf79b1918097f4996/fonttools-4.31.2-py3-none-any.whl
-  sha256: 2df636a3f402ef14593c6811dac0609563b8c374bd7850e76919eb51ea205426
+  url: https://files.pythonhosted.org/packages/bc/83/43991c6f0dfb395cc9ccf5c19fd51fc6068cb3919cee4b78eddd4b16efd1/fonttools-4.32.0-py3-none-any.whl
+  sha256: b038d1a0dee0079de7ade57071e2e2aced6e35bd697de244ac62938b2b1628c1
 test:
   imports:
     - fontTools

--- a/packages/sympy/meta.yaml
+++ b/packages/sympy/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: sympy
-  version: "1.9"
+  version: 1.10.1
 requirements:
   run:
     - distutils
     - mpmath
 source:
-  sha256: 8bc5de4608b7aa4e7ffd1b25452ae87ccc5f6ca667c661aafb854a1ade337d0c
-  url: https://files.pythonhosted.org/packages/78/43/33c5a5e7fbafbf51520f4e09cb0634a1ca1d4cd5469c57967e43183d7a42/sympy-1.9-py3-none-any.whl
+  sha256: df75d738930f6fe9ebe7034e59d56698f29e85f443f743e51e47df0caccc2130
+  url: https://files.pythonhosted.org/packages/d0/04/66be21ceb305c66a4b326b0ae44cc4f027a43bc08cac204b48fb45bb3653/sympy-1.10.1-py3-none-any.whl
 test:
   imports:
     - sympy


### PR DESCRIPTION
- chore: updated autograd to 1.4
- ~~chore: updated cryptography to 36.0.2~~
- chore: updated fonttools to 4.32.0
- chore: updated sympy to 1.10.1

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Some quick & easy updates. Two packages said "wheel or SDist not available", and had to fight sympy a little - updating from 1.9 -> 1.10 doesn't seem to be supported by the pyodide-build script; guessing it doesn't know 10 > 9.
