### PR TITLE
Fix invocations of _PyArg_ParseStackAndKeywords

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -710,8 +710,7 @@ JsProxy_toPy(PyObject* self,
   static struct _PyArg_Parser _parser = { "|$iO:toPy", _keywords, 0 };
   int depth = -1;
   PyObject* default_converter = NULL;
-  if (kwnames != NULL &&
-      !_PyArg_ParseStackAndKeywords(
+  if (!_PyArg_ParseStackAndKeywords(
         args, nargs, kwnames, &_parser, &depth, &default_converter)) {
     return NULL;
   }

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -688,16 +688,16 @@ to_js(PyObject* self,
   //      default_converter.
   //         :to_js - name of this function for error messages
   static struct _PyArg_Parser _parser = { "O|$ipOOO:to_js", _keywords, 0 };
-  if (kwnames != NULL && !_PyArg_ParseStackAndKeywords(args,
-                                                       nargs,
-                                                       kwnames,
-                                                       &_parser,
-                                                       &obj,
-                                                       &depth,
-                                                       &create_proxies,
-                                                       &pyproxies,
-                                                       &py_dict_converter,
-                                                       &py_default_converter)) {
+  if (!_PyArg_ParseStackAndKeywords(args,
+                                    nargs,
+                                    kwnames,
+                                    &_parser,
+                                    &obj,
+                                    &depth,
+                                    &create_proxies,
+                                    &pyproxies,
+                                    &py_dict_converter,
+                                    &py_default_converter)) {
     return NULL;
   }
 


### PR DESCRIPTION
In #1882, @rth is hitting a bug: we say
```C
if (kwnames != NULL && !_PyArg_ParseStackAndKeywords(args, nargs, kwnames, ...)) {
	return NULL; // error
}
```
So this assumes that there is no problem if `kwnames` is `NULL`, or if it isn't `NULL` and `_PyArg_ParseStackAndKeywords` succeeds. But we are relying on `_PyArg_ParseStackAndKeywords` to initialize a bunch of variables, and if `kwnames` is `NULL`, we just leave these all as `NULL` and then bad stuff happens.

For whatever reason when compiled normally, `kwnames` is never `NULL`. Apparently when compiling with `-Os` it is `NULL` sometimes? This would explain why the problem only shows up on #1882. 