### PR TITLE
Rename 'build' directory to 'dist'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
 
       - run:
           name: check-size
-          command: ls -lh build/
+          command: ls -lh dist/
 
       - save_cache:
           paths:
@@ -95,7 +95,7 @@ jobs:
       - run:
           name: Zip build directory
           command: |
-            tar cjf pyodide-build.tar.gz  build
+            tar cjf pyodide-build.tar.gz dist
 
       - persist_to_workspace:
           root: .
@@ -103,7 +103,7 @@ jobs:
             - .
 
       - store_artifacts:
-          path: /root/repo/build/
+          path: /root/repo/dist/
 
       - store_artifacts:
           path: /root/repo/pyodide-build.tar.gz
@@ -143,7 +143,7 @@ jobs:
 
       - run:
           name: check-size
-          command: ls -lh build/
+          command: ls -lh dist/
 
       - save_cache:
           paths:
@@ -154,12 +154,12 @@ jobs:
           root: .
           paths:
             - ./packages
-            - ./build
+            - ./dist
 
       - run:
           name: Zip build directory
           command: |
-            tar cjf pyodide-build.tar.gz  build
+            tar cjf pyodide-build.tar.gz  dist
             tar cjf build-logs.tar.gz  packages/build-logs
 
       - persist_to_workspace:
@@ -168,7 +168,7 @@ jobs:
             - .
 
       - store_artifacts:
-          path: /root/repo/build/
+          path: /root/repo/dist/
 
       - store_artifacts:
           path: /root/repo/pyodide-build.tar.gz
@@ -211,7 +211,7 @@ jobs:
 
       - run:
           name: check-size
-          command: ls -lh build/
+          command: ls -lh dist/
 
       - save_cache:
           paths:
@@ -221,17 +221,17 @@ jobs:
       - run:
           name: Zip build directory
           command: |
-            tar cjf pyodide-build.tar.gz  build
+            tar cjf pyodide-build.tar.gz dist
             tar cjf build-logs.tar.gz  packages/build-logs
 
       - persist_to_workspace:
           root: .
           paths:
             - ./packages/.artifacts
-            - ./build
+            - ./dist
 
       - store_artifacts:
-          path: /root/repo/build/
+          path: /root/repo/dist/
 
       - store_artifacts:
           path: /root/repo/pyodide-build.tar.gz
@@ -331,10 +331,10 @@ jobs:
       - run:
           name: benchmark
           command: |
-            python benchmark/benchmark.py all --output build/benchmarks.json
+            python benchmark/benchmark.py all --output dist/benchmarks.json
 
       - store_artifacts:
-          path: /root/repo/build/benchmarks.json
+          path: /root/repo/dist/benchmarks.json
 
   deploy-release:
     # To reduce chance of deployment issues, try to keep the steps here as
@@ -356,7 +356,7 @@ jobs:
       - run:
           name: Deploy Github Releases
           command: |
-            cp -r build /tmp/pyodide
+            cp -r dist /tmp/pyodide
             cd /tmp/
             tar cjf pyodide-build-${CIRCLE_TAG}.tar.bz2  pyodide/
             ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
@@ -367,9 +367,9 @@ jobs:
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
           command: |
-            find build/ -type f -print0 | xargs -0 -n1 -I@ bash -c "echo \"Compressing @\"; gzip @; mv @.gz @;"
-            aws s3 sync build/ "s3://pyodide-cdn2.iodide.io/v${CIRCLE_TAG}/full/" --exclude '*.data' --cache-control 'max-age=30758400, immutable, public' --content-encoding 'gzip'    # 1 year cache
-            aws s3 sync build/ "s3://pyodide-cdn2.iodide.io/v${CIRCLE_TAG}/full/" --exclude '*' --include '*.data' --cache-control 'max-age=30758400, immutable, public'  --content-type 'application/wasm' --content-encoding 'gzip'  # 1 year
+            find dist/ -type f -print0 | xargs -0 -n1 -I@ bash -c "echo \"Compressing @\"; gzip @; mv @.gz @;"
+            aws s3 sync dist/ "s3://pyodide-cdn2.iodide.io/v${CIRCLE_TAG}/full/" --exclude '*.data' --cache-control 'max-age=30758400, immutable, public' --content-encoding 'gzip'    # 1 year cache
+            aws s3 sync dist/ "s3://pyodide-cdn2.iodide.io/v${CIRCLE_TAG}/full/" --exclude '*' --include '*.data' --cache-control 'max-age=30758400, immutable, public'  --content-type 'application/wasm' --content-encoding 'gzip'  # 1 year
             # update 301 redirect for the /latest/* route.
             aws s3api put-bucket-website --cli-input-json file://.circleci/s3-website-config.json
 
@@ -396,10 +396,10 @@ jobs:
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
           command: |
-            find build/ -type f -print0 | xargs -0 -n1 -I@ bash -c "echo \"Compressing @\"; gzip @; mv @.gz @;"
+            find dist/ -type f -print0 | xargs -0 -n1 -I@ bash -c "echo \"Compressing @\"; gzip @; mv @.gz @;"
             aws s3 rm --recursive "s3://pyodide-cdn2.iodide.io/dev/full/"
-            aws s3 sync build/ "s3://pyodide-cdn2.iodide.io/dev/full/" --exclude '*.data' --cache-control 'max-age=3600, public' --content-encoding 'gzip'  # 1 hour cache
-            aws s3 sync build/ "s3://pyodide-cdn2.iodide.io/dev/full/" --exclude '*' --include '*.data' --cache-control 'max-age=3600, public'  --content-type 'application/wasm' --content-encoding 'gzip'  # 1 hour cache
+            aws s3 sync dist/ "s3://pyodide-cdn2.iodide.io/dev/full/" --exclude '*.data' --cache-control 'max-age=3600, public' --content-encoding 'gzip'  # 1 hour cache
+            aws s3 sync dist/ "s3://pyodide-cdn2.iodide.io/dev/full/" --exclude '*' --include '*.data' --cache-control 'max-age=3600, public'  --content-type 'application/wasm' --content-encoding 'gzip'  # 1 hour cache
 
 workflows:
   version: 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,13 +88,13 @@ jobs:
           ccache -s
 
       - name: check-size
-        run: ls -lh build/
+        run: ls -lh dist/
 
       - name: Store artifacts build
         uses: actions/upload-artifact@v2
         with:
           name: core-build
-          path: ./build/
+          path: ./dist/
           retention-days: 60
 
   test-core:
@@ -114,7 +114,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: core-build
-          path: ./build/
+          path: ./dist/
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -133,7 +133,7 @@ jobs:
         shell: bash -l {0}
         run: |
           ls -lh
-          ls -lh build/
+          ls -lh dist/
           tools/pytest_wrapper.py src packages/micropip/ -v -k "${SELENIUM_RUNNER}"
 
       - name: run package tests
@@ -142,5 +142,5 @@ jobs:
         shell: bash -l {0}
         run: |
           ls -lh
-          ls -lh build/
+          ls -lh dist/
           tools/pytest_wrapper.py packages/test* packages/*/test* -v -k "numpy and not joblib and ${SELENIUM_RUNNER}"

--- a/Dockerfile-prebuilt
+++ b/Dockerfile-prebuilt
@@ -11,4 +11,4 @@ COPY . pyodide
 # the rm at the end deletes the build results such that the resulting image can still be used for building pyodide
 # from source (including partial and customized builds). Due to the previous run of make, builds
 # executed with this image will be much faster than the ones executed with pyodide-env
-RUN cd pyodide && PYODIDE_PACKAGES='*' make && rm -r ./build
+RUN cd pyodide && PYODIDE_PACKAGES='*' make && rm -r ./dist

--- a/Makefile
+++ b/Makefile
@@ -9,27 +9,27 @@ CXX=em++
 
 
 all: check \
-	build/pyodide.asm.js \
-	build/pyodide.js \
-	build/console.html \
-	build/distutils.tar \
-	build/packages.json \
-	build/pyodide_py.tar \
-	build/test.tar \
-	build/test.html \
-	build/module_test.html \
-	build/webworker.js \
-	build/webworker_dev.js \
-	build/module_webworker_dev.js
+	dist/pyodide.asm.js \
+	dist/pyodide.js \
+	dist/console.html \
+	dist/distutils.tar \
+	dist/packages.json \
+	dist/pyodide_py.tar \
+	dist/test.tar \
+	dist/test.html \
+	dist/module_test.html \
+	dist/webworker.js \
+	dist/webworker_dev.js \
+	dist/module_webworker_dev.js
 	echo -e "\nSUCCESS!"
 
 $(CPYTHONLIB)/tzdata :
 	pip install tzdata --target=$(CPYTHONLIB)
 
-build/pyodide_py.tar: $(wildcard src/py/pyodide/*.py)  $(wildcard src/py/_pyodide/*.py)
-	cd src/py && tar --exclude '*__pycache__*' -cf ../../build/pyodide_py.tar pyodide _pyodide
+dist/pyodide_py.tar: $(wildcard src/py/pyodide/*.py)  $(wildcard src/py/_pyodide/*.py)
+	cd src/py && tar --exclude '*__pycache__*' -cf ../../dist/pyodide_py.tar pyodide _pyodide
 
-build/pyodide.asm.js: \
+dist/pyodide.asm.js: \
 	src/core/docstring.o \
 	src/core/error_handling.o \
 	src/core/error_handling_cpp.o \
@@ -44,26 +44,26 @@ build/pyodide.asm.js: \
 	$(CPYTHONLIB)/tzdata \
 	$(CPYTHONLIB)
 	date +"[%F %T] Building pyodide.asm.js..."
-	[ -d build ] || mkdir build
-	$(CXX) -o build/pyodide.asm.js $(filter %.o,$^) \
+	[ -d dist ] || mkdir dist
+	$(CXX) -o dist/pyodide.asm.js $(filter %.o,$^) \
 		$(MAIN_MODULE_LDFLAGS)
    # Strip out C++ symbols which all start __Z.
    # There are 4821 of these and they have VERY VERY long names.
    # To show some stats on the symbols you can use the following:
-   # cat build/pyodide.asm.js | grep -ohE 'var _{0,5}.' | sort | uniq -c | sort -nr | head -n 20
-	sed -i -E 's/var __Z[^;]*;//g' build/pyodide.asm.js
+   # cat dist/pyodide.asm.js | grep -ohE 'var _{0,5}.' | sort | uniq -c | sort -nr | head -n 20
+	sed -i -E 's/var __Z[^;]*;//g' dist/pyodide.asm.js
 	sed -i '1i\
 		"use strict";\
 		let setImmediate = globalThis.setImmediate;\
 		let clearImmediate = globalThis.clearImmediate;\
 		let baseName, fpcGOT, dyncallGOT, fpVal, dcVal;\
-	' build/pyodide.asm.js
+	' dist/pyodide.asm.js
 	# Remove last 6 lines of pyodide.asm.js, see issue #2282
 	# Hopefully we will remove this after emscripten fixes it, upstream issue
 	# emscripten-core/emscripten#16518
 	# Sed nonsense from https://stackoverflow.com/a/13383331
-	sed -i -n -e :a -e '1,6!{P;N;D;};N;ba' build/pyodide.asm.js
-	echo "globalThis._createPyodideModule = _createPyodideModule;" >> build/pyodide.asm.js
+	sed -i -n -e :a -e '1,6!{P;N;D;};N;ba' dist/pyodide.asm.js
+	echo "globalThis._createPyodideModule = _createPyodideModule;" >> dist/pyodide.asm.js
 	date +"[%F %T] done building pyodide.asm.js."
 
 
@@ -76,7 +76,7 @@ node_modules/.installed : src/js/package.json src/js/package-lock.json
 	ln -sfn src/js/node_modules/ node_modules
 	touch node_modules/.installed
 
-build/pyodide.js: src/js/*.ts src/js/pyproxy.gen.ts src/js/error_handling.gen.ts node_modules/.installed
+dist/pyodide.js: src/js/*.ts src/js/pyproxy.gen.ts src/js/error_handling.gen.ts node_modules/.installed
 	npx rollup -c src/js/rollup.config.js
 
 src/js/error_handling.gen.ts : src/core/error_handling.ts
@@ -106,14 +106,14 @@ src/js/pyproxy.gen.ts : src/core/pyproxy.* src/core/*.h
 		$(CC) -E -C -P -imacros src/core/pyproxy.c $(MAIN_MODULE_CFLAGS) - \
 		>> $@
 
-build/test.html: src/templates/test.html
+dist/test.html: src/templates/test.html
 	cp $< $@
 
-build/module_test.html: src/templates/module_test.html
+dist/module_test.html: src/templates/module_test.html
 	cp $< $@
 
-.PHONY: build/console.html
-build/console.html: src/templates/console.html
+.PHONY: dist/console.html
+dist/console.html: src/templates/console.html
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
@@ -125,25 +125,25 @@ docs/_build/html/console.html: src/templates/console.html
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
 
-.PHONY: build/webworker.js
-build/webworker.js: src/templates/webworker.js
+.PHONY: dist/webworker.js
+dist/webworker.js: src/templates/webworker.js
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
-.PHONY: build/module_webworker_dev.js
-build/module_webworker_dev.js: src/templates/module_webworker.js
+.PHONY: dist/module_webworker_dev.js
+dist/module_webworker_dev.js: src/templates/module_webworker.js
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#./#g' $@
 
-.PHONY: build/webworker_dev.js
-build/webworker_dev.js: src/templates/webworker.js
+.PHONY: dist/webworker_dev.js
+dist/webworker_dev.js: src/templates/webworker.js
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#./#g' $@
 
 
 update_base_url: \
-	build/console.html \
-	build/webworker.js
+	dist/console.html \
+	dist/webworker.js
 
 
 
@@ -152,12 +152,12 @@ lint:
 	pre-commit run -a --show-diff-on-failure
 
 benchmark: all
-	$(HOSTPYTHON) benchmark/benchmark.py all --output build/benchmarks.json
-	$(HOSTPYTHON) benchmark/plot_benchmark.py build/benchmarks.json build/benchmarks.png
+	$(HOSTPYTHON) benchmark/benchmark.py all --output dist/benchmarks.json
+	$(HOSTPYTHON) benchmark/plot_benchmark.py dist/benchmarks.json dist/benchmarks.png
 
 
 clean:
-	rm -fr build/*
+	rm -fr dist/*
 	rm -fr src/*/*.o
 	rm -fr node_modules
 	make -C packages clean
@@ -189,7 +189,7 @@ TEST_EXTENSIONS= \
 TEST_MODULE_CFLAGS= $(SIDE_MODULE_CFLAGS) -I Include/ -I .
 
 # TODO: also include test directories included in other stdlib modules
-build/test.tar: $(CPYTHONLIB) node_modules/.installed
+dist/test.tar: $(CPYTHONLIB) node_modules/.installed
 	cd $(CPYTHONBUILD) && emcc $(TEST_MODULE_CFLAGS) -c Modules/_testinternalcapi.c -o Modules/_testinternalcapi.o \
 							   -I Include/internal/ -DPy_BUILD_CORE_MODULE
 	cd $(CPYTHONBUILD) && emcc $(TEST_MODULE_CFLAGS) -c Modules/_testcapimodule.c -o Modules/_testcapi.o
@@ -204,14 +204,14 @@ build/test.tar: $(CPYTHONLIB) node_modules/.installed
 		ln -s $(CPYTHONBUILD)/$$testname $(CPYTHONLIB)/$$testname ; \
 	done
 
-	cd $(CPYTHONLIB) && tar -h --exclude=__pycache__ -cf $(PYODIDE_ROOT)/build/test.tar \
+	cd $(CPYTHONLIB) && tar -h --exclude=__pycache__ -cf $(PYODIDE_ROOT)/dist/test.tar \
 		test $(TEST_EXTENSIONS) unittest/test sqlite3/test ctypes/test
 
 	cd $(CPYTHONLIB) && rm $(TEST_EXTENSIONS)
 
 
-build/distutils.tar: $(CPYTHONLIB) node_modules/.installed
-	cd $(CPYTHONLIB) && tar --exclude=__pycache__ -cf $(PYODIDE_ROOT)/build/distutils.tar distutils
+dist/distutils.tar: $(CPYTHONLIB) node_modules/.installed
+	cd $(CPYTHONLIB) && tar --exclude=__pycache__ -cf $(PYODIDE_ROOT)/dist/distutils.tar distutils
 
 
 $(CPYTHONLIB): emsdk/emsdk/.complete $(PYODIDE_EMCC) $(PYODIDE_CXX)
@@ -220,7 +220,7 @@ $(CPYTHONLIB): emsdk/emsdk/.complete $(PYODIDE_EMCC) $(PYODIDE_CXX)
 	date +"[%F %T] done building cpython..."
 
 
-build/packages.json: FORCE
+dist/packages.json: FORCE
 	date +"[%F %T] Building packages..."
 	make -C packages
 	date +"[%F %T] done building packages..."

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -137,7 +137,7 @@ def parse_args(benchmarks):
     parser.add_argument(
         "-o",
         "--output",
-        default="build/benchmarks.json",
+        default="dist/benchmarks.json",
         help="path to the json file where benchmark results will be saved",
     )
     parser.add_argument(

--- a/conftest.py
+++ b/conftest.py
@@ -705,14 +705,14 @@ def selenium(request, selenium_module_scope):
 @pytest.fixture(scope="session")
 def web_server_main(request):
     """Web server that serves files in the dist/ directory"""
-    with spawn_web_server(request.config.option.build_dir) as output:
+    with spawn_web_server(request.config.option.dist_dir) as output:
         yield output
 
 
 @pytest.fixture(scope="session")
 def web_server_secondary(request):
     """Secondary web server that serves files dist/ directory"""
-    with spawn_web_server(request.config.option.build_dir) as output:
+    with spawn_web_server(request.config.option.dist_dir) as output:
         yield output
 
 
@@ -724,15 +724,15 @@ def web_server_tst_data(request):
 
 
 @contextlib.contextmanager
-def spawn_web_server(build_dir=None):
+def spawn_web_server(dist_dir=None):
 
-    if build_dir is None:
-        build_dir = DIST_PATH
+    if dist_dir is None:
+        dist_dir = DIST_PATH
 
     tmp_dir = tempfile.mkdtemp()
     log_path = pathlib.Path(tmp_dir) / "http-server.log"
     q: multiprocessing.Queue[str] = multiprocessing.Queue()
-    p = multiprocessing.Process(target=run_web_server, args=(q, log_path, build_dir))
+    p = multiprocessing.Process(target=run_web_server, args=(q, log_path, dist_dir))
 
     try:
         p.start()
@@ -750,7 +750,7 @@ def spawn_web_server(build_dir=None):
         shutil.rmtree(tmp_dir)
 
 
-def run_web_server(q, log_filepath, build_dir):
+def run_web_server(q, log_filepath, dist_dir):
     """Start the HTTP web server
 
     Parameters
@@ -763,7 +763,7 @@ def run_web_server(q, log_filepath, build_dir):
     import http.server
     import socketserver
 
-    os.chdir(build_dir)
+    os.chdir(dist_dir)
 
     log_fh = log_filepath.open("w", buffering=1)
     sys.stdout = log_fh

--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,7 @@ import pytest
 
 ROOT_PATH = pathlib.Path(__file__).parents[0].resolve()
 TEST_PATH = ROOT_PATH / "src" / "tests"
-BUILD_PATH = ROOT_PATH / "build"
+BUILD_PATH = ROOT_PATH / "dist"
 
 sys.path.append(str(ROOT_PATH / "pyodide-build"))
 sys.path.append(str(ROOT_PATH / "src" / "py"))
@@ -385,7 +385,7 @@ class NodeWrapper(SeleniumWrapper):
     browser = "node"
 
     def init_node(self):
-        os.chdir("build")
+        os.chdir("dist")
         self.p = pexpect.spawn(
             f"node --expose-gc --experimental-wasm-bigint ../tools/node_test_driver.js {self.base_url}",
             timeout=60,

--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,7 @@ import pytest
 
 ROOT_PATH = pathlib.Path(__file__).parents[0].resolve()
 TEST_PATH = ROOT_PATH / "src" / "tests"
-BUILD_PATH = ROOT_PATH / "dist"
+DIST_PATH = ROOT_PATH / "dist"
 
 sys.path.append(str(ROOT_PATH / "pyodide-build"))
 sys.path.append(str(ROOT_PATH / "src" / "py"))
@@ -31,10 +31,10 @@ from pyodide_build.testing import parse_driver_timeout, set_webdriver_script_tim
 def pytest_addoption(parser):
     group = parser.getgroup("general")
     group.addoption(
-        "--build-dir",
+        "--dist-dir",
         action="store",
-        default=BUILD_PATH,
-        help="Path to the build directory",
+        default=DIST_PATH,
+        help="Path to the dist directory",
     )
     group.addoption(
         "--run-xfail",
@@ -76,7 +76,7 @@ def pytest_collection_modifyitems(config, items):
 @functools.cache
 def built_packages() -> list[str]:
     """Returns the list of built package names from packages.json"""
-    packages_json_path = BUILD_PATH / "packages.json"
+    packages_json_path = DIST_PATH / "packages.json"
     if not packages_json_path.exists():
         return []
     return list(json.loads(packages_json_path.read_text())["packages"].keys())
@@ -704,14 +704,14 @@ def selenium(request, selenium_module_scope):
 
 @pytest.fixture(scope="session")
 def web_server_main(request):
-    """Web server that serves files in the build/ directory"""
+    """Web server that serves files in the dist/ directory"""
     with spawn_web_server(request.config.option.build_dir) as output:
         yield output
 
 
 @pytest.fixture(scope="session")
 def web_server_secondary(request):
-    """Secondary web server that serves files build/ directory"""
+    """Secondary web server that serves files dist/ directory"""
     with spawn_web_server(request.config.option.build_dir) as output:
         yield output
 
@@ -727,7 +727,7 @@ def web_server_tst_data(request):
 def spawn_web_server(build_dir=None):
 
     if build_dir is None:
-        build_dir = BUILD_PATH
+        build_dir = DIST_PATH
 
     tmp_dir = tempfile.mkdtemp()
     log_path = pathlib.Path(tmp_dir) / "http-server.log"

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -58,9 +58,9 @@ used.
    docker environment using external browser programs on the host system. To do
    this, run: `pyodide-build serve`
 
-3. This serves the `build` directory of the Pyodide project on port 8000.
+3. This serves the `dist` directory of the Pyodide project on port 8000.
 
-   - To serve a different directory, use the `--build_dir` argument followed
+   - To serve a different directory, use the `--dist_dir` argument followed
      by the path of the directory.
    - To serve on a different port, use the `--port` argument followed by the
      desired port number. Make sure that the port passed in `--port` argument

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -35,40 +35,29 @@ There are 3 test locations that are collected by pytest,
 
 To run tests on the JavaScript Pyodide package using Mocha, run the following commands,
 
-```
+```sh
 cd src/js
 npm test
 ```
 
 To check TypeScript type definitions run,
 
-```
+```sh
 npx tsd
 ```
 
 ### Manual interactive testing
 
-To run manual interactive tests, a docker environment and a webserver will be
-used.
+To run tests manually:
 
-1. Bind port 8000 for testing. To automatically bind port 8000 of the docker
-   environment and the host system, run: `./run_docker`
+1. Build Pyodide, perhaps in the docker image
 
-2. Now, this can be used to test the Pyodide builds running within the
-   docker environment using external browser programs on the host system. To do
-   this, run: `pyodide-build serve`
+2. From outside of the docker image, `cd` into the `dist` directory and run `python -m http.server`.
 
-3. This serves the `dist` directory of the Pyodide project on port 8000.
-
-   - To serve a different directory, use the `--dist_dir` argument followed
-     by the path of the directory.
-   - To serve on a different port, use the `--port` argument followed by the
-     desired port number. Make sure that the port passed in `--port` argument
-     is same as the one defined as `DOCKER_PORT` in the `run_docker` script.
-
-4. Once the webserver is running, simple interactive testing can be run by
-   visiting this URL:
-   [http://localhost:8000/console.html](http://localhost:8000/console.html)
+3. Once the webserver is running, simple interactive testing can be run by
+   visiting the URL:
+   `http://localhost:<PORT>/console.html`
+   It's recommended to use `pyodide.runPython` in the browser console rather than using the repl.
 
 ## Benchmarking
 

--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -143,7 +143,7 @@ You would just need to call `.postMessages()` with the right arguments as
 this API does.
 
 ```js
-const pyodideWorker = new Worker("./build/webworker.js");
+const pyodideWorker = new Worker("./dist/webworker.js");
 
 const callbacks = {};
 

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -10,7 +10,7 @@ endif
 
 all: pyodide-build
 	mkdir -p $(HOSTINSTALLDIR)
-	PYODIDE_ROOT=$(PYODIDE_ROOT) python -m pyodide_build buildall . $(PYODIDE_ROOT)/build \
+	PYODIDE_ROOT=$(PYODIDE_ROOT) python -m pyodide_build buildall . $(PYODIDE_ROOT)/dist \
 	$(ONLY_PACKAGES) --n-jobs $${PYODIDE_JOBS:-4} \
 	--log-dir=./build-logs
 

--- a/packages/matplotlib/meta.yaml
+++ b/packages/matplotlib/meta.yaml
@@ -33,8 +33,8 @@ build:
     rm -rf sphinxext
     cp $PKGDIR/src/fontlist.json matplotlib
     cp $PKGDIR/src/Humor-Sans-1.0.ttf matplotlib/mpl-data/fonts/ttf/Humor-Sans.ttf
-    mkdir -p $PKGDIR/../../build/fonts
-    cp matplotlib/mpl-data/fonts/ttf/* $PKGDIR/../../build/fonts/
+    mkdir -p $PKGDIR/../../dist/fonts
+    cp matplotlib/mpl-data/fonts/ttf/* $PKGDIR/../../dist/fonts/
 
 requirements:
   run:

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -164,7 +164,7 @@ def test_install_custom_url(selenium_standalone_micropip, base_url):
 
     root = Path(__file__).resolve().parents[2]
     src = root / "src" / "tests" / "data"
-    target = root / "build" / "test_data"
+    target = root / "dist" / "test_data"
     target.symlink_to(src, True)
     path = "/test_data/snowballstemmer-2.0.0-py2.py3-none-any.whl"
     try:

--- a/pyodide-build/pyodide_build/serve.py
+++ b/pyodide-build/pyodide_build/serve.py
@@ -16,9 +16,9 @@ Handler.extensions_map[".wasm"] = "application/wasm"
 
 
 def make_parser(parser):
-    parser.description = "Start a server with the supplied dist_dir and port."
+    parser.description = "Start a server with the supplied dist-dir and port."
     parser.add_argument(
-        "--dist_dir",
+        "--dist-dir",
         action="store",
         type=str,
         default="dist",

--- a/pyodide-build/pyodide_build/serve.py
+++ b/pyodide-build/pyodide_build/serve.py
@@ -16,13 +16,13 @@ Handler.extensions_map[".wasm"] = "application/wasm"
 
 
 def make_parser(parser):
-    parser.description = "Start a server with the supplied " "build_dir and port."
+    parser.description = "Start a server with the supplied dist_dir and port."
     parser.add_argument(
-        "--build_dir",
+        "--dist_dir",
         action="store",
         type=str,
-        default="build",
-        help="set the build directory (default: %(default)s)",
+        default="dist",
+        help="set the dist directory (default: %(default)s)",
     )
     parser.add_argument(
         "--port",

--- a/src/js/rollup.config.js
+++ b/src/js/rollup.config.js
@@ -4,7 +4,7 @@ import { terser } from "rollup-plugin-terser";
 import ts from "rollup-plugin-ts";
 
 function config({ input, format, minify, ext }) {
-  const dir = `build/`;
+  const dir = `dist/`;
   // const minifierSuffix = minify ? ".min" : "";
   const minifierSuffix = "";
   return {

--- a/src/js/tsconfig.json
+++ b/src/js/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "lib": ["ES2021", "DOM"],
-    "outDir": "../../build",
+    "outDir": "../../dist",
     "esModuleInterop": true,
     "target": "ES6",
     "module": "ES2020",

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -159,17 +159,17 @@ def test_load_failure_retry(selenium_standalone):
 
 
 def test_load_package_unknown(selenium_standalone):
-    build_dir = Path(__file__).parents[2] / "build"
+    dist_dir = Path(__file__).parents[2] / "dist"
     pyparsing_wheel_name = get_pyparsing_wheel_name()
     shutil.copyfile(
-        build_dir / pyparsing_wheel_name,
-        build_dir / "pyparsing-custom-3.0.6-py3-none-any.whl",
+        dist_dir / pyparsing_wheel_name,
+        dist_dir / "pyparsing-custom-3.0.6-py3-none-any.whl",
     )
 
     try:
         selenium_standalone.load_package("./pyparsing-custom-3.0.6-py3-none-any.whl")
     finally:
-        (build_dir / "pyparsing-custom-3.0.6-py3-none-any.whl").unlink()
+        (dist_dir / "pyparsing-custom-3.0.6-py3-none-any.whl").unlink()
 
     assert selenium_standalone.run_js(
         "return pyodide.loadedPackages.hasOwnProperty('pyparsing-custom')"
@@ -265,14 +265,14 @@ def test_test_unvendoring(selenium_standalone):
 
 
 def test_install_archive(selenium):
-    build_dir = Path(__file__).parents[2] / "build"
+    dist_dir = Path(__file__).parents[2] / "dist"
     test_dir = Path(__file__).parent
     # TODO: first argument actually works as a path due to implementation,
     # maybe it can be proposed to typeshed?
     shutil.make_archive(
         str(test_dir / "test_pkg"), "gztar", root_dir=test_dir, base_dir="test_pkg"
     )
-    build_test_pkg = build_dir / "test_pkg.tar.gz"
+    build_test_pkg = dist_dir / "test_pkg.tar.gz"
     if not build_test_pkg.exists():
         build_test_pkg.symlink_to((test_dir / "test_pkg.tar.gz").absolute())
     try:
@@ -303,7 +303,7 @@ def test_install_archive(selenium):
                 """
             )
     finally:
-        (build_dir / "test_pkg.tar.gz").unlink(missing_ok=True)
+        (dist_dir / "test_pkg.tar.gz").unlink(missing_ok=True)
         (test_dir / "test_pkg.tar.gz").unlink(missing_ok=True)
 
 

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -3,15 +3,15 @@ from pathlib import Path
 
 import pytest
 
-from conftest import BUILD_PATH
+from conftest import DIST_PATH
 
 
 def get_pyparsing_wheel_name():
-    return list(BUILD_PATH.glob("pyparsing*.whl"))[0].name
+    return list(DIST_PATH.glob("pyparsing*.whl"))[0].name
 
 
 def get_pytz_wheel_name():
-    return list(BUILD_PATH.glob("pytz*.whl"))[0].name
+    return list(DIST_PATH.glob("pytz*.whl"))[0].name
 
 
 @pytest.mark.parametrize("active_server", ["main", "secondary"])


### PR DESCRIPTION
`dist` is both more accurate (the 'build' directory is normally where you do the build, and normally consists of intermediate build artifacts no one cares about). `dist` also occurs less frequently in the code base: after this change `\bbuild\b` has 466 matches, whereas `\bdist\b` has 101 matches. `build` has 1072 matches whereas `dist` has 362.