### PR TITLE
Fix interrupt handler patch

### DIFF
--- a/cpython/patches/0001-Interrupt-handling.patch
+++ b/cpython/patches/0001-Interrupt-handling.patch
@@ -1,4 +1,4 @@
-From 743d9b5eff9a05f8187141a44403968f9bb457e3 Mon Sep 17 00:00:00 2001
+From e2e91c8940302f3c431d81c6ea2af2ea0571165d Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 30 Mar 2022 14:50:30 -0700
 Subject: [PATCH] Interrupt handling
@@ -63,7 +63,7 @@ index 96881d4a49..1926f650b6 100644
          return 0;
      }
 diff --git a/Python/ceval.c b/Python/ceval.c
-index ab10b4166d..b06a453a97 100644
+index ab10b4166d..98bc690fae 100644
 --- a/Python/ceval.c
 +++ b/Python/ceval.c
 @@ -1152,6 +1152,30 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
@@ -101,7 +101,7 @@ index ab10b4166d..b06a453a97 100644
  
  
  #define CHECK_EVAL_BREAKER() \
-+    _Py_CHECK_EMSCRIPTEN_SIGNALS_PERIODICALLY(); \
++    _Py_CheckEmscriptenSignalsPeriodically(); \
      if (_Py_atomic_load_relaxed(eval_breaker)) { \
          continue; \
      }

--- a/cpython/patches/0001-Interrupt-handling.patch
+++ b/cpython/patches/0001-Interrupt-handling.patch
@@ -1,12 +1,12 @@
-From a59b6694ff9b216b5632079522a47df46c464b9b Mon Sep 17 00:00:00 2001
+From 743d9b5eff9a05f8187141a44403968f9bb457e3 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 30 Mar 2022 14:50:30 -0700
 Subject: [PATCH] Interrupt handling
 
 ---
  Modules/signalmodule.c | 38 ++++++++++++++++++++++++++++++++++++++
- Python/ceval.c         | 28 ++++++++++++++++++++++++++++
- 2 files changed, 66 insertions(+)
+ Python/ceval.c         | 29 +++++++++++++++++++++++++++++
+ 2 files changed, 67 insertions(+)
 
 diff --git a/Modules/signalmodule.c b/Modules/signalmodule.c
 index 96881d4a49..1926f650b6 100644
@@ -63,7 +63,7 @@ index 96881d4a49..1926f650b6 100644
          return 0;
      }
 diff --git a/Python/ceval.c b/Python/ceval.c
-index ab10b4166d..5ed67ee398 100644
+index ab10b4166d..b06a453a97 100644
 --- a/Python/ceval.c
 +++ b/Python/ceval.c
 @@ -1152,6 +1152,30 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
@@ -97,7 +97,15 @@ index ab10b4166d..5ed67ee398 100644
  
  /* Handle signals, pending calls, GIL drop request
     and asynchronous exception */
-@@ -1742,6 +1766,10 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
+@@ -1313,6 +1337,7 @@ eval_frame_handle_pending(PyThreadState *tstate)
+ 
+ 
+ #define CHECK_EVAL_BREAKER() \
++    _Py_CHECK_EMSCRIPTEN_SIGNALS_PERIODICALLY(); \
+     if (_Py_atomic_load_relaxed(eval_breaker)) { \
+         continue; \
+     }
+@@ -1742,6 +1767,10 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
          assert(STACK_LEVEL() <= co->co_stacksize);  /* else overflow */
          assert(!_PyErr_Occurred(tstate));
  

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -366,12 +366,9 @@ def test_keyboard_interrupt(selenium):
         try {
             pyodide.runPython(`
                 from js import triggerKeyboardInterrupt
-                def f():
-                    pass
                 for x in range(100000):
                     if x == 2000:
                         triggerKeyboardInterrupt()
-                    f()
             `);
         } catch(e){}
         pyodide.setInterruptBuffer(undefined);


### PR DESCRIPTION
When Python is compiled with `USE_COMPUTED_GOTOS` (which seems to be the case in emscripten) `DISPATCH` does a calculated `goto` directly from one opcode to the next and never executes the top of the main loop. Instructions then opt into the eval breaker check by calling `CHECK_EVAL_BREAKER`. Thus the `CHECK_EVAL_BREAKER` macro needs to call `_Py_CHECK_EMSCRIPTEN_SIGNALS_PERIODICALLY` or else Emscripten signal handling won't work. The upstream patch included this call but when I backported the patch to Python v3.10 I accidentally left it out.

Resolves #2400.