### PR TITLE
Reuse selenium instance for package import test

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -79,7 +79,7 @@ def parse_benchmark(filename):
     return "".join(lines)
 
 
-def get_benchmark_scripts(scripts_dir, repeat=11, number=5):
+def get_benchmark_scripts(scripts_dir, repeat=5, number=5):
     root = Path(__file__).resolve().parent / scripts_dir
     for filename in sorted(root.iterdir()):
         name = filename.stem

--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -41,7 +41,7 @@ def test_parse_package(name):
 
 
 @pytest.mark.skip_refcount_check
-@pytest.mark.driver_timeout(40)
+@pytest.mark.driver_timeout(60)
 @pytest.mark.parametrize("name", registered_packages())
 def test_import(name, selenium):
     if not _package_is_built(name):


### PR DESCRIPTION
The purpose of this PR is to reduce CI running time.

- Reuse selenium instance for package import tests.
- Reduce the number of repetitions of benchmarks.