### PR TITLE
MAINT declare module_init functions in TRY_INIT macros

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -33,6 +33,7 @@
 
 #define TRY_INIT(mod)                                                          \
   do {                                                                         \
+    int mod##_init();                                                          \
     if (mod##_init()) {                                                        \
       FATAL_ERROR("Failed to initialize module %s.", #mod);                    \
     }                                                                          \
@@ -40,6 +41,7 @@
 
 #define TRY_INIT_WITH_CORE_MODULE(mod)                                         \
   do {                                                                         \
+    int mod##_init(PyObject* mod);                                             \
     if (mod##_init(core_module)) {                                             \
       FATAL_ERROR("Failed to initialize module %s.", #mod);                    \
     }                                                                          \


### PR DESCRIPTION
This is a very minor convenience improvement for working on the C codebase.