### PR TITLE
update: added missing build==0.7.0 dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
   # lint
   pre-commit
   # testing
+  build==0.7.0
   hypothesis
   pexpect
   pytest


### PR DESCRIPTION
While building Pyodide and running tests, I came across a missing dependency in the requirements.txt file, so I added the requirement build==0.7.0.
