### PR TITLE
Add SHA-256 hash to packages.json entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ all: check \
 	npm-link \
 	dist/console.html \
 	dist/distutils.tar \
+	dist/test.tar \
 	dist/packages.json \
 	dist/pyodide_py.tar \
-	dist/test.tar \
 	dist/test.html \
 	dist/module_test.html \
 	dist/webworker.js \

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -31,6 +31,8 @@ substitutions:
 
 - {{ Bugfix }} The build will error out earlier if `cmake` or `libtool` are not installed.
 
+- {{ Enhancement }} Add SHA-256 hash of package to entries in `packages.json`
+
 ### Packages
 
 - {{ Enhancement }} Pillow now supports WEBP image format {pr}`2407`.

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -434,8 +434,8 @@ def build_from_graph(pkg_map: dict[str, BasePackage], outputdir: Path, args) -> 
 def _generate_package_hash(full_path: Path) -> str:
     sha256_hash = hashlib.sha256()
     with open(full_path, "rb") as f:
-        for byte_block in iter(lambda: f.read(4096), b""):
-            sha256_hash.update(byte_block)
+        while chunk := f.read(4096):
+            sha256_hash.update(chunk)
     return sha256_hash.hexdigest()
 
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -439,7 +439,7 @@ def generate_package_hash(full_path: Path) -> str:
     return sha256_hash.hexdigest()
 
 
-def generate_packages_json(packages_dir: Path, pkg_map: dict[str, BasePackage]) -> dict:
+def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) -> dict:
     """Generate the package.json file"""
     # Build package.json data.
     package_data: dict[str, dict[str, Any]] = {
@@ -457,7 +457,7 @@ def generate_packages_json(packages_dir: Path, pkg_map: dict[str, BasePackage]) 
             "version": pkg.version,
             "file_name": pkg.file_name,
             "install_dir": pkg.install_dir,
-            "sha_256": generate_package_hash(Path(packages_dir, pkg.file_name)),
+            "sha_256": generate_package_hash(Path(output_dir, pkg.file_name)),
         }
         if pkg.shared_library:
             pkg_entry["shared_library"] = True
@@ -493,12 +493,12 @@ def generate_packages_json(packages_dir: Path, pkg_map: dict[str, BasePackage]) 
     return package_data
 
 
-def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
+def build_packages(packages_dir: Path, output_dir: Path, args) -> None:
     packages = common._parse_package_subset(args.only)
 
     pkg_map = generate_dependency_graph(packages_dir, packages)
 
-    build_from_graph(pkg_map, outputdir, args)
+    build_from_graph(pkg_map, output_dir, args)
     for pkg in pkg_map.values():
         if pkg.library:
             continue
@@ -514,9 +514,9 @@ def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
         pkg.file_name = pkg.wheel_path().name
         pkg.unvendored_tests = pkg.tests_path()
 
-    package_data = generate_packages_json(packages_dir, pkg_map)
+    package_data = generate_packages_json(output_dir, pkg_map)
 
-    with open(outputdir / "packages.json", "w") as fd:
+    with open(output_dir / "packages.json", "w") as fd:
         json.dump(package_data, fd)
         fd.write("\n")
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -431,7 +431,7 @@ def build_from_graph(pkg_map: dict[str, BasePackage], outputdir: Path, args) -> 
     )
 
 
-def generate_package_hash(full_path: Path) -> str:
+def _generate_package_hash(full_path: Path) -> str:
     sha256_hash = hashlib.sha256()
     with open(full_path, "rb") as f:
         for byte_block in iter(lambda: f.read(4096), b""):
@@ -457,7 +457,7 @@ def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) ->
             "version": pkg.version,
             "file_name": pkg.file_name,
             "install_dir": pkg.install_dir,
-            "sha_256": generate_package_hash(Path(output_dir, pkg.file_name)),
+            "sha_256": _generate_package_hash(Path(output_dir, pkg.file_name)),
         }
         if pkg.shared_library:
             pkg_entry["shared_library"] = True

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -1,3 +1,4 @@
+import os
 from collections import namedtuple
 from pathlib import Path
 from time import sleep
@@ -22,12 +23,18 @@ def test_generate_dependency_graph():
     assert pkg_map["beautifulsoup4"].dependents == set()
 
 
-def test_generate_packages_json():
+def test_generate_packages_json(tmp_path):
+    # Set up directory to store dummy package files for SHA-256 hash verification
+    if not os.path.exists(tmp_path):
+        os.makedirs(tmp_path)
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"pkg_1", "pkg_2"})
     for pkg in pkg_map.values():
         pkg.file_name = pkg.file_name or pkg.name + ".file"
+        # Write dummy package file for SHA-256 hash verification
+        with open(os.path.join(tmp_path, pkg.file_name), "w") as f:
+            f.write(pkg.name)
 
-    package_data = buildall.generate_packages_json(PACKAGES_DIR, pkg_map)
+    package_data = buildall.generate_packages_json(tmp_path, pkg_map)
     assert set(package_data.keys()) == {"info", "packages"}
     assert package_data["info"] == {"arch": "wasm32", "platform": "Emscripten-1.0"}
     assert set(package_data["packages"]) == {
@@ -44,6 +51,7 @@ def test_generate_packages_json():
         "depends": ["pkg_1_1", "pkg_3"],
         "imports": ["pkg_1"],
         "install_dir": "site",
+        "sha_256": "c1e38241013b5663e902fff97eb8585e98e6df446585da1dcf2ad121b52c2143",
     }
 
 

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -27,7 +27,7 @@ def test_generate_packages_json():
     for pkg in pkg_map.values():
         pkg.file_name = pkg.file_name or pkg.name + ".file"
 
-    package_data = buildall.generate_packages_json(pkg_map)
+    package_data = buildall.generate_packages_json(PACKAGES_DIR, pkg_map)
     assert set(package_data.keys()) == {"info", "packages"}
     assert package_data["info"] == {"arch": "wasm32", "platform": "Emscripten-1.0"}
     assert set(package_data["packages"]) == {

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -1,4 +1,3 @@
-import os
 from collections import namedtuple
 from pathlib import Path
 from time import sleep
@@ -24,14 +23,11 @@ def test_generate_dependency_graph():
 
 
 def test_generate_packages_json(tmp_path):
-    # Set up directory to store dummy package files for SHA-256 hash verification
-    if not os.path.exists(tmp_path):
-        os.makedirs(tmp_path)
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"pkg_1", "pkg_2"})
     for pkg in pkg_map.values():
         pkg.file_name = pkg.file_name or pkg.name + ".file"
         # Write dummy package file for SHA-256 hash verification
-        with open(os.path.join(tmp_path, pkg.file_name), "w") as f:
+        with open(tmp_path / pkg.file_name, "w") as f:
             f.write(pkg.name)
 
     package_data = buildall.generate_packages_json(tmp_path, pkg_map)


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

This PR adds a SHA-256 hash to the entries in the `packages.json` (the JSON is built in `generate_packages_json()` in `buildall.py`) which is the first step for #2431. This PR also modifies the test for `generate_packages_json()`. For the test, we create dummy package files to test the SHA-256 generation.

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
