### PR TITLE
Use emscripten's -Oz option for pandas

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -47,6 +47,9 @@ substitutions:
 
 - {{ Enhancement }} Pillow now supports WEBP image format {pr}`2407`.
 
+- Pandas is now compiled with `-Oz`, which significantly speeds up loading the library
+  on Chrome {pr}`2457`
+
 - New packages: opencv-python v4.5.5.64 {pr}`2305`, ffmpeg {pr}`2305`, libwebp {pr}`2305`,
   h5py, pkgconfig and libhdf5 {pr}`2411`, bitarray {pr}`2459`
 

--- a/packages/pandas/meta.yaml
+++ b/packages/pandas/meta.yaml
@@ -9,8 +9,8 @@ source:
 build:
   cflags:
     -Werror=implicit-function-declaration -Werror=mismatched-parameter-types
-    -Werror=mismatched-return-types
-  ldflags: --Wl,--fatal-warnings
+    -Werror=mismatched-return-types -Oz
+  ldflags: --Wl,--fatal-warnings -Oz
 requirements:
   run:
     - distutils


### PR DESCRIPTION
We found in #347 that one of the main culprits of slow load times
for pandas was WASM compilation times. Let's try using emscripten's
[-Oz optimization](https://emscripten.org/docs/tools_reference/emcc.html#emcc-oz) just for this package, which seems to reduce
the size of the wheel from 5.0M -> 4.4M on my machine.
