### PR TITLE
allow running mkpkg without npx installed

### DIFF
--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -145,7 +145,11 @@ def make_package(
         raise MkpkgFailedException(f"The package {package} already exists")
 
     yaml.dump(yaml_content, meta_path)
-    run_prettier(meta_path)
+    try:
+        run_prettier(meta_path)
+    except FileNotFoundError:
+        warnings.warn(
+            "'npx' executable missing, output has not been prettified.")
 
     success(f"Output written to {meta_path}")
 
@@ -282,9 +286,6 @@ def main(args):
     PYODIDE_ROOT = os.environ.get("PYODIDE_ROOT")
     if PYODIDE_ROOT is None:
         raise ValueError("PYODIDE_ROOT is not set")
-
-    if shutil.which("npx") is None:
-        raise ValueError("npx is not installed")
 
     PACKAGES_ROOT = Path(PYODIDE_ROOT) / "packages"
 

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -148,8 +148,7 @@ def make_package(
     try:
         run_prettier(meta_path)
     except FileNotFoundError:
-        warnings.warn(
-            "'npx' executable missing, output has not been prettified.")
+        warnings.warn("'npx' executable missing, output has not been prettified.")
 
     success(f"Output written to {meta_path}")
 


### PR DESCRIPTION
### Description

Allow `mkpkg` to run (what is the proposed command for generating a yaml skeleton for a new package) when `npx` is not installed.

Seems like a non vital step, since the expected yaml is output without it) and I think it should not hold up people that don't have it installed or make them look into how to install `npx` or how vital it is.

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation

None of the checklist items apply, I think.