### PR TITLE
DOC Improve GH PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
 <!-- Thank you for contributing to Pyodide! All improvements are welcome,
      so don't be afraid to make a PR. -->
 
-
 ### Description
 
 <!-- Please explain what your PR is about:
@@ -16,7 +15,7 @@
      If you think some of these steps are not necessary for your PR,
      remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
      we will assume that your PR is not ready to be merged  -->
-    
+
 - [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
 - [ ] Add / update tests
 - [ ] Add new / update outdated documentation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,6 @@
 <!-- Thank you for contributing to Pyodide! All improvements are welcome,
      so don't be afraid to make a PR. -->
 
-<!-- [IMPORTANT] Note on CI failures:
-     Currently, we are having issues with selenium-based tests.
-     Don't panic if the CI fails on your PR because of timeouts.
-     It's probably not your fault. We will investigate :) -->
 
 ### Description
 
@@ -16,12 +12,11 @@
 
 ### Checklists
 
-<!-- Note on checklists:
+<!-- Note:
      If you think some of these steps are not necessary for your PR,
-     just remove those checkboxes, or mark them as checked. Otherwise,
-     if some checkboxes are left unmarked, we might assume that your PR
-     is not ready to be merged and we might keep you waiting -->
-
+     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
+     we will assume that your PR is not ready to be merged  -->
+    
 - [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
 - [ ] Add / update tests
 - [ ] Add new / update outdated documentation


### PR DESCRIPTION
Small improvement to the PR template to put stronger wording in the section indicating that contributors shouldn't keep unchecked checkboxes, as this has been happening very frequently for new contributors. 

Overall I would rather repeatedly comment that a PR needs a test or a changelog, rather than saying that the author needs to edit the description for removing bullet points, as it feels like nitpicking. Though this confusion in communication still bothers me a bit. Anyway, I hope the improved wording will make it better.

Also removed the part about CI failures, as we are overall OK now.