### PR TITLE
Add browser polyfills for webpack compilation.

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,6 +14,8 @@ substitutions:
 
 ## Unreleased
 
+- {{ Fix }} We now tell packagers (e.g., Webpack) to ignore npm-specific imports when packing files for the browser. {pr}`2468`
+
 - {{ Fix }} micropip now correctly handles package names that include dashes
   {pr}`2414`
 

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -29,12 +29,12 @@ export async function initNodeModules() {
     return;
   }
   // @ts-ignore
-  nodePathMod = (await import(/* webpackIgnore: true */ "path")).default;
-  nodeFsPromisesMod = await import(/* webpackIgnore: true */ "fs/promises");
+  nodePathMod = (await import("path")).default;
+  nodeFsPromisesMod = await import("fs/promises");
   // @ts-ignore
-  nodeFetch = (await import(/* webpackIgnore: true */ "node-fetch")).default;
+  nodeFetch = (await import("node-fetch")).default;
   // @ts-ignore
-  nodeVmMod = (await import(/* webpackIgnore: true */ "vm")).default;
+  nodeVmMod = (await import("vm")).default;
   if (typeof require !== "undefined") {
     return;
   }
@@ -46,10 +46,10 @@ export async function initNodeModules() {
   // These are all the packages required in pyodide.asm.js. You can get this
   // list with:
   // $ grep -o 'require("[a-z]*")' pyodide.asm.js  | sort -u
-  const fs = await import(/* webpackIgnore: true */ "fs");
-  const crypto = await import(/* webpackIgnore: true */ "crypto");
-  const ws = await import(/* webpackIgnore: true */ "ws");
-  const child_process = await import(/* webpackIgnore: true */ "child_process");
+  const fs = await import("fs");
+  const crypto = await import("crypto");
+  const ws = await import("ws");
+  const child_process = await import("child_process");
   const node_modules: { [mode: string]: any } = {
     fs,
     crypto,
@@ -144,7 +144,7 @@ export let loadScript: (url: string) => Promise<void>;
 
 if (globalThis.document) {
   // browser
-  loadScript = async (url) => await import(/* webpackIgnore: true */ url);
+  loadScript = async (url) => await import(url);
 } else if (globalThis.importScripts) {
   // webworker
   loadScript = async (url) => {

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -61,6 +61,15 @@
     "distutils.tar",
     "console.html"
   ],
+  "browser": {
+    "child_process": false,
+    "crypto": false,
+    "fs": false,
+    "fs/promises": false,
+    "path": false,
+    "vm": false,
+    "ws": false
+  },
   "scripts": {
     "test": "npm-run-all test:*",
     "test:unit": "cross-env TEST_NODE=1 ts-mocha -p tsconfig.test.json test/unit/**/*.test.ts",


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

This adds the necessary polyfills, according to the spec at https://github.com/defunctzombie/package-browser-field-spec to enable webpack to ignore any imports of these modules when packing files for the browser.

To be clear, the "polyfills" added here are to just ignore the imports, since the imports shouldn't happen in the browser.

With this change, we can successfully webpack a simple js file that imports pyodide:
```js
import { loadPyodide } from "pyodide";
```
### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [X] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry

