### PR TITLE
Update typescript target to es2017

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,6 +14,8 @@ substitutions:
 
 ## Unreleased
 
+- {{ Enhancement }} Update Typescript target to ES2017 to generate more modern Javascript code. {pr}`2471`
+
 - {{ Fix }} micropip now correctly handles package names that include dashes
   {pr}`2414`
 

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -105,7 +105,7 @@
   "tsd": {
     "compilerOptions": {
       "lib": [
-        "ES2018",
+        "ES2017",
         "DOM"
       ]
     }

--- a/src/js/tsconfig.json
+++ b/src/js/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "lib": ["ES2021", "DOM"],
     "outDir": "../../dist",
     "esModuleInterop": true,
-    "target": "ES6",
+    "target": "ES2017",
     "module": "ES2020",
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

<!-- [IMPORTANT] Note on CI failures:
     Currently, we are having issues with selenium-based tests.
     Don't panic if the CI fails on your PR because of timeouts.
     It's probably not your fault. We will investigate :) -->

### Description

This will generate code that uses native async/await. Safari 14.1, Chrome, and Firefox appear to have [support for es2021](https://caniuse.com/?feats=mdn-javascript_builtins_string_replaceall,mdn-javascript_builtins_promise_any,mdn-javascript_builtins_weakref,mdn-javascript_operators_logical_or_assignment,mdn-javascript_operators_logical_and_assignment,mdn-javascript_operators_logical_nullish_assignment,mdn-javascript_grammar_numeric_separators): 

### Checklists

<!-- Note on checklists:
     If you think some of these steps are not necessary for your PR,
     just remove those checkboxes, or mark them as checked. Otherwise,
     if some checkboxes are left unmarked, we might assume that your PR
     is not ready to be merged and we might keep you waiting -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
