### PR TITLE
MAINT Add `jsproxy_typedict` to `_core_module`

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2145,6 +2145,8 @@ JsProxy_init(PyObject* core_module)
   JsProxy_TypeDict = PyDict_New();
   FAIL_IF_NULL(JsProxy_TypeDict);
 
+  PyModule_AddObject(core_module, "jsproxy_typedict", JsProxy_TypeDict);
+
   PyExc_BaseException_Type = (PyTypeObject*)PyExc_BaseException;
   _Exc_JsException.tp_base = (PyTypeObject*)PyExc_Exception;
 


### PR DESCRIPTION
This should make debugging `jsproxy.c` easier