### PR TITLE
CI Don't cache dist/node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
             PYODIDE_PACKAGES="core" make
             ccache -s
             # Dont cache node_modules
-            rm -r dist/node_modules
+            rm -rf dist/node_modules
 
       - run:
           name: check-size
@@ -145,7 +145,7 @@ jobs:
             ccache -s
 
             # Dont cache node_modules
-            rm -r dist/node_modules
+            rm -rf dist/node_modules
 
           environment:
             PYODIDE_JOBS: 5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,8 @@ jobs:
             ccache -z
             PYODIDE_PACKAGES="core" make
             ccache -s
+            # Dont cache node_modules
+            rm -r dist/node_modules
 
       - run:
           name: check-size
@@ -141,6 +143,10 @@ jobs:
             ccache -z
             PYODIDE_PACKAGES='<< parameters.packages >>' make -C packages
             ccache -s
+
+            # Dont cache node_modules
+            rm -r dist/node_modules
+
           environment:
             PYODIDE_JOBS: 5
 
@@ -156,7 +162,7 @@ jobs:
       - run:
           name: Zip build directory
           command: |
-            tar --exclude="node_modules" -cjf pyodide-build.tar.gz dist
+            tar -cjf pyodide-build.tar.gz dist
             tar cjf build-logs.tar.gz  packages/build-logs
 
       - store_artifacts:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,9 @@ jobs:
           PYODIDE_PACKAGES="core,numpy" make
           ccache -s
 
+          # Don't cache node_modules/
+          rm -r dist/node_modules
+
       - name: check-size
         run: ls -lh dist/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
           ccache -s
 
           # Don't cache node_modules/
-          rm -r dist/node_modules
+          rm -rf dist/node_modules
 
       - name: check-size
         run: ls -lh dist/


### PR DESCRIPTION
For some reason, there is a `dist/node_modules` now after the build. This takes a long time to be cached by the CI (in particular because it includes chromium). 

So I remove it as a quick fix to improve CI runtimes, but we should definitely figure out why it's there in the first place and get rid of it.