### PR TITLE
FIX to_string encoding argument is not position only

### DIFF
--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -280,7 +280,7 @@ class JsProxy:
         data.
         """
 
-    def to_string(self, encoding=None, /) -> str:
+    def to_string(self, encoding=None) -> str:
         """Convert a buffer to a string object.
 
         Copies the data twice.


### PR DESCRIPTION
This fixes a mistake I made in #2427.