### PR TITLE
explore adding obspy

### DIFF
--- a/packages/obspy/meta.yaml
+++ b/packages/obspy/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: obspy
+  version: 1.3.0
+
+source:
+  url: https://files.pythonhosted.org/packages/b5/40/cebd39066edb6d91b7fddeb676a788ac89c59d3e31e820c2b64983b368d8/obspy-1.3.0.tar.gz
+  sha256: 932eb8af44542d605184a07f518f4839c7f42c22939fc848a9ddb9d8f7125077
+
+test:
+  imports:
+    - obspy
+
+about:
+  home: https://www.obspy.org
+  PyPI: https://pypi.org/project/obspy
+  summary: ObsPy - a Python framework for seismological observatories.
+  license: GNU Lesser General Public License, Version 3 (LGPLv3)


### PR DESCRIPTION
### Description

This PR explores whether [obspy](https://github.com/obspy/obspy) can be added to pyodide/pyscript. **It is mostly for information / documentation of WIP / as a draft right now.**

With a minimal recipe stub, after building the compiled wheel locally, the current state is..

 - C extensions get built
 - tried one of our really simple C extension (inside the `console.html` in Firefox) and it worked
 - tried one of our complex C extension and it crashed, saying something about GIL
 - quite a lot of obspy functionality can't be used at this state because of `requests`, either..
   - because `requests` is imported at the top of one of our submodules, or..
   - because a call goes through our entry point / plugin setup with `setuptools`, and as soon as we hit that, `setuptools` complains about `requests` missing which is listed as a hard dependency in our `setup.py`

So besides being unsure how much more work it would be to get all C extensions to work, the main caveat seems `requests`. So for now this is mostly "toying around" at the moment and I'm not sure how much more work it would be to get it done properly, both here in the recipe (for C extensions etc) and upstream/in patches (to workaround `requests` which we use quite heavily) which likely would take some major workarounds.

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

#### Side comments

It took me some time to figure out how to go forward with testing the locally built compiled wheel. I was using [this docs page](https://pyodide.org/en/stable/development/new-packages.html#creating-a-pyodide-package) mostly, but I think what it is lacking is how to test the locally built package. Maybe the following could be outlined in that page?

 - download the current build of pyodide and unpack locally
 - put the compiled wheel in there
 - add it manually in the `packages.json`
 - serve the folder locally with `python -m hhtp.server`
 - navigate browser to `http://localhost:8000/console.html` (or whatever port is stated on CL)
 - import package, play around etc..

What I still didn't figure out is how to try the locally built wheel in `pyscript`, I tried replacing in a downloaded `pyscript.js` the part that loads in `pyodide` with `http://localhost:8000/pyodide.js` but I didn't get it to work (some cross origin errors I believe).

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation

![pyodide_obspy](https://user-images.githubusercontent.com/1842780/166673317-c45acde5-66a1-4755-a3e9-011ba8d0fb82.jpg)
