### PR TITLE
DOC new packages: add info how to try out locally built wheel

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -133,6 +133,30 @@ find ways to include your patches into the package. Many package maintainers are
 very receptive to including Pyodide-related patches and they reduce future
 maintenance work for us.
 
+### 4. Try out locally built package
+
+On a successful local build you should now have a wheel
+`<package-name>-<version>-cp310-cp310-emscripten_wasm32.whl` in directory
+`packages/<package-name>/dist/`.
+
+You can download the
+[current pyodide build](https://github.com/pyodide/pyodide/releases), unpack it
+in a location of your choice and mix in your locally built wheel. Copy your
+wheel into the unpacked directory and manually add the appropriate information
+to the `packages.json` file in a text editor of your choice (e.g.
+`"<package-name>": {"name": "<package-name>", "version": "<version>", "file_name": "<package-name>-<version>-cp310-cp310-emscripten_wasm32.whl", "install_dir": "site", "depends": ["setuptools", "numpy", "scipy"], "imports": ["<package-name>"]}`).
+
+Then navigate to that directory in a terminal and serve it locally:
+
+```sh
+python -m http.server
+```
+
+By default Python will serve it locally on port 8000 (the target address will
+be stated on the terminal), then navigate your browser to
+`http://localhost:8000/console.html` and try out using your Python module in
+the pyodide terminal in your browser.
+
 ## The package build pipeline
 
 Pyodide includes a toolchain to add new third-party Python libraries to the


### PR DESCRIPTION
### Description

This is only changing docs.

After managing to build the first wheel for a new package locally, I was kinda sitting there with the compiled wheel and trying to figure out how to try it out locally.
I took a bit to figure out these steps and maybe they might help other people too.

If there's a better way to do this, like auto-add to the `package.json` or anything (without building the full pyodide build), this commit should be improved obviously. Total newb to pyodide.

see obspy/obspy#3061, pyodide/pyodide#2483

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation

Only adding to docs, so don't think any checklist items apply.