### PR TITLE
DOC Fix documentation error at pyodide.pyimport

### DIFF
--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -332,7 +332,7 @@ export function toPy(
  *    .. code-block:: js
  *
  *      let sysmodule = pyodide.pyimport("sys");
- *      let recursionLimit = sys.getrecursionlimit();
+ *      let recursionLimit = sysmodule.getrecursionlimit();
  *
  * @param mod_name The name of the module to import
  * @returns A PyProxy for the imported module


### PR DESCRIPTION
This is just a documentation fix, as per #2421 

Where it currently reads 

```
let sysmodule = pyodide.pyimport("sys");
let recursionLimit = sys.getrecursionlimit();
```

replaced for

```
let sysmodule = pyodide.pyimport("sys");
let recursionLimit = sysmodule.getrecursionlimit();
```

### Checklists
- [x] Add new / update outdated documentation
