### PR TITLE
ENH Verifying checksum when loading packages in browser

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,6 +14,9 @@ substitutions:
 
 ## Unreleased
 
+- {{ Enhancement }} Integrity of Pyodide packages are now verified before loading them. This is for now only 
+  limited to browser environments. {pr}`2513`
+
 - {{ Fix }} Fix building on macOS {issue}`2360` {pr}`2554`
 
 - {{ Fix }} Fix a REPL error in printing high-dimensional lists.

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,7 +14,7 @@ substitutions:
 
 ## Unreleased
 
-- {{ Enhancement }} Integrity of Pyodide packages are now verified before loading them. This is for now only 
+- {{ Enhancement }} Integrity of Pyodide packages are now verified before loading them. This is for now only
   limited to browser environments. {pr}`2513`
 
 - {{ Fix }} Fix building on macOS {issue}`2360` {pr}`2554`

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -5,7 +5,6 @@ Build all of the packages in a given directory.
 """
 
 import argparse
-import base64
 import hashlib
 import json
 import os
@@ -432,12 +431,12 @@ def build_from_graph(pkg_map: dict[str, BasePackage], outputdir: Path, args) -> 
     )
 
 
-def _generate_package_sub_resource_hash(full_path: Path) -> str:
+def _generate_package_hash(full_path: Path) -> str:
     sha256_hash = hashlib.sha256()
     with open(full_path, "rb") as f:
         while chunk := f.read(4096):
             sha256_hash.update(chunk)
-    return "sha256-" + base64.b64encode(sha256_hash.digest()).decode()
+    return sha256_hash.hexdigest()
 
 
 def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) -> dict:
@@ -458,9 +457,7 @@ def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) ->
             "version": pkg.version,
             "file_name": pkg.file_name,
             "install_dir": pkg.install_dir,
-            "sub_resource_hash": _generate_package_sub_resource_hash(
-                Path(output_dir, pkg.file_name)
-            ),
+            "sha_256": _generate_package_hash(Path(output_dir, pkg.file_name)),
         }
         if pkg.shared_library:
             pkg_entry["shared_library"] = True

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -457,7 +457,7 @@ def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) ->
             "version": pkg.version,
             "file_name": pkg.file_name,
             "install_dir": pkg.install_dir,
-            "sha_256": _generate_package_hash(Path(output_dir, pkg.file_name)),
+            "sha256": _generate_package_hash(Path(output_dir, pkg.file_name)),
         }
         if pkg.shared_library:
             pkg_entry["shared_library"] = True

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -5,6 +5,7 @@ Build all of the packages in a given directory.
 """
 
 import argparse
+import base64
 import hashlib
 import json
 import os
@@ -431,12 +432,12 @@ def build_from_graph(pkg_map: dict[str, BasePackage], outputdir: Path, args) -> 
     )
 
 
-def _generate_package_hash(full_path: Path) -> str:
+def _generate_package_sub_resource_hash(full_path: Path) -> str:
     sha256_hash = hashlib.sha256()
     with open(full_path, "rb") as f:
         while chunk := f.read(4096):
             sha256_hash.update(chunk)
-    return sha256_hash.hexdigest()
+    return "sha256-" + base64.b64encode(sha256_hash.digest()).decode()
 
 
 def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) -> dict:
@@ -457,7 +458,7 @@ def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) ->
             "version": pkg.version,
             "file_name": pkg.file_name,
             "install_dir": pkg.install_dir,
-            "sha_256": _generate_package_hash(Path(output_dir, pkg.file_name)),
+            "sub_resource_hash": _generate_package_sub_resource_hash(Path(output_dir, pkg.file_name)),
         }
         if pkg.shared_library:
             pkg_entry["shared_library"] = True

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -479,7 +479,9 @@ def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) ->
                 "imports": [],
                 "file_name": pkg.unvendored_tests.name,
                 "install_dir": pkg.install_dir,
-                "sha256": _generate_package_hash(Path(output_dir, pkg.unvendored_tests.name)),
+                "sha256": _generate_package_hash(
+                    Path(output_dir, pkg.unvendored_tests.name)
+                ),
             }
             package_data["packages"][name.lower() + "-tests"] = pkg_entry
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -479,6 +479,7 @@ def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) ->
                 "imports": [],
                 "file_name": pkg.unvendored_tests.name,
                 "install_dir": pkg.install_dir,
+                "sha256": _generate_package_hash(Path(output_dir, pkg.unvendored_tests.name)),
             }
             package_data["packages"][name.lower() + "-tests"] = pkg_entry
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -458,7 +458,9 @@ def generate_packages_json(output_dir: Path, pkg_map: dict[str, BasePackage]) ->
             "version": pkg.version,
             "file_name": pkg.file_name,
             "install_dir": pkg.install_dir,
-            "sub_resource_hash": _generate_package_sub_resource_hash(Path(output_dir, pkg.file_name)),
+            "sub_resource_hash": _generate_package_sub_resource_hash(
+                Path(output_dir, pkg.file_name)
+            ),
         }
         if pkg.shared_library:
             pkg_entry["shared_library"] = True

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -47,7 +47,7 @@ def test_generate_packages_json(tmp_path):
         "depends": ["pkg_1_1", "pkg_3"],
         "imports": ["pkg_1"],
         "install_dir": "site",
-        "sha_256": "c1e38241013b5663e902fff97eb8585e98e6df446585da1dcf2ad121b52c2143",
+        "sha256": "c1e38241013b5663e902fff97eb8585e98e6df446585da1dcf2ad121b52c2143",
     }
 
 

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -26,7 +26,7 @@ def test_generate_packages_json(tmp_path):
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"pkg_1", "pkg_2"})
     for pkg in pkg_map.values():
         pkg.file_name = pkg.file_name or pkg.name + ".file"
-        # Write dummy package file for SHA-256 hash verification
+        # Write dummy package file for sub resource hash verification
         with open(tmp_path / pkg.file_name, "w") as f:
             f.write(pkg.name)
 
@@ -47,7 +47,7 @@ def test_generate_packages_json(tmp_path):
         "depends": ["pkg_1_1", "pkg_3"],
         "imports": ["pkg_1"],
         "install_dir": "site",
-        "sha_256": "c1e38241013b5663e902fff97eb8585e98e6df446585da1dcf2ad121b52c2143",
+        "sub_resource_hash": "sha256-uRTkBUih9DcSGPKrCsX889wCyxXX/rDOnAUmlUrYwOU=",
     }
 
 

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -26,7 +26,7 @@ def test_generate_packages_json(tmp_path):
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"pkg_1", "pkg_2"})
     for pkg in pkg_map.values():
         pkg.file_name = pkg.file_name or pkg.name + ".file"
-        # Write dummy package file for sub resource hash verification
+        # Write dummy package file for SHA-256 hash verification
         with open(tmp_path / pkg.file_name, "w") as f:
             f.write(pkg.name)
 
@@ -47,7 +47,7 @@ def test_generate_packages_json(tmp_path):
         "depends": ["pkg_1_1", "pkg_3"],
         "imports": ["pkg_1"],
         "install_dir": "site",
-        "sub_resource_hash": "sha256-weOCQQE7VmPpAv/5frhYXpjm30RlhdodzyrRIbUsIUM=",
+        "sha_256": "c1e38241013b5663e902fff97eb8585e98e6df446585da1dcf2ad121b52c2143",
     }
 
 

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -47,7 +47,7 @@ def test_generate_packages_json(tmp_path):
         "depends": ["pkg_1_1", "pkg_3"],
         "imports": ["pkg_1"],
         "install_dir": "site",
-        "sub_resource_hash": "sha256-uRTkBUih9DcSGPKrCsX889wCyxXX/rDOnAUmlUrYwOU=",
+        "sub_resource_hash": "sha256-weOCQQE7VmPpAv/5frhYXpjm30RlhdodzyrRIbUsIUM=",
     }
 
 

--- a/pyodide-test-runner/pyodide_test_runner/browser.py
+++ b/pyodide-test-runner/pyodide_test_runner/browser.py
@@ -177,6 +177,7 @@ class SeleniumWrapper:
             pyodide._api.importlib.invalidate_caches;
             pyodide._api.package_loader.unpack_buffer;
             pyodide._api.package_loader.get_dynlibs;
+            pyodide._api.package_loader.sub_resource_hash;
             pyodide.runPython("");
             """
         )

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -77,7 +77,6 @@ async function node_loadBinaryFile(
   path: string,
   _checksum: string | undefined // Ignoring package checksum. See issue-XXX
 ): Promise<Uint8Array> {
-
   if (!path.startsWith("/") && !path.includes("://")) {
     // If path starts with a "/" or starts with a protocol "blah://", we
     // interpret it as an absolute path, otherwise "resolve" it by

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -6,7 +6,7 @@ export const IN_NODE =
   process.release &&
   process.release.name === "node" &&
   typeof process.browser ===
-    "undefined"; /* This last condition checks if we run the browser shim of process */
+  "undefined"; /* This last condition checks if we run the browser shim of process */
 
 let nodePathMod: any;
 let nodeFetch: any;
@@ -75,7 +75,7 @@ export async function initNodeModules() {
 async function node_loadBinaryFile(
   indexURL: string,
   path: string,
-  _checksum: string | undefined // Ignoring package checksum. See issue-XXX
+  _file_sub_resource_hash?: string | undefined // Ignoring sub resource hash. See issue-XXX
 ): Promise<Uint8Array> {
   if (!path.startsWith("/") && !path.includes("://")) {
     // If path starts with a "/" or starts with a protocol "blah://", we
@@ -107,18 +107,19 @@ async function node_loadBinaryFile(
  *
  * @param indexURL base path to resolve relative paths
  * @param path the path to load
+ * @param subResourceHash the sub resource hash for fetch() integrity check
  * @returns A Uint8Array containing the binary data
  * @private
  */
 async function browser_loadBinaryFile(
   indexURL: string,
   path: string,
-  checksum: string | undefined
+  subResourceHash: string | undefined
 ): Promise<Uint8Array> {
   // @ts-ignore
   const base = new URL(indexURL, location);
   const url = new URL(path, base);
-  let options = checksum ? { integrity: "sha256-" + checksum } : {};
+  let options = subResourceHash ? { integrity: subResourceHash } : {};
   // @ts-ignore
   let response = await fetch(url, options);
   if (!response.ok) {
@@ -131,7 +132,7 @@ async function browser_loadBinaryFile(
 export let _loadBinaryFile: (
   indexURL: string,
   path: string,
-  file_checksum?: string | undefined
+  file_sub_resource_hash?: string | undefined
 ) => Promise<Uint8Array>;
 if (IN_NODE) {
   _loadBinaryFile = node_loadBinaryFile;

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -68,13 +68,16 @@ export async function initNodeModules() {
  * then fetch from a URL, else load from the file system.
  * @param indexURL base path to resolve relative paths
  * @param path the path to load
+ * @param checksum sha-256 checksum of the package
  * @returns An ArrayBuffer containing the binary data
  * @private
  */
 async function node_loadBinaryFile(
   indexURL: string,
-  path: string
+  path: string,
+  checksum: string | undefined
 ): Promise<Uint8Array> {
+  console.log("Ignoring package checksum. See issue-XXX.", checksum);
   if (!path.startsWith("/") && !path.includes("://")) {
     // If path starts with a "/" or starts with a protocol "blah://", we
     // interpret it as an absolute path, otherwise "resolve" it by
@@ -110,13 +113,15 @@ async function node_loadBinaryFile(
  */
 async function browser_loadBinaryFile(
   indexURL: string,
-  path: string
+  path: string,
+  checksum: string | undefined
 ): Promise<Uint8Array> {
   // @ts-ignore
   const base = new URL(indexURL, location);
   const url = new URL(path, base);
+  let options = checksum ? { 'integrity': 'sha256-' + checksum } : {};
   // @ts-ignore
-  let response = await fetch(url);
+  let response = await fetch(url, options);
   if (!response.ok) {
     throw new Error(`Failed to load '${url}': request failed.`);
   }
@@ -126,7 +131,8 @@ async function browser_loadBinaryFile(
 /** @private */
 export let _loadBinaryFile: (
   indexURL: string,
-  path: string
+  path: string,
+  file_checksum?: string | undefined
 ) => Promise<Uint8Array>;
 if (IN_NODE) {
   _loadBinaryFile = node_loadBinaryFile;

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -75,9 +75,9 @@ export async function initNodeModules() {
 async function node_loadBinaryFile(
   indexURL: string,
   path: string,
-  checksum: string | undefined
+  _checksum: string | undefined // Ignoring package checksum. See issue-XXX
 ): Promise<Uint8Array> {
-  console.log("Ignoring package checksum. See issue-XXX.", checksum);
+
   if (!path.startsWith("/") && !path.includes("://")) {
     // If path starts with a "/" or starts with a protocol "blah://", we
     // interpret it as an absolute path, otherwise "resolve" it by

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -6,7 +6,7 @@ export const IN_NODE =
   process.release &&
   process.release.name === "node" &&
   typeof process.browser ===
-  "undefined"; /* This last condition checks if we run the browser shim of process */
+    "undefined"; /* This last condition checks if we run the browser shim of process */
 
 let nodePathMod: any;
 let nodeFetch: any;

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -75,7 +75,7 @@ export async function initNodeModules() {
 async function node_loadBinaryFile(
   indexURL: string,
   path: string,
-  _file_sub_resource_hash?: string | undefined // Ignoring sub resource hash. See issue-XXX
+  _file_sub_resource_hash?: string | undefined // Ignoring sub resource hash. See issue-2431.
 ): Promise<Uint8Array> {
   if (!path.startsWith("/") && !path.includes("://")) {
     // If path starts with a "/" or starts with a protocol "blah://", we

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -119,7 +119,7 @@ async function browser_loadBinaryFile(
   // @ts-ignore
   const base = new URL(indexURL, location);
   const url = new URL(path, base);
-  let options = checksum ? { 'integrity': 'sha256-' + checksum } : {};
+  let options = checksum ? { integrity: "sha256-" + checksum } : {};
   // @ts-ignore
   let response = await fetch(url, options);
   if (!response.ok) {

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -168,7 +168,9 @@ async function downloadPackage(
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.packages[name].file_name;
-    file_sub_resource_hash = API.packages[name].sub_resource_hash;
+    file_sub_resource_hash = API.package_loader.sub_resource_hash(
+      API.packages[name].sha_256
+    );
   } else {
     file_name = channel;
     file_sub_resource_hash = undefined;

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -162,17 +162,19 @@ async function downloadPackage(
   name: string,
   channel: string
 ): Promise<Uint8Array> {
-  let file_name;
+  let file_name, file_checksum;
   if (channel === DEFAULT_CHANNEL) {
     if (!(name in API.packages)) {
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.packages[name].file_name;
+    file_checksum = API.packages[name].sha_256;
   } else {
     file_name = channel;
+    file_checksum = undefined;
   }
   try {
-    return await _loadBinaryFile(baseURL, file_name);
+    return await _loadBinaryFile(baseURL, file_name, file_checksum);
   } catch (e) {
     if (!IN_NODE) {
       throw e;

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -351,8 +351,8 @@ export async function loadPackage(
     } else {
       errorCallback(
         `URI mismatch, attempting to load package ${pkg} from ${uri} ` +
-        `while it is already loaded from ${loaded}. To override a dependency, ` +
-        `load the custom package first.`
+          `while it is already loaded from ${loaded}. To override a dependency, ` +
+          `load the custom package first.`
       );
     }
   }

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -169,7 +169,7 @@ async function downloadPackage(
     }
     file_name = API.packages[name].file_name;
     file_sub_resource_hash = API.package_loader.sub_resource_hash(
-      API.packages[name].sha_256
+      API.packages[name].sha256
     );
   } else {
     file_name = channel;

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -162,19 +162,19 @@ async function downloadPackage(
   name: string,
   channel: string
 ): Promise<Uint8Array> {
-  let file_name, file_checksum;
+  let file_name, file_sub_resource_hash;
   if (channel === DEFAULT_CHANNEL) {
     if (!(name in API.packages)) {
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.packages[name].file_name;
-    file_checksum = API.packages[name].sha_256;
+    file_sub_resource_hash = API.packages[name].sub_resource_hash;
   } else {
     file_name = channel;
-    file_checksum = undefined;
+    file_sub_resource_hash = undefined;
   }
   try {
-    return await _loadBinaryFile(baseURL, file_name, file_checksum);
+    return await _loadBinaryFile(baseURL, file_name, file_sub_resource_hash);
   } catch (e) {
     if (!IN_NODE) {
       throw e;
@@ -351,8 +351,8 @@ export async function loadPackage(
     } else {
       errorCallback(
         `URI mismatch, attempting to load package ${pkg} from ${uri} ` +
-          `while it is already loaded from ${loaded}. To override a dependency, ` +
-          `load the custom package first.`
+        `while it is already loaded from ${loaded}. To override a dependency, ` +
+        `load the custom package first.`
       );
     }
   }

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -194,6 +194,10 @@ def sub_resource_hash(sha_256: str) -> str:
     Returns
     -------
         The sub resource integrity hash corresponding to the sum.
+
+    >>> sha_256 = 'c0dc86efda0060d4084098a90ec92b3d4aa89d7f7e0fba5424561d21451e1758'
+    >>> sub_resource_hash(sha_256)
+    'sha256-wNyG79oAYNQIQJipDskrPUqonX9+D7pUJFYdIUUeF1g='
     """
     binary_digest = binascii.unhexlify(sha_256)
     return "sha256-" + base64.b64encode(binary_digest).decode()

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import re
 import shutil
 import sysconfig
@@ -179,3 +181,19 @@ def get_dynlibs(archive: IO[bytes], target_dir: Path) -> list[str]:
         for path in dynlib_paths_iter
         if should_load_dynlib(path)
     ]
+
+
+def sub_resource_hash(sha_256: str) -> str:
+    """Calculates the sub resource integrity hash given a SHA-256
+
+    Parameters
+    ----------
+    sha_256
+        A hexdigest of the SHA-256 sum.
+
+    Returns
+    -------
+        The sub resource integrity hash corresponding to the sum.
+    """
+    binary_digest = binascii.unhexlify(sha_256)
+    return "sha256-" + base64.b64encode(binary_digest).decode()


### PR DESCRIPTION
### Description

This PR does the following to complete https://github.com/pyodide/pyodide/issues/2431:

- Updates the change made in https://github.com/pyodide/pyodide/pull/2455 to generate Subresource integrity hash as explained [here](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity). As the document explains, it is a base64 encoded string of the "binary" hash, not the data returned by `hexdigest()` method. Hence, this change is made as well so that `package.json` contains the subresource integrity hash directly
- Implement the verification of the checksum when loading packages

This ignores the verification for NodeJS environment as the `node-fetch` module doesn't support the `integrity` option. Node 17.5.0 has added the fetch API as experimental, it would be prudent to come back and fix this when we are ready to use that version.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
