### PR TITLE
Add js_id attribute to JsProxy for use as a dictionary key

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -49,6 +49,11 @@ substitutions:
   translated to negative Python ints.
   {pr}`2484`
 
+- {{ Enhancement }} Added the `js_id` attribute to `JsProxy` to allow using
+  JavaScript object identity as a dictionary key.
+  {pr}`2515`
+
+
 ### Packages
 
 - {{ Enhancement }} Pillow now supports WEBP image format {pr}`2407`.

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -68,7 +68,7 @@ EM_JS_NUM(int, hiwire_init, (), {
 
   Hiwire.new_value = function(jsval)
   {
-    let idval = _hiwire.obj_to_key.has(jsval);
+    let idval = _hiwire.obj_to_key.get(jsval);
     if(idval !== undefined){
       _hiwire.objects.get(idval)[1]++;
       return idval;

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -16,7 +16,7 @@ const JsRef Js_false = ((JsRef)(6));
 const JsRef Js_null = ((JsRef)(8));
 
 // For when the return value would be Option<JsRef>
-const JsRef Js_novalue = ((JsRef)(1000));
+const JsRef Js_novalue = ((JsRef)(10));
 
 JsRef
 hiwire_from_bool(bool boolean)
@@ -59,7 +59,7 @@ EM_JS_NUM(int, hiwire_init, (), {
   HIWIRE_INIT_CONST(_Js_null, JSNULL, null);
   HIWIRE_INIT_CONST(_Js_true, TRUE, true);
   HIWIRE_INIT_CONST(_Js_false, FALSE, false);
-  let hiwire_next_permanent = Hiwire.FALSE + 2;
+  let hiwire_next_permanent = HEAPU8[_Js_novalue] + 2;
 
 #ifdef DEBUG_F
   Hiwire._hiwire = _hiwire;

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -34,9 +34,9 @@ EM_JS(bool, hiwire_to_bool, (JsRef val), {
 bool tracerefs;
 #endif
 
-#define HIWIRE_INIT_CONST(js_const, hiwire_attr, js_value) \
-  Hiwire.hiwire_attr = DEREF_U8(js_const, 0); \
-  _hiwire.objects.set(Hiwire.hiwire_attr, [ js_value, -1 ]); \
+#define HIWIRE_INIT_CONST(js_const, hiwire_attr, js_value)                     \
+  Hiwire.hiwire_attr = DEREF_U8(js_const, 0);                                  \
+  _hiwire.objects.set(Hiwire.hiwire_attr, [ js_value, -1 ]);                   \
   _hiwire.obj_to_key.set(js_value, Hiwire.hiwire_attr);
 
 EM_JS_NUM(int, hiwire_init, (), {
@@ -69,7 +69,7 @@ EM_JS_NUM(int, hiwire_init, (), {
   Hiwire.new_value = function(jsval)
   {
     let idval = _hiwire.obj_to_key.get(jsval);
-    if(idval !== undefined){
+    if (idval != = undefined) {
       _hiwire.objects.get(idval)[1]++;
       return idval;
     }

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -42,6 +42,8 @@ bool tracerefs;
 EM_JS_NUM(int, hiwire_init, (), {
   let _hiwire = {
     objects : new Map(),
+    // The reverse of the object maps, needed to deduplicate keys so that key
+    // equality is object identity.
     obj_to_key : new Map(),
     // counter is used to allocate keys for the objects map.
     // We use even integers to represent singleton constants which we won't
@@ -68,6 +70,8 @@ EM_JS_NUM(int, hiwire_init, (), {
 
   Hiwire.new_value = function(jsval)
   {
+    // If jsval already has a hiwire key, then use existing key. We need this to
+    // ensure that obj1 === obj2 implies key1 == key2.
     let idval = _hiwire.obj_to_key.get(jsval);
     // clang-format off
     if (idval !== undefined) {

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -69,10 +69,12 @@ EM_JS_NUM(int, hiwire_init, (), {
   Hiwire.new_value = function(jsval)
   {
     let idval = _hiwire.obj_to_key.get(jsval);
-    if (idval != = undefined) {
+    // clang-format off
+    if (idval !== undefined) {
       _hiwire.objects.get(idval)[1]++;
       return idval;
     }
+    // clang-format on
     while (_hiwire.objects.has(_hiwire.counter[0])) {
       // Increment by two here (and below) because even integers are reserved
       // for singleton constants

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -136,6 +136,13 @@ JsProxy_typeof(PyObject* self, void* _unused)
   return result;
 }
 
+static PyObject*
+JsProxy_js_id(PyObject* self, void* _unused)
+{
+  JsRef idval = JsProxy_REF(self);
+  return PyLong_FromLong((int)idval);
+}
+
 /**
  * getattr overload, first checks whether the attribute exists in the JsProxy
  * dict, and if so returns that. Otherwise, it attempts lookup on the wrapped
@@ -971,6 +978,7 @@ static PyNumberMethods JsProxy_NumberMethods = {
 // clang-format on
 
 static PyGetSetDef JsProxy_GetSet[] = { { "typeof", .get = JsProxy_typeof },
+                                        { "js_id", .get = JsProxy_js_id}
                                         { NULL } };
 
 static PyTypeObject JsProxyType = {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -150,6 +150,18 @@ finally:
   return result;
 }
 
+static PyObject*
+JsProxy_js_id_private(PyObject* mod, PyObject* obj)
+{
+  if (!JsProxy_Check(obj)) {
+    PyErr_SetString(PyExc_TypeError, "Expected argument to be a JsProxy");
+    return NULL;
+  }
+
+  JsRef idval = JsProxy_REF(obj);
+  return PyLong_FromLong((int)idval);
+}
+
 /**
  * getattr overload, first checks whether the attribute exists in the JsProxy
  * dict, and if so returns that. Otherwise, it attempts lookup on the wrapped
@@ -2109,6 +2121,16 @@ JsException_AsJs(PyObject* err)
   return hiwire_incref(js_error->js);
 }
 
+static PyMethodDef methods[] = {
+  {
+    "hiwire_id",
+    JsProxy_js_id_private,
+    METH_O,
+  },
+  { NULL } /* Sentinel */
+};
+
+
 int
 JsProxy_init(PyObject* core_module)
 {
@@ -2149,6 +2171,8 @@ JsProxy_init(PyObject* core_module)
   SET_DOCSTRING(JsBuffer_read_from_file_MethodDef);
   SET_DOCSTRING(JsBuffer_into_file_MethodDef);
 #undef SET_DOCSTRING
+
+  FAIL_IF_MINUS_ONE(PyModule_AddFunctions(core_module, methods));
 
   asyncio_module = PyImport_ImportModule("asyncio");
   FAIL_IF_NULL(asyncio_module);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -141,16 +141,15 @@ static PyTypeObject JsProxyType;
 static PyObject*
 JsProxy_js_id(PyObject* self, void* _unused)
 {
-  PyObject* idpy = NULL;
-  PyObject* tuple = NULL;
+  PyObject* result = NULL;
   
   JsRef idval = JsProxy_REF(self);
-  idpy = PyLong_FromLong((int)idval);
-  tuple = Py_BuildValue("(OO)", &JsProxyType, idpy);
-
+  int x[2] = { (int)&JsProxyType, (int)idval };
+  Py_hash_t result_c = _Py_HashBytes(x, 8);
+  FAIL_IF_MINUS_ONE(result_c);
+  result = PyLong_FromLong(result_c);
 finally:
-  Py_CLEAR(idpy);
-  return tuple;
+  return result;
 }
 
 /**

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -142,7 +142,7 @@ static PyObject*
 JsProxy_js_id(PyObject* self, void* _unused)
 {
   PyObject* result = NULL;
-  
+
   JsRef idval = JsProxy_REF(self);
   int x[2] = { (int)&JsProxyType, (int)idval };
   Py_hash_t result_c = _Py_HashBytes(x, 8);
@@ -987,7 +987,7 @@ static PyNumberMethods JsProxy_NumberMethods = {
 // clang-format on
 
 static PyGetSetDef JsProxy_GetSet[] = { { "typeof", .get = JsProxy_typeof },
-                                        { "js_id", .get = JsProxy_js_id }, 
+                                        { "js_id", .get = JsProxy_js_id },
                                         { NULL } };
 
 static PyTypeObject JsProxyType = {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -136,11 +136,21 @@ JsProxy_typeof(PyObject* self, void* _unused)
   return result;
 }
 
+static PyTypeObject JsProxyType;
+
 static PyObject*
 JsProxy_js_id(PyObject* self, void* _unused)
 {
+  PyObject* idpy = NULL;
+  PyObject* tuple = NULL;
+  
   JsRef idval = JsProxy_REF(self);
-  return PyLong_FromLong((int)idval);
+  idpy = PyLong_FromLong((int)idval);
+  tuple = Py_BuildValue("(OO)", &JsProxyType, idpy);
+
+finally:
+  Py_CLEAR(idpy);
+  return tuple;
 }
 
 /**
@@ -978,7 +988,7 @@ static PyNumberMethods JsProxy_NumberMethods = {
 // clang-format on
 
 static PyGetSetDef JsProxy_GetSet[] = { { "typeof", .get = JsProxy_typeof },
-                                        { "js_id", .get = JsProxy_js_id}
+                                        { "js_id", .get = JsProxy_js_id }, 
                                         { NULL } };
 
 static PyTypeObject JsProxyType = {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -136,15 +136,13 @@ JsProxy_typeof(PyObject* self, void* _unused)
   return result;
 }
 
-static PyTypeObject JsProxyType;
-
 static PyObject*
 JsProxy_js_id(PyObject* self, void* _unused)
 {
   PyObject* result = NULL;
 
   JsRef idval = JsProxy_REF(self);
-  int x[2] = { (int)&JsProxyType, (int)idval };
+  int x[2] = { (int)Py_TYPE(self), (int)idval };
   Py_hash_t result_c = _Py_HashBytes(x, 8);
   FAIL_IF_MINUS_ONE(result_c);
   result = PyLong_FromLong(result_c);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2130,7 +2130,6 @@ static PyMethodDef methods[] = {
   { NULL } /* Sentinel */
 };
 
-
 int
 JsProxy_init(PyObject* core_module)
 {

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -47,6 +47,15 @@ class JsProxy:
         """
         return 0
 
+    @property
+    def typeof(self) -> str:
+        """Returns the JavaScript type of the JsProxy.
+
+        Corresponds to `typeof obj;` in JavaScript. You may also be interested
+        in the `constuctor` attribute which returns the type as an object.
+        """
+        return "object"
+
     def object_entries(self) -> "JsProxy":
         "The JavaScript API ``Object.entries(object)``"
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -38,7 +38,7 @@ class JsProxy:
     """
 
     @property
-    def js_id() -> int:
+    def js_id(self) -> int:
         """An id number which can be used as a dictionary/set key if you want to
         key on JavaScript object identity.
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -37,6 +37,16 @@ class JsProxy:
     that are (conditionally) implemented on :any:`JsProxy`.
     """
 
+    @property
+    def js_id() -> int:
+        """An id number which can be used as a dictionary/set key if you want to
+        key on JavaScript object identity.
+
+        If two `JsProxy` are made with the same backing JavaScript object, they
+        will have the same `js_id`. The reault is a "pseudorandom" 32 bit integer.
+        """
+        return 0
+
     def object_entries(self) -> "JsProxy":
         "The JavaScript API ``Object.entries(object)``"
 

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1156,11 +1156,12 @@ def test_memory_leaks(selenium):
         """
     )
 
+
 @run_in_pyodide
 def test_js_id():
     from js import eval as run_js
+
     [x, y, z] = run_js("let a = {}; let b = {}; [a, a, b]")
     assert x.js_id == y.js_id
     assert x is not y
     assert x.js_id != z.js_id
-    

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1155,3 +1155,12 @@ def test_memory_leaks(selenium):
         `);
         """
     )
+
+@run_in_pyodide
+def test_js_id():
+    from js import eval as run_js
+    [x, y, z] = run_js("let a = {}; let b = {}; [a, a, b]")
+    assert x.js_id == y.js_id
+    assert x is not y
+    assert x.js_id != z.js_id
+    


### PR DESCRIPTION
### Description

It's useful to be able to hash on object identity. For instance in Python if we want to store objects in a dictionary using object identity to store/access `obj` we use `id(obj)` as the index. This adds `js_id` as an attribute to `JsProxy` so that `jsobj.js_id` can be used as a dictionary key to key on identity of the JavaScript object.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
