### PR TITLE
Escape double bracket in REPL

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,6 +14,9 @@ substitutions:
 
 ## Unreleased
 
+- {{ Fix }} Fix a REPL error in printing high-dimensional lists.
+  {pr}`2517`
+
 - {{ Fix }} Fix output bug with using `input()` on online console
   {pr}`2509`
 

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -51,6 +51,7 @@
         let await_fut = namespace.get("await_fut");
         let pyconsole = namespace.get("pyconsole");
         let clear_console = namespace.get("clear_console");
+        const echo = (msg) => term.echo(msg.replace("]]", "&rsqb;&rsqb;"));
         namespace.destroy();
 
         let ps1 = ">>> ",
@@ -91,7 +92,7 @@
             try {
               let [value] = await wrapped;
               if (value !== undefined) {
-                term.echo(
+                echo(
                   repr_shorten.callKwargs(value, {
                     separator: "\n[[;orange;]<long output truncated>]\n",
                   })
@@ -128,7 +129,7 @@
             "CTRL+C": async function (event, original) {
               clear_console();
               term.enter();
-              term.echo("KeyboardInterrupt");
+              echo("KeyboardInterrupt");
               term.set_command("");
               term.set_prompt(ps1);
             },
@@ -144,7 +145,7 @@
           },
         });
         window.term = term;
-        pyconsole.stdout_callback = (s) => term.echo(s, { newline: false });
+        pyconsole.stdout_callback = (s) => echo(s, { newline: false });
         pyconsole.stderr_callback = (s) => {
           term.error(s.trimEnd());
         };

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -59,7 +59,10 @@
         let pyconsole = namespace.get("pyconsole");
         let clear_console = namespace.get("clear_console");
         const echo = (msg, ...opts) =>
-          term.echo(msg.replace("]]", "&rsqb;&rsqb;"), ...opts);
+          term.echo(
+            msg.replace("]]", "&rsqb;&rsqb;").replace("[[", "&lsqb;&lsqb;"),
+            ...opts
+          );
         namespace.destroy();
 
         let ps1 = ">>> ",
@@ -102,7 +105,7 @@
               if (value !== undefined) {
                 echo(
                   repr_shorten.callKwargs(value, {
-                    separator: "\n[[;orange;]<long output truncated>]\n",
+                    separator: "\n<long output truncated>\n",
                   })
                 );
               }

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -25,11 +25,11 @@
       }
 
       async function main() {
-        var term;
+        let term;
         globalThis.pyodide = await loadPyodide({
           stdin: () => {
-            var result = prompt();
-            term.echo(result);
+            let result = prompt();
+            echo(result);
             return result;
           },
         });
@@ -58,7 +58,8 @@
         let await_fut = namespace.get("await_fut");
         let pyconsole = namespace.get("pyconsole");
         let clear_console = namespace.get("clear_console");
-        const echo = (msg) => term.echo(msg.replace("]]", "&rsqb;&rsqb;"));
+        const echo = (msg, ...opts) =>
+          term.echo(msg.replace("]]", "&rsqb;&rsqb;"), ...opts);
         namespace.destroy();
 
         let ps1 = ">>> ",

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -443,7 +443,7 @@ def test_console_html(console_html_fixture):
 
     long_output = exec_and_get_result("list(range(1000))").split("\n")
     assert len(long_output) == 4
-    assert long_output[2] == "[[;orange;]<long output truncated>]"
+    assert long_output[2] == "<long output truncated>"
 
     term_exec("from _pyodide_core import trigger_fatal_error; trigger_fatal_error()")
     time.sleep(0.3)


### PR DESCRIPTION
### Description

Fix #2399
Fix #2485

We don't want to invoke text formatting when using JQuery Terminal. So escaping the double bracket.

I'm not sure this handles all edge cases, but it works for the most common case: printing a 2D array.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
