### PR TITLE
FIX Fix micropip version comparison with prerelease version

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,10 +14,6 @@ substitutions:
 
 ## Unreleased
 
-- {{ Enhancement }} {func}`micropip.install` now accepts a `deps` parameter.
-  If set to `False`, micropip will not install dependencies of the package.
-  {pr}`2433`
-
 - {{ Fix }} Fix a REPL error in printing high-dimensional lists.
   {pr}`2517`
 
@@ -75,8 +71,12 @@ substitutions:
 - {{ Enhancement }} Allow passing `credentials` to `micropip.install()`
   {pr}`2458`
 
+- {{ Enhancement }} {func}`micropip.install` now accepts a `deps` parameter.
+  If set to `False`, micropip will not install dependencies of the package.
+  {pr}`2433`
+
 - {{ Fix }} micropip now correctly compares packages with prerelease version
-  {pr}`2531`
+  {pr}`2532`
 
 ### Packages
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -25,13 +25,7 @@ substitutions:
 
 - {{ Fix }} We now tell packagers (e.g., Webpack) to ignore npm-specific imports when packing files for the browser. {pr}`2468`
 
-- {{ Enhancement }} Allow passing `credentials` to `micropip.install()`
-  {pr}`2458`
-
 - {{ Enhancement }} Update Typescript target to ES2017 to generate more modern Javascript code. {pr}`2471`
-
-- {{ Fix }} micropip now correctly handles package names that include dashes
-  {pr}`2414`
 
 - {{ Enhancement }} We now put our built files into the `dist` directory rather
   than the `build` directory. {pr}`2387`
@@ -68,6 +62,17 @@ substitutions:
 - {{ Enhancement }} Added the `js_id` attribute to `JsProxy` to allow using
   JavaScript object identity as a dictionary key.
   {pr}`2515`
+
+### micropip
+
+- {{ Fix }} micropip now correctly handles package names that include dashes
+  {pr}`2414`
+
+- {{ Enhancement }} Allow passing `credentials` to `micropip.install()`
+  {pr}`2458`
+
+- {{ Fix }} micropip now correctly compares packages with prerelease version
+  {pr}`2531`
 
 ### Packages
 

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -276,14 +276,12 @@ class _PackageManager:
         else:
             req = Requirement(requirement)
 
-        req.specifier.prereleases = True
         req.name = req.name.lower()
 
         # If there's a Pyodide package that matches the version constraint, use
         # the Pyodide package instead of the one on PyPI
-        if (
-            req.name in BUILTIN_PACKAGES
-            and BUILTIN_PACKAGES[req.name]["version"] in req.specifier
+        if req.name in BUILTIN_PACKAGES and req.specifier.contains(
+            BUILTIN_PACKAGES[req.name]["version"], prereleases=True
         ):
             version = BUILTIN_PACKAGES[req.name]["version"]
             transaction["pyodide_packages"].append(
@@ -300,7 +298,7 @@ class _PackageManager:
         # Is some version of this package is already installed?
         if req.name in transaction["locked"]:
             ver = transaction["locked"][req.name].version
-            if ver in req.specifier:
+            if req.specifier.contains(ver, prereleases=True):
                 # installed version matches, nothing to do
                 return
             else:

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -272,6 +272,8 @@ class _PackageManager:
             return
         else:
             req = Requirement(requirement)
+
+        req.specifier.prereleases = True
         req.name = req.name.lower()
 
         # If there's a Pyodide package that matches the version constraint, use

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -16,7 +16,7 @@ def mock_get_pypi_json(pkg_map):
 
     Parameters
     ----------
-    pkg_map : ``None | Dict[str, str]``
+    pkg_map : ``None | Dict[str, Any]``
 
         Dictionary that maps package name to dummy release file.
         Packages that are not in this dictionary will return
@@ -34,13 +34,14 @@ def mock_get_pypi_json(pkg_map):
 
     async def _mock_get_pypi_json(pkgname, **kwargs):
         if pkgname in pkg_map:
-            pkg_file = pkg_map[pkgname]
+            pkg_file = pkg_map[pkgname]["name"]
+            pkg_version = pkg_map[pkgname].get("version", "1.0.0")
         else:
             pkg_file = f"{pkgname}-1.0.0.tar.gz"
-
+            pkg_version = "1.0.0"
         return {
             "releases": {
-                "1.0.0": [
+                pkg_version: [
                     {
                         "filename": pkg_file,
                         "url": "",
@@ -331,7 +332,7 @@ def test_install_keep_going(monkeypatch):
 
     dummy_pkg_name = "dummy"
     _mock_get_pypi_json = mock_get_pypi_json(
-        {dummy_pkg_name: f"{dummy_pkg_name}-1.0.0-py3-none-any.whl"}
+        {dummy_pkg_name: {"name": f"{dummy_pkg_name}-1.0.0-py3-none-any.whl"}}
     )
     _mock_fetch_bytes = mock_fetch_bytes(
         dummy_pkg_name, "Requires-Dist: dep1\nRequires-Dist: dep2\n\nUNKNOWN"
@@ -346,6 +347,51 @@ def test_install_keep_going(monkeypatch):
         asyncio.get_event_loop().run_until_complete(
             _micropip.install(dummy_pkg_name, keep_going=True)
         )
+
+
+def test_install_version_compare_prerelease(monkeypatch):
+    pytest.importorskip("packaging")
+    from micropip import _micropip
+
+    dummy_pkg_name = "dummy"
+    version_new = "3.2.1a1"
+    version_old = "3.2.0"
+
+    _mock_get_pypi_json_new = mock_get_pypi_json(
+        {
+            dummy_pkg_name: {
+                "name": f"{dummy_pkg_name}-{version_new}-py3-none-any.whl",
+                "version": version_new,
+            }
+        }
+    )
+
+    _mock_get_pypi_json_old = mock_get_pypi_json(
+        {
+            dummy_pkg_name: {
+                "name": f"{dummy_pkg_name}-{version_old}-py3-none-any.whl",
+                "version": version_old,
+            }
+        }
+    )
+
+    _mock_fetch_bytes = mock_fetch_bytes(dummy_pkg_name, "UNKNOWN")
+
+    monkeypatch.setattr(_micropip, "fetch_bytes", _mock_fetch_bytes)
+
+    monkeypatch.setattr(_micropip, "_get_pypi_json", _mock_get_pypi_json_new)
+    asyncio.get_event_loop().run_until_complete(
+        _micropip.install(f"{dummy_pkg_name}=={version_new}")
+    )
+
+    monkeypatch.setattr(_micropip, "_get_pypi_json", _mock_get_pypi_json_old)
+    asyncio.get_event_loop().run_until_complete(
+        _micropip.install(f"{dummy_pkg_name}>={version_old}")
+    )
+
+    installed_pkgs = _micropip._list()
+    # Older version should not be installed
+    assert installed_pkgs[dummy_pkg_name].version == version_new
 
 
 def test_fetch_wheel_fail(monkeypatch):
@@ -370,7 +416,7 @@ def test_list_pypi_package(monkeypatch):
 
     dummy_pkg_name = "dummy"
     _mock_get_pypi_json = mock_get_pypi_json(
-        {dummy_pkg_name: f"{dummy_pkg_name}-1.0.0-py3-none-any.whl"}
+        {dummy_pkg_name: {"name": f"{dummy_pkg_name}-1.0.0-py3-none-any.whl"}}
     )
     _mock_fetch_bytes = mock_fetch_bytes(dummy_pkg_name, "UNKNOWN")
 


### PR DESCRIPTION
### Description

Previously,

```py
await micropip.install("package==1.2.3a1")
await micropip.install("package>=1.0.0")  # Error: "Requested package>=1.0.0 but package==1.2.3a1 is already installed"
```

raised an error because package specifier ignores prerelease versions in default.

Fix #2487

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
