### PR TITLE
ENH Add `pre` option in micropip.install

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -87,6 +87,10 @@ substitutions:
 - {{ Fix }} micropip now correctly compares packages with prerelease version
   {pr}`2532`
 
+- {{ Enhancement }} {func}`micropip.install` now accepts a `pre` parameter.
+  If set to `True`, micropip will include pre-release and development versions.
+  {pr}`2542`
+
 ### Packages
 
 - {{ Enhancement }} Pillow now supports WEBP image format {pr}`2407`.

--- a/pyodide-test-runner/pyodide_test_runner/utils.py
+++ b/pyodide-test-runner/pyodide_test_runner/utils.py
@@ -40,6 +40,8 @@ def maybe_skip_test(item, dist_dir, delayed=False):
 
     loading the selenium_standalone fixture which takes a long time.
     """
+    browsers = "|".join(["firefox", "chrome", "node"])
+
     skip_msg = None
     # Testing a package. Skip the test if the package is not built.
     match = re.match(
@@ -47,7 +49,9 @@ def maybe_skip_test(item, dist_dir, delayed=False):
     )
     if match:
         package_name = match.group("name")
-        if not package_is_built(package_name, dist_dir):
+        if not package_is_built(package_name, dist_dir) and re.match(
+            rf"test_[\w\-]+\[({browsers})\]", item.name
+        ):
             skip_msg = f"package '{package_name}' is not built."
 
     # Common package import test. Skip it if the package is not built.
@@ -56,9 +60,7 @@ def maybe_skip_test(item, dist_dir, delayed=False):
         and str(item.fspath).endswith("test_packages_common.py")
         and item.name.startswith("test_import")
     ):
-        match = re.match(
-            r"test_import\[(firefox|chrome|node)-(?P<name>[\w-]+)\]", item.name
-        )
+        match = re.match(rf"test_import\[({browsers})-(?P<name>[\w-]+)\]", item.name)
         if match:
             package_name = match.group("name")
             if not package_is_built(package_name, dist_dir):


### PR DESCRIPTION
### Description

Add `pre` option in micropip.install which is equivalent to `pre install --pre`

This PR also fixes CI bug that `test-python` job was not running micropip tests.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
