### PR TITLE
Add pyodide_build create_xbuildenv and install_xbuildenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ packages/.artifacts
 packages/*/build.log*
 packages/build-logs
 dist/
+
+xbuildenv/

--- a/pyodide-build/pyodide_build/__main__.py
+++ b/pyodide-build/pyodide_build/__main__.py
@@ -2,7 +2,7 @@
 import argparse
 import sys
 
-from . import buildall, buildpkg, mkpkg, serve
+from . import buildall, buildpkg, create_xbuildenv, install_xbuildenv, mkpkg, serve
 from .common import init_environment
 
 
@@ -18,6 +18,8 @@ def make_parser() -> argparse.ArgumentParser:
         ("buildall", buildall),
         ("serve", serve),
         ("mkpkg", mkpkg),
+        ("create_xbuildenv", create_xbuildenv),
+        ("install_xbuildenv", install_xbuildenv),
     ):
         if "sphinx" in sys.modules and command_name in [
             "buildpkg",

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -240,7 +240,7 @@ def get_unisolated_packages():
     PYODIDE_ROOT = get_pyodide_root()
     unisolated_packages = []
     for pkg in (PYODIDE_ROOT / "packages").glob("**/meta.yaml"):
-        config = parse_package_config(pkg, False)
+        config = parse_package_config(pkg, check=False)
         if config.get("build", {}).get("cross-build-env", False):
             unisolated_packages.append(config["package"]["name"])
     os.environ["UNISOLATED_PACKAGES"] = json.dumps(unisolated_packages)

--- a/pyodide-build/pyodide_build/create_xbuildenv.py
+++ b/pyodide-build/pyodide_build/create_xbuildenv.py
@@ -18,7 +18,7 @@ def make_parser(parser: argparse.ArgumentParser):
 def copy_xbuild_files(xbuildenv_path):
     PYODIDE_ROOT = get_pyodide_root()
     site_packages = Path(get_make_flag("HOSTSITEPACKAGES"))
-    xbuild_site_packages = xbuildenv_path / "site_packages"
+    xbuild_site_packages = xbuildenv_path / "site-packages"
     for pkg in (PYODIDE_ROOT / "packages").glob("**/meta.yaml"):
         config = parse_package_config(pkg, check=False)
         xbuild_files = config.get("build", {}).get("cross-build-files", [])

--- a/pyodide-build/pyodide_build/create_xbuildenv.py
+++ b/pyodide-build/pyodide_build/create_xbuildenv.py
@@ -1,0 +1,42 @@
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+from .common import get_make_flag, get_pyodide_root, parse_package_config
+
+
+def make_parser(parser: argparse.ArgumentParser):
+    parser.description = (
+        "Create xbuild env.\n\n"
+        "Note: this is a private endpoint that should not be used "
+        "outside of the Pyodide Makefile."
+    )
+    return parser
+
+
+def copy_xbuild_files(xbuildenv_path):
+    PYODIDE_ROOT = get_pyodide_root()
+    site_packages = Path(get_make_flag("HOSTSITEPACKAGES"))
+    xbuild_site_packages = xbuildenv_path / "site_packages"
+    for pkg in (PYODIDE_ROOT / "packages").glob("**/meta.yaml"):
+        config = parse_package_config(pkg, False)
+        xbuild_files = config.get("build", {}).get("cross-build-files", [])
+        for path in xbuild_files:
+            target = xbuild_site_packages / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(site_packages / path, target)
+
+
+def main(args):
+    pyodide_root = get_pyodide_root()
+    xbuildenv_path = pyodide_root / "xbuildenv"
+    shutil.rmtree(xbuildenv_path, ignore_errors=True)
+    xbuildenv_path.mkdir()
+    shutil.copytree(get_make_flag("PYTHONINCLUDE"), xbuildenv_path / "python-include")
+    copy_xbuild_files(xbuildenv_path)
+    res = subprocess.run(
+        ["pip", "freeze", "--path", get_make_flag("HOSTSITEPACKAGES")],
+        stdout=subprocess.PIPE,
+    )
+    (xbuildenv_path / "requirements.txt").write_bytes(res.stdout)

--- a/pyodide-build/pyodide_build/create_xbuildenv.py
+++ b/pyodide-build/pyodide_build/create_xbuildenv.py
@@ -20,7 +20,7 @@ def copy_xbuild_files(xbuildenv_path):
     site_packages = Path(get_make_flag("HOSTSITEPACKAGES"))
     xbuild_site_packages = xbuildenv_path / "site_packages"
     for pkg in (PYODIDE_ROOT / "packages").glob("**/meta.yaml"):
-        config = parse_package_config(pkg, False)
+        config = parse_package_config(pkg, check=False)
         xbuild_files = config.get("build", {}).get("cross-build-files", [])
         for path in xbuild_files:
             target = xbuild_site_packages / path

--- a/pyodide-build/pyodide_build/install_xbuildenv.py
+++ b/pyodide-build/pyodide_build/install_xbuildenv.py
@@ -1,0 +1,44 @@
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+from sys import version_info
+
+from .common import get_make_flag, get_pyodide_root
+
+
+def make_parser(parser: argparse.ArgumentParser):
+    parser.description = (
+        "Install xbuild env.\n\n"
+        "Note: this is a private endpoint that should not be used "
+        "outside of the Pyodide Makefile."
+    )
+    return parser
+
+
+def main(args):
+    pyodide_root = get_pyodide_root()
+    host_site_packages = Path(get_make_flag("HOSTSITEPACKAGES"))
+    xbuildenv_path = pyodide_root / "xbuildenv"
+    major_minor = f"{version_info.major}.{version_info.minor}"
+    major_minor_patch = f"{major_minor}.{version_info.micro}"
+    include_path = (
+        pyodide_root
+        / f"cpython/installs/python-{major_minor_patch}/include/python{major_minor}/"
+    )
+    include_path.mkdir(exist_ok=True, parents=True)
+    shutil.copytree(xbuildenv_path / "python-include", include_path, dirs_exist_ok=True)
+    host_site_packages.mkdir(exist_ok=True, parents=True)
+    subprocess.run(
+        [
+            "pip",
+            "install",
+            "-t",
+            host_site_packages,
+            "-r",
+            xbuildenv_path / "requirements.txt",
+        ]
+    )
+    shutil.copytree(
+        xbuildenv_path / "site_packages", host_site_packages, dirs_exist_ok=True
+    )

--- a/pyodide-build/pyodide_build/install_xbuildenv.py
+++ b/pyodide-build/pyodide_build/install_xbuildenv.py
@@ -2,7 +2,6 @@ import argparse
 import shutil
 import subprocess
 from pathlib import Path
-from sys import version_info
 
 from .common import get_make_flag, get_pyodide_root
 
@@ -23,12 +22,7 @@ def main(args):
     pyodide_root = get_pyodide_root()
     host_site_packages = Path(get_make_flag("HOSTSITEPACKAGES"))
     xbuildenv_path = pyodide_root / "xbuildenv"
-    major_minor = f"{version_info.major}.{version_info.minor}"
-    major_minor_patch = f"{major_minor}.{version_info.micro}"
-    include_path = (
-        pyodide_root
-        / f"cpython/installs/python-{major_minor_patch}/include/python{major_minor}/"
-    )
+    include_path = Path(get_make_flag("PYTHONINCLUDE"))
     include_path.mkdir(exist_ok=True, parents=True)
     shutil.copytree(xbuildenv_path / "python-include", include_path, dirs_exist_ok=True)
     host_site_packages.mkdir(exist_ok=True, parents=True)
@@ -43,5 +37,5 @@ def main(args):
         ]
     )
     shutil.copytree(
-        xbuildenv_path / "site_packages", host_site_packages, dirs_exist_ok=True
+        xbuildenv_path / "site-packages", host_site_packages, dirs_exist_ok=True
     )

--- a/pyodide-build/pyodide_build/install_xbuildenv.py
+++ b/pyodide-build/pyodide_build/install_xbuildenv.py
@@ -10,8 +10,11 @@ from .common import get_make_flag, get_pyodide_root
 def make_parser(parser: argparse.ArgumentParser):
     parser.description = (
         "Install xbuild env.\n\n"
-        "Note: this is a private endpoint that should not be used "
-        "outside of the Pyodide Makefile."
+        "The installed environment is the same as the one that would result from\n"
+        "`PYODIDE_PACKAGES='scipy' make` except that it is much faster.\n"
+        "The goal is to enable out-of-tree builds for binary packages that depend\n"
+        "on numpy or scipy.\n"
+        "Note: this is a private endpoint that should not be used outside of the Pyodide Makefile."
     )
     return parser
 

--- a/pyodide-build/pyodide_build/io.py
+++ b/pyodide-build/pyodide_build/io.py
@@ -199,7 +199,7 @@ def check_package_config(config: dict[str, Any], file_path: Path | str | None = 
         )
 
 
-def parse_package_config(path: Path | str, check: bool = True) -> dict[str, Any]:
+def parse_package_config(path: Path | str, *, check: bool = True) -> dict[str, Any]:
     """Load a meta.yaml file
 
     Parameters


### PR DESCRIPTION
This adds `pyodide_build` command `create_xbuildenv` which creates a crossbuild environment (from a copy of Pyodide where scipy has been build) and `install_xbuildenv` which installs the cross build environment into a fresh copy of Pyodide.

I successfully installed the xbuild environment into a fresh checkout of Pyodide then built statsmodels and scikit-learn in isolation, without building the Python interpreter, numpy, or scipy. I dumped the generated wheels into a copy of Pyodide downloaded from CI, and was able to import and use them as normal.

The size of the xbuild environment is 1.5 megabytes, of which 1.2 megabytes is Python headers.

In a subsequent PR, we can update the CI to automatically upload these to aws s3 and then install the environment from there.
