### PR TITLE
BLD Install libraries to centralized directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ emsdk/emsdk
 geckodriver.log
 node_modules
 packages/.artifacts
+packages/.libs
 packages/*/build.log*
 packages/build-logs
 dist/

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -26,6 +26,8 @@ export CPYTHONBUILD=$(CPYTHONROOT)/build/Python-$(PYVERSION)/
 export TARGETINSTALLDIR=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)
 export HOSTINSTALLDIR=$(PYODIDE_ROOT)/packages/.artifacts
 export HOSTSITEPACKAGES=$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages
+export HOST_LD_LIBRARY_PATH=$(PYODIDE_ROOT)/packages/.artifacts/lib
+export HOST_C_INCLUDE_PATH=$(PYODIDE_ROOT)/packages/.artifacts/include
 
 export PYTHONINCLUDE=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)/include/python$(PYMAJOR).$(PYMINOR)
 
@@ -61,12 +63,15 @@ export DBGFLAGS=$(DBGFLAGS_NODEBUG)
 export OPTFLAGS=-O2
 export CFLAGS_BASE=\
 	$(OPTFLAGS) \
+	-I $(HOST_C_INCLUDE_PATH) \
 	$(DBGFLAGS) \
 	-fPIC \
 	$(EXTRA_CFLAGS)
 
+
 export LDFLAGS_BASE=\
 	$(OPTFLAGS) \
+	-L $(HOST_LD_LIBRARY_PATH) \
 	$(DBGFLAGS) \
 	$(DBG_LDFLAGS) \
 	-s MODULARIZE=1 \

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -37,7 +37,6 @@ export PYODIDE_BASE_URL?=./
 # For packages that depend on numpy.
 # TODO: maybe move this somewhere else?
 export NUMPY_LIB=$(HOSTSITEPACKAGES)/numpy/
-export OPEN_SSL_ROOT=$(PYODIDE_ROOT)/packages/openssl/build/openssl-1.1.1n/
 
 
 # This environment variable is used for packages to detect if they are built

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -27,7 +27,7 @@ export TARGETINSTALLDIR=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)
 export HOSTINSTALLDIR=$(PYODIDE_ROOT)/packages/.artifacts
 export HOSTSITEPACKAGES=$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages
 export WASM_LIBRARY_DIR=$(PYODIDE_ROOT)/packages/.libs
-export WASM_PKG_CONFIG_PATH=$(PYODIDE_ROOT)/packages/.libs/pkgconfig
+export WASM_PKG_CONFIG_PATH=$(PYODIDE_ROOT)/packages/.libs/lib/pkgconfig
 
 export PYTHONINCLUDE=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)/include/python$(PYMAJOR).$(PYMINOR)
 

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -26,8 +26,8 @@ export CPYTHONBUILD=$(CPYTHONROOT)/build/Python-$(PYVERSION)/
 export TARGETINSTALLDIR=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)
 export HOSTINSTALLDIR=$(PYODIDE_ROOT)/packages/.artifacts
 export HOSTSITEPACKAGES=$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages
-export HOST_LD_LIBRARY_PATH=$(PYODIDE_ROOT)/packages/.artifacts/lib
-export HOST_C_INCLUDE_PATH=$(PYODIDE_ROOT)/packages/.artifacts/include
+export WASM_LIBRARY_DIR=$(PYODIDE_ROOT)/packages/.libs
+export WASM_PKG_CONFIG_PATH=$(PYODIDE_ROOT)/packages/.libs/pkgconfig
 
 export PYTHONINCLUDE=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)/include/python$(PYMAJOR).$(PYMINOR)
 
@@ -62,7 +62,6 @@ export DBGFLAGS=$(DBGFLAGS_NODEBUG)
 export OPTFLAGS=-O2
 export CFLAGS_BASE=\
 	$(OPTFLAGS) \
-	-I $(HOST_C_INCLUDE_PATH) \
 	$(DBGFLAGS) \
 	-fPIC \
 	$(EXTRA_CFLAGS)
@@ -70,7 +69,6 @@ export CFLAGS_BASE=\
 
 export LDFLAGS_BASE=\
 	$(OPTFLAGS) \
-	-L $(HOST_LD_LIBRARY_PATH) \
 	$(DBGFLAGS) \
 	$(DBG_LDFLAGS) \
 	-s MODULARIZE=1 \

--- a/packages/CLAPACK/meta.yaml
+++ b/packages/CLAPACK/meta.yaml
@@ -33,5 +33,7 @@ build:
     sed -i 's/^	ld /^	$(LD)/' **/Makefile
 
     emmake make -j ${PYODIDE_JOBS:-3} blaslib lapacklib
-    mkdir -p dist/lib
-    emcc blas_WA.a lapack_WA.a F2CLIBS/libf2c.a -sSIDE_MODULE -o dist/lib/clapack_all.so
+    emcc blas_WA.a lapack_WA.a F2CLIBS/libf2c.a -sSIDE_MODULE -o clapack_all.so
+    mkdir -p ${WASM_LIBRARY_DIR}/CLAPACK/lib
+    cp -r INCLUDE ${WASM_LIBRARY_DIR}/CLAPACK/
+    cp clapack_all.so ${WASM_LIBRARY_DIR}/CLAPACK/lib

--- a/packages/CLAPACK/meta.yaml
+++ b/packages/CLAPACK/meta.yaml
@@ -33,7 +33,7 @@ build:
     sed -i 's/^	ld /^	$(LD)/' **/Makefile
 
     emmake make -j ${PYODIDE_JOBS:-3} blaslib lapacklib
-    emcc blas_WA.a lapack_WA.a F2CLIBS/libf2c.a -sSIDE_MODULE -o clapack_all.so
-    mkdir -p ${WASM_LIBRARY_DIR}/CLAPACK/lib
+    mkdir -p dist/lib
+    emcc blas_WA.a lapack_WA.a F2CLIBS/libf2c.a -sSIDE_MODULE -o dist/lib/clapack_all.so
+    mkdir -p ${WASM_LIBRARY_DIR}/CLAPACK
     cp -r INCLUDE ${WASM_LIBRARY_DIR}/CLAPACK/
-    cp clapack_all.so ${WASM_LIBRARY_DIR}/CLAPACK/lib

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -24,4 +24,4 @@ update-all:
 
 clean:
 	rm -rf ./*/build ./*/build.log ./*/dist
-	rm -rf ./.artifacts
+	rm -rf ./.artifacts ./.libs

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -9,7 +9,7 @@ else
 endif
 
 all: pyodide-build
-	mkdir -p $(HOSTINSTALLDIR)
+	mkdir -p $(HOSTINSTALLDIR) $(WASM_LIBRARY_DIR)
 	PYODIDE_ROOT=$(PYODIDE_ROOT) python -m pyodide_build buildall . $(PYODIDE_ROOT)/dist \
 	$(ONLY_PACKAGES) --n-jobs $${PYODIDE_JOBS:-4} \
 	--log-dir=./build-logs

--- a/packages/Pillow/meta.yaml
+++ b/packages/Pillow/meta.yaml
@@ -11,7 +11,6 @@ source:
       - ./setup.cfg
 build:
   script: |
-    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
     export LIBWEBP_INCLUDE_PATH=$(pkg-config --cflags-only-I --dont-define-prefix libwebp)
     export LIBWEBP_LIBRARY_PATH=$(pkg-config --libs-only-L --dont-define-prefix libwebp)
   cflags: |

--- a/packages/Pillow/meta.yaml
+++ b/packages/Pillow/meta.yaml
@@ -15,10 +15,8 @@ build:
     -s USE_LIBJPEG=1
     -s USE_FREETYPE=1
     -s SIDE_MODULE=1
-    -I$(PYODIDE_ROOT)/packages/libwebp/build/libwebp-1.2.2/build/lib/include
   ldflags: |
     -ljpeg
-    -L$(PYODIDE_ROOT)/packages/libwebp/build/libwebp-1.2.2/build/lib/lib/
 requirements:
   run:
     - libwebp

--- a/packages/Pillow/meta.yaml
+++ b/packages/Pillow/meta.yaml
@@ -12,8 +12,8 @@ source:
 build:
   script: |
     export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
-    export LIBWEBP_INCLUDE_PATH=$(pkg-config --cflags-only-I libwebp)
-    export LIBWEBP_LIBRARY_PATH=$(pkg-config --libs-only-L libwebp)
+    export LIBWEBP_INCLUDE_PATH=$(pkg-config --cflags-only-I --dont-define-prefix libwebp)
+    export LIBWEBP_LIBRARY_PATH=$(pkg-config --libs-only-L --dont-define-prefix libwebp)
   cflags: |
     -s USE_ZLIB=1
     -s USE_LIBJPEG=1

--- a/packages/Pillow/meta.yaml
+++ b/packages/Pillow/meta.yaml
@@ -10,13 +10,19 @@ source:
     - - src/setup.cfg
       - ./setup.cfg
 build:
+  script: |
+    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
+    export LIBWEBP_INCLUDE_PATH=$(pkg-config --cflags-only-I libwebp)
+    export LIBWEBP_LIBRARY_PATH=$(pkg-config --libs-only-L libwebp)
   cflags: |
     -s USE_ZLIB=1
     -s USE_LIBJPEG=1
     -s USE_FREETYPE=1
     -s SIDE_MODULE=1
+    $(LIBWEBP_INCLUDE_PATH)
   ldflags: |
     -ljpeg
+    $(LIBWEBP_LIBRARY_PATH)
 requirements:
   run:
     - libwebp

--- a/packages/cryptography/meta.yaml
+++ b/packages/cryptography/meta.yaml
@@ -13,7 +13,7 @@ build:
     $(OPENSSL_LIBRARY_PATH)
   script: |
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1
-    export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${WASM_PKG_CONFIG_PATH}
+    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
     export OPENSSL_INCLUDE_PATH=$(pkg-config --cflags-only-I openssl)
     export OPENSSL_LIBRARY_PATH=$(pkg-config --libs-only-L openssl)
 requirements:

--- a/packages/cryptography/meta.yaml
+++ b/packages/cryptography/meta.yaml
@@ -13,7 +13,6 @@ build:
     $(OPENSSL_LIBRARY_PATH)
   script: |
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1
-    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
     export OPENSSL_INCLUDE_PATH=$(pkg-config --cflags-only-I --dont-define-prefix openssl)
     export OPENSSL_LIBRARY_PATH=$(pkg-config --libs-only-L --dont-define-prefix openssl)
 requirements:

--- a/packages/cryptography/meta.yaml
+++ b/packages/cryptography/meta.yaml
@@ -7,10 +7,7 @@ source:
   sha256: 94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c
 build:
   cflags: |
-    -I$(OPEN_SSL_ROOT)/include/
     -Wno-implicit-function-declaration
-  ldflags: |
-    -L$(OPEN_SSL_ROOT)/dist/
   script: |
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1
 requirements:

--- a/packages/cryptography/meta.yaml
+++ b/packages/cryptography/meta.yaml
@@ -8,8 +8,14 @@ source:
 build:
   cflags: |
     -Wno-implicit-function-declaration
+    $(OPENSSL_INCLUDE_PATH)
+  ldflags: |
+    $(OPENSSL_LIBRARY_PATH)
   script: |
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1
+    export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${WASM_PKG_CONFIG_PATH}
+    export OPENSSL_INCLUDE_PATH=$(pkg-config --cflags-only-I openssl)
+    export OPENSSL_LIBRARY_PATH=$(pkg-config --libs-only-L openssl)
 requirements:
   run:
     - openssl

--- a/packages/cryptography/meta.yaml
+++ b/packages/cryptography/meta.yaml
@@ -14,8 +14,8 @@ build:
   script: |
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1
     export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
-    export OPENSSL_INCLUDE_PATH=$(pkg-config --cflags-only-I openssl)
-    export OPENSSL_LIBRARY_PATH=$(pkg-config --libs-only-L openssl)
+    export OPENSSL_INCLUDE_PATH=$(pkg-config --cflags-only-I --dont-define-prefix openssl)
+    export OPENSSL_LIBRARY_PATH=$(pkg-config --libs-only-L --dont-define-prefix openssl)
 requirements:
   run:
     - openssl

--- a/packages/ffmpeg/meta.yaml
+++ b/packages/ffmpeg/meta.yaml
@@ -19,8 +19,7 @@ build:
       --disable-pthreads \
       --nm="$PYODIDE_ROOT/emsdk/emsdk/upstream/bin/llvm-nm -g" \
       --ar=emar --cc=emcc --cxx=em++ --objcc=emcc --dep-cc=emcc --ranlib=emranlib \
-      --prefix=${WASM_LIBRARY_DIR}/ffmpeg
+      --prefix=${WASM_LIBRARY_DIR}
 
     emmake make -j${PYODIDE_JOBS:-3}
     emmake make install
-    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/ffmpeg/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/ffmpeg/meta.yaml
+++ b/packages/ffmpeg/meta.yaml
@@ -23,3 +23,4 @@ build:
 
     emmake make -j${PYODIDE_JOBS:-3}
     emmake make install
+    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/ffmpeg/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/ffmpeg/meta.yaml
+++ b/packages/ffmpeg/meta.yaml
@@ -19,7 +19,7 @@ build:
       --disable-pthreads \
       --nm="$PYODIDE_ROOT/emsdk/emsdk/upstream/bin/llvm-nm -g" \
       --ar=emar --cc=emcc --cxx=em++ --objcc=emcc --dep-cc=emcc --ranlib=emranlib \
-      --prefix=./lib
+      --prefix=${WASM_LIBRARY_DIR}/ffmpeg
 
     emmake make -j${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/glpk/meta.yaml
+++ b/packages/glpk/meta.yaml
@@ -9,5 +9,6 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emconfigure ./configure  --prefix=$PWD
+    CFLAGS="-fPIC" emconfigure ./configure  --prefix=${HOSTINSTALLDIR}
     emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install

--- a/packages/glpk/meta.yaml
+++ b/packages/glpk/meta.yaml
@@ -9,6 +9,6 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emconfigure ./configure  --prefix=${HOSTINSTALLDIR}
+    CFLAGS="-fPIC" emconfigure ./configure  --prefix=${WASM_LIBRARY_DIR}/glpk
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/glpk/meta.yaml
+++ b/packages/glpk/meta.yaml
@@ -9,6 +9,6 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emconfigure ./configure  --prefix=${WASM_LIBRARY_DIR}/glpk
+    CFLAGS="-fPIC" emconfigure ./configure  --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/h5py/meta.yaml
+++ b/packages/h5py/meta.yaml
@@ -23,5 +23,4 @@ build:
   script: |
     export HDF5_MPI=OFF
     export H5PY_SETUP_REQUIRES="0"
-    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
     export HDF5_VERSION=1.13.1

--- a/packages/h5py/meta.yaml
+++ b/packages/h5py/meta.yaml
@@ -23,6 +23,5 @@ build:
   script: |
     export HDF5_MPI=OFF
     export H5PY_SETUP_REQUIRES="0"
-    export HDF5_DIR=$PYODIDE_ROOT/packages/libhdf5/build/hdf5
-    export PKG_CONFIG_PATH=${HDF5_DIR}/lib/pkgconfig:${PKG_CONFIG_PATH}
+    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
     export HDF5_VERSION=1.13.1

--- a/packages/libgsl/meta.yaml
+++ b/packages/libgsl/meta.yaml
@@ -8,5 +8,7 @@ build:
   library: true
   script: |
     emconfigure ./configure \
-        CFLAGS="-fPIC"
+        CFLAGS="-fPIC" \
+        --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install

--- a/packages/libhdf5/meta.yaml
+++ b/packages/libhdf5/meta.yaml
@@ -16,7 +16,7 @@ build:
     mkdir -p build;
     cd build \
         && LDFLAGS="-s NODERAWFS=1 -sUSE_ZLIB=1 -sFORCE_FILESYSTEM=1" emcmake cmake ../ \
-        -DCMAKE_INSTALL_PREFIX=../../hdf5 \
+        -DCMAKE_INSTALL_PREFIX=${WASM_LIBRARY_DIR}/libhdf5 \
         -DH5_HAVE_GETPWUID=0 \
         -DH5_HAVE_SIGNAL=0 \
         -DBUILD_SHARED_LIBS=0 \
@@ -28,4 +28,5 @@ build:
         -DHDF5_BUILD_UTILS=0 \
         -DHDF5_ENABLE_Z_LIB_SUPPORT=1 \
         -DHDF5_ENABLE_ROS3_VFD=0;
-    emmake make -j ${PYODIDE_JOBS:-3} install;
+    emmake make -j ${PYODIDE_JOBS:-3} install
+    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/libhdf5/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/libhdf5/meta.yaml
+++ b/packages/libhdf5/meta.yaml
@@ -16,7 +16,7 @@ build:
     mkdir -p build;
     cd build \
         && LDFLAGS="-s NODERAWFS=1 -sUSE_ZLIB=1 -sFORCE_FILESYSTEM=1" emcmake cmake ../ \
-        -DCMAKE_INSTALL_PREFIX=${WASM_LIBRARY_DIR}/libhdf5 \
+        -DCMAKE_INSTALL_PREFIX=${WASM_LIBRARY_DIR} \
         -DH5_HAVE_GETPWUID=0 \
         -DH5_HAVE_SIGNAL=0 \
         -DBUILD_SHARED_LIBS=0 \
@@ -29,4 +29,3 @@ build:
         -DHDF5_ENABLE_Z_LIB_SUPPORT=1 \
         -DHDF5_ENABLE_ROS3_VFD=0;
     emmake make -j ${PYODIDE_JOBS:-3} install
-    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/libhdf5/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/libiconv/meta.yaml
+++ b/packages/libiconv/meta.yaml
@@ -12,5 +12,8 @@ build:
     emconfigure ./configure \
        CFLAGS="-fPIC" \
        --disable-dependency-tracking \
-       --disable-shared
+       --disable-shared \
+       --prefix=${HOSTINSTALLDIR}
+
     emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install

--- a/packages/libiconv/meta.yaml
+++ b/packages/libiconv/meta.yaml
@@ -13,7 +13,7 @@ build:
        CFLAGS="-fPIC" \
        --disable-dependency-tracking \
        --disable-shared \
-       --prefix=${WASM_PKG_CONFIG_PATH}
+       --prefix=${WASM_LIBRARY_DIR}
 
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libiconv/meta.yaml
+++ b/packages/libiconv/meta.yaml
@@ -13,7 +13,7 @@ build:
        CFLAGS="-fPIC" \
        --disable-dependency-tracking \
        --disable-shared \
-       --prefix=${WASM_LIBRARY_DIR}/libiconv
+       --prefix=${WASM_PKG_CONFIG_PATH}
 
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libiconv/meta.yaml
+++ b/packages/libiconv/meta.yaml
@@ -13,7 +13,7 @@ build:
        CFLAGS="-fPIC" \
        --disable-dependency-tracking \
        --disable-shared \
-       --prefix=${HOSTINSTALLDIR}
+       --prefix=${WASM_LIBRARY_DIR}/libiconv
 
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libwebp/meta.yaml
+++ b/packages/libwebp/meta.yaml
@@ -9,7 +9,6 @@ source:
 build:
   library: true
   script: |
-    mkdir build && cd build && emcmake cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=${WASM_LIBRARY_DIR}/libwebp ../
+    mkdir build && cd build && emcmake cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=${WASM_LIBRARY_DIR} ../
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/libwebp/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/libwebp/meta.yaml
+++ b/packages/libwebp/meta.yaml
@@ -12,3 +12,4 @@ build:
     mkdir build && cd build && emcmake cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=${WASM_LIBRARY_DIR}/libwebp ../
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
+    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/libwebp/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/libwebp/meta.yaml
+++ b/packages/libwebp/meta.yaml
@@ -9,6 +9,6 @@ source:
 build:
   library: true
   script: |
-    mkdir build && cd build && emcmake cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=${HOSTINSTALLDIR} ../
+    mkdir build && cd build && emcmake cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=${WASM_LIBRARY_DIR}/libwebp ../
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libwebp/meta.yaml
+++ b/packages/libwebp/meta.yaml
@@ -9,6 +9,6 @@ source:
 build:
   library: true
   script: |
-    mkdir build && cd build && emcmake cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=./lib ../
+    mkdir build && cd build && emcmake cmake -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_INSTALL_PREFIX=${HOSTINSTALLDIR} ../
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libxml/meta.yaml
+++ b/packages/libxml/meta.yaml
@@ -19,8 +19,9 @@ build:
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-iconv="${HOSTINSTALLDIR}" \
-        --with-zlib="${HOSTINSTALLDIR}" \
-        --prefix=${HOSTINSTALLDIR}
+        --with-iconv="${WASM_LIBRARY_DIR}/libiconv" \
+        --with-zlib="${WASM_LIBRARY_DIR}/zlib" \
+        --prefix=${WASM_LIBRARY_DIR}/libxml
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
+    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/libxml/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/libxml/meta.yaml
+++ b/packages/libxml/meta.yaml
@@ -19,6 +19,8 @@ build:
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-iconv="$PYODIDE_ROOT/packages/libiconv/build/libiconv-1.16/lib/.libs" \
-        --with-zlib="$PYODIDE_ROOT/packages/zlib/build/zlib-1.2.11/"
+        --with-iconv="${HOSTINSTALLDIR}" \
+        --with-zlib="${HOSTINSTALLDIR}" \
+        --prefix=${HOSTINSTALLDIR}
     emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install

--- a/packages/libxml/meta.yaml
+++ b/packages/libxml/meta.yaml
@@ -19,7 +19,7 @@ build:
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-iconv="${WASM_LIBRARY_DIR}/libiconv" \
+        --with-iconv="${WASM_LIBRARY_DIR}/libiconv/lib" \
         --with-zlib="${WASM_LIBRARY_DIR}/zlib" \
         --prefix=${WASM_LIBRARY_DIR}/libxml
     emmake make -j ${PYODIDE_JOBS:-3}

--- a/packages/libxml/meta.yaml
+++ b/packages/libxml/meta.yaml
@@ -19,9 +19,8 @@ build:
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-iconv="${WASM_LIBRARY_DIR}/libiconv/lib" \
-        --with-zlib="${WASM_LIBRARY_DIR}/zlib" \
-        --prefix=${WASM_LIBRARY_DIR}/libxml
+        --with-iconv="${WASM_LIBRARY_DIR}/lib" \
+        --with-zlib="${WASM_LIBRARY_DIR}/lib" \
+        --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/libxml/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/libxslt/meta.yaml
+++ b/packages/libxslt/meta.yaml
@@ -12,6 +12,7 @@ requirements:
 
 build:
   library: true
+
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
@@ -20,8 +21,6 @@ build:
         --without-python \
         --with-libxml-prefix="${WASM_LIBRARY_DIR}/libxml" \
         --without-crypto \
-        --without-debug \
-        --without-debugger \
         --prefix=${WASM_LIBRARY_DIR}/libxslt
 
     emmake make -j ${PYODIDE_JOBS:-3}

--- a/packages/libxslt/meta.yaml
+++ b/packages/libxslt/meta.yaml
@@ -13,7 +13,6 @@ requirements:
 build:
   library: true
   script: |
-    export VERBOSE=1
     emconfigure ./configure \
         CFLAGS="-fPIC" \
         --disable-dependency-tracking \

--- a/packages/libxslt/meta.yaml
+++ b/packages/libxslt/meta.yaml
@@ -19,10 +19,9 @@ build:
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-libxml-prefix="${WASM_LIBRARY_DIR}/libxml" \
+        --with-libxml-prefix="${WASM_LIBRARY_DIR}" \
         --without-crypto \
-        --prefix=${WASM_LIBRARY_DIR}/libxslt
+        --prefix=${WASM_LIBRARY_DIR}
 
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/libxslt/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/libxslt/meta.yaml
+++ b/packages/libxslt/meta.yaml
@@ -13,12 +13,15 @@ requirements:
 build:
   library: true
   script: |
+    export VERBOSE=1
     emconfigure ./configure \
         CFLAGS="-fPIC" \
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-libxml-src="$PYODIDE_ROOT/packages/libxml/build/libxml-2.9.10" \
-        --without-crypto
+        --with-libxml-prefix="${HOSTINSTALLDIR}" \
+        --without-crypto \
+        --prefix=${HOSTINSTALLDIR}
+
     emmake make -j ${PYODIDE_JOBS:-3}
-    chmod 755 xslt-config
+    emmake make install

--- a/packages/libxslt/meta.yaml
+++ b/packages/libxslt/meta.yaml
@@ -18,9 +18,12 @@ build:
         --disable-dependency-tracking \
         --disable-shared \
         --without-python \
-        --with-libxml-prefix="${HOSTINSTALLDIR}" \
+        --with-libxml-prefix="${WASM_LIBRARY_DIR}/libxml" \
         --without-crypto \
-        --prefix=${HOSTINSTALLDIR}
+        --without-debug \
+        --without-debugger \
+        --prefix=${WASM_LIBRARY_DIR}/libxslt
 
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
+    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/libxslt/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/libyaml/meta.yaml
+++ b/packages/libyaml/meta.yaml
@@ -12,6 +12,4 @@ build:
     CFLAGS="-fPIC" emcmake cmake -DCMAKE_INSTALL_PREFIX=${HOSTINSTALLDIR} .
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-
-    # ln -s libyaml-0.2.1/libyaml_static.a ../libyaml.a
-    # ln -s libyaml-0.2.1/include ..
+    ln -s ${HOST_LD_LIBRARY_PATH}/libyaml_static.a ${HOST_LD_LIBRARY_PATH}/libyaml.a

--- a/packages/libyaml/meta.yaml
+++ b/packages/libyaml/meta.yaml
@@ -9,7 +9,7 @@ source:
 build:
   library: true
   script: |
-    export INSTALL_DIR=${WASM_LIBRARY_DIR}/libyaml
+    export INSTALL_DIR=${WASM_LIBRARY_DIR}
 
     CFLAGS="-fPIC" emcmake cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .
     emmake make -j ${PYODIDE_JOBS:-3}

--- a/packages/libyaml/meta.yaml
+++ b/packages/libyaml/meta.yaml
@@ -9,7 +9,9 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emcmake cmake -DCMAKE_INSTALL_PREFIX=${HOSTINSTALLDIR} .
+    export INSTALL_DIR=${WASM_LIBRARY_DIR}/libyaml
+
+    CFLAGS="-fPIC" emcmake cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-    ln -s libyaml_static.a ${HOST_LD_LIBRARY_PATH}/libyaml.a
+    ln -s libyaml_static.a ${INSTALL_DIR}/lib/libyaml.a

--- a/packages/libyaml/meta.yaml
+++ b/packages/libyaml/meta.yaml
@@ -12,4 +12,4 @@ build:
     CFLAGS="-fPIC" emcmake cmake -DCMAKE_INSTALL_PREFIX=${HOSTINSTALLDIR} .
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-    ln -s ${HOST_LD_LIBRARY_PATH}/libyaml_static.a ${HOST_LD_LIBRARY_PATH}/libyaml.a
+    ln -s libyaml_static.a ${HOST_LD_LIBRARY_PATH}/libyaml.a

--- a/packages/libyaml/meta.yaml
+++ b/packages/libyaml/meta.yaml
@@ -9,7 +9,9 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emcmake cmake -DCMAKE_INSTALL_PREFIX=.. .
+    CFLAGS="-fPIC" emcmake cmake -DCMAKE_INSTALL_PREFIX=${HOSTINSTALLDIR} .
     emmake make -j ${PYODIDE_JOBS:-3}
-    ln -s libyaml-0.2.1/libyaml_static.a ../libyaml.a
-    ln -s libyaml-0.2.1/include ..
+    emmake make install
+
+    # ln -s libyaml-0.2.1/libyaml_static.a ../libyaml.a
+    # ln -s libyaml-0.2.1/include ..

--- a/packages/lxml/meta.yaml
+++ b/packages/lxml/meta.yaml
@@ -16,8 +16,6 @@ requirements:
     - html5lib
     - libxml
     - libxslt
-    - zlib
-    - libiconv
 test:
   imports:
     - lxml

--- a/packages/lxml/meta.yaml
+++ b/packages/lxml/meta.yaml
@@ -6,7 +6,7 @@ source:
   url: https://files.pythonhosted.org/packages/3b/94/e2b1b3bad91d15526c7e38918795883cee18b93f6785ea8ecf13f8ffa01e/lxml-4.8.0.tar.gz
 build:
   script: |
-    export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${WASM_PKG_CONFIG_PATH}
+    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
   cflags: |
     -Wno-implicit-function-declaration
 requirements:

--- a/packages/lxml/meta.yaml
+++ b/packages/lxml/meta.yaml
@@ -6,20 +6,10 @@ source:
   url: https://files.pythonhosted.org/packages/3b/94/e2b1b3bad91d15526c7e38918795883cee18b93f6785ea8ecf13f8ffa01e/lxml-4.8.0.tar.gz
 build:
   script: |
-    export WITH_XML2_CONFIG=$PYODIDE_ROOT/packages/libxml/build/libxml-2.9.10/xml2-config
-    export WITH_XSLT_CONFIG=$PYODIDE_ROOT/packages/libxslt/build/libxslt-1.1.33/xslt-config
+    export WITH_XML2_CONFIG="${HOSTINSTALLDIR}/bin/xml2-config"
+    export WITH_XSLT_CONFIG="${HOSTINSTALLDIR}/bin/xslt-config"
   cflags: |
-    -I$(PYODIDE_ROOT)/packages/libxml/build/libxml-2.9.10/include
-    -I$(PYODIDE_ROOT)/packages/libxslt/build/libxslt-1.1.33/
-    -L$(PYODIDE_ROOT)/packages/zlib/build/zlib-1.2.11/include
-    -I$(PYODIDE_ROOT)/packages/libiconv/build/libiconv-1.16/include
     -Wno-implicit-function-declaration
-  ldflags: |
-    -L$(PYODIDE_ROOT)/packages/libxml/build/libxml-2.9.10/.libs/
-    -L$(PYODIDE_ROOT)/packages/libxslt/build/libxslt-1.1.33/libxslt/.libs/
-    -L$(PYODIDE_ROOT)/packages/libxslt/build/libxslt-1.1.33/libexslt/.libs/
-    -L$(PYODIDE_ROOT)/packages/zlib/build/zlib-1.2.11/lib/
-    -L$(PYODIDE_ROOT)/packages/libiconv/build/libiconv-1.16/lib/.libs/
 requirements:
   run:
     - beautifulsoup4

--- a/packages/lxml/meta.yaml
+++ b/packages/lxml/meta.yaml
@@ -5,8 +5,6 @@ source:
   sha256: f63f62fc60e6228a4ca9abae28228f35e1bd3ce675013d1dfb828688d50c6e23
   url: https://files.pythonhosted.org/packages/3b/94/e2b1b3bad91d15526c7e38918795883cee18b93f6785ea8ecf13f8ffa01e/lxml-4.8.0.tar.gz
 build:
-  script: |
-    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
   cflags: |
     -Wno-implicit-function-declaration
 requirements:

--- a/packages/lxml/meta.yaml
+++ b/packages/lxml/meta.yaml
@@ -6,8 +6,7 @@ source:
   url: https://files.pythonhosted.org/packages/3b/94/e2b1b3bad91d15526c7e38918795883cee18b93f6785ea8ecf13f8ffa01e/lxml-4.8.0.tar.gz
 build:
   script: |
-    export WITH_XML2_CONFIG="${HOSTINSTALLDIR}/bin/xml2-config"
-    export WITH_XSLT_CONFIG="${HOSTINSTALLDIR}/bin/xslt-config"
+    export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${WASM_PKG_CONFIG_PATH}
   cflags: |
     -Wno-implicit-function-declaration
 requirements:

--- a/packages/lxml/test_lxml.py
+++ b/packages/lxml/test_lxml.py
@@ -1,0 +1,18 @@
+from pyodide_test_runner import run_in_pyodide
+
+
+@run_in_pyodide(packages=["lxml"])
+def test_lxml():
+    from lxml import etree
+
+    root = etree.XML(
+        """<root>
+        <TEXT1 class="myitem">one</TEXT1>
+        <TEXT2 class="myitem">two</TEXT2>
+        <TEXT3 class="myitem">three</TEXT3>
+        <v-TEXT4 class="v-list">four</v-TEXT4>
+    </root>"""
+    )
+
+    items = root.xpath("//*[@class='myitem']")
+    assert ["one", "two", "three"] == [item.text for item in items]

--- a/packages/msprime/meta.yaml
+++ b/packages/msprime/meta.yaml
@@ -5,11 +5,13 @@ source:
   url: https://files.pythonhosted.org/packages/30/ac/22b9d2dc6e3233cc35e613b714d52cf87e4af00064a53d226824401629cb/msprime-1.1.1.tar.gz
   sha256: e840bed2ba37ae572b234f0b55af006dc408881593f184304481ee6058ea6f30
 build:
+  script:
+    export LIBGSL_INCLUDE_PATH=$(pkg-config --cflags-only-I --dont-define-prefix gsl)
+    export LIBGSL_LIBRARY_PATH=$(pkg-config --libs-only-L --dont-define-prefix gsl)
   cflags: |
-    -I$(PYODIDE_ROOT)/packages/libgsl/build/libgsl-2.7
+    $(LIBGSL_INCLUDE_PATH)
   ldflags: |
-    -L$(PYODIDE_ROOT)/packages/libgsl/build/libgsl-2.7/.libs
-    -L$(PYODIDE_ROOT)/packages/libgsl/build/libgsl-2.7/cblas/.libs
+    $(LIBGSL_LIBRARY_PATH)
 requirements:
   run:
     - numpy

--- a/packages/opencv-python/cmake/build_args.sh
+++ b/packages/opencv-python/cmake/build_args.sh
@@ -13,8 +13,8 @@ export CMAKE_ARGS=" \
 -DWITH_PNG=ON \
 -DWITH_WEBP=ON \
 -DBUILD_WEBP=OFF \
--DWEBP_INCLUDE_DIR=$WASM_LIBRARY_DIR/libwebp/include \
--DWEBP_LIBRARY=$WASM_LIBRARY_DIR/libwebp/lib/libwebp.a \
+-DWEBP_INCLUDE_DIR=$WASM_LIBRARY_DIR/include \
+-DWEBP_LIBRARY=$WASM_LIBRARY_DIR/lib/libwebp.a \
 \
 -DBUILD_opencv_python3=ON \
 -DBUILD_opencv_world=ON \

--- a/packages/opencv-python/cmake/build_args.sh
+++ b/packages/opencv-python/cmake/build_args.sh
@@ -13,8 +13,8 @@ export CMAKE_ARGS=" \
 -DWITH_PNG=ON \
 -DWITH_WEBP=ON \
 -DBUILD_WEBP=OFF \
--DWEBP_INCLUDE_DIR=$LIBWEBP_ROOT/include \
--DWEBP_LIBRARY=$LIBWEBP_ROOT/lib/libwebp.a \
+-DWEBP_INCLUDE_DIR=$WASM_LIBRARY_DIR/libwebp/include \
+-DWEBP_LIBRARY=$WASM_LIBRARY_DIR/libwebp/lib/libwebp.a \
 \
 -DBUILD_opencv_python3=ON \
 -DBUILD_opencv_world=ON \

--- a/packages/opencv-python/meta.yaml
+++ b/packages/opencv-python/meta.yaml
@@ -55,7 +55,7 @@ build:
 
     export NUMPY_INCLUDE_DIR="$HOSTINSTALLDIR/lib/python$PYMAJOR.$PYMINOR/site-packages/numpy/core/include/"
     export EMSCRIPTEN="$PYODIDE_ROOT/emsdk/emsdk/upstream/emscripten/"
-    export FFMPEG_ROOT="$WASM_LIBRARY_DIR/ffmpeg"
+    export FFMPEG_ROOT="$WASM_LIBRARY_DIR"
 
     source $PYODIDE_ROOT/packages/opencv-python/cmake/build_args.sh
 

--- a/packages/opencv-python/meta.yaml
+++ b/packages/opencv-python/meta.yaml
@@ -56,7 +56,7 @@ build:
     export NUMPY_INCLUDE_DIR="$HOSTINSTALLDIR/lib/python$PYMAJOR.$PYMINOR/site-packages/numpy/core/include/"
     export EMSCRIPTEN="$PYODIDE_ROOT/emsdk/emsdk/upstream/emscripten/"
     export FFMPEG_ROOT="$PYODIDE_ROOT/packages/ffmpeg/build/ffmpeg-4.4.1/lib"
-    export LIBWEBP_ROOT="$PYODIDE_ROOT/packages/libwebp/build/libwebp-1.2.2/build/lib"
+    export LIBWEBP_ROOT="$HOSTINSTALLDIR"
 
     source $PYODIDE_ROOT/packages/opencv-python/cmake/build_args.sh
 

--- a/packages/opencv-python/meta.yaml
+++ b/packages/opencv-python/meta.yaml
@@ -55,8 +55,7 @@ build:
 
     export NUMPY_INCLUDE_DIR="$HOSTINSTALLDIR/lib/python$PYMAJOR.$PYMINOR/site-packages/numpy/core/include/"
     export EMSCRIPTEN="$PYODIDE_ROOT/emsdk/emsdk/upstream/emscripten/"
-    export FFMPEG_ROOT="$PYODIDE_ROOT/packages/ffmpeg/build/ffmpeg-4.4.1/lib"
-    export LIBWEBP_ROOT="$HOSTINSTALLDIR"
+    export FFMPEG_ROOT="$WASM_LIBRARY_DIR/ffmpeg"
 
     source $PYODIDE_ROOT/packages/opencv-python/cmake/build_args.sh
 

--- a/packages/openssl/meta.yaml
+++ b/packages/openssl/meta.yaml
@@ -8,12 +8,22 @@ source:
 build:
   sharedlibrary: true
   script: |
-    emconfigure ./Configure gcc -no-ui-console -DHAVE_FORK=0 -DOPENSSL_NO_SECURE_MEMORY -DNO_SYSLOG -fPIC
+    emconfigure ./Configure \
+      gcc \
+      -no-ui-console \
+      -no-tests \
+      -DHAVE_FORK=0 \
+      -DOPENSSL_NO_SECURE_MEMORY \
+      -DNO_SYSLOG \
+      -fPIC \
+      --prefix=${HOSTINSTALLDIR}
+
     sed -i 's!^CROSS_COMPILE=.*!!g' Makefile
     make build_generated
     make -j ${PYODIDE_JOBS:-3} libcrypto.a
     make -j ${PYODIDE_JOBS:-3} libssl.a
     emar -d libcrypto.a liblegacy-lib-bn_asm.o liblegacy-lib-des_enc.o liblegacy-lib-fcrypt_b.o
     mkdir dist
-    emcc -sSIDE_MODULE=1 libcrypto.a -o dist/libcrypto.so
-    emcc -sSIDE_MODULE=1 libssl.a -o dist/libssl.so
+    emcc -sSIDE_MODULE=1 libcrypto.a -o libcrypto.so
+    emcc -sSIDE_MODULE=1 libssl.a -o libssl.so
+    make install_sw

--- a/packages/openssl/meta.yaml
+++ b/packages/openssl/meta.yaml
@@ -16,7 +16,7 @@ build:
       -DOPENSSL_NO_SECURE_MEMORY \
       -DNO_SYSLOG \
       -fPIC \
-      --prefix=${HOSTINSTALLDIR}
+      --prefix=${WASM_LIBRARY_DIR}/openssl
 
     sed -i 's!^CROSS_COMPILE=.*!!g' Makefile
     make build_generated
@@ -27,3 +27,5 @@ build:
     emcc -sSIDE_MODULE=1 libcrypto.a -o libcrypto.so
     emcc -sSIDE_MODULE=1 libssl.a -o libssl.so
     make install_sw
+
+    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/openssl/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/openssl/meta.yaml
+++ b/packages/openssl/meta.yaml
@@ -16,7 +16,7 @@ build:
       -DOPENSSL_NO_SECURE_MEMORY \
       -DNO_SYSLOG \
       -fPIC \
-      --prefix=${WASM_LIBRARY_DIR}/openssl
+      --prefix=${WASM_LIBRARY_DIR}
 
     sed -i 's!^CROSS_COMPILE=.*!!g' Makefile
     make build_generated
@@ -27,5 +27,3 @@ build:
     emcc -sSIDE_MODULE=1 libcrypto.a -o libcrypto.so
     emcc -sSIDE_MODULE=1 libssl.a -o libssl.so
     make install_sw
-
-    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/openssl/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/pyyaml/meta.yaml
+++ b/packages/pyyaml/meta.yaml
@@ -7,7 +7,6 @@ source:
 build:
   cflags: |
     -I$(PYTHONINCLUDE)
-    -I$(PYODIDE_ROOT)/emsdk/emsdk/fastcomp/emscripten/system/include/libc
     -I$(WASM_LIBRARY_DIR)/include
   ldflags: |
     -L$(WASM_LIBRARY_DIR)/lib

--- a/packages/pyyaml/meta.yaml
+++ b/packages/pyyaml/meta.yaml
@@ -8,6 +8,9 @@ build:
   cflags: |
     -I$(PYTHONINCLUDE)
     -I$(PYODIDE_ROOT)/emsdk/emsdk/fastcomp/emscripten/system/include/libc
+    -I$(WASM_LIBRARY_DIR)/libyaml/include
+  ldflags: |
+    -L$(WASM_LIBRARY_DIR)/libyaml/lib
 requirements:
   run:
     - libyaml

--- a/packages/pyyaml/meta.yaml
+++ b/packages/pyyaml/meta.yaml
@@ -8,9 +8,9 @@ build:
   cflags: |
     -I$(PYTHONINCLUDE)
     -I$(PYODIDE_ROOT)/emsdk/emsdk/fastcomp/emscripten/system/include/libc
-    -I$(WASM_LIBRARY_DIR)/libyaml/include
+    -I$(WASM_LIBRARY_DIR)/include
   ldflags: |
-    -L$(WASM_LIBRARY_DIR)/libyaml/lib
+    -L$(WASM_LIBRARY_DIR)/lib
 requirements:
   run:
     - libyaml

--- a/packages/pyyaml/meta.yaml
+++ b/packages/pyyaml/meta.yaml
@@ -5,10 +5,9 @@ source:
   url: https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz
   sha256: 68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2
 build:
-  cflags:
-    "-I$(PYTHONINCLUDE)\n-I$(PYODIDE_ROOT)/emsdk/emsdk/fastcomp/emscripten/system/include/libc\n\
-    -I$(PYODIDE_ROOT)/packages/libyaml/build/include\n"
-  ldflags: "-L$(PYODIDE_ROOT)/packages/libyaml/build/\n"
+  cflags: |
+    -I$(PYTHONINCLUDE)
+    -I$(PYODIDE_ROOT)/emsdk/emsdk/fastcomp/emscripten/system/include/libc
 requirements:
   run:
     - libyaml

--- a/packages/pyyaml/test_pyyaml.py
+++ b/packages/pyyaml/test_pyyaml.py
@@ -1,0 +1,16 @@
+from pyodide_test_runner import run_in_pyodide
+
+
+@run_in_pyodide(packages=["pyyaml"])
+def test_pyyaml():
+    import yaml
+    from yaml import CLoader as Loader
+
+    document = """
+    - Hesperiidae
+    - Papilionidae
+    - Apatelodidae
+    - Epiplemidae
+    """
+    loaded = yaml.load(document, Loader=Loader)
+    assert loaded == ["Hesperiidae", "Papilionidae", "Apatelodidae", "Epiplemidae"]

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -34,7 +34,7 @@ source:
 
 build:
   cflags: |
-    -I$(PYODIDE_ROOT)/packages/CLAPACK/build/CLAPACK-3.2.1/INCLUDE
+    -I$(WASM_LIBRARY_DIR)/CLAPACK/INCLUDE
     -I$(HOSTSITEPACKAGES)/pythran/
     -Wno-return-type
     -DUNDERSCORE_G77

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -8,7 +8,7 @@ build:
   script: |
     mkdir dist
     export DISTDIR=$(pwd)/dist
-    export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${WASM_PKG_CONFIG_PATH}
+    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
     cd $CPYTHONBUILD
     emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
     emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -8,9 +8,11 @@ build:
   script: |
     mkdir dist
     export DISTDIR=$(pwd)/dist
+    export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${WASM_PKG_CONFIG_PATH}
     cd $CPYTHONBUILD
     emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
-    emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o -I${HOST_C_INCLUDE_PATH} \
+    emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \
+      $(pkg-config --cflags-only-I openssl) \
       -DOPENSSL_THREADS # This declares that OPENSSL is threadsafe. We are single threaded so everything is threadsafe.
     emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS
     emcc Modules/socketmodule.o -o $DISTDIR/socketmodule.so $SIDE_MODULE_LDFLAGS

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -10,7 +10,7 @@ build:
     export DISTDIR=$(pwd)/dist
     cd $CPYTHONBUILD
     emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
-    emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o -I$OPEN_SSL_ROOT/include/ \
+    emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o -I${HOST_C_INCLUDE_PATH} \
       -DOPENSSL_THREADS # This declares that OPENSSL is threadsafe. We are single threaded so everything is threadsafe.
     emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS
     emcc Modules/socketmodule.o -o $DISTDIR/socketmodule.so $SIDE_MODULE_LDFLAGS

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -12,9 +12,10 @@ build:
     cd $CPYTHONBUILD
     emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
     emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \
-      $(pkg-config --cflags-only-I openssl) \
+      $(pkg-config --cflags openssl) \
+      $(pkg-config --libs openssl) \
       -DOPENSSL_THREADS # This declares that OPENSSL is threadsafe. We are single threaded so everything is threadsafe.
-    emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS
+    emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS $(pkg-config --libs openssl)
     emcc Modules/socketmodule.o -o $DISTDIR/socketmodule.so $SIDE_MODULE_LDFLAGS
 requirements:
   run:

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -8,7 +8,6 @@ build:
   script: |
     mkdir dist
     export DISTDIR=$(pwd)/dist
-    export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
     cd $CPYTHONBUILD
     emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
     emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -9,6 +9,8 @@ build:
     mkdir dist
     export DISTDIR=$(pwd)/dist
     export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
+    echo $(pkg-config --cflags openssl)
+    echo $(pkg-config --libs openssl)
     cd $CPYTHONBUILD
     emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
     emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -9,13 +9,11 @@ build:
     mkdir dist
     export DISTDIR=$(pwd)/dist
     export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
-    echo $(pkg-config --cflags --dont-define-prefix openssl)
-    echo $(pkg-config --libs --dont-define-prefix openssl)
     cd $CPYTHONBUILD
     emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
     emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \
-      $(pkg-config --cflags openssl) \
-      $(pkg-config --libs openssl) \
+      $(pkg-config --cflags --dont-define-prefix openssl) \
+      $(pkg-config --libs --dont-define-prefix openssl) \
       -DOPENSSL_THREADS # This declares that OPENSSL is threadsafe. We are single threaded so everything is threadsafe.
     emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS $(pkg-config --libs --dont-define-prefix openssl)
     emcc Modules/socketmodule.o -o $DISTDIR/socketmodule.so $SIDE_MODULE_LDFLAGS

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -9,15 +9,15 @@ build:
     mkdir dist
     export DISTDIR=$(pwd)/dist
     export PKG_CONFIG_PATH=${WASM_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
-    echo $(pkg-config --cflags openssl)
-    echo $(pkg-config --libs openssl)
+    echo $(pkg-config --cflags --dont-define-prefix openssl)
+    echo $(pkg-config --libs --dont-define-prefix openssl)
     cd $CPYTHONBUILD
     emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
     emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \
       $(pkg-config --cflags openssl) \
       $(pkg-config --libs openssl) \
       -DOPENSSL_THREADS # This declares that OPENSSL is threadsafe. We are single threaded so everything is threadsafe.
-    emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS $(pkg-config --libs openssl)
+    emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS $(pkg-config --libs --dont-define-prefix openssl)
     emcc Modules/socketmodule.o -o $DISTDIR/socketmodule.so $SIDE_MODULE_LDFLAGS
 requirements:
   run:

--- a/packages/swiglpk/meta.yaml
+++ b/packages/swiglpk/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   script: |
-    export ENV_GLPK_HEADER_PATH="${HOST_C_INCLUDE_PATH}/glpk.h"
+    export ENV_GLPK_HEADER_PATH="${WASM_LIBRARY_DIR}/glpk/include/glpk.h"
 
 requirements:
   run:

--- a/packages/swiglpk/meta.yaml
+++ b/packages/swiglpk/meta.yaml
@@ -5,11 +5,10 @@ package:
 source:
   sha256: 32f9fa0a082d80e32234f060704b6d7f07843a7aefffa5008b315b0970bab199
   url: https://github.com/biosustain/swiglpk/archive/refs/tags/5.0.3.tar.gz
-  extras:
-    - [../glpk/build/glpk-5.0/src/glpk.h, ./glpk.h]
 
 build:
-  ldflags: -L$(PYODIDE_ROOT)/packages/glpk/build/glpk-5.0/src/.libs/
+  script: |
+    export ENV_GLPK_HEADER_PATH="$(HOSTINSTALLDIR)/include/glpk.h"
 
 requirements:
   run:

--- a/packages/swiglpk/meta.yaml
+++ b/packages/swiglpk/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   script: |
-    export ENV_GLPK_HEADER_PATH="$(HOSTINSTALLDIR)/include/glpk.h"
+    export ENV_GLPK_HEADER_PATH="${HOST_C_INCLUDE_PATH}/glpk.h"
 
 requirements:
   run:

--- a/packages/swiglpk/meta.yaml
+++ b/packages/swiglpk/meta.yaml
@@ -8,7 +8,8 @@ source:
 
 build:
   script: |
-    export ENV_GLPK_HEADER_PATH="${WASM_LIBRARY_DIR}/glpk/include/glpk.h"
+    export GLPK_HEADER_PATH="${WASM_LIBRARY_DIR}/glpk/include/"
+  ldflags: -L$(WASM_LIBRARY_DIR)/glpk/lib
 
 requirements:
   run:

--- a/packages/swiglpk/meta.yaml
+++ b/packages/swiglpk/meta.yaml
@@ -8,8 +8,8 @@ source:
 
 build:
   script: |
-    export GLPK_HEADER_PATH="${WASM_LIBRARY_DIR}/glpk/include/"
-  ldflags: -L$(WASM_LIBRARY_DIR)/glpk/lib
+    export GLPK_HEADER_PATH="${WASM_LIBRARY_DIR}/include/"
+  ldflags: -L$(WASM_LIBRARY_DIR)/lib
 
 requirements:
   run:

--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -9,5 +9,5 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emconfigure ./configure --prefix=$PWD
+    CFLAGS="-fPIC" emconfigure ./configure --prefix=${HOSTINSTALLDIR}
     emmake make install -j ${PYODIDE_JOBS:-3}

--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -9,6 +9,5 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emconfigure ./configure --prefix=${WASM_LIBRARY_DIR}/zlib
+    CFLAGS="-fPIC" emconfigure ./configure --prefix=${WASM_LIBRARY_DIR}
     emmake make install -j ${PYODIDE_JOBS:-3}
-    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/zlib/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -9,5 +9,6 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emconfigure ./configure --prefix=${HOSTINSTALLDIR}
+    CFLAGS="-fPIC" emconfigure ./configure --prefix=${WASM_LIBRARY_DIR}/zlib
     emmake make install -j ${PYODIDE_JOBS:-3}
+    mkdir -p ${WASM_PKG_CONFIG_PATH} && cp ${WASM_LIBRARY_DIR}/zlib/lib/pkgconfig/*.pc ${WASM_PKG_CONFIG_PATH}

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -152,6 +152,11 @@ def get_bash_runner():
     } | {"PYODIDE": "1"}
     if "PYODIDE_JOBS" in os.environ:
         env["PYODIDE_JOBS"] = os.environ["PYODIDE_JOBS"]
+
+    env["PKG_CONFIG_PATH"] = env["WASM_PKG_CONFIG_PATH"]
+    if "PKG_CONFIG_PATH" in os.environ:
+        env["PKG_CONFIG_PATH"] += f":{os.environ['PKG_CONFIG_PATH']}"
+
     with BashRunnerWithSharedEnvironment(env=env) as b:
         b.run(
             f"source {PYODIDE_ROOT}/emsdk/emsdk/emsdk_env.sh", stderr=subprocess.DEVNULL

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -146,8 +146,8 @@ def get_bash_runner():
             "SIDE_MODULE_LDFLAGS",
             "STDLIB_MODULE_CFLAGS",
             "UNISOLATED_PACKAGES",
-            "HOST_C_INCLUDE_PATH",
-            "HOST_LD_LIBRARY_PATH",
+            "WASM_LIBRARY_DIR",
+            "WASM_PKG_CONFIG_PATH",
         ]
     } | {"PYODIDE": "1"}
     if "PYODIDE_JOBS" in os.environ:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -145,8 +145,9 @@ def get_bash_runner():
             "SIDE_MODULE_CFLAGS",
             "SIDE_MODULE_LDFLAGS",
             "STDLIB_MODULE_CFLAGS",
-            "OPEN_SSL_ROOT",
             "UNISOLATED_PACKAGES",
+            "HOST_C_INCLUDE_PATH",
+            "HOST_LD_LIBRARY_PATH",
         ]
     } | {"PYODIDE": "1"}
     if "PYODIDE_JOBS" in os.environ:


### PR DESCRIPTION
### Description

Resolve #2436

Install libraries to `packages/.libs` and use `pkg-config` if possible. After this patch, we don't have to hardcode paths for each library.

In the future, maybe we can try setting [`EM_PKG_CONFIG_PATH`](https://github.com/emscripten-core/emscripten/blob/592f67ff77fea404f07f901b37ec4ff5eb017a25/tools/building.py#L153) variable to make emscripten to automatically detect library paths.
