### PR TITLE
DOC update FAQ instruction for detecting Emscripten runtime

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -110,7 +110,7 @@ my_namespace.get("z"); // ==> 4
 
 ## How to detect that code is run with Pyodide?
 
-**At run time**, you can check if Python built with Emscripten (which is the
+**At run time**, you can check if Python is built with Emscripten (which is the
 case Pyodide) with,
 
 ```py

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -111,7 +111,7 @@ my_namespace.get("z"); // ==> 4
 ## How to detect that code is run with Pyodide?
 
 **At run time**, you can check if Python is built with Emscripten (which is the
-case Pyodide) with,
+case for Pyodide) with,
 
 ```py
 import sys

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -110,23 +110,24 @@ my_namespace.get("z"); // ==> 4
 
 ## How to detect that code is run with Pyodide?
 
-**At run time**, you can detect that a code is running with Pyodide using,
+**At run time**, you can check if Python built with Emscripten (which is the
+case Pyodide) with,
+
+```py
+import sys
+
+if sys.platform == 'emscripten':
+    # running in Pyodide or other Emscripten based build
+```
+
+To detect that a code is running with Pyodide specifically, you can check
+for the loaded `pyodide` module,
 
 ```py
 import sys
 
 if "pyodide" in sys.modules:
    # running in Pyodide
-```
-
-More generally you can detect Python built with Emscripten (which includes
-Pyodide) with,
-
-```py
-import platform
-
-if platform.system() == 'Emscripten':
-    # running in Pyodide or other Emscripten based build
 ```
 
 This however will not work at build time (i.e. in a `setup.py`) due to the way


### PR DESCRIPTION
As suggested by @tiran in https://discuss.python.org/t/expected-behavior-for-unsupported-stdlib-modules-in-the-browser/15689/2

I agree that using `sys` is better than `platform`.