### PR TITLE
Add PyProj to packages

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -208,7 +208,7 @@ substitutions:
   svgwrite, jsonschema, tskit {pr}`2506`, xarray {pr}`2538`, demes, libgsl, newick,
   ruamel, msprime {pr}`2548`, gmpy2 {pr}`2665`, xgboost {pr}`2537`, galpy {pr}`2676`,
   shapely, geos {pr}`2725`, suitesparse, sparseqr {pr}`2685`, libtiff {pr}`2762`,
-  pytest-benchmark {pr}`2799`, termcolor {pr}`2809`
+  pytest-benchmark {pr}`2799`, termcolor {pr}`2809`, sqlite3, libproj, pyproj, certifi {pr}`2555`
 
 ### Miscellaneous
 

--- a/packages/certifi/meta.yaml
+++ b/packages/certifi/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: certifi
+  version: 2022.6.15
+
+source:
+  url: https://files.pythonhosted.org/packages/e9/06/d3d367b7af6305b16f0d28ae2aaeb86154fa91f144f036c2d5002a5a202b/certifi-2022.6.15-py3-none-any.whl
+  sha256: fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412
+
+test:
+  imports:
+    - certifi
+
+about:
+  home: https://github.com/certifi/python-certifi
+  PyPI: https://pypi.org/project/certifi
+  summary: Certifi provides Mozilla’s carefully curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts.
+  license: "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"

--- a/packages/libproj/meta.yaml
+++ b/packages/libproj/meta.yaml
@@ -17,7 +17,7 @@ build:
     mkdir -p build;
     cd build \
         && LDFLAGS="-s NODERAWFS=1 -sUSE_ZLIB=1 -sFORCE_FILESYSTEM=1" emcmake cmake ../ \
-        -DCMAKE_INSTALL_PREFIX=../../proj \
+        -DCMAKE_INSTALL_PREFIX=$WASM_LIBRARY_DIR \
         -DCMAKE_BUILD_TYPE=Release \
         -DENABLE_CURL=OFF \
         -DBUILD_APPS=OFF \

--- a/packages/libproj/meta.yaml
+++ b/packages/libproj/meta.yaml
@@ -9,6 +9,7 @@ source:
 requirements:
   run:
     - sqlite3
+    - libtiff
 
 build:
   library: true
@@ -19,10 +20,11 @@ build:
         -DCMAKE_INSTALL_PREFIX=../../proj \
         -DCMAKE_BUILD_TYPE=Release \
         -DENABLE_CURL=OFF \
-        -DENABLE_TIFF=OFF \
         -DBUILD_APPS=OFF \
         -DBUILD_SHARED_LIBS=OFF \
         -DBUILD_TESTING=OFF \
+        -DTIFF_INCLUDE_DIR=$WASM_LIBRARY_DIR/include \
+        -DTIFF_LIBRARY=$WASM_LIBRARY_DIR/lib/libtiff.a \
         -DSQLITE3_LIBRARY=${WASM_LIBRARY_DIR}/lib/libsqlite3.a \
         -DSQLITE3_INCLUDE_DIR=${WASM_LIBRARY_DIR}/include \
         -DCMAKE_C_FLAGS="-fPIC" \

--- a/packages/libproj/meta.yaml
+++ b/packages/libproj/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: libproj
+  version: 8.2.1
+
+source:
+  sha256: 76ed3d0c3a348a6693dfae535e5658bbfd47f71cb7ff7eb96d9f12f7e068b1cf
+  url: https://download.osgeo.org/proj/proj-8.2.1.tar.gz
+
+requirements:
+  run:
+    - sqlite3
+
+build:
+  library: true
+  script: |
+    mkdir -p build;
+    cd build \
+        && LDFLAGS="-s NODERAWFS=1 -sUSE_ZLIB=1 -sFORCE_FILESYSTEM=1" emcmake cmake ../ \
+        -DCMAKE_INSTALL_PREFIX=../../proj \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DENABLE_CURL=OFF \
+        -DENABLE_TIFF=OFF \
+        -DBUILD_APPS=OFF \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_TESTING=OFF \
+        -DSQLITE3_LIBRARY=${WASM_LIBRARY_DIR}/lib/libsqlite3.a \
+        -DSQLITE3_INCLUDE_DIR=${WASM_LIBRARY_DIR}/include \
+        -DCMAKE_C_FLAGS="-fPIC" \
+        -DCMAKE_CXX_FLAGS="-fPIC";
+    emmake make -j ${PYODIDE_JOBS:-3} install;

--- a/packages/pyproj/meta.yaml
+++ b/packages/pyproj/meta.yaml
@@ -19,7 +19,9 @@ build:
     export PROJ_DIR=${WASM_LIBRARY_DIR}
     export PROJ_INCDIR=${WASM_LIBRARY_DIR}/include
     export PROJ_LIBDIR=${WASM_LIBRARY_DIR}/lib
-
+    export PROJ_WHEEL=1
+    mkdir -p pyproj/proj_dir
+    cp -r ${WASM_LIBRARY_DIR}/share pyproj/proj_dir
 test:
   imports:
     - pyproj

--- a/packages/pyproj/meta.yaml
+++ b/packages/pyproj/meta.yaml
@@ -5,6 +5,8 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/e3/4d/348402c2fb0d8a8e85a88b8babc6f4efaae9692b7524aedce5fddbef3baf/pyproj-3.3.1.tar.gz
   sha256: b3d8e14d91cc95fb3dbc03a9d0588ac58326803eefa5bbb0978d109de3304fbe
+  patches:
+    - patches/fix-build.patch
 
 requirements:
   run:

--- a/packages/pyproj/meta.yaml
+++ b/packages/pyproj/meta.yaml
@@ -11,6 +11,7 @@ source:
 requirements:
   run:
     - libproj
+    - certifi
 
 build:
   script: |

--- a/packages/pyproj/meta.yaml
+++ b/packages/pyproj/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: pyproj
+  version: 3.3.1
+
+source:
+  url: https://files.pythonhosted.org/packages/e3/4d/348402c2fb0d8a8e85a88b8babc6f4efaae9692b7524aedce5fddbef3baf/pyproj-3.3.1.tar.gz
+  sha256: b3d8e14d91cc95fb3dbc03a9d0588ac58326803eefa5bbb0978d109de3304fbe
+
+requirements:
+  run:
+    - libproj
+
+build:
+  script: |
+    export PROJ_VERSION=8.2.1
+    export PROJ_DIR=${WASM_LIBRARY_DIR}
+    export PROJ_INCDIR=${WASM_LIBRARY_DIR}/include
+    export PROJ_LIBDIR=${WASM_LIBRARY_DIR}/lib
+
+test:
+  imports:
+    - pyproj
+
+about:
+  home: https://github.com/pyproj4/pyproj
+  PyPI: https://pypi.org/project/pyproj/
+  summary: Python interface to PROJ (cartographic projections and coordinate transformations library)
+  license: "License :: OSI Approved :: MIT License"

--- a/packages/pyproj/patches/fix-build.patch
+++ b/packages/pyproj/patches/fix-build.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index d8c1872a..ad396e02 100644
+--- a/setup.py
++++ b/setup.py
+@@ -167,7 +167,6 @@ def get_extension_modules():
+     ext_options = {
+         "include_dirs": include_dirs,
+         "library_dirs": library_dirs,
+-        "runtime_library_dirs": library_dirs if os.name != "nt" else None,
+         "libraries": get_libraries(library_dirs),
+     }
+     # setup cythonized modules

--- a/packages/pyproj/test_pyproj.py
+++ b/packages/pyproj/test_pyproj.py
@@ -1,0 +1,19 @@
+from pyodide_test_runner import run_in_pyodide
+
+
+@run_in_pyodide(packages=["pyproj"])
+def test_pyproj(selenium):
+    from pyproj import CRS, Transformer
+
+    latlon = CRS.from_epsg(4326)
+
+    # Check major axis radius of Earth for this projection
+    assert latlon.get_geod().a == 6378137
+
+    lcc = CRS.from_proj4("+proj=lcc +lat_1=25 +lat_2=40 +lat_0=35 +lon_0=-90")
+    t = Transformer.from_crs(latlon, lcc)
+
+    # Check that this transform gets us the origin
+    x, y = t.transform(35, -90)
+    assert int(x) == 0
+    assert int(y) == 0

--- a/packages/sqlite3/meta.yaml
+++ b/packages/sqlite3/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: sqlite3
+  version: 3.38.5
+
+source:
+  sha256: 5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c
+  url: https://www.sqlite.org/2022/sqlite-autoconf-3380500.tar.gz
+
+requirements:
+  run:
+    - zlib
+
+build:
+  library: true
+  script: |
+    emconfigure ./configure \
+        CFLAGS="-fPIC" \
+        CPPFLAGS=-DSQLITE_OMIT_POPEN \
+        --with-zlib="${WASM_LIBRARY_DIR}/lib" \
+        --prefix=${WASM_LIBRARY_DIR}
+    emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

This adds PyProj to the packages, as well as its dependency PROJ (libproj). This required pointing directly to the sqlite3.wasm that's built with Python (or else the build refused to detect the dependency as present).

I also tried to build as a shared library, but it said that wasn't supported. 🤷‍♂️ 

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
