### PR TITLE
Improve micropip error message when no package is found

### DIFF
--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -310,7 +310,14 @@ class _PackageManager:
                     f"Requested '{requirement}', "
                     f"but {req.name}=={ver} is already installed"
                 )
-        metadata = await _get_pypi_json(req.name, **fetch_extra_kwargs)
+        try:
+            metadata = await _get_pypi_json(req.name, **fetch_extra_kwargs)
+        except Exception as e:
+            raise ValueError(
+                f"Couldn't fetch metadata of '{req.name}' from PyPI. "
+                "Please make sure you have entered a correct package name."
+            ) from e
+
         maybe_wheel, maybe_ver = self.find_wheel(metadata, req)
         if maybe_wheel is None or maybe_ver is None:
             if transaction["keep_going"]:

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -89,7 +89,7 @@ async def _get_pypi_json(pkgname: str, fetch_extra_kwargs: dict[str, str]):
         metadata = await fetch_string(url, fetch_extra_kwargs)
     except Exception as e:
         raise ValueError(
-            f"Couldn't fetch metadata for '{pkgname}' from PyPI. "
+            f"Can't fetch metadata for '{pkgname}' from PyPI. "
             "Please make sure you have entered a correct package name."
         ) from e
     return json.loads(metadata)


### PR DESCRIPTION
### Description

Show better error message when fetching metadata from PyPI fails. Previously it just showed "Failed to Fetch"
