### PR TITLE
Fix ordering in micropip add_requirement

### DIFF
--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -305,19 +305,6 @@ class _PackageManager:
         if transaction.pre:
             req.specifier.prereleases = True
 
-        req.name = canonicalize_name(req.name)
-
-        # If there's a Pyodide package that matches the version constraint, use
-        # the Pyodide package instead of the one on PyPI
-        if req.name in BUILTIN_PACKAGES and req.specifier.contains(
-            BUILTIN_PACKAGES[req.name]["version"], prereleases=True
-        ):
-            version = BUILTIN_PACKAGES[req.name]["version"]
-            transaction.pyodide_packages.append(
-                PackageMetadata(name=req.name, version=str(version), source="pyodide")
-            )
-            return
-
         if req.marker:
             # handle environment markers
             # https://www.python.org/dev/peps/pep-0508/#environment-markers
@@ -335,6 +322,20 @@ class _PackageManager:
                     f"Requested '{requirement}', "
                     f"but {req.name}=={ver} is already installed"
                 )
+
+        req.name = canonicalize_name(req.name)
+
+        # If there's a Pyodide package that matches the version constraint, use
+        # the Pyodide package instead of the one on PyPI
+        if req.name in BUILTIN_PACKAGES and req.specifier.contains(
+            BUILTIN_PACKAGES[req.name]["version"], prereleases=True
+        ):
+            version = BUILTIN_PACKAGES[req.name]["version"]
+            transaction.pyodide_packages.append(
+                PackageMetadata(name=req.name, version=str(version), source="pyodide")
+            )
+            return
+
         metadata = await _get_pypi_json(req.name, fetch_extra_kwargs)
 
         try:


### PR DESCRIPTION
I think the logic here is slightly wrong. Steps for `add_requirement`:

1. Convert `req` from a string to a Requirement if necessary
2. If `req.marker` is present, check whether `req.marker` matches `ctx`, if not we don't need it.
3. Check if `req` is already installed
4. Check if `req` is available from `packages.json`
5. Check if `req` is available from pypi

For some reason we had step 4 occurring before steps 2 and 3. This puts them back in the correct order. 

