### PR TITLE
MAINT Consolidate `ctx` and `fetch_extra_kwargs` into `Transaction`

### DIFF
--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -6,7 +6,7 @@ import importlib
 import io
 import json
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from zipfile import ZipFile

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -116,9 +116,9 @@ class Transaction:
     locked: PackageDict
     fetch_extra_kwargs: dict[str, str]
 
-    wheels: list[WheelInfo] = []
-    pyodide_packages: list[PackageMetadata] = []
-    failed: list[Requirement] = []
+    wheels: list[WheelInfo] = field(default_factory=list)
+    pyodide_packages: list[PackageMetadata] = field(default_factory=list)
+    failed: list[Requirement] = field(default_factory=list)
 
 
 def _parse_wheel_url(url: str) -> WheelInfo:

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -326,7 +326,7 @@ class _PackageManager:
                 return
             else:
                 raise ValueError(
-                    f"Requested '{requirement}', "
+                    f"Requested '{req}', "
                     f"but {req.name}=={ver} is already installed"
                 )
         metadata = await _get_pypi_json(req.name, transaction.fetch_extra_kwargs)

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -273,7 +273,7 @@ class _PackageManager:
     async def add_requirement(
         self,
         transaction: Transaction,
-        requirement: str | Requirement,
+        requirement: str,
     ):
         """Add a requirement to the transaction.
 
@@ -281,10 +281,7 @@ class _PackageManager:
         https://www.python.org/dev/peps/pep-0508
         """
 
-        # 1. Convert `req` from a string to a Requirement if necessary
-        if isinstance(requirement, Requirement):
-            req = requirement
-        elif requirement.endswith(".whl"):
+        if requirement.endswith(".whl"):
             # custom download location
             wheel = _parse_wheel_url(requirement)
             if not _is_pure_python_wheel(wheel.filename):
@@ -292,8 +289,8 @@ class _PackageManager:
 
             await self.add_wheel(transaction, wheel, extras=set())
             return
-        else:
-            req = Requirement(requirement)
+
+        req = Requirement(requirement)
 
         if transaction.pre:
             req.specifier.prereleases = True
@@ -378,8 +375,7 @@ class _PackageManager:
             wheel.project_name = wheel.name
 
         if transaction.deps:
-            for recurs_req in dist.requires(extras):
-                await self.add_requirement(transaction, recurs_req)
+            await self.gather_requirements(transaction, dist.requires(extras))
 
         transaction.wheels.append(wheel)
 

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -325,8 +325,7 @@ class _PackageManager:
                 return
             else:
                 raise ValueError(
-                    f"Requested '{req}', "
-                    f"but {req.name}=={ver} is already installed"
+                    f"Requested '{req}', " f"but {req.name}=={ver} is already installed"
                 )
         metadata = await _get_pypi_json(req.name, transaction.fetch_extra_kwargs)
 

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -203,9 +203,11 @@ def test_add_requirement():
             pre=False,
             pyodide_packages=[],
             failed=[],
+            ctx={},
+            fetch_extra_kwargs={},
         )
         asyncio.get_event_loop().run_until_complete(
-            _micropip.PACKAGE_MANAGER.add_requirement(url, {}, transaction, {})
+            _micropip.PACKAGE_MANAGER.add_requirement(transaction, url)
         )
 
     wheel = transaction.wheels[0]
@@ -222,9 +224,13 @@ def test_add_requirement():
 def test_add_requirement_marker():
     pytest.importorskip("packaging")
     from micropip import _micropip
+    from micropip._micropip import Transaction
 
-    transaction = asyncio.get_event_loop().run_until_complete(
+    transaction = Transaction({"extra": ""}, False, False, False, {}, {})
+
+    asyncio.get_event_loop().run_until_complete(
         _micropip.PACKAGE_MANAGER.gather_requirements(
+            transaction,
             [
                 "werkzeug",
                 'contextvars ; python_version < "3.7"',
@@ -236,11 +242,6 @@ def test_add_requirement_marker():
                 "numpy ; extra == 'socketio'",
                 "python-socketio[client] ; extra == 'socketio'",
             ],
-            {"extra": ""},
-            False,
-            False,
-            False,
-            {},
         )
     )
     assert len(transaction.wheels) == 1
@@ -279,7 +280,7 @@ def test_install_non_pure_python_wheel():
         url = "http://scikit_learn-0.22.2.post1-cp35-cp35m-macosx_10_9_intel.whl"
         transaction = {"wheels": list[Any](), "locked": dict[str, Any]()}
         asyncio.get_event_loop().run_until_complete(
-            _micropip.PACKAGE_MANAGER.add_requirement(url, {}, transaction, {})
+            _micropip.PACKAGE_MANAGER.add_requirement(transaction, url)
         )
 
 


### PR DESCRIPTION
This is more cleanup in micropip. I moved `ctx` and `fetch_extra_kwargs` into `Transaction` properties so that we don't have to pass them through everywhere as separate arguments. I also switch to creating the `Transaction` in `install` so that we don't have to pass the arguments down into `gather_requirements` separately.

The only state of `_PackageManager` is `installed_packages` so I think we should move most of the methods of `_PackageManager` onto `Transaction`. I will probably open a subsequent PR for that.