### PR TITLE
MAINT micropip Move wheel-related methods into WheelInfo class

### DIFF
--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -265,7 +265,7 @@ class Transaction:
             )
             return
 
-        metadata = await _get_pypi_json(req.name, self.fetch_extra_kwargs)
+        metadata = await _get_pypi_json(req.name, self.fetch_kwargs)
 
         try:
             wheel = find_wheel(metadata, req)

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -195,7 +195,7 @@ def create_transaction(Transaction):
         pyodide_packages=[],
         failed=[],
         ctx={"extra": ""},
-        fetch_extra_kwargs={},
+        fetch_kwargs={},
     )
 
 

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -138,10 +138,10 @@ def test_install_simple(selenium_standalone_micropip):
 
 def test_parse_wheel_url():
     pytest.importorskip("packaging")
-    from micropip import _micropip
+    from micropip._micropip import WheelInfo
 
     url = "https://a/snowballstemmer-2.0.0-py2.py3-none-any.whl"
-    wheel = _micropip._parse_wheel_url(url)
+    wheel = WheelInfo.from_url(url)
     assert wheel.name == "snowballstemmer"
     assert str(wheel.version) == "2.0.0"
     assert wheel.digests is None
@@ -155,10 +155,10 @@ def test_parse_wheel_url():
     msg = "not a valid wheel file name"
     with pytest.raises(ValueError, match=msg):
         url = "https://a/snowballstemmer-2.0.0-py2.whl"
-        wheel = _micropip._parse_wheel_url(url)
+        wheel = WheelInfo.from_url(url)
 
     url = "http://scikit_learn-0.22.2.post1-cp35-cp35m-macosx_10_9_intel.whl"
-    wheel = _micropip._parse_wheel_url(url)
+    wheel = WheelInfo.from_url(url)
     assert wheel.name == "scikit_learn"
     assert wheel.platform == "macosx_10_9_intel"
 


### PR DESCRIPTION
More micropip maintenance.
* `_parse_wheel_url` ==> static method `WheelInfo.from_url`
* `_extract_wheel` ==> `WheelInfo.extract`
* `_validate_wheel` ==> `WheelInfo.validate`
* `_install_wheel` ==> `WheelInfo.install`
* Parts of `Transaction.add_wheel` were extracted into new methods `WheelInfo.download` and `WheelInfo.requires`.