### PR TITLE
micropip Fix async race condition

### DIFF
--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -222,6 +222,22 @@ class Transaction:
 
         await self.add_wheel(wheel, extras=set())
 
+    def check_version_satisfied(self, req: Requirement):
+        ver = None
+        if req.name in self.locked:
+            ver = self.locked[req.name].version
+
+        if not ver:
+            return False
+
+        if req.specifier.contains(ver, prereleases=True):
+            # installed version matches, nothing to do
+            return True
+
+        raise ValueError(
+            f"Requested '{req}', " f"but {req.name}=={ver} is already installed"
+        )
+
     async def add_requirement_inner(
         self,
         req: Requirement,
@@ -242,17 +258,10 @@ class Transaction:
                 return
 
         # Is some version of this package is already installed?
-        if req.name in self.locked:
-            ver = self.locked[req.name].version
-            if req.specifier.contains(ver, prereleases=True):
-                # installed version matches, nothing to do
-                return
-            else:
-                raise ValueError(
-                    f"Requested '{req}', " f"but {req.name}=={ver} is already installed"
-                )
 
         req.name = canonicalize_name(req.name)
+        if self.check_version_satisfied(req):
+            return
 
         # If there's a Pyodide package that matches the version constraint, use
         # the Pyodide package instead of the one on PyPI
@@ -273,11 +282,15 @@ class Transaction:
             self.failed.append(req)
             if not self.keep_going:
                 raise
-        else:
-            await self.add_wheel(
-                wheel,
-                req.extras,
-            )
+            else:
+                return
+
+        if self.check_version_satisfied(req):
+            # Maybe while we were downloading pypi_json some other branch
+            # installed the wheel?
+            return
+
+        await self.add_wheel(wheel, req.extras)
 
     async def add_wheel(
         self,


### PR DESCRIPTION
It's possible that while we were awaiting on `_get_pypi_json`, some other branch
of the resolver already installed a different version of the same wheel. We need
to check a second time for whether the constraint is satisfied between when we
get the `pypi` metadata and when we put the information into `transaction.locked`
or else we might accidentally install the same wheel twice.
