### PR TITLE
ENH Use dist-info + `importlib.metadata` to store and retrieve package metadata

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -102,6 +102,17 @@ substitutions:
   If set to `True`, micropip will include pre-release and development versions.
   {pr}`2542`
 
+- {{ Enhancement }} `micropip` was refactored to improve readability and ease of maintenance.
+  {pr}`2561`, {pr}`2563`, {pr}`2564`, {pr}`2565`, {pr}`2568`
+
+- {{ Enhancement }} Various error messages were fine tuned and improved.
+  {pr}`2562`, {pr}`2558`
+
+- {{ Enhancement }} `micropip` was adjusted to keep its state in the wheel
+  `.dist-info` directories which improves consistenency with the Python standard
+  library and other tools used to install packages.
+  {pr}`2572`
+
 ### Packages
 
 - {{ Enhancement }} Pillow now supports WEBP image format {pr}`2407`.

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -3,6 +3,7 @@ import hashlib
 import importlib
 import json
 from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import distributions as importlib_distributions
 from importlib.metadata import version as importlib_version
 from io import BytesIO
@@ -235,7 +236,7 @@ class Transaction:
         ver = None
         try:
             ver = importlib_version(req.name)
-        except ModuleNotFoundError:
+        except PackageNotFoundError:
             pass
         if req.name in self.locked:
             ver = self.locked[req.name].version

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -17,7 +17,7 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from pyodide import to_js
-from pyodide._package_loader import set_wheel_installer
+from pyodide._package_loader import parse_wheel_name, set_wheel_installer
 
 from ._compat import (
     BUILTIN_PACKAGES,
@@ -72,12 +72,7 @@ class WheelInfo:
         file_name = Path(url).name
         # also strip '.whl' extension.
         wheel_name = Path(url).stem
-        tokens = wheel_name.split("-")
-        # TODO: support optional build tags in the filename (cf PEP 427)
-        if len(tokens) < 5:
-            raise ValueError(f"{file_name} is not a valid wheel file name.")
-        version, python_tag, abi_tag, platform = tokens[-4:]
-        name = "-".join(tokens[:-4])
+        name, version, python_tag, abi_tag, platform = parse_wheel_name(wheel_name)
         return WheelInfo(
             name=name,
             version=Version(version),

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -141,7 +141,9 @@ class WheelInfo:
     def set_installer(self):
         assert self.data
         wheel_source = "pypi" if self.digests is not None else self.url
-        set_wheel_installer(self.data, WHEEL_BASE, "micropip", wheel_source)
+        set_wheel_installer(
+            self.filename, self.data, WHEEL_BASE, "micropip", wheel_source
+        )
 
     async def install(self):
         url = self.url

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -16,6 +16,7 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from pyodide import to_js
+from pyodide._package_loader import set_installer
 
 from ._compat import (
     BUILTIN_PACKAGES,
@@ -144,6 +145,8 @@ class WheelInfo:
             )
         self.validate()
         self.extract()
+        wheel_source = "pypi" if self.digests is not None else self.url
+        set_installer(self.data, WHEEL_BASE, "micropip", wheel_source)
         name = self.project_name
         assert name
         setattr(loadedPackages, name, url)

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -470,7 +470,15 @@ def _list():
         name = dist.name
         version = dist.version
         source = dist.read_text("PYODIDE_SOURCE")
-        if not source:
+        if source is None:
+            # source is None if PYODIDE_SOURCE does not exist. In this case the
+            # wheel was installed manually, not via `pyodide.loadPackage` or
+            # `micropip`.
+            #
+            # tzdata is a funny special case: we install it with pip and then
+            # vendor it into our standard library. We should probably remove
+            # tzdata's dist-info because it's kind of weird to have dist-info in
+            # the stdlib.
             continue
         packages[name] = PackageMetadata(
             name=name,

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -17,7 +17,7 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 from pyodide import to_js
-from pyodide._package_loader import set_installer
+from pyodide._package_loader import set_wheel_installer
 
 from ._compat import (
     BUILTIN_PACKAGES,
@@ -138,6 +138,11 @@ class WheelInfo:
             )
         return self._dist.requires(extras)
 
+    def set_installer(self):
+        assert self.data
+        wheel_source = "pypi" if self.digests is not None else self.url
+        set_wheel_installer(self.data, WHEEL_BASE, "micropip", wheel_source)
+
     async def install(self):
         url = self.url
         if not self.data:
@@ -146,8 +151,7 @@ class WheelInfo:
             )
         self.validate()
         self.extract()
-        wheel_source = "pypi" if self.digests is not None else self.url
-        set_installer(self.data, WHEEL_BASE, "micropip", wheel_source)
+        self.set_installer()
         name = self.project_name
         assert name
         setattr(loadedPackages, name, url)

--- a/packages/micropip/src/micropip/package.py
+++ b/packages/micropip/src/micropip/package.py
@@ -60,6 +60,10 @@ class PackageDict(UserDict):
         normalized_key = canonicalize_name(key)
         return super().__getitem__(normalized_key)
 
+    def __setitem__(self, key, val):
+        normalized_key = canonicalize_name(key)
+        return super().__setitem__(normalized_key, val)
+
     def __contains__(self, key):
         normalized_key = canonicalize_name(key)
         return super().__contains__(normalized_key)

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -572,7 +572,6 @@ def test_list_wheel_package(monkeypatch, mock_importlib):
     asyncio.get_event_loop().run_until_complete(_micropip.install(dummy_url))
 
     pkg_list = _micropip._list()
-    repr(pkg_list)
     assert dummy_pkg_name in pkg_list
     assert pkg_list[dummy_pkg_name].source.lower() == dummy_url
 
@@ -591,7 +590,6 @@ def test_list_wheel_name_mismatch(monkeypatch, mock_importlib):
     asyncio.get_event_loop().run_until_complete(_micropip.install(dummy_url))
 
     pkg_list = _micropip._list()
-    print(pkg_list)
     assert dummy_pkg_name in pkg_list
     assert pkg_list[dummy_pkg_name].source.lower() == dummy_url
 

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -116,14 +116,17 @@ def mock_fetch_bytes(pkg_name, metadata, version="1.0.0"):
         mock_metadata = metadata
         mock_wheel = "Wheel-Version: 1.0"
         version = wheel_info.version
+        normalized_pkg_name = pkg_name.replace("-", "_")
 
         with io.BytesIO() as tmp:
             with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as archive:
                 archive.writestr(
-                    f"{pkg_name}-{version}.dist-info/METADATA",
+                    f"{normalized_pkg_name}-{version}.dist-info/METADATA",
                     f"Name:{pkg_name}\nVersion:{version}\n{mock_metadata}",
                 )
-                archive.writestr(f"{pkg_name}-{version}.dist-info/WHEEL", mock_wheel)
+                archive.writestr(
+                    f"{normalized_pkg_name}-{version}.dist-info/WHEEL", mock_wheel
+                )
 
             tmp.seek(0)
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -393,6 +393,7 @@ export function unpackArchive(
     buffer,
     format,
     extract_dir,
+    installer: "pyodide.unpackArchive",
   });
 }
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -201,7 +201,11 @@ async function downloadPackage(
  * @param buffer The binary data returned by downloadPkgBuffer
  * @private
  */
-async function installPackage(name: string, buffer: Uint8Array, channel: string) {
+async function installPackage(
+  name: string,
+  buffer: Uint8Array,
+  channel: string
+) {
   let pkg = API.packages[name];
   if (!pkg) {
     pkg = {
@@ -219,8 +223,8 @@ async function installPackage(name: string, buffer: Uint8Array, channel: string)
     filename,
     target: pkg.install_dir,
     calculate_dynlibs: true,
-    installer : "pyodide.loadPackage",
-    source : channel === DEFAULT_CHANNEL ? "pyodide" : channel,
+    installer: "pyodide.loadPackage",
+    source: channel === DEFAULT_CHANNEL ? "pyodide" : channel,
   });
   for (const dynlib of dynlibs) {
     await loadDynlib(dynlib, pkg.shared_library);

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -201,7 +201,7 @@ async function downloadPackage(
  * @param buffer The binary data returned by downloadPkgBuffer
  * @private
  */
-async function installPackage(name: string, buffer: Uint8Array) {
+async function installPackage(name: string, buffer: Uint8Array, channel: string) {
   let pkg = API.packages[name];
   if (!pkg) {
     pkg = {
@@ -219,6 +219,8 @@ async function installPackage(name: string, buffer: Uint8Array) {
     filename,
     target: pkg.install_dir,
     calculate_dynlibs: true,
+    installer : "pyodide.loadPackage",
+    source : channel === DEFAULT_CHANNEL ? "pyodide" : channel,
   });
   for (const dynlib of dynlibs) {
     await loadDynlib(dynlib, pkg.shared_library);
@@ -399,7 +401,7 @@ export async function loadPackage(
     for (const [name, channel] of toLoadShared) {
       sharedLibraryInstallPromises[name] = sharedLibraryLoadPromises[name]
         .then(async (buffer) => {
-          await installPackage(name, buffer);
+          await installPackage(name, buffer, channel);
           loaded.push(name);
           loadedPackages[name] = channel;
         })
@@ -413,7 +415,7 @@ export async function loadPackage(
     for (const [name, channel] of toLoad) {
       packageInstallPromises[name] = packageLoadPromises[name]
         .then(async (buffer) => {
-          await installPackage(name, buffer);
+          await installPackage(name, buffer, channel);
           loaded.push(name);
           loadedPackages[name] = channel;
         })

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -6,7 +6,6 @@ import sysconfig
 import tarfile
 import zipfile
 from importlib.machinery import EXTENSION_SUFFIXES
-from importlib.metadata import distribution
 from pathlib import Path
 from site import getsitepackages
 from tempfile import NamedTemporaryFile
@@ -63,7 +62,7 @@ def unpack_buffer(
     extract_dir: str | None = None,
     calculate_dynlibs: bool = False,
     installer: str | None = None,
-    source: str | None = None
+    source: str | None = None,
 ) -> JsProxy | None:
     """Used to install a package either into sitepackages or into the standard
     library.
@@ -156,10 +155,12 @@ def should_load_dynlib(path: str):
     return not PLATFORM_TAG_REGEX.match(tag)
 
 
-def set_installer(archive: IO[bytes], target_dir: Path, installer: str | None, source : str | None):
+def set_installer(
+    archive: IO[bytes], target_dir: Path, installer: str | None, source: str | None
+):
     z = ZipFile(archive)
     for x in zipfile.Path(z).iterdir():
-        if x.name.endswith('.dist-info'):
+        if x.name.endswith(".dist-info"):
             break
     if installer:
         (target_dir / x.name / "INSTALLER").write_text(installer)

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -128,9 +128,9 @@ def unpack_buffer(
     with NamedTemporaryFile(suffix=filename) as f:
         buffer._into_file(f)
         shutil.unpack_archive(f.name, extract_path, format)
-        suffix = Path(f.name).suffix
+        suffix = Path(filename).suffix
         if suffix == ".whl":
-            set_wheel_installer(f, extract_path, installer, source)
+            set_wheel_installer(filename, f, extract_path, installer, source)
         if calculate_dynlibs:
             return to_js(get_dynlibs(f, extract_path))
         else:
@@ -156,10 +156,14 @@ def should_load_dynlib(path: str):
 
 
 def set_wheel_installer(
-    archive: IO[bytes], target_dir: Path, installer: str | None, source: str | None
+    filename: str,
+    archive: IO[bytes],
+    target_dir: Path,
+    installer: str | None,
+    source: str | None,
 ):
     z = ZipFile(archive)
-    name, version = archive.name.split("-", 2)[:-1]
+    name, version = filename.split("-", 2)[:-1]
     dist_info_name = f"{name}-{version}.dist-info"
     if not (zipfile.Path(z) / dist_info_name).is_dir():
         raise Exception("archive is not a valid wheel")

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -159,15 +159,15 @@ def set_wheel_installer(
     archive: IO[bytes], target_dir: Path, installer: str | None, source: str | None
 ):
     z = ZipFile(archive)
-    for x in zipfile.Path(z).iterdir():
-        if x.name.endswith(".dist-info"):
-            break
-    else:
+    name, version = archive.name.split("-", 2)[:-1]
+    dist_info_name = f"{name}-{version}.dist-info"
+    if not (zipfile.Path(z) / dist_info_name).is_dir():
         raise Exception("archive is not a valid wheel")
+    dist_info = target_dir / dist_info_name
     if installer:
-        (target_dir / x.name / "INSTALLER").write_text(installer)
+        (dist_info / "INSTALLER").write_text(installer)
     if source:
-        (target_dir / x.name / "PYODIDE_SOURCE").write_text(source)
+        (dist_info / "PYODIDE_SOURCE").write_text(source)
 
 
 def get_dynlibs(archive: IO[bytes], target_dir: Path) -> list[str]:

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -130,7 +130,7 @@ def unpack_buffer(
         shutil.unpack_archive(f.name, extract_path, format)
         suffix = Path(f.name).suffix
         if suffix == ".whl":
-            set_installer(f, extract_path, installer, source)
+            set_wheel_installer(f, extract_path, installer, source)
         if calculate_dynlibs:
             return to_js(get_dynlibs(f, extract_path))
         else:
@@ -155,13 +155,15 @@ def should_load_dynlib(path: str):
     return not PLATFORM_TAG_REGEX.match(tag)
 
 
-def set_installer(
+def set_wheel_installer(
     archive: IO[bytes], target_dir: Path, installer: str | None, source: str | None
 ):
     z = ZipFile(archive)
     for x in zipfile.Path(z).iterdir():
         if x.name.endswith(".dist-info"):
             break
+    else:
+        raise Exception("archive is not a valid wheel")
     if installer:
         (target_dir / x.name / "INSTALLER").write_text(installer)
     if source:

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -214,14 +214,45 @@ def should_load_dynlib(path: str):
 
 
 def set_wheel_installer(
-    name: str,
+    filename: str,
     archive: IO[bytes],
     target_dir: Path,
     installer: str | None,
     source: str | None,
 ):
+    """Record the installer and source of a wheel into the `dist-info`
+    directory.
+
+    We put the installer into an INSTALLER file according to the packaging spec:
+    packaging.python.org/en/latest/specifications/recording-installed-packages/#the-dist-info-directory
+
+    We put the source into PYODIDE_SORUCE.
+
+    The packaging spec allows us to make custom files. It also allows wheels to
+    include custom files in their .dist-info directory. The spec has no attempt
+    to coordinate these so that installers don't trample files that wheels
+    include. We make a best effort with our PYODIDE prefix.
+
+    Parameters
+    ----------
+    filename
+        The file name of the wheel.
+
+    archive
+        A binary representation of a wheel archive
+
+    target_dir
+        The directory the wheel is being installed into. Probably site-packages.
+
+    installer
+        The name of the installer. Currently either `pyodide.unpackArchive`,
+        `pyodide.loadPackage` or `micropip`.
+
+    source
+        Where did the package come from? Either a url, `pyodide`, or `PyPI`.
+    """
     z = ZipFile(archive)
-    wheel_name = parse_wheel_name(name)[0]
+    wheel_name = parse_wheel_name(filename)[0]
     dist_info_name = wheel_dist_info_dir(z, wheel_name)
     dist_info = target_dir / dist_info_name
     if installer:


### PR DESCRIPTION
This switches to using the file system to store the information about packages
and using `importlib.metadata` to retrieve it.
This has two related benefits:

1. We don't have to separately maintain our own separate state about what
we've installed.

2. We are guaranteed to agree with the Python stdlib about whether or not a
package is installed, and if so which version is installed. Since the state is 
maintained in only one place, there is no chance of it diverging.

According to the packaging specs, if the package is from a url we should put 
that into a file here:
https://packaging.python.org/en/latest/specifications/direct-url/#direct-url
Other than that, we should set the `INSTALLER` to `pyodide.loadPackage` 
if the package was loaded with `pyodide.loadPackage` either directly or 
indirectly via `micropip`. Otherwise set `INSTALLER` to `micropip`. That
way we can maintain the current behavior of `micropip.list`:
1. if `direct_url.json` is present, then `source` is the url in `direct_url.json`
2. otherwise, set `source` to `pyodide` if `INSTALLER` is `pyodide.loadPackage`
and set it to `micropip` if `INSTALLER` is `micropip`.

Oddly enough, the packaging specs suggest no place to put the source
index, so it seems that according to the specs if a package was installed
by name from some custom index, this info should not be recorded.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
