### PR TITLE
MAINT Remove outdated commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,17 +137,14 @@ docs/_build/html/console.html: src/templates/console.html
 .PHONY: dist/webworker.js
 dist/webworker.js: src/templates/webworker.js
 	cp $< $@
-	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
 .PHONY: dist/module_webworker_dev.js
 dist/module_webworker_dev.js: src/templates/module_webworker.js
 	cp $< $@
-	sed -i -e 's#{{ PYODIDE_BASE_URL }}#./#g' $@
 
 .PHONY: dist/webworker_dev.js
 dist/webworker_dev.js: src/templates/webworker.js
 	cp $< $@
-	sed -i -e 's#{{ PYODIDE_BASE_URL }}#./#g' $@
 
 
 update_base_url: \
@@ -223,7 +220,7 @@ dist/distutils.tar: $(CPYTHONLIB) node_modules/.installed
 	cd $(CPYTHONLIB) && tar --exclude=__pycache__ -cf $(PYODIDE_ROOT)/dist/distutils.tar distutils
 
 
-$(CPYTHONLIB): emsdk/emsdk/.complete $(PYODIDE_EMCC) $(PYODIDE_CXX)
+$(CPYTHONLIB): emsdk/emsdk/.complete
 	date +"[%F %T] Building cpython..."
 	make -C $(CPYTHONROOT)
 	date +"[%F %T] done building cpython..."

--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,7 @@ dist/webworker_dev.js: src/templates/webworker.js
 
 
 update_base_url: \
-	dist/console.html \
-	dist/webworker.js
+	dist/console.html
 
 
 


### PR DESCRIPTION
- `PYODIDE_EMCC`, `PYODIDE_CXX`: removed in #1218
- `PYODIDE_BASE_URL` in webworker.js: removed in #2292