### PR TITLE
Remove uneeded numpy install in tskit build

### DIFF
--- a/packages/tskit/meta.yaml
+++ b/packages/tskit/meta.yaml
@@ -4,9 +4,6 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/fb/0d/00407181bf409da76dd9a63741d54d57cfa6afec42957ca6a6b93dbfb530/tskit-0.4.1.tar.gz
   sha256: 28b07fb7f7b19dadd133ab49938c2a38e1558b1cb76122e57f4d1d1230c383ca
-build:
-  script: |
-    pip install -t $HOSTSITEPACKAGES numpy
 requirements:
   run:
     - numpy


### PR DESCRIPTION
As suggested at https://github.com/pyodide/pyodide/pull/2506#discussion_r876407036