### PR TITLE
FIX: compile all .so files concurrently rather than sequentially

### DIFF
--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -226,7 +226,9 @@ async function installPackage(
     installer: "pyodide.loadPackage",
     source: channel === DEFAULT_CHANNEL ? "pyodide" : channel,
   });
-  await Promise.all(dynlibs.map((dynlib : string) => loadDynlib(dynlib, pkg.shared_library)))
+  await Promise.all(
+    dynlibs.map((dynlib: string) => loadDynlib(dynlib, pkg.shared_library))
+  );
   loadedPackages[name] = pkg;
 }
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -226,9 +226,7 @@ async function installPackage(
     installer: "pyodide.loadPackage",
     source: channel === DEFAULT_CHANNEL ? "pyodide" : channel,
   });
-  for (const dynlib of dynlibs) {
-    await loadDynlib(dynlib, pkg.shared_library);
-  }
+  await Promise.all(dynlibs.map((dynlib : string) => loadDynlib(dynlib, pkg.shared_library)))
   loadedPackages[name] = pkg;
 }
 


### PR DESCRIPTION
@wlach @rth I haven't profiled it but there is a chance this could be a significant performance improvement for loading wheels with many .so files. Because of poor coding, we have been loading so files one at a time.
