### PR TITLE
Fix pyfetch when there is a cors error

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -89,6 +89,9 @@ substitutions:
 - {{ Enhancement }} Pyodide now directly exposes the Emscripten `PATH` and `ERRNO_CODES` APIs.
   {pr}`2582`
 
+- {{ Fix }} If the request errors due to CORS, `pyfetch` now raises an `OSError` not a `JSException`.
+  {pr}`2598`
+
 ### micropip
 
 - {{ Fix }} micropip now correctly handles package names that include dashes

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -232,4 +232,4 @@ async def pyfetch(url: str, **kwargs: Any) -> FetchResponse:
             url, await _jsfetch(url, to_js(kwargs, dict_converter=Object.fromEntries))
         )
     except JsException as e:
-        raise OSError(e.js_error.message)
+        raise OSError(e.js_error.message) from None

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     pass
 
-from ._core import IN_BROWSER
+from ._core import IN_BROWSER, JsException
 from ._package_loader import unpack_buffer
 
 __all__ = [
@@ -227,6 +227,9 @@ async def pyfetch(url: str, **kwargs: Any) -> FetchResponse:
         from js import Object
         from js import fetch as _jsfetch
 
-    return FetchResponse(
-        url, await _jsfetch(url, to_js(kwargs, dict_converter=Object.fromEntries))
-    )
+    try:
+        return FetchResponse(
+            url, await _jsfetch(url, to_js(kwargs, dict_converter=Object.fromEntries))
+        )
+    except JsException as e:
+        raise OSError(e.js_error.message)

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -13,9 +13,9 @@ def test_open_url(selenium, httpserver):
     assert (
         selenium.run(
             f"""
-        import pyodide
-        pyodide.open_url('{request_url}').read()
-        """
+            import pyodide
+            pyodide.open_url('{request_url}').read()
+            """
         )
         == "HELLO"
     )
@@ -75,10 +75,30 @@ def test_pyfetch_set_valid_credentials_value(selenium, httpserver):
     assert (
         selenium.run_async(
             f"""
-        import pyodide.http
-        data = await pyodide.http.pyfetch('{request_url}', credentials='omit')
-        data.string()
-        """
+            import pyodide.http
+            data = await pyodide.http.pyfetch('{request_url}', credentials='omit')
+            data.string()
+            """
         )
         == "HELLO"
+    )
+
+
+def test_pyfetch_coors_error(selenium, httpserver):
+    if selenium.browser == "node":
+        pytest.xfail("XMLHttpRequest not available in node")
+    httpserver.expect_request("/data").respond_with_data(
+        b"HELLO",
+        content_type="text/plain",
+    )
+    request_url = httpserver.url_for("/data")
+
+    selenium.run_async(
+        f"""
+        import pyodide.http
+        from unittest import TestCase
+        raises = TestCase().assertRaises
+        with raises(OSError):
+            data = await pyodide.http.pyfetch('{request_url}')
+        """
     )


### PR DESCRIPTION
As pointed out by @ryanking13 in https://github.com/pyodide/pyodide/pull/2589#discussion_r878950933:
If `pyfetch` generates a cors error, it is thrown as a `JsException` rather than as an `OSError`.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
