### PR TITLE
MAINT Add pytest.mark.xfail_browsers and use it to reduce boilerplate

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,7 @@ from pyodide_test_runner.fixture import (  # noqa: F401
 )
 from pyodide_test_runner.utils import maybe_skip_test
 from pyodide_test_runner.utils import package_is_built as _package_is_built
+from pyodide_test_runner.utils import parse_xfail_browsers
 
 
 def pytest_addoption(parser):
@@ -100,17 +101,24 @@ def pytest_runtest_call(item):
         if fixture.startswith("selenium"):
             browser = item.funcargs[fixture]
             break
-    if browser and browser.pyodide_loaded:
-        trace_pyproxies = pytest.mark.skip_pyproxy_check.mark not in item.own_markers
-        trace_hiwire_refs = (
-            trace_pyproxies
-            and pytest.mark.skip_refcount_check.mark not in item.own_markers
-        )
-        yield from extra_checks_test_wrapper(
-            browser, trace_hiwire_refs, trace_pyproxies
-        )
-    else:
+
+    if not browser:
         yield
+        return
+
+    xfail_msg = parse_xfail_browsers(item).get(browser.browser, None)
+    if xfail_msg is not None:
+        pytest.xfail(xfail_msg)
+
+    if not browser.pyodide_loaded:
+        yield
+        return
+
+    trace_pyproxies = pytest.mark.skip_pyproxy_check.mark not in item.own_markers
+    trace_hiwire_refs = (
+        trace_pyproxies and pytest.mark.skip_refcount_check.mark not in item.own_markers
+    )
+    yield from extra_checks_test_wrapper(browser, trace_hiwire_refs, trace_pyproxies)
 
 
 def extra_checks_test_wrapper(browser, trace_hiwire_refs, trace_pyproxies):

--- a/packages/matplotlib/test_matplotlib.py
+++ b/packages/matplotlib/test_matplotlib.py
@@ -91,6 +91,7 @@ def compare_with_reference_image(selenium, reference_image):
     return deviation == 0.0
 
 
+@matplotlib_test_decorator
 def test_matplotlib(selenium):
     selenium.load_package("matplotlib")
     selenium.run(

--- a/packages/matplotlib/test_matplotlib.py
+++ b/packages/matplotlib/test_matplotlib.py
@@ -1,10 +1,21 @@
 import base64
 import pathlib
 import textwrap
+from functools import reduce
 
 import pytest
 
 REFERENCE_IMAGES_PATH = pathlib.Path(__file__).parent / "reference-images"
+
+DECORATORS = [
+    pytest.mark.xfail_browsers(node="No supported matplotlib backends on node"),
+    pytest.mark.skip_refcount_check,
+    pytest.mark.skip_pyproxy_check,
+]
+
+
+def matplotlib_test_decorator(f):
+    return reduce(lambda x, g: g(x), DECORATORS, f)
 
 
 def run_with_resolve(selenium, code):
@@ -80,11 +91,7 @@ def compare_with_reference_image(selenium, reference_image):
     return deviation == 0.0
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
 def test_matplotlib(selenium):
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
     selenium.load_package("matplotlib")
     selenium.run(
         """
@@ -96,11 +103,8 @@ def test_matplotlib(selenium):
     )
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_svg(selenium):
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
     selenium.load_package("matplotlib")
     content = selenium.run(
         """
@@ -117,10 +121,8 @@ def test_svg(selenium):
     assert content.startswith("<?xml")
 
 
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_pdf(selenium):
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
     selenium.load_package("matplotlib")
     selenium.run(
         """
@@ -166,12 +168,9 @@ def test_font_manager(selenium):
     assert selenium.run("fontlist_built == fontlist_vendor")
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_rendering(selenium_standalone):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
 
     selenium.load_package("matplotlib")
     selenium.set_script_timeout(60)
@@ -198,12 +197,9 @@ def test_rendering(selenium_standalone):
     )
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_draw_image(selenium_standalone):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
 
     selenium.load_package("matplotlib")
     selenium.set_script_timeout(60)
@@ -238,12 +234,9 @@ def test_draw_image(selenium_standalone):
     )
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_draw_image_affine_transform(selenium_standalone):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
 
     selenium.load_package("matplotlib")
     selenium.set_script_timeout(60)
@@ -307,12 +300,9 @@ def test_draw_image_affine_transform(selenium_standalone):
     )
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_draw_text_rotated(selenium_standalone):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
 
     selenium.load_package("matplotlib")
     selenium.set_script_timeout(60)
@@ -362,12 +352,9 @@ def test_draw_text_rotated(selenium_standalone):
     )
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_draw_math_text(selenium_standalone):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
 
     selenium.load_package("matplotlib")
     selenium.set_script_timeout(60)
@@ -489,12 +476,9 @@ def test_draw_math_text(selenium_standalone):
     )
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_custom_font_text(selenium_standalone):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
 
     selenium.load_package("matplotlib")
     selenium.set_script_timeout(60)
@@ -526,12 +510,9 @@ def test_custom_font_text(selenium_standalone):
     )
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_zoom_on_polar_plot(selenium_standalone):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
 
     selenium.load_package("matplotlib")
     selenium.set_script_timeout(60)
@@ -569,12 +550,9 @@ def test_zoom_on_polar_plot(selenium_standalone):
     )
 
 
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
+@matplotlib_test_decorator
 def test_transparency(selenium_standalone):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("No supported matplotlib backends on node")
 
     selenium.load_package("matplotlib")
     selenium.set_script_timeout(60)

--- a/packages/numcodecs/test_numcodecs.py
+++ b/packages/numcodecs/test_numcodecs.py
@@ -1,12 +1,13 @@
+import pytest
 from pyodide_test_runner import run_in_pyodide
 
 
+@pytest.mark.xfail_browsers(
+    chrome="test_numcodecs triggers a recursion error in chrome"
+)
 @run_in_pyodide(
     selenium_fixture_name="selenium_standalone",
     packages=["numcodecs", "numpy"],
-    xfail_browsers={
-        "chrome": "test_numcodecs triggers a recursion error in chrome",
-    },
 )
 def test_blosc():
     import array

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -196,11 +196,11 @@ def test_runpythonasync_numpy(selenium_standalone):
         )
 
 
+@pytest.mark.xfail_browsers(
+    firefox="Timeout in WebWorker when using numpy in Firefox 87"
+)
 @pytest.mark.driver_timeout(30)
 def test_runwebworker_numpy(selenium_webworker_standalone):
-    if selenium_webworker_standalone.browser == "firefox":
-        pytest.xfail("Timeout in WebWorker when using numpy in Firefox 87")
-
     output = selenium_webworker_standalone.run_webworker(
         """
         import numpy as np

--- a/packages/pandas/test_pandas.py
+++ b/packages/pandas/test_pandas.py
@@ -41,17 +41,14 @@ def test_extra_import(selenium, request):
     selenium.run("from pandas import Series, DataFrame")
 
 
+@pytest.mark.xfail_browsers(
+    chrome="test_load_largish_file triggers a fatal runtime error in Chrome 89 see #1495",
+    node="open_url doesn't work in node",
+)
 @pytest.mark.driver_timeout(40)
 @pytest.mark.skip_refcount_check
 def test_load_largish_file(selenium_standalone, request, httpserver):
     selenium = selenium_standalone
-    if selenium.browser == "chrome":
-        pytest.xfail(
-            "test_load_largish_file triggers a fatal runtime error in Chrome 89 see #1495"
-        )
-    if selenium.browser == "node":
-        pytest.xfail("open_url doesn't work in node")
-
     selenium.load_package("pandas")
     selenium.load_package("matplotlib")
 

--- a/packages/pywavelets/test_pywt.py
+++ b/packages/pywavelets/test_pywt.py
@@ -1,9 +1,9 @@
+import pytest
 from pyodide_test_runner import run_in_pyodide
 
 
-@run_in_pyodide(
-    packages=["pywavelets"], driver_timeout=30, xfail_browsers={"chrome": "xfail"}
-)
+@pytest.mark.xfail_browsers(chrome="xfail")
+@run_in_pyodide(packages=["pywavelets"], driver_timeout=30)
 def test_pywt():
     import numpy as np
     import pywt

--- a/packages/scikit-image/test_skimage.py
+++ b/packages/scikit-image/test_skimage.py
@@ -1,16 +1,19 @@
 import os
+from typing import Any, Callable
 
+import pytest
 from pyodide_test_runner import run_in_pyodide
 
 if "CI" in os.environ:
-    xfail_browsers = {"chrome": "scikit-image takes too long to load in CI "}
+    xfail_browsers: Callable[[Any], Any] = pytest.mark.xfail_browsers(
+        chrome="scikit-image takes too long to load in CI "
+    )
 else:
-    xfail_browsers = {}
+    xfail_browsers = lambda x: x
 
 
-@run_in_pyodide(
-    packages=["scikit-image"], driver_timeout=40, xfail_browsers=xfail_browsers
-)
+@xfail_browsers
+@run_in_pyodide(packages=["scikit-image"], driver_timeout=40)
 def test_skimage():
     import numpy as np
     from skimage import color, data

--- a/packages/scikit-learn/test_scikit-learn.py
+++ b/packages/scikit-learn/test_scikit-learn.py
@@ -3,9 +3,8 @@ from pyodide_test_runner.fixture import selenium_context_manager
 
 
 @pytest.mark.driver_timeout(40)
+@pytest.mark.xfail_browsers(chrome="Times out in chrome")
 def test_scikit_learn(selenium_module_scope):
-    if selenium_module_scope.browser == "chrome":
-        pytest.xfail("Times out in chrome")
     with selenium_context_manager(selenium_module_scope) as selenium:
         selenium.load_package("scikit-learn")
         assert (
@@ -30,9 +29,8 @@ def test_scikit_learn(selenium_module_scope):
 
 
 @pytest.mark.driver_timeout(40)
+@pytest.mark.xfail_browsers(chrome="Times out in chrome")
 def test_logistic_regression(selenium_module_scope):
-    if selenium_module_scope.browser == "chrome":
-        pytest.xfail("Times out in chrome")
     with selenium_context_manager(selenium_module_scope) as selenium:
         selenium.load_package("scikit-learn")
         selenium.run(

--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -3,7 +3,6 @@ from pyodide_test_runner import run_in_pyodide
 run_in_pyodide_scipy = run_in_pyodide(
     selenium_fixture_name="selenium_module_scope",
     packages=["scipy"],
-    # xfail_browsers={"chrome": "Times out in chrome"},
     driver_timeout=40,
 )
 

--- a/pyodide-test-runner/pyodide_test_runner/decorator.py
+++ b/pyodide-test-runner/pyodide_test_runner/decorator.py
@@ -115,7 +115,6 @@ class run_in_pyodide:
         self,
         selenium_fixture_name: str = "selenium",
         packages: Collection[str] = (),
-        xfail_browsers: dict[str, str] | None = None,
         driver_timeout: float | None = None,
         pytest_assert_rewrites: bool = True,
     ):
@@ -135,9 +134,6 @@ class run_in_pyodide:
         packages : List[str]
             List of packages to load before running the test
 
-        xfail_browsers: dict[str, str]
-            A dictionary of browsers to xfail the test and reasons for the xfails.
-
         driver_timeout : Optional[float]
             selenium driver timeout (in seconds). If missing, use the default
             timeout.
@@ -156,7 +152,6 @@ class run_in_pyodide:
         self._pkgs = list(packages)
         if pytest_assert_rewrites:
             self._pkgs.append("pytest")
-        self._xfail_browsers = xfail_browsers or {}
         self._driver_timeout = driver_timeout
         self._pytest_assert_rewrites = pytest_assert_rewrites
         self._selenium_fixture_name = selenium_fixture_name
@@ -196,10 +191,6 @@ class run_in_pyodide:
     def _run_test(self, selenium: SeleniumType, args: tuple):
         """The main test runner, called from the AST generated in
         _create_outer_test_function."""
-        if selenium.browser in self._xfail_browsers:
-            xfail_message = self._xfail_browsers[selenium.browser]
-            pytest.xfail(xfail_message)
-
         code = self._code_template(args)
         with set_webdriver_script_timeout(selenium, self._driver_timeout):
             if self._pkgs:

--- a/pyodide-test-runner/pyodide_test_runner/fixture.py
+++ b/pyodide-test-runner/pyodide_test_runner/fixture.py
@@ -45,7 +45,7 @@ def selenium_common(request, web_server_main, load_pyodide=True, script_type="cl
 def selenium_standalone(request, web_server_main):
     with selenium_common(request, web_server_main) as selenium:
         with set_webdriver_script_timeout(
-            selenium, script_timeout=parse_driver_timeout(request)
+            selenium, script_timeout=parse_driver_timeout(request.node)
         ):
             try:
                 yield selenium
@@ -59,7 +59,7 @@ def selenium_esm(request, web_server_main):
         request, web_server_main, load_pyodide=True, script_type="module"
     ) as selenium:
         with set_webdriver_script_timeout(
-            selenium, script_timeout=parse_driver_timeout(request)
+            selenium, script_timeout=parse_driver_timeout(request.node)
         ):
             try:
                 yield selenium
@@ -73,7 +73,7 @@ def selenium_standalone_noload_common(request, web_server_main, script_type="cla
         request, web_server_main, load_pyodide=False, script_type=script_type
     ) as selenium:
         with set_webdriver_script_timeout(
-            selenium, script_timeout=parse_driver_timeout(request)
+            selenium, script_timeout=parse_driver_timeout(request.node)
         ):
             try:
                 yield selenium
@@ -130,7 +130,7 @@ def selenium_context_manager(selenium_module_scope):
 def selenium(request, selenium_module_scope):
     with selenium_context_manager(selenium_module_scope) as selenium:
         with set_webdriver_script_timeout(
-            selenium, script_timeout=parse_driver_timeout(request)
+            selenium, script_timeout=parse_driver_timeout(request.node)
         ):
             yield selenium
 

--- a/pyodide-test-runner/pyodide_test_runner/tests/test_decorator.py
+++ b/pyodide-test-runner/pyodide_test_runner/tests/test_decorator.py
@@ -174,7 +174,6 @@ def test_selenium(selenium, monkeypatch):
     check_err(exc_list, AssertionError, "AssertionError: assert 6 == 7\n")
 
 
-@pytest.mark.xfail_browsers(chrome="blah")
 @run_in_pyodide
 def test_trivial1():
     x = 7

--- a/pyodide-test-runner/pyodide_test_runner/tests/test_decorator.py
+++ b/pyodide-test-runner/pyodide_test_runner/tests/test_decorator.py
@@ -174,6 +174,7 @@ def test_selenium(selenium, monkeypatch):
     check_err(exc_list, AssertionError, "AssertionError: assert 6 == 7\n")
 
 
+@pytest.mark.xfail_browsers(chrome="blah")
 @run_in_pyodide
 def test_trivial1():
     x = 7

--- a/pyodide-test-runner/pyodide_test_runner/utils.py
+++ b/pyodide-test-runner/pyodide_test_runner/utils.py
@@ -26,13 +26,21 @@ def set_webdriver_script_timeout(selenium, script_timeout: float | None):
         selenium.set_script_timeout(selenium.script_timeout)
 
 
-def parse_driver_timeout(request) -> float | None:
+def parse_driver_timeout(node) -> float | None:
     """Parse driver timeout value from pytest request object"""
-    mark = request.node.get_closest_marker("driver_timeout")
+    mark = node.get_closest_marker("driver_timeout")
     if mark is None:
         return None
     else:
         return mark.args[0]
+
+
+def parse_xfail_browsers(node) -> dict[str, str]:
+    mark = node.get_closest_marker("xfail_browsers")
+    print("parse_xfail_browsers", node, mark)
+    if mark is None:
+        return {}
+    return mark.kwargs
 
 
 def maybe_skip_test(item, dist_dir, delayed=False):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,8 @@ markers =
     skip_refcount_check: Dont run refcount checks
     skip_pyproxy_check: Dont run pyproxy allocation checks
     driver_timeout: Set script timeout in WebDriver
+    xfail_browsers: xfail a test in specific browsers
+
 testpaths =
     src
     pyodide-build

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -81,9 +81,8 @@ def test_jsproxy_getattr(selenium):
     )
 
 
+@pytest.mark.xfail_browsers(node="No document in node")
 def test_jsproxy_document(selenium):
-    if selenium.browser == "node":
-        pytest.xfail("No document in node")
     selenium.run("from js import document")
     assert (
         selenium.run(

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -14,11 +14,10 @@ def get_pytz_wheel_name():
     return list(DIST_PATH.glob("pytz*.whl"))[0].name
 
 
+@pytest.mark.xfail_browsers(node="Loading urls in node seems to time out right now")
 @pytest.mark.parametrize("active_server", ["main", "secondary"])
 def test_load_from_url(selenium_standalone, web_server_secondary, active_server):
     selenium = selenium_standalone
-    if selenium.browser == "node":
-        pytest.xfail("Loading urls in node seems to time out right now")
     if active_server == "secondary":
         url, port, log_main = web_server_secondary
         log_backup = selenium.server_log

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -2,9 +2,8 @@ import pytest
 from pyodide_test_runner import run_in_pyodide
 
 
+@pytest.mark.xfail_browsers(node="XMLHttpRequest is not available in node")
 def test_open_url(selenium, httpserver):
-    if selenium.browser == "node":
-        pytest.xfail("XMLHttpRequest not available in node")
     httpserver.expect_request("/data").respond_with_data(
         b"HELLO", content_type="text/text", headers={"Access-Control-Allow-Origin": "*"}
     )
@@ -62,9 +61,8 @@ async def test_pyfetch_unpack_archive():
     ]
 
 
+@pytest.mark.xfail_browsers(node="XMLHttpRequest is not available in node")
 def test_pyfetch_set_valid_credentials_value(selenium, httpserver):
-    if selenium.browser == "node":
-        pytest.xfail("XMLHttpRequest not available in node")
     httpserver.expect_request("/data").respond_with_data(
         b"HELLO",
         content_type="text/plain",
@@ -84,9 +82,8 @@ def test_pyfetch_set_valid_credentials_value(selenium, httpserver):
     )
 
 
+@pytest.mark.xfail_browsers(node="XMLHttpRequest is not available in node")
 def test_pyfetch_coors_error(selenium, httpserver):
-    if selenium.browser == "node":
-        pytest.xfail("XMLHttpRequest not available in node")
     httpserver.expect_request("/data").respond_with_data(
         b"HELLO",
         content_type="text/plain",

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -5,9 +5,8 @@ def test_init(selenium_standalone):
     assert "Python initialization complete" in selenium_standalone.logs.splitlines()
 
 
+@pytest.mark.xfail_browsers(node="Webbrowser doesn't work in node")
 def test_webbrowser(selenium):
-    if selenium.browser == "node":
-        pytest.xfail("Webbrowser doesn't work in node")
     selenium.run_async("import antigravity")
     assert len(selenium.driver.window_handles) == 2
 
@@ -17,9 +16,8 @@ def test_print(selenium):
     assert "This should be logged" in selenium.logs.splitlines()
 
 
+@pytest.mark.xfail_browsers(node="No window in node")
 def test_import_js(selenium):
-    if selenium.browser == "node":
-        pytest.xfail("No window in node")
     result = selenium.run(
         """
         import js

--- a/src/tests/test_python_esm.py
+++ b/src/tests/test_python_esm.py
@@ -10,9 +10,8 @@ def test_print(selenium_esm):
     assert "This should be logged" in selenium_esm.logs.splitlines()
 
 
+@pytest.mark.xfail_browsers(node="No window in node")
 def test_import_js(selenium_esm):
-    if selenium_esm.browser == "node":
-        pytest.xfail("No window in node")
     result = selenium_esm.run(
         """
         import js


### PR DESCRIPTION
Use a decorator to indicate which browsers we want to xfail test. This works for `run_in_pyodide` as well as normal tests.