### PR TITLE
MAINT improve isolation for micropip tests

### DIFF
--- a/packages/micropip/src/micropip/_compat.py
+++ b/packages/micropip/src/micropip/_compat.py
@@ -3,7 +3,6 @@ from pyodide._core import IN_BROWSER
 if IN_BROWSER:
     from ._compat_in_pyodide import (
         BUILTIN_PACKAGES,
-        WHEEL_BASE,
         fetch_bytes,
         fetch_string,
         loadedPackages,
@@ -12,7 +11,6 @@ if IN_BROWSER:
 else:
     from ._compat_not_in_pyodide import (
         BUILTIN_PACKAGES,
-        WHEEL_BASE,
         fetch_bytes,
         fetch_string,
         loadedPackages,
@@ -22,7 +20,6 @@ else:
 __all__ = [
     "fetch_bytes",
     "fetch_string",
-    "WHEEL_BASE",
     "BUILTIN_PACKAGES",
     "loadedPackages",
     "pyodide_js",

--- a/packages/micropip/src/micropip/_compat_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_in_pyodide.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from pyodide._core import IN_BROWSER
 from pyodide.http import pyfetch
 
@@ -8,13 +6,6 @@ try:
     from pyodide_js import loadedPackages
 
     BUILTIN_PACKAGES = pyodide_js._api.packages.to_py()
-
-    # Random note: getsitepackages is not available in a virtual environment...
-    # See https://github.com/pypa/virtualenv/issues/228 (issue is closed but
-    # problem is not fixed)
-    from site import getsitepackages
-
-    WHEEL_BASE = Path(getsitepackages()[0])
 except ImportError:
     if IN_BROWSER:
         raise
@@ -32,7 +23,6 @@ async def fetch_string(url: str, kwargs: dict[str, str]) -> str:
 __all__ = [
     "fetch_bytes",
     "fetch_string",
-    "WHEEL_BASE",
     "BUILTIN_PACKAGES",
     "loadedPackages",
     "pyodide_js",

--- a/packages/micropip/src/micropip/_compat_not_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_not_in_pyodide.py
@@ -1,9 +1,8 @@
-import tempfile
 from pathlib import Path
 from typing import Any
 
 # Provide stubs for testing in native python
-WHEEL_BASE = Path(tempfile.mkdtemp())
+WHEEL_BASE = Path("/tmp/probably-does-not-exist")
 BUILTIN_PACKAGES: dict[str, dict[str, Any]] = {}
 
 

--- a/packages/micropip/src/micropip/_compat_not_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_not_in_pyodide.py
@@ -1,8 +1,5 @@
-from pathlib import Path
 from typing import Any
 
-# Provide stubs for testing in native python
-WHEEL_BASE = Path("/tmp/probably-does-not-exist")
 BUILTIN_PACKAGES: dict[str, dict[str, Any]] = {}
 
 
@@ -34,7 +31,6 @@ pyodide_js: Any = pyodide_js_()
 __all__ = [
     "fetch_bytes",
     "fetch_string",
-    "WHEEL_BASE",
     "BUILTIN_PACKAGES",
     "loadedPackages",
     "pyodide_js",

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -22,7 +22,6 @@ from pyodide._package_loader import parse_wheel_name, wheel_dist_info_dir
 
 from ._compat import (
     BUILTIN_PACKAGES,
-    WHEEL_BASE,
     fetch_bytes,
     fetch_string,
     loadedPackages,
@@ -62,7 +61,7 @@ class WheelInfo:
     digests: dict[str, str] | None = None
     data: BytesIO | None = None
     _dist: Any = None
-    _dist_info: Path | None = None
+    dist_info: Path | None = None
     _requires: list[Requirement] | None = None
 
     @staticmethod
@@ -123,10 +122,12 @@ class WheelInfo:
         if m.hexdigest() != sha256:
             raise ValueError("Contents don't match hash")
 
-    def extract(self):
+    def extract(self, target: Path) -> None:
         assert self.data
         with ZipFile(self.data) as zf:
-            zf.extractall(WHEEL_BASE)
+            zf.extractall(target)
+        dist_info_name: str = wheel_dist_info_dir(ZipFile(self.data), self.name)
+        self.dist_info = target / dist_info_name
 
     def requires(self, extras: set[str]) -> list[str]:
         if not self._dist:
@@ -137,20 +138,11 @@ class WheelInfo:
         self._requires = requires
         return requires
 
-    @property
-    def dist_info(self) -> Path:
-        if self._dist_info:
-            return self._dist_info
-        assert self.data
-        dist_info_name: str = wheel_dist_info_dir(ZipFile(self.data), self.name)
-        dist_info = WHEEL_BASE / dist_info_name
-        self._dist_info = dist_info
-        return dist_info
-
     def write_dist_info(self, file: str, content: str) -> None:
+        assert self.dist_info
         (self.dist_info / file).write_text(content)
 
-    def set_installer(self):
+    def set_installer(self) -> None:
         assert self.data
         wheel_source = "pypi" if self.digests is not None else self.url
 
@@ -163,14 +155,14 @@ class WheelInfo:
                 "PYODIDE_REQUIRES", json.dumps(sorted(x.name for x in self._requires))
             )
 
-    async def install(self):
+    async def install(self, target: Path) -> None:
         url = self.url
         if not self.data:
             raise RuntimeError(
                 "Micropip internal error: attempted to install wheel before downloading it?"
             )
         self.validate()
-        self.extract()
+        self.extract(target)
         self.set_installer()
         name = self.project_name
         assert name
@@ -429,6 +421,13 @@ async def install(
     if credentials:
         fetch_kwargs["credentials"] = credentials
 
+    # Note: getsitepackages is not available in a virtual environment...
+    # See https://github.com/pypa/virtualenv/issues/228 (issue is closed but
+    # problem is not fixed)
+    from site import getsitepackages
+
+    wheel_base = Path(getsitepackages()[0])
+
     transaction = Transaction(
         ctx=ctx,
         keep_going=keep_going,
@@ -463,7 +462,7 @@ async def install(
     for wheel in transaction.wheels:
         # detect whether the wheel metadata is from PyPI or from custom location
         # wheel metadata from PyPI has SHA256 checksum digest.
-        wheel_promises.append(wheel.install())
+        wheel_promises.append(wheel.install(wheel_base))
 
     await gather(*wheel_promises)
 

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -2,6 +2,7 @@ import io
 import sys
 import zipfile
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 from pyodide_test_runner import run_in_pyodide, spawn_web_server
@@ -38,16 +39,6 @@ def mock_importlib(monkeypatch):
     monkeypatch.setattr(
         _micropip, "importlib_distributions", _mock_importlib_distributions
     )
-
-
-DUMMY_IDX = 0
-
-
-@pytest.fixture
-def dummy_pkg_name():
-    global DUMMY_IDX
-    DUMMY_IDX += 1
-    return f"dummy{DUMMY_IDX}"
 
 
 class Wildcard:
@@ -153,7 +144,17 @@ class mock_fetch_cls:
 
 
 @pytest.fixture
-def mock_fetch(monkeypatch):
+def wheel_base():
+    pytest.importorskip("packaging")
+    from micropip import _micropip
+
+    with TemporaryDirectory() as tmpdirname:
+        _micropip.WHEEL_BASE = Path(tmpdirname).absolute()
+        yield
+
+
+@pytest.fixture
+def mock_fetch(monkeypatch, mock_importlib, wheel_base):
     pytest.importorskip("packaging")
     from micropip import _micropip
 
@@ -405,71 +406,70 @@ def test_install_mixed_case2(selenium_standalone_micropip, jinja2):
 
 
 @pytest.mark.asyncio
-async def test_install_keep_going(
-    mock_fetch: mock_fetch_cls, dummy_pkg_name: str
-) -> None:
-    dep1 = f"{dummy_pkg_name}-dep1"
-    dep2 = f"{dummy_pkg_name}-dep2"
-    mock_fetch.add_pkg_version(dummy_pkg_name, requirements=[dep1, dep2])
+async def test_install_keep_going(mock_fetch: mock_fetch_cls) -> None:
+    dummy = "dummy"
+    dep1 = "dep1"
+    dep2 = "dep2"
+    mock_fetch.add_pkg_version(dummy, requirements=[dep1, dep2])
     mock_fetch.add_pkg_version(dep1, platform="native")
     mock_fetch.add_pkg_version(dep2, platform="native")
 
     # report order is non-deterministic
     msg = f"({dep1}|{dep2}).*({dep2}|{dep1})"
     with pytest.raises(ValueError, match=msg):
-        await micropip.install(dummy_pkg_name, keep_going=True)
+        await micropip.install(dummy, keep_going=True)
 
 
 @pytest.mark.asyncio
-async def test_install_version_compare_prerelease(
-    mock_fetch: mock_fetch_cls, dummy_pkg_name: str, mock_importlib: None
-) -> None:
+async def test_install_version_compare_prerelease(mock_fetch: mock_fetch_cls) -> None:
+    dummy = "dummy"
     version_old = "3.2.0"
     version_new = "3.2.1a1"
 
-    mock_fetch.add_pkg_version(dummy_pkg_name, version_old)
-    mock_fetch.add_pkg_version(dummy_pkg_name, version_new)
+    mock_fetch.add_pkg_version(dummy, version_old)
+    mock_fetch.add_pkg_version(dummy, version_new)
 
-    await micropip.install(f"{dummy_pkg_name}=={version_new}")
-    await micropip.install(f"{dummy_pkg_name}>={version_old}")
+    await micropip.install(f"{dummy}=={version_new}")
+    await micropip.install(f"{dummy}>={version_old}")
 
     installed_pkgs = micropip.list()
     # Older version should not be installed
-    assert installed_pkgs[dummy_pkg_name].version == version_new
+    assert installed_pkgs[dummy].version == version_new
 
 
 @pytest.mark.asyncio
-async def test_install_no_deps(
-    mock_fetch: mock_fetch_cls, dummy_pkg_name: str, mock_importlib: None
-) -> None:
-    dep_pkg_name = "dependency_dummy"
-    mock_fetch.add_pkg_version(dummy_pkg_name, requirements=[dep_pkg_name])
-    mock_fetch.add_pkg_version(dep_pkg_name)
+async def test_install_no_deps(mock_fetch: mock_fetch_cls) -> None:
+    dummy = "dummy"
+    dep = "dep"
+    mock_fetch.add_pkg_version(dummy, requirements=[dep])
+    mock_fetch.add_pkg_version(dep)
 
-    await micropip.install(dummy_pkg_name, deps=False)
+    await micropip.install(dummy, deps=False)
 
-    assert dummy_pkg_name in micropip.list()
-    assert dep_pkg_name not in micropip.list()
+    assert dummy in micropip.list()
+    assert dep not in micropip.list()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("pre", [True, False])
 async def test_install_pre(
-    mock_fetch: mock_fetch_cls, mock_importlib: None, pre: bool, dummy_pkg_name: str
+    mock_fetch: mock_fetch_cls,
+    pre: bool,
 ) -> None:
+    dummy = "dummy"
     version_alpha = "2.0.1a1"
     version_stable = "1.0.0"
 
     version_should_select = version_alpha if pre else version_stable
 
-    mock_fetch.add_pkg_version(dummy_pkg_name, version_stable)
-    mock_fetch.add_pkg_version(dummy_pkg_name, version_alpha)
-    await micropip.install(dummy_pkg_name, pre=pre)
-    assert micropip.list()[dummy_pkg_name].version == version_should_select
+    mock_fetch.add_pkg_version(dummy, version_stable)
+    mock_fetch.add_pkg_version(dummy, version_alpha)
+    await micropip.install(dummy, pre=pre)
+    assert micropip.list()[dummy].version == version_should_select
 
 
 @pytest.mark.asyncio
-async def test_fetch_wheel_fail(monkeypatch):
+async def test_fetch_wheel_fail(monkeypatch, wheel_base):
     pytest.importorskip("packaging")
     from micropip import _micropip
 
@@ -484,35 +484,31 @@ async def test_fetch_wheel_fail(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_list_pypi_package(
-    mock_fetch: mock_fetch_cls, mock_importlib: None, dummy_pkg_name: str
-) -> None:
-    mock_fetch.add_pkg_version(dummy_pkg_name)
+async def test_list_pypi_package(mock_fetch: mock_fetch_cls) -> None:
+    dummy = "dummy"
+    mock_fetch.add_pkg_version(dummy)
 
-    await micropip.install(dummy_pkg_name)
+    await micropip.install(dummy)
     pkg_list = micropip.list()
-    assert dummy_pkg_name in pkg_list
-    assert pkg_list[dummy_pkg_name].source.lower() == "pypi"
+    assert dummy in pkg_list
+    assert pkg_list[dummy].source.lower() == "pypi"
 
 
 @pytest.mark.asyncio
-async def test_list_wheel_package(
-    mock_fetch: mock_fetch_cls, mock_importlib: None, dummy_pkg_name: str
-) -> None:
-    mock_fetch.add_pkg_version(dummy_pkg_name)
-    dummy_url = f"https://dummy.com/{dummy_pkg_name}-1.0.0-py3-none-any.whl"
+async def test_list_wheel_package(mock_fetch: mock_fetch_cls) -> None:
+    dummy = "dummy"
+    mock_fetch.add_pkg_version(dummy)
+    dummy_url = f"https://dummy.com/{dummy}-1.0.0-py3-none-any.whl"
 
     await micropip.install(dummy_url)
 
     pkg_list = micropip.list()
-    assert dummy_pkg_name in pkg_list
-    assert pkg_list[dummy_pkg_name].source.lower() == dummy_url
+    assert dummy in pkg_list
+    assert pkg_list[dummy].source.lower() == dummy_url
 
 
 @pytest.mark.asyncio
-async def test_list_wheel_name_mismatch(
-    mock_fetch: mock_fetch_cls, mock_importlib: None
-) -> None:
+async def test_list_wheel_name_mismatch(mock_fetch: mock_fetch_cls) -> None:
     dummy_pkg_name = "dummy-Dummy"
     mock_fetch.add_pkg_version(dummy_pkg_name)
     dummy_url = "https://dummy.com/dummy_dummy-1.0.0-py3-none-any.whl"
@@ -594,26 +590,23 @@ async def test_install_with_credentials(selenium):
 
 
 @pytest.mark.asyncio
-async def test_freeze(
-    mock_fetch: mock_fetch_cls, dummy_pkg_name: str, mock_importlib: None
-) -> None:
-    pkg = dummy_pkg_name
-    dep1 = f"{pkg}-dep1"
-    dep2 = f"{pkg}-dep2"
+async def test_freeze(mock_fetch: mock_fetch_cls) -> None:
+    dummy = "dummy"
+    dep1 = "dep1"
+    dep2 = "dep2"
     toplevel = [["abc", "def", "geh"], ["c", "h", "i"], ["a12", "b13"]]
 
-    mock_fetch.add_pkg_version(pkg, requirements=[dep1, dep2], top_level=toplevel[0])
+    mock_fetch.add_pkg_version(dummy, requirements=[dep1, dep2], top_level=toplevel[0])
     mock_fetch.add_pkg_version(dep1, top_level=toplevel[1])
     mock_fetch.add_pkg_version(dep2, top_level=toplevel[2])
 
-    await micropip.install(pkg)
+    await micropip.install(dummy)
+
     import json
 
     lockfile = json.loads(micropip.freeze())
-    import pprint
 
-    pprint.pprint(lockfile["packages"])
-    pkg_metadata = lockfile["packages"][pkg]
+    pkg_metadata = lockfile["packages"][dummy]
     dep1_metadata = lockfile["packages"][dep1]
     dep2_metadata = lockfile["packages"][dep2]
     assert pkg_metadata["depends"] == [dep1, dep2]

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -9,7 +9,7 @@ from pyodide_test_runner import run_in_pyodide, spawn_web_server
 
 sys.path.append(str(Path(__file__).resolve().parent / "src"))
 
-from importlib.metadata import PackageNotFoundError, distributions
+from importlib.metadata import Distribution, PackageNotFoundError
 
 try:
     import micropip
@@ -28,7 +28,7 @@ def _mock_importlib_version(name: str) -> str:
 def _mock_importlib_distributions():
     from micropip._micropip import WHEEL_BASE
 
-    return distributions(path=[WHEEL_BASE])
+    return (Distribution.at(p) for p in WHEEL_BASE.glob("*.dist-info"))
 
 
 @pytest.fixture
@@ -106,7 +106,6 @@ class mock_fetch_cls:
 
     async def _get_pypi_json(self, pkgname, kwargs):
         try:
-            print("_get_pypi_json", pkgname, self.releases_map[pkgname])
             return self.releases_map[pkgname]
         except KeyError as e:
             raise ValueError(


### PR DESCRIPTION
I added a new `wheel_base` fixture which creates a new temporary directory and mocks `site.getsitepackages()` to return it. I also removed the `WHEEL_BASE` global variable from micropip and instead calculate it each time in `micropip.install`.