### PR TITLE
MAINT Rather than fatally failing, throw away errors in check methods

### DIFF
--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -121,6 +121,19 @@ console_error_obj(JsRef obj);
     }                                                                          \
     return 0;  /* some of these were void */                                   \
   })
+
+// If there is a Js error, catch it and return false.
+#define EM_JS_BOOL(ret, func_name, args, body...)                              \
+  EM_JS_DEFER(ret WARN_UNUSED, func_name, args, {                              \
+    "use strict";                                                              \
+    try    /* intentionally no braces, body already has them */                \
+      body /* <== body of func */                                              \
+    catch (e) {                                                                \
+        LOG_EM_JS_ERROR(func_name, e);                                         \
+        return false;                                                          \
+    }                                                                          \
+  })
+
 // clang-format on
 
 /**

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -370,7 +370,7 @@ EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
   throw Hiwire.pop_value(iderr);
 });
 
-EM_JS(bool, JsArray_Check, (JsRef idobj), {
+EM_JS_BOOL(bool, JsArray_Check, (JsRef idobj), {
   let obj = Hiwire.get_value(idobj);
   if (Array.isArray(obj)) {
     return true;
@@ -539,7 +539,7 @@ EM_JS_REF(JsRef,
 });
 // clang-format on
 
-EM_JS(bool, hiwire_HasMethod, (JsRef obj_id, JsRef name), {
+EM_JS_BOOL(bool, hiwire_HasMethod, (JsRef obj_id, JsRef name), {
   // clang-format off
   let obj = Hiwire.get_value(obj_id);
   return obj && typeof obj[Hiwire.get_value(name)] === "function";
@@ -631,7 +631,7 @@ EM_JS_REF(JsRef, hiwire_construct, (JsRef idobj, JsRef idargs), {
   return Hiwire.new_value(Reflect.construct(jsobj, jsargs));
 });
 
-EM_JS(bool, hiwire_has_length, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_has_length, (JsRef idobj), {
   let val = Hiwire.get_value(idobj);
   // clang-format off
   return (typeof val.size === "number") ||
@@ -652,7 +652,7 @@ EM_JS_NUM(int, hiwire_get_length, (JsRef idobj), {
   return ERROR_NUM;
 });
 
-EM_JS(bool, hiwire_get_bool, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_get_bool, (JsRef idobj), {
   let val = Hiwire.get_value(idobj);
   // clang-format off
   if (!val) {
@@ -669,22 +669,22 @@ EM_JS(bool, hiwire_get_bool, (JsRef idobj), {
   // clang-format on
 });
 
-EM_JS(bool, hiwire_is_pyproxy, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_is_pyproxy, (JsRef idobj), {
   return API.isPyProxy(Hiwire.get_value(idobj));
 });
 
-EM_JS(bool, hiwire_is_function, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_is_function, (JsRef idobj), {
   // clang-format off
   return typeof Hiwire.get_value(idobj) === 'function';
   // clang-format on
 });
 
-EM_JS(bool, hiwire_is_comlink_proxy, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_is_comlink_proxy, (JsRef idobj), {
   let value = Hiwire.get_value(idobj);
   return !!(API.Comlink && value[API.Comlink.createEndpoint]);
 });
 
-EM_JS(bool, hiwire_is_error, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_is_error, (JsRef idobj), {
   // From https://stackoverflow.com/a/45496068
   let value = Hiwire.get_value(idobj);
   // clang-format off
@@ -693,7 +693,7 @@ EM_JS(bool, hiwire_is_error, (JsRef idobj), {
   // clang-format on
 });
 
-EM_JS(bool, hiwire_is_promise, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_is_promise, (JsRef idobj), {
   // clang-format off
   let obj = Hiwire.get_value(idobj);
   return Hiwire.isPromise(obj);
@@ -721,7 +721,7 @@ EM_JS_REF(char*, hiwire_constructor_name, (JsRef idobj), {
 });
 
 #define MAKE_OPERATOR(name, op)                                                \
-  EM_JS(bool, hiwire_##name, (JsRef ida, JsRef idb), {                         \
+  EM_JS_BOOL(bool, hiwire_##name, (JsRef ida, JsRef idb), {                    \
     return !!(Hiwire.get_value(ida) op Hiwire.get_value(idb));                 \
   })
 
@@ -734,7 +734,7 @@ MAKE_OPERATOR(not_equal, !==);
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
-EM_JS(bool, hiwire_is_iterator, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_is_iterator, (JsRef idobj), {
   let jsobj = Hiwire.get_value(idobj);
   // clang-format off
   return typeof jsobj.next === 'function';
@@ -751,7 +751,7 @@ EM_JS_NUM(int, hiwire_next, (JsRef idobj, JsRef* result_ptr), {
   return done;
 });
 
-EM_JS(bool, hiwire_is_iterable, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_is_iterable, (JsRef idobj), {
   let jsobj = Hiwire.get_value(idobj);
   // clang-format off
   return typeof jsobj[Symbol.iterator] === 'function';
@@ -778,7 +778,7 @@ EM_JS_REF(JsRef, JsObject_Values, (JsRef idobj), {
   return Hiwire.new_value(Object.values(jsobj));
 });
 
-EM_JS(bool, hiwire_is_typedarray, (JsRef idobj), {
+EM_JS_BOOL(bool, hiwire_is_typedarray, (JsRef idobj), {
   let jsobj = Hiwire.get_value(idobj);
   // clang-format off
   return ArrayBuffer.isView(jsobj) || (jsobj.constructor && jsobj.constructor.name === "ArrayBuffer");


### PR DESCRIPTION
I think this will fix the following error:

> ```
> Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.
> The cause of the fatal error was:
> PythonError: OverflowError: Python int too large to convert to C ssize_t
> ```
> 
> _Originally posted by @amitsaha in https://github.com/pyodide/pyodide/issues/2584#issuecomment-1139530294_


I am not sure though because I can't reproduce the error.