### PR TITLE
MAINT Use new run_in_pyodide features for some type conversions tests

### DIFF
--- a/pyodide-test-runner/pyodide_test_runner/hypothesis.py
+++ b/pyodide-test-runner/pyodide_test_runner/hypothesis.py
@@ -1,0 +1,51 @@
+import pickle
+from zoneinfo import ZoneInfo
+
+from hypothesis import HealthCheck, settings, strategies
+
+
+def is_picklable(x):
+    try:
+        pickle.dumps(x)
+        return True
+    except Exception:
+        return False
+
+
+def is_equal_to_self(x):
+    try:
+        return x == x
+    except Exception:
+        return False
+
+
+# Generate an object of any type
+any_strategy = (
+    strategies.from_type(type)
+    .flatmap(strategies.from_type)
+    .filter(lambda x: not isinstance(x, ZoneInfo))
+    .filter(is_picklable)
+)
+
+any_equal_to_self_strategy = any_strategy.filter(is_equal_to_self)
+
+std_hypothesis_settings = settings(
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+
+
+def is_picklable(x):
+    try:
+        pickle.dumps(x)
+        return True
+    except Exception:
+        return False
+
+
+strategy = (
+    strategies.from_type(type)
+    .flatmap(strategies.from_type)
+    .filter(lambda x: not isinstance(x, ZoneInfo))
+    .filter(is_picklable)
+)

--- a/pyodide-test-runner/pyodide_test_runner/tests/test_decorator.py
+++ b/pyodide-test-runner/pyodide_test_runner/tests/test_decorator.py
@@ -1,7 +1,9 @@
 import asyncio
 
 import pytest
+from hypothesis import given, settings
 from pyodide_test_runner.decorator import run_in_pyodide
+from pyodide_test_runner.hypothesis import any_strategy, std_hypothesis_settings
 from pyodide_test_runner.utils import parse_driver_timeout
 
 from pyodide import eval_code_async
@@ -189,34 +191,11 @@ async def test_run_in_pyodide_async(selenium):
     assert x == 6
 
 
-import pickle
-from zoneinfo import ZoneInfo
-
-from hypothesis import HealthCheck, given, settings, strategies
-
-
-def is_picklable(x):
-    try:
-        pickle.dumps(x)
-        return True
-    except Exception:
-        return False
-
-
-strategy = (
-    strategies.from_type(type)
-    .flatmap(strategies.from_type)
-    .filter(lambda x: not isinstance(x, ZoneInfo))
-    .filter(is_picklable)
-)
-
-
 @pytest.mark.skip_refcount_check
 @pytest.mark.skip_pyproxy_check
-@given(obj=strategy)
+@given(obj=any_strategy)
 @settings(
-    deadline=2000,
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
+    std_hypothesis_settings,
     max_examples=25,
 )
 @run_in_pyodide

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1,9 +1,11 @@
 # See also test_pyproxy, test_jsproxy, and test_python.
+import pickle
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import pytest
-from hypothesis import assume, given, settings, strategies
-from hypothesis.strategies import from_type, text
+from hypothesis import HealthCheck, given, settings, strategies
+from hypothesis.strategies import text
 from pyodide_test_runner import run_in_pyodide
 from pyodide_test_runner.fixture import selenium_context_manager
 
@@ -87,19 +89,20 @@ def test_number_conversions(selenium_module_scope, n):
         )
 
 
+@run_in_pyodide
 def test_nan_conversions(selenium):
-    selenium.run_js(
+    from pyodide import run_js
+
+    jsnan = run_js("NaN")
+    from math import isnan
+
+    assert isnan(jsnan)
+    assert run_js(
         """
-        self.a = NaN;
-        pyodide.runPython(`
-            from js import a
-            from math import isnan, nan
-            assert isnan(a)
-        `);
-        let b = pyodide.runPython("nan");
-        if(!Number.isNaN(b)){
-            throw new Error();
-        }
+        let mathmod = pyodide.pyimport("math");
+        const res = Number.isNaN(mathmod.nan);
+        mathmod.destroy();
+        res
         """
     )
 
@@ -210,98 +213,111 @@ def test_big_int_conversions3(selenium_module_scope, n, exp):
         assert x1 == x2
 
 
-# Generate an object of any type
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
-@given(obj=from_type(type).flatmap(from_type))
-@settings(deadline=2000)
-def test_hyp_py2js2py(selenium_module_scope, obj):
-    with selenium_context_manager(selenium_module_scope) as selenium:
-        import pickle
-        from zoneinfo import ZoneInfo
-
-        assume(not isinstance(obj, ZoneInfo))
-
-        # When we compare x == x, there are three possible outcomes:
-        # 1. returns True
-        # 2. returns False (e.g., nan)
-        # 3. raises an exception
-        #
-        # Hypothesis *will* test this function on objects in case 2 and 3, so we
-        # have to defend against them here.
-        try:
-            assume(obj == obj)
-        except Exception:
-            assume(False)
-        try:
-            obj_bytes = list(pickle.dumps(obj))
-        except Exception:
-            assume(False)
-        selenium.run(
-            f"""
-            import pickle
-            x1 = pickle.loads(bytes({obj_bytes!r}))
-            """
-        )
-        selenium.run_js(
-            """
-            self.x2 = pyodide.globals.get("x1");
-            pyodide.runPython(`
-                from js import x2
-                if x1 != x2:
-                    print(f"Assertion Error: {x1!r} != {x2!r}")
-                    assert False
-            `);
-            """
-        )
+def is_picklable(x):
+    try:
+        pickle.dumps(x)
+        return True
+    except Exception:
+        return False
 
 
-def test_big_integer_py2js2py(selenium):
-    a = 9992361673228537
-    selenium.run_js(
-        f"""
-        self.a = pyodide.runPython("{a}")
-        pyodide.runPython(`
-            from js import a
-            assert a == {a}
-        `);
-        """
-    )
-    a = -a
-    selenium.run_js(
-        f"""
-        self.a = pyodide.runPython("{a}")
-        pyodide.runPython(`
-            from js import a
-            assert a == {a}
-        `);
-        """
-    )
+def is_equal_to_self(x):
+    try:
+        return x == x
+    except Exception:
+        return False
 
 
 # Generate an object of any type
-@pytest.mark.skip_refcount_check
-@pytest.mark.skip_pyproxy_check
-@given(obj=from_type(type).flatmap(from_type))
-@settings(deadline=2000)
-def test_hyp_tojs_no_crash(selenium_module_scope, obj):
-    with selenium_context_manager(selenium_module_scope) as selenium:
-        import pickle
-        from zoneinfo import ZoneInfo
+any_strategy = (
+    strategies.from_type(type)
+    .flatmap(strategies.from_type)
+    .filter(lambda x: not isinstance(x, ZoneInfo))
+    .filter(is_picklable)
+    .filter(is_equal_to_self)
+)
 
-        assume(not isinstance(obj, ZoneInfo))
 
-        try:
-            obj_bytes = list(pickle.dumps(obj))
-        except Exception:
-            assume(False)
-        selenium.run(
-            f"""
-            import pickle
-            x = pickle.loads(bytes({obj_bytes!r}))
+@given(obj=any_strategy)
+@settings(
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@run_in_pyodide
+def test_hyp_py2js2py(selenium, obj):
+    import __main__
+
+    from pyodide import run_js
+
+    __main__.obj = obj
+
+    try:
+        run_js('self.obj2 = pyodide.globals.get("obj"); 0;')
+        from js import obj2
+
+        assert obj2 == obj
+        run_js(
+            """
+            if(self.obj2 && self.obj2.destroy){
+                self.obj2.destroy();
+            }
+            delete self.obj2
             """
         )
-        selenium.run_js(
+    finally:
+        del __main__.obj
+
+
+@given(obj=any_strategy)
+@settings(
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@run_in_pyodide
+def test_hyp_py2js2py_2(selenium, obj):
+    import __main__
+
+    from pyodide import run_js
+
+    __main__.o = obj
+    try:
+        assert obj == run_js("pyodide.globals.get('o')")
+    finally:
+        del __main__.o
+
+
+@pytest.mark.parametrize("a", [9992361673228537, -9992361673228537])
+@run_in_pyodide
+def test_big_integer_py2js2py(selenium, a):
+    import __main__
+
+    from pyodide import run_js
+
+    __main__.a = a
+    try:
+        b = run_js("pyodide.globals.get('a')")
+        assert a == b
+    finally:
+        del __main__.a
+
+
+# Generate an object of any type
+@pytest.mark.skip_refcount_check
+@pytest.mark.skip_pyproxy_check
+@given(obj=any_strategy)
+@settings(
+    deadline=2000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@run_in_pyodide
+def test_hyp_tojs_no_crash(selenium, obj):
+    import __main__
+
+    from pyodide import run_js
+
+    __main__.x = obj
+    try:
+        run_js(
             """
             let x = pyodide.globals.get("x");
             if(x && x.toJs){
@@ -309,6 +325,8 @@ def test_hyp_tojs_no_crash(selenium_module_scope, obj):
             }
             """
         )
+    finally:
+        del __main__.x
 
 
 def test_python2js1(selenium):
@@ -1429,7 +1447,7 @@ def test_buffer_format_string(selenium):
 def test_object_with_null_constructor(selenium):
     from unittest import TestCase
 
-    from js import eval as run_js
+    from pyodide import run_js
 
     o = run_js("Object.create(null)")
     with TestCase().assertRaises(TypeError):


### PR DESCRIPTION
This should improve the tests by quite a lot:
1. assertions get formatted automatically
2. many fewer doubly / triply nested eval strings
3. IDE support for code formatting, syntax highlighting (the IDEs are pretty confused about other stuff but still...)

Also, messing around with these type conversions tests is a really good way to find lots of bugs, cf my other PRs from this afternoon.