### PR TITLE
Add loadDynlib to micropip._compat (split off from #2591)

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -1,4 +1,6 @@
 export PYVERSION ?= 3.10.2
+# Note: when updating EMSCRIPTEN_VERSION make sure to update
+# the version number in the "uname" patch.
 export PYODIDE_EMSCRIPTEN_VERSION ?= 2.0.27
 
 export PLATFORM_TRIPLET=wasm32-emscripten

--- a/packages/micropip/src/micropip/_compat.py
+++ b/packages/micropip/src/micropip/_compat.py
@@ -5,6 +5,7 @@ if IN_BROWSER:
         BUILTIN_PACKAGES,
         fetch_bytes,
         fetch_string,
+        loadDynlib,
         loadedPackages,
         pyodide_js,
     )
@@ -13,6 +14,7 @@ else:
         BUILTIN_PACKAGES,
         fetch_bytes,
         fetch_string,
+        loadDynlib,
         loadedPackages,
         pyodide_js,
     )
@@ -22,5 +24,6 @@ __all__ = [
     "fetch_string",
     "BUILTIN_PACKAGES",
     "loadedPackages",
+    "loadDynlib",
     "pyodide_js",
 ]

--- a/packages/micropip/src/micropip/_compat_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_in_pyodide.py
@@ -4,6 +4,7 @@ from pyodide.http import pyfetch
 try:
     import pyodide_js
     from pyodide_js import loadedPackages
+    from pyodide_js._api import loadDynlib  # type: ignore[import]
 
     BUILTIN_PACKAGES = pyodide_js._api.packages.to_py()
 except ImportError:
@@ -25,5 +26,6 @@ __all__ = [
     "fetch_string",
     "BUILTIN_PACKAGES",
     "loadedPackages",
+    "loadDynlib",
     "pyodide_js",
 ]

--- a/packages/micropip/src/micropip/_compat_not_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_not_in_pyodide.py
@@ -20,6 +20,10 @@ async def fetch_string(url: str, kwargs: dict[str, str]) -> str:
     return (await fetch_bytes(url, kwargs)).decode()
 
 
+async def loadDynlib(dynlib: str, is_shared_lib: bool) -> None:
+    pass
+
+
 class pyodide_js_:
     def __get__(self, attr):
         raise RuntimeError(f"Attempted to access property '{attr}' on pyodide_js dummy")
@@ -29,6 +33,7 @@ pyodide_js: Any = pyodide_js_()
 
 
 __all__ = [
+    "loadDynlib",
     "fetch_bytes",
     "fetch_string",
     "BUILTIN_PACKAGES",


### PR DESCRIPTION
More work split off of #2591 because #2591 mysteriously fails *all* the github actions tests, even though #2591 currently only changes micropip and not all tests load micropip.