### PR TITLE
MAINT Remove pywasmcross rule to drop libs and includes from HOST_INSTALL_DIR

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -400,7 +400,6 @@ def compile(
     bash_runner: BashRunnerWithSharedEnvironment,
     *,
     target_install_dir: str,
-    host_install_dir: str,
 ) -> None:
     """
     Runs pywasmcross for the package. The effect of this is to first run setup.py
@@ -429,10 +428,6 @@ def compile(
     target_install_dir
         The path to the target Python installation
 
-    host_install_dir
-        Directory for installing built host packages. Defaults to setup.py
-        default. Set to 'skip' to skip installation. Installation is
-        needed if you want to build other packages that depend on this one.
     """
     # This function runs setup.py. library and sharedlibrary don't have setup.py
     if build_metadata.get("sharedlibrary"):
@@ -446,7 +441,6 @@ def compile(
             cflags=build_metadata["cflags"],
             cxxflags=build_metadata["cxxflags"],
             ldflags=build_metadata["ldflags"],
-            host_install_dir=host_install_dir,
             target_install_dir=target_install_dir,
             replace_libs=replace_libs,
         )
@@ -780,7 +774,6 @@ def build_package(
                 build_metadata,
                 bash_runner,
                 target_install_dir=target_install_dir,
-                host_install_dir=host_install_dir,
             )
         if not sharedlibrary:
             package_wheel(

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -44,7 +44,6 @@ ReplayArgs = namedtuple(
         "cflags",
         "cxxflags",
         "ldflags",
-        "host_install_dir",
         "target_install_dir",
         "replace_libs",
         "builddir",
@@ -83,7 +82,6 @@ def compile(
     cflags: str,
     cxxflags: str,
     ldflags: str,
-    host_install_dir: str,
     target_install_dir: str,
     replace_libs: str,
 ) -> None:
@@ -92,7 +90,6 @@ def compile(
         cflags=cflags,
         cxxflags=cxxflags,
         ldflags=ldflags,
-        host_install_dir=host_install_dir,
         target_install_dir=target_install_dir,
         replace_libs=replace_libs,
     )
@@ -396,8 +393,8 @@ def handle_command_generate_args(
     --------
 
     >>> from collections import namedtuple
-    >>> Args = namedtuple('args', ['cflags', 'cxxflags', 'ldflags', 'host_install_dir','replace_libs','target_install_dir'])
-    >>> args = Args(cflags='', cxxflags='', ldflags='', host_install_dir='',replace_libs='',target_install_dir='')
+    >>> Args = namedtuple('args', ['cflags', 'cxxflags', 'ldflags', 'replace_libs','target_install_dir'])
+    >>> args = Args(cflags='', cxxflags='', ldflags='', replace_libs='',target_install_dir='')
     >>> handle_command_generate_args(['gcc', 'test.c'], args, False)
     ['emcc', '-Werror=implicit-function-declaration', '-Werror=mismatched-parameter-types', '-Werror=return-type', 'test.c']
     """
@@ -475,13 +472,6 @@ def handle_command_generate_args(
             # conda uses custom compiler search paths with the compiler_compat folder.
             # Ignore it.
             del new_args[-1]
-            continue
-
-        # don't include libraries from native builds
-        if args.host_install_dir and (
-            arg.startswith("-L" + args.host_install_dir)
-            or arg.startswith("-l" + args.host_install_dir)
-        ):
             continue
 
         replace_libs = parse_replace_libs(args.replace_libs)

--- a/pyodide-build/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide-build/pyodide_build/tests/test_pywasmcross.py
@@ -16,7 +16,6 @@ class BuildArgs:
     cxxflags: str = ""
     ldflags: str = ""
     replace_libs: str = ""
-    host_install_dir: str = ""
     target_install_dir: str = ""
     pythoninclude: str = "python/include"
 
@@ -92,7 +91,6 @@ def test_handle_command():
         cflags="",
         cxxflags="",
         ldflags="-lm",
-        host_install_dir="",
         replace_libs="",
         target_install_dir="",
     )


### PR DESCRIPTION
This rule is out of date, we intend to ensure that HOST_INSTALL_DIR
consists of cross-build packages which have the right libs and includes
so they can be used.

