### PR TITLE
MAINT Improve debug settings in Makefile.envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ dist/pyodide.asm.js: \
 	[ -d dist ] || mkdir dist
 	$(CXX) -o dist/pyodide.asm.js $(filter %.o,$^) \
 		$(MAIN_MODULE_LDFLAGS)
+
+	if [[ -n $${PYODIDE_SOURCEMAP+x} ]] || [[ -n $${PYODIDE_SYMBOLS+x} ]]; then \
+		cd dist && npx prettier -w pyodide.asm.js ; \
+	fi
+
    # Strip out C++ symbols which all start __Z.
    # There are 4821 of these and they have VERY VERY long names.
    # To show some stats on the symbols you can use the following:

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -71,7 +71,6 @@ ifdef PYODIDE_ASSERTIONS
 endif
 
 
-
 export OPTFLAGS=-O2
 export CFLAGS_BASE=\
 	$(OPTFLAGS) \

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -55,12 +55,22 @@ export DBG_LDFLAGS_SOURCEMAPDEBUG=-gseparate-dwarf
 
 export DBGFLAGS=$(DBGFLAGS_NODEBUG)
 
-# Include debug symbols but no source maps (most useful)
-#export DBGFLAGS=$(DBGFLAGS_WASMDEBUG)
+ifdef PYODIDE_SOURCEMAP
+	# Debug with source maps (less useful than WASMDEBUG but easier if it helps)
+	export DBGFLAGS=$(DBGFLAGS_SOURCEMAPDEBUG)
+	export DBG_LDFLAGS=$(DBG_LDFLAGS_SOURCEMAPDEBUG)
+else
+	ifdef PYODIDE_SYMBOLS
+		# Include debug symbols but no source maps (most useful)
+		export DBGFLAGS=$(DBGFLAGS_WASMDEBUG)
+	endif
+endif
 
-# Debug with source maps (less useful than WASMDEBUG but easier if it helps)
-#export DBGFLAGS=$(DBGFLAGS_SOURCEMAPDEBUG)
-#export DBG_LDFLAGS=$(DBG_LDFLAGS_SOURCEMAPDEBUG)
+ifdef PYODIDE_ASSERTIONS
+	EXTRA_CFLAGS+=" -DDEBUG_F"
+endif
+
+
 
 export OPTFLAGS=-O2
 export CFLAGS_BASE=\


### PR DESCRIPTION
Add PYODIDE_SYMBOLS and PYODIDE_SOURCEMAP environment variables to adjust
debug symbol settings.

If either is set, run prettier on `pyodide.asm.js`.

Add PYODIDE_ASSERTIONS to set -DDEBUG_F.

