### PR TITLE
Fix run_in_pyodide to return values and update tests

### DIFF
--- a/pyodide-test-runner/pyodide_test_runner/decorator.py
+++ b/pyodide-test-runner/pyodide_test_runner/decorator.py
@@ -77,7 +77,7 @@ def _create_outer_test_function(
     # Make onwards call with two args:
     # 1. <selenium_arg_name>
     # 2. all other arguments in a tuple
-    func_body = ast.parse("run_test(selenium_arg_name, (arg1, arg2, ...))").body
+    func_body = ast.parse("return run_test(selenium_arg_name, (arg1, arg2, ...))").body
     onwards_call = func_body[0].value
     onwards_call.args[0].id = selenium_arg_name  # Set variable name
     onwards_call.args[1].elts = [  # Set tuple elements

--- a/pyodide-test-runner/pyodide_test_runner/tests/test_decorator.py
+++ b/pyodide-test-runner/pyodide_test_runner/tests/test_decorator.py
@@ -74,7 +74,28 @@ def test_local_inner_function():
         assert x == 6
         return 7
 
-    inner_function(selenium_mock, 6)
+    assert inner_function(selenium_mock, 6) == 7
+
+
+def test_local_inner_function_closure_error():
+    x = 6
+
+    @run_in_pyodide
+    def inner_function(selenium):
+        assert x == 6
+        return 7
+
+    with pytest.raises(NameError, match="'x' is not defined"):
+        inner_function(selenium_mock)
+
+
+def test_inner_function(selenium):
+    @run_in_pyodide
+    def inner_function(selenium, x):
+        assert x == 6
+        return 7
+
+    assert inner_function(selenium, 6) == 7
 
 
 def complicated_decorator(attr_name: str):


### PR DESCRIPTION
Adding `return` here allows `run_in_pyodide` functions to return values. Also, add a test specifying what should happen if a `run_in_pyodide` function tries to access a closure variable (it should `NameError`)