### PR TITLE
Remove tzdata from the build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,6 @@ all: check \
 	dist/module_webworker_dev.js
 	echo -e "\nSUCCESS!"
 
-$(CPYTHONLIB)/tzdata :
-	pip install tzdata --target=$(CPYTHONLIB)
-
 dist/pyodide_py.tar: $(wildcard src/py/pyodide/*.py)  $(wildcard src/py/_pyodide/*.py)
 	cd src/py && tar --exclude '*__pycache__*' -cf ../../dist/pyodide_py.tar pyodide _pyodide
 
@@ -44,7 +41,6 @@ dist/pyodide.asm.js: \
 	src/core/python2js.o \
 	src/js/_pyodide.out.js \
 	$(wildcard src/py/lib/*.py) \
-	$(CPYTHONLIB)/tzdata \
 	$(CPYTHONLIB)
 	date +"[%F %T] Building pyodide.asm.js..."
 	[ -d dist ] || mkdir dist


### PR DESCRIPTION
### Description

`tzdata` is a first-party package primarily used in a standard library `zoneinfo` as a fall-back source of data for platforms that don't ship the IANA database.
(See: https://github.com/python/cpython/blob/877ad7b3b2778a305d3989d58ebd68cb01baf26e/Doc/whatsnew/3.9.rst#new-modules)

Currently, we install `tzdata` during the build step in default (added in #1637). I guess we added it because there is no system time zone data available in browser environments (cc @hoodmane).

However, I think we don't have to include it in the Pyodide distribution by default.
For example, in Windows (which also doesn't have system time zone data), `tzdata` is not included by default.

WDYT?
