### PR TITLE
Use strict mode for pytest-asyncio

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,5 @@ testpaths =
     src
     pyodide-build
     packages
+
+asyncio_mode = strict


### PR DESCRIPTION
`pytest-asyncio` was complaining about this lately.

```
../../usr/local/lib/python3.10/site-packages/pytest_asyncio/plugin.py:191
  /usr/local/lib/python3.10/site-packages/pytest_asyncio/plugin.py:191: DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)
```