### PR TITLE
Add gmpy2 and its dependencies

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -169,7 +169,7 @@ substitutions:
 - New packages: opencv-python v4.5.5.64 {pr}`2305`, ffmpeg {pr}`2305`, libwebp {pr}`2305`,
   h5py, pkgconfig and libhdf5 {pr}`2411`, bitarray {pr}`2459`, gsw {pr}`2511`, cftime {pr}`2504`,
   svgwrite, jsonschema, tskit {pr}`2506`, xarray {pr}`2538`, demes, libgsl, newick,
-  ruamel, msprime {pr}`4138`.
+  ruamel, msprime {pr}`2548`, gmpy2 {pr}`2665`.
 
 ## Version 0.20.0
 

--- a/packages/gmpy2/meta.yaml
+++ b/packages/gmpy2/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: gmpy2
+  version: 2.1.2
+
+source:
+  url: https://files.pythonhosted.org/packages/80/02/a9f4de927fc1677a68b40d966f9ea757b58997cfe06cf305ffa2159979ce/gmpy2-2.1.2.tar.gz
+  sha256: da75140bca128ece795895477e53b43773e3748aa90ba6170eae7ca2c74b82d1
+
+requirements:
+  run:
+    - libmpc
+
+build:
+  cflags: |
+    -I$(WASM_LIBRARY_DIR)/include
+  ldflags: |
+    -L$(WASM_LIBRARY_DIR)/lib
+
+test:
+  imports:
+    - gmpy2
+
+about:
+  home: https://github.com/aleaxit/gmpy
+  PyPI: https://pypi.org/project/gmpy2
+  summary: gmpy2 interface to GMP/MPIR, MPFR, and MPC for Python 2.7 and 3.5+
+  license: LGPL-3.0+

--- a/packages/gmpy2/test_gmpy2.py
+++ b/packages/gmpy2/test_gmpy2.py
@@ -2,7 +2,7 @@ from pyodide_test_runner import run_in_pyodide
 
 
 @run_in_pyodide(packages=["gmpy2"])
-def test_sympy(selenium):
+def test_gmpy2(selenium):
     import gmpy2
     from gmpy2 import mpc, mpfr, mpq, mpz, sqrt
 

--- a/packages/gmpy2/test_gmpy2.py
+++ b/packages/gmpy2/test_gmpy2.py
@@ -4,10 +4,10 @@ from pyodide_test_runner import run_in_pyodide
 @run_in_pyodide(packages=["gmpy2"])
 def test_sympy(selenium):
     import gmpy2
-    from gmpy2 import mpz, mpq, mpc, mpfr, sqrt
+    from gmpy2 import mpc, mpfr, mpq, mpz, sqrt
 
     assert mpz(99) * 43 == mpz(4257)
-    assert mpq(3,7)/7 == mpq(3,49)
+    assert mpq(3, 7) / 7 == mpq(3, 49)
 
-    gmpy2.get_context().allow_complex=True
-    assert sqrt(mpfr(-2)) == mpc('0.0+1.4142135623730951j')
+    gmpy2.get_context().allow_complex = True
+    assert sqrt(mpfr(-2)) == mpc("0.0+1.4142135623730951j")

--- a/packages/gmpy2/test_gmpy2.py
+++ b/packages/gmpy2/test_gmpy2.py
@@ -3,6 +3,11 @@ from pyodide_test_runner import run_in_pyodide
 
 @run_in_pyodide(packages=["gmpy2"])
 def test_sympy(selenium):
-    from gmpy2 import mpz
+    import gmpy2
+    from gmpy2 import mpz, mpq, mpc, mpfr, sqrt
 
     assert mpz(99) * 43 == mpz(4257)
+    assert mpq(3,7)/7 == mpq(3,49)
+
+    gmpy2.get_context().allow_complex=True
+    assert sqrt(mpfr(-2)) == mpc('0.0+1.4142135623730951j')

--- a/packages/gmpy2/test_gmpy2.py
+++ b/packages/gmpy2/test_gmpy2.py
@@ -1,0 +1,7 @@
+from pyodide_test_runner import run_in_pyodide
+
+
+@run_in_pyodide(packages=["gmpy2"])
+def test_sympy(selenium):
+    from gmpy2 import mpz
+    assert mpz(99) * 43 == mpz(4257)

--- a/packages/gmpy2/test_gmpy2.py
+++ b/packages/gmpy2/test_gmpy2.py
@@ -4,4 +4,5 @@ from pyodide_test_runner import run_in_pyodide
 @run_in_pyodide(packages=["gmpy2"])
 def test_sympy(selenium):
     from gmpy2 import mpz
+
     assert mpz(99) * 43 == mpz(4257)

--- a/packages/libgmp/meta.yaml
+++ b/packages/libgmp/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: libgmp
+  version: 6.2.1
+
+source:
+  url: https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz
+  sha256: fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2
+
+build:
+  library: true
+  script: |
+    emconfigure ./configure \
+        CFLAGS="-fPIC" \
+        --host none \
+        --prefix=${WASM_LIBRARY_DIR}
+    emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install

--- a/packages/libmpc/meta.yaml
+++ b/packages/libmpc/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: libmpc
+  version: 1.2.1
+
+source:
+  url: https://ftp.gnu.org/gnu/mpc/mpc-1.2.1.tar.gz
+  sha256: 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459
+
+requirements:
+  run:
+    - libmpfr
+
+build:
+  library: true
+  script: |
+    emconfigure ./configure \
+        CFLAGS="-fPIC" \
+        --with-gmp="${WASM_LIBRARY_DIR}" \
+        --with-mpfr="${WASM_LIBRARY_DIR}" \
+        --prefix=${WASM_LIBRARY_DIR}
+    emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install

--- a/packages/libmpfr/meta.yaml
+++ b/packages/libmpfr/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: libmpfr
+  version: 4.1.0
+
+source:
+  url: https://mpfr.loria.fr/mpfr-current/mpfr-4.1.0.tar.xz
+  sha256: 0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
+
+requirements:
+  run:
+    - libgmp
+
+build:
+  library: true
+  script: |
+    emconfigure ./configure \
+        CFLAGS="-fPIC" \
+        --with-gmp="${WASM_LIBRARY_DIR}" \
+        --prefix=${WASM_LIBRARY_DIR}
+    emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->
Add gmpy2 and its dependencies libmpc, libmpfr and libgmp. gmpy2 is an optional dependency of SymPy.
I don't know how building parameters should be configured for the dependencies, so I keep them minimal.
I tested the built gmpy2 package with SymPy. It generally works fine and test errors are all due to SymPy code.
### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests