### PR TITLE
Disable cursor blinking in the REPL if `noblink` is specified 

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -121,6 +121,10 @@ substitutions:
 - {{ Enhancement }} Add a spinner while the REPL is loading
   {pr}`2635`
 
+- {{ Enhancement }} Cursor blinking in the REPL can be disabled by setting
+  `noblink` in URL search params.
+  {pr}`2666`
+
 ### micropip
 
 - {{ Fix }} micropip now correctly handles package names that include dashes

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -15,6 +15,9 @@
         --size: 1.5;
         --color: rgba(255, 255, 255, 0.8);
       }
+      .noblink {
+        --animation: terminal-none;
+      }
       body {
         background-color: black;
       }
@@ -217,6 +220,11 @@
           await sleep(15);
           term.pause();
         };
+
+        const searchParams = new URLSearchParams(window.location.search);
+        if (searchParams.has("noblink")) {
+          $(".cmd-cursor").addClass("noblink");
+        }
       }
       window.console_ready = main();
     </script>


### PR DESCRIPTION
### Description

Resolve #2620

Disable cursor blinking if `noblink` is set in the URL search params.

> e.g. `https://pyodide.org/en/latest/console.html?noblink`

@mark-summerfield How do you like this approach?

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
