### PR TITLE
ENH Add a new "disabled" key to meta.yaml

### DIFF
--- a/packages/scikit-learn/meta.yaml
+++ b/packages/scikit-learn/meta.yaml
@@ -15,7 +15,6 @@ build:
 
 requirements:
   run:
-    - numpy
     - scipy
     - joblib
     - threadpoolctl

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -108,7 +108,7 @@ class Package(BasePackage):
         self.meta = parse_package_config(pkgpath)
         self.name = self.meta["package"]["name"]
         self.version = self.meta["package"]["version"]
-        self.disabled = self.meta["package"].get("disabled", False)
+        self.disabled = self.meta["package"].get("_disabled", False)
         self.meta["build"] = self.meta.get("build", {})
         self.meta["requirements"] = self.meta.get("requirements", {})
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 from functools import total_ordering
+from graphlib import TopologicalSorter
 from pathlib import Path
 from queue import PriorityQueue, Queue
 from threading import Lock, Thread
@@ -37,6 +38,7 @@ class BasePackage:
     pkgdir: Path
     name: str
     version: str
+    disabled: bool
     meta: dict[str, Any]
     library: bool
     shared_library: bool
@@ -75,6 +77,7 @@ class StdLibPackage(BasePackage):
         self.meta = {}
         self.name = pkgdir.stem
         self.version = "1.0"
+        self.disabled = False
         self.library = False
         self.shared_library = False
         self.dependencies = []
@@ -105,6 +108,7 @@ class Package(BasePackage):
         self.meta = parse_package_config(pkgpath)
         self.name = self.meta["package"]["name"]
         self.version = self.meta["package"]["version"]
+        self.disabled = self.meta["package"].get("disabled", False)
         self.meta["build"] = self.meta.get("build", {})
         self.meta["requirements"] = self.meta.get("requirements", {})
 
@@ -211,7 +215,8 @@ def generate_dependency_graph(
     Returns:
      - pkg_map: dictionary mapping package names to BasePackage objects
     """
-
+    pkg: BasePackage
+    pkgname: str
     pkg_map: dict[str, BasePackage] = {}
 
     if "*" in packages:
@@ -224,33 +229,70 @@ def generate_dependency_graph(
     if no_numpy_dependents:
         packages.discard("no-numpy-dependents")
 
-    packages_exclude = list(filter(lambda pkg: pkg.startswith("!"), packages))
-    for pkg_exclude in packages_exclude:
-        packages.discard(pkg_exclude)
-        packages.discard(pkg_exclude[1:])
+    disabled_packages = set()
+    for pkgname in list(packages):
+        if pkgname.startswith("!"):
+            packages.discard(pkgname)
+            disabled_packages.add(pkgname[1:])
 
+    # Record which packages were requested. We need this information because
+    # some packages are reachable from the initial set but are only reachable
+    # via a disabled dependency.
+    # Example: scikit-learn needs joblib & scipy, scipy needs numpy but numpy disabled.
+    # We don't want to build joblib.
+    requested = set(packages)
+
+    # Create dependency graph.
+    # On first pass add all dependencies regardless of whether
+    # disabled since it might happen because of a transitive dependency
+    graph = {}
     while packages:
         pkgname = packages.pop()
 
-        pkg: BasePackage
         if pkgname in UNVENDORED_STDLIB_MODULES:
             pkg = StdLibPackage(packages_dir / pkgname)
         else:
             pkg = Package(packages_dir / pkgname)
-        if no_numpy_dependents and "numpy" in pkg.dependencies:
-            continue
-        pkg_map[pkg.name] = pkg
-
+        pkg_map[pkgname] = pkg
+        graph[pkgname] = pkg.dependencies
         for dep in pkg.dependencies:
             if pkg_map.get(dep) is None:
                 packages.add(dep)
 
-    # Compute dependents
-    for pkg in pkg_map.values():
+    # Traverse in build order (dependencies first then dependents)
+    # Mark a package as disabled if they've either been explicitly disabled
+    # or if any of its transitive dependencies were marked disabled.
+    for pkgname in TopologicalSorter(graph).static_order():
+        pkg = pkg_map[pkgname]
+        if pkgname in disabled_packages:
+            pkg.disabled = True
+            continue
+        if no_numpy_dependents and "numpy" in pkg.dependencies:
+            pkg.disabled = True
+            continue
+        for dep in pkg.dependencies:
+            if pkg_map[dep].disabled:
+                pkg.disabled = True
+                break
+
+    # Now traverse in reverse build order (dependents first then their
+    # dependencies).
+    # Locate the subset of packages that are transitive dependencies of packages
+    # that are requested and not disabled.
+    for pkgname in reversed(list(TopologicalSorter(graph).static_order())):
+        pkg = pkg_map[pkgname]
+        if pkg.disabled:
+            requested.discard(pkgname)
+            continue
+
+        if pkgname not in requested:
+            continue
+
+        requested.update(pkg.dependencies)
         for dep in pkg.dependencies:
             pkg_map[dep].dependents.add(pkg.name)
 
-    return pkg_map
+    return {name: pkg_map[name] for name in requested}
 
 
 def job_priority(pkg: BasePackage) -> int:

--- a/pyodide-build/pyodide_build/io.py
+++ b/pyodide-build/pyodide_build/io.py
@@ -8,6 +8,7 @@ PACKAGE_CONFIG_SPEC: dict[str, dict[str, Any]] = {
         "name": str,
         "version": str,
         "_tag": str,
+        "disabled": bool,
     },
     "source": {
         "url": str,

--- a/pyodide-build/pyodide_build/io.py
+++ b/pyodide-build/pyodide_build/io.py
@@ -8,7 +8,7 @@ PACKAGE_CONFIG_SPEC: dict[str, dict[str, Any]] = {
         "name": str,
         "version": str,
         "_tag": str,
-        "disabled": bool,
+        "_disabled": bool,
     },
     "source": {
         "url": str,

--- a/pyodide-build/pyodide_build/tests/_test_packages/CLAPACK/meta.yaml
+++ b/pyodide-build/pyodide_build/tests/_test_packages/CLAPACK/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: CLAPACK
+  version: 3.2.1
+
+source:
+  sha256: 6dc4c382164beec8aaed8fd2acc36ad24232c406eda6db462bd4c41d5e455fac
+  url: http://www.netlib.org/clapack/clapack.tgz
+
+build:
+  sharedlibrary: true
+  script: "pass"

--- a/pyodide-build/pyodide_build/tests/_test_packages/joblib/meta.yaml
+++ b/pyodide-build/pyodide_build/tests/_test_packages/joblib/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: joblib
+  version: 1.1.0
+
+requirements:
+  run:
+    - distutils
+
+source:
+  url: https://files.pythonhosted.org/packages/92/b9/9e3616e7e00c8165fb25175c53444533bdde05f3e974d45d9fcbbe451ee6/joblib-1.1.0.tar.gz
+  sha256: 4158fcecd13733f8be669be0683b96ebdbbd38d23559f54dca7205aea1bf1e35
+
+test:
+  imports:
+    - joblib

--- a/pyodide-build/pyodide_build/tests/_test_packages/numpy/meta.yaml
+++ b/pyodide-build/pyodide_build/tests/_test_packages/numpy/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: numpy
+  version: 1.22.3
+
+source:
+  url: https://files.pythonhosted.org/packages/64/4a/b008d1f8a7b9f5206ecf70a53f84e654707e7616a771d84c05151a4713e9/numpy-1.22.3.zip
+  sha256: dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18
+
+test:
+  imports:
+    - numpy

--- a/pyodide-build/pyodide_build/tests/_test_packages/scikit-learn/meta.yaml
+++ b/pyodide-build/pyodide_build/tests/_test_packages/scikit-learn/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: scikit-learn
+  version: 1.1.0
+
+source:
+  url: https://files.pythonhosted.org/packages/8b/99/b1ec652f2d60a13871a3053f312f9d78977be57e420f2a49d52ba503f1f4/scikit-learn-1.1.0.tar.gz
+  sha256: 80f9904f5b1356adfc32406725dd94c8cc9c8d265047d98390033a6c238cbb29
+
+requirements:
+  run:
+    - scipy
+    - joblib
+    - threadpoolctl
+
+test:
+  imports:
+    - sklearn

--- a/pyodide-build/pyodide_build/tests/_test_packages/scipy/meta.yaml
+++ b/pyodide-build/pyodide_build/tests/_test_packages/scipy/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: scipy
+  version: 1.8.0
+
+source:
+  url: https://files.pythonhosted.org/packages/b4/a2/4faa34bf0cdbefd5c706625f1234987795f368eb4e97bde9d6f46860843e/scipy-1.8.0.tar.gz
+  sha256: 31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd
+
+requirements:
+  run:
+    - numpy
+    - CLAPACK
+
+test:
+  imports:
+    - scipy

--- a/pyodide-build/pyodide_build/tests/_test_packages/threadpoolctl/meta.yaml
+++ b/pyodide-build/pyodide_build/tests/_test_packages/threadpoolctl/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: threadpoolctl
+  version: 3.1.0
+
+source:
+  url: https://files.pythonhosted.org/packages/61/cf/6e354304bcb9c6413c4e02a747b600061c21d38ba51e7e544ac7bc66aecc/threadpoolctl-3.1.0-py3-none-any.whl
+  sha256: 8b99adda265feb6773280df41eece7b2e6561b772d21ffd52e372f999024907b

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from pyodide_build import buildall
+from pyodide_build import buildall, io
 
 PACKAGES_DIR = Path(__file__).parent / "_test_packages"
 
@@ -21,6 +21,35 @@ def test_generate_dependency_graph():
     assert pkg_map["soupsieve"].dependents == {"beautifulsoup4"}
     assert pkg_map["beautifulsoup4"].dependencies == ["soupsieve"]
     assert pkg_map["beautifulsoup4"].dependents == set()
+
+
+@pytest.mark.parametrize(
+    "in_set, out_set",
+    [
+        ({"scipy"}, {"scipy", "numpy", "CLAPACK"}),
+        ({"scipy", "!numpy"}, set()),
+        ({"scipy", "!numpy", "CLAPACK"}, {"CLAPACK"}),
+        ({"scikit-learn", "!numpy"}, set()),
+        ({"scikit-learn", "scipy", "!joblib"}, {"scipy", "numpy", "CLAPACK"}),
+        ({"scikit-learn", "no-numpy-dependents"}, set()),
+        ({"scikit-learn", "no-numpy-dependents", "numpy"}, {"numpy"}),
+    ],
+)
+def test_generate_dependency_graph2(in_set, out_set):
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, in_set)
+    assert set(pkg_map.keys()) == out_set
+
+
+def test_generate_dependency_graph_disabled(monkeypatch):
+    def mock_parse_package_config(path):
+        d = io.parse_package_config(path)
+        if "numpy" in str(path):
+            d["package"]["disabled"] = True
+        return d
+
+    monkeypatch.setattr(buildall, "parse_package_config", mock_parse_package_config)
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"scipy"})
+    assert set(pkg_map.keys()) == set()
 
 
 def test_generate_packages_json(tmp_path):

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -44,7 +44,7 @@ def test_generate_dependency_graph_disabled(monkeypatch):
     def mock_parse_package_config(path):
         d = io.parse_package_config(path)
         if "numpy" in str(path):
-            d["package"]["disabled"] = True
+            d["package"]["_disabled"] = True
         return d
 
     monkeypatch.setattr(buildall, "parse_package_config", mock_parse_package_config)


### PR DESCRIPTION
Frequently when updating Python or Emscripten, a handlful of packages
stop working. Because of the way that the CI works, these prevent
other packages from being built or tested. However, packages with
many dependents are currently annoying to disable. This adds a key
to meta.yaml "disable: true" that turns off a package.

I also fixed the "!package" and no-numpy-dependents to be transitive.

We use graphlib to sort the packages topologically, then we traverse
the packages once in build order to locate all the packages which
transitively depend on disabled packages. Then we traverse in reverse
build order to locate all packages that are dependencies of non-disabled
requested packages.
