### PR TITLE
FIX Don't build a shared library for libgsl

### DIFF
--- a/packages/libgsl/meta.yaml
+++ b/packages/libgsl/meta.yaml
@@ -9,6 +9,7 @@ build:
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
-        --prefix=${WASM_LIBRARY_DIR}
+        --prefix=${WASM_LIBRARY_DIR} \
+        --disable-shared
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install


### PR DESCRIPTION
It is slow, we aren't using it, and it is incorrect. Newer versions
of Emscripten notice that there are problems and error out.