### PR TITLE
FIX TextDecoder is not a left inverse for TextEncoder

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1678,7 +1678,7 @@ JsBuffer_DecodeString_js,
   if (encoding) {
     encoding_js = UTF8ToString(encoding);
   }
-  let decoder = new TextDecoder(encoding_js, {fatal : true});
+  let decoder = new TextDecoder(encoding_js, {fatal : true, ignoreBOM: true});
   let res;
   try {
     res = decoder.decode(buffer);

--- a/src/core/python2js_buffer.js
+++ b/src/core/python2js_buffer.js
@@ -244,7 +244,7 @@ JS_FILE(python2js_buffer_init, () => {
     let formatChar = formatStr.slice(-1);
     switch (formatChar) {
       case "s":
-        let decoder = new TextDecoder("utf8");
+        let decoder = new TextDecoder("utf8", { ignoreBOM: true });
         return (buff) => decoder.decode(buff);
       case "?":
         return (buff) => Array.from(new Uint8Array(buff), (x) => !!x);

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -21,11 +21,7 @@ def test_string_conversion(selenium_module_scope, s):
         from pyodide import run_js
 
         run_js("self.encoder = new TextEncoder()")
-        run_js("self.decoder = new TextDecoder()")
-
-        if run_js("(spy) => self.decoder(self.encoder(spy)) !== spy"):
-            # Apparently TextDecoder is not a left inverse of TextEncoder. *sigh*
-            return
+        run_js("self.decoder = new TextDecoder('utf8', {ignoreBOM: true})")
 
         spy = bytes(sbytes).decode()
         sjs = run_js(
@@ -51,11 +47,7 @@ def test_string_conversion2(selenium, s):
     from pyodide import run_js
 
     run_js("self.encoder = new TextEncoder()")
-    run_js("self.decoder = new TextDecoder()")
-
-    if run_js("(spy) => self.decoder(self.encoder(spy)) !== spy"):
-        # Apparently TextDecoder is not a left inverse of TextEncoder. *sigh*
-        return
+    run_js("self.decoder = new TextDecoder('utf8', {ignoreBOM: true})")
 
     s_encoded = s.encode()
     sjs = run_js(

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -20,11 +20,18 @@ def test_string_conversion(selenium_module_scope, s):
     def main(selenium, sbytes):
         from pyodide import run_js
 
+        run_js("self.encoder = new TextEncoder()")
+        run_js("self.decoder = new TextDecoder()")
+
+        if run_js("(spy) => self.decoder(self.encoder(spy)) !== spy"):
+            # Apparently TextDecoder is not a left inverse of TextEncoder. *sigh*
+            return
+
         spy = bytes(sbytes).decode()
         sjs = run_js(
             """
             (sbytes) => {
-                self.sjs = (new TextDecoder("utf8")).decode(new Uint8Array(sbytes));
+                self.sjs = self.decoder.decode(new Uint8Array(sbytes));
                 return sjs;
             }
             """
@@ -43,12 +50,19 @@ def test_string_conversion(selenium_module_scope, s):
 def test_string_conversion2(selenium, s):
     from pyodide import run_js
 
+    run_js("self.encoder = new TextEncoder()")
+    run_js("self.decoder = new TextDecoder()")
+
+    if run_js("(spy) => self.decoder(self.encoder(spy)) !== spy"):
+        # Apparently TextDecoder is not a left inverse of TextEncoder. *sigh*
+        return
+
     s_encoded = s.encode()
     sjs = run_js(
         """
         (s_encoded) => {
             let buf = s_encoded.getBuffer();
-            self.sjs = (new TextDecoder("utf8")).decode(buf.data);
+            self.sjs = self.decoder.decode(buf.data);
             buf.release();
             return sjs
         }


### PR DESCRIPTION
Strings on which decode(encode(s)) !== s will fail these tests
due to no fault of Pyodide. Took Hypothesis a long time to find this
though.

Counter example: '\ufeff'
https://app.circleci.com/pipelines/github/hoodmane/pyodide/3238/workflows/ca2c0d13-db82-43b3-b8e4-d4aad7c1cd3b/jobs/37480