### PR TITLE
TST Use short pytest tracebacks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ norecursedirs =
 addopts =
     --doctest-modules
     --ignore="packages/matplotlib/src"
+    --tb=short
 markers =
     skip_refcount_check: Dont run refcount checks
     skip_pyproxy_check: Dont run pyproxy allocation checks


### PR DESCRIPTION
By default, pytest uses the `--tb=auto` option with 'long' tracebacks for the first and last entry, but 'short' style for the other entries.

Since the last entry is typically a very long selenium function, it would print all the source code of that function making it more difficult to find relevant information. The first entry is the test function, and it's also not very useful to print it in full.

**Example of a timeout**

<details>

```
selenium = <pyodide_test_runner.browser.SeleniumChromeWrapper object at 0x7fb410a77e20>

    def test_run_python_async_toplevel_await(selenium):
>       selenium.run_js(
            """
            await pyodide.runPythonAsync(`
                from js import fetch
                import asyncio
                resp = await fetch("packages.json")
                json = (await resp.json()).to_py()["packages"]
                assert "micropip" in json
                await asyncio.sleep(25)
            `);
            """
        )

src/tests/test_pyodide.py:399: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pyodide-test-runner/pyodide_test_runner/browser.py:270: in run_js
    return self.run_js_inner(code, check_code)
pyodide-test-runner/pyodide_test_runner/browser.py:370: in run_js_inner
    retval = self.driver.execute_async_script(wrapper % (code, check_code))
/usr/local/lib/python3.10/site-packages/selenium/webdriver/remote/webdriver.py:900: in execute_async_script
    return self.execute(command, {
/usr/local/lib/python3.10/site-packages/selenium/webdriver/remote/webdriver.py:424: in execute
    self.error_handler.check_response(response)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <selenium.webdriver.remote.errorhandler.ErrorHandler object at 0x7fb410a77d30>
response = {'status': 500, 'value': '{"value":{"error":"script timeout","message":"script timeout\\n  (Session info: headless chr...\\n#14 0x564bf5f63788 \\u003Cunknown>\\n#15 0x564bf5f7df1d \\u003Cunknown>\\n#16 0x7f0ff0164fa3 \\u003Cunknown>\\n"}}'}

    def check_response(self, response: Dict[str, Any]) -> None:
        """
        Checks that a JSON response from the WebDriver does not have an error.
    
        :Args:
         - response - The JSON response from the WebDriver server as a dictionary
           object.
    
        :Raises: If the response contains an error message.
        """
        status = response.get('status', None)
        if not status or status == ErrorCode.SUCCESS:
            return
        value = None
        message = response.get("message", "")
        screen: str = response.get("screen", "")
        stacktrace = None
        if isinstance(status, int):
            value_json = response.get('value', None)
            if value_json and isinstance(value_json, str):
                import json
                try:
                    value = json.loads(value_json)
                    if len(value.keys()) == 1:
                        value = value['value']
                    status = value.get('error', None)
                    if not status:
                        status = value.get("status", ErrorCode.UNKNOWN_ERROR)
                        message = value.get("value") or value.get("message")
                        if not isinstance(message, str):
                            value = message
                            message = message.get('message')
                    else:
                        message = value.get('message', None)
                except ValueError:
                    pass
    
        exception_class: Type[WebDriverException]
        if status in ErrorCode.NO_SUCH_ELEMENT:
            exception_class = NoSuchElementException
        elif status in ErrorCode.NO_SUCH_FRAME:
            exception_class = NoSuchFrameException
        elif status in ErrorCode.NO_SUCH_SHADOW_ROOT:
            exception_class = NoSuchShadowRootException
        elif status in ErrorCode.NO_SUCH_WINDOW:
            exception_class = NoSuchWindowException
        elif status in ErrorCode.STALE_ELEMENT_REFERENCE:
            exception_class = StaleElementReferenceException
        elif status in ErrorCode.ELEMENT_NOT_VISIBLE:
            exception_class = ElementNotVisibleException
        elif status in ErrorCode.INVALID_ELEMENT_STATE:
            exception_class = InvalidElementStateException
        elif status in ErrorCode.INVALID_SELECTOR \
                or status in ErrorCode.INVALID_XPATH_SELECTOR \
                or status in ErrorCode.INVALID_XPATH_SELECTOR_RETURN_TYPER:
            exception_class = InvalidSelectorException
        elif status in ErrorCode.ELEMENT_IS_NOT_SELECTABLE:
            exception_class = ElementNotSelectableException
        elif status in ErrorCode.ELEMENT_NOT_INTERACTABLE:
            exception_class = ElementNotInteractableException
        elif status in ErrorCode.INVALID_COOKIE_DOMAIN:
            exception_class = InvalidCookieDomainException
        elif status in ErrorCode.UNABLE_TO_SET_COOKIE:
            exception_class = UnableToSetCookieException
        elif status in ErrorCode.TIMEOUT:
            exception_class = TimeoutException
        elif status in ErrorCode.SCRIPT_TIMEOUT:
            exception_class = TimeoutException
        elif status in ErrorCode.UNKNOWN_ERROR:
            exception_class = WebDriverException
        elif status in ErrorCode.UNEXPECTED_ALERT_OPEN:
            exception_class = UnexpectedAlertPresentException
        elif status in ErrorCode.NO_ALERT_OPEN:
            exception_class = NoAlertPresentException
        elif status in ErrorCode.IME_NOT_AVAILABLE:
            exception_class = ImeNotAvailableException
        elif status in ErrorCode.IME_ENGINE_ACTIVATION_FAILED:
            exception_class = ImeActivationFailedException
        elif status in ErrorCode.MOVE_TARGET_OUT_OF_BOUNDS:
            exception_class = MoveTargetOutOfBoundsException
        elif status in ErrorCode.JAVASCRIPT_ERROR:
            exception_class = JavascriptException
        elif status in ErrorCode.SESSION_NOT_CREATED:
            exception_class = SessionNotCreatedException
        elif status in ErrorCode.INVALID_ARGUMENT:
            exception_class = InvalidArgumentException
        elif status in ErrorCode.NO_SUCH_COOKIE:
            exception_class = NoSuchCookieException
        elif status in ErrorCode.UNABLE_TO_CAPTURE_SCREEN:
            exception_class = ScreenshotException
        elif status in ErrorCode.ELEMENT_CLICK_INTERCEPTED:
            exception_class = ElementClickInterceptedException
        elif status in ErrorCode.INSECURE_CERTIFICATE:
            exception_class = InsecureCertificateException
        elif status in ErrorCode.INVALID_COORDINATES:
            exception_class = InvalidCoordinatesException
        elif status in ErrorCode.INVALID_SESSION_ID:
            exception_class = InvalidSessionIdException
        elif status in ErrorCode.UNKNOWN_METHOD:
            exception_class = UnknownMethodException
        else:
            exception_class = WebDriverException
        if not value:
            value = response['value']
        if isinstance(value, str):
            raise exception_class(value)
        if message == "" and 'message' in value:
            message = value['message']
    
        screen = None  # type: ignore[assignment]
        if 'screen' in value:
            screen = value['screen']
    
        stacktrace = None
        st_value = value.get('stackTrace') or value.get('stacktrace')
        if st_value:
            if isinstance(st_value, str):
                stacktrace = st_value.split('\n')
            else:
                stacktrace = []
                try:
                    for frame in st_value:
                        line = self._value_or_default(frame, 'lineNumber', '')
                        file = self._value_or_default(frame, 'fileName', '<anonymous>')
                        if line:
                            file = "%s:%s" % (file, line)
                        meth = self._value_or_default(frame, 'methodName', '<anonymous>')
                        if 'className' in frame:
                            meth = "%s.%s" % (frame['className'], meth)
                        msg = "    at %s (%s)"
                        msg = msg % (meth, file)
                        stacktrace.append(msg)
                except TypeError:
                    pass
        if exception_class == UnexpectedAlertPresentException:
            alert_text = None
            if 'data' in value:
                alert_text = value['data'].get('text')
            elif 'alert' in value:
                alert_text = value['alert'].get('text')
            raise exception_class(message, screen, stacktrace, alert_text)  # type: ignore[call-arg]  # mypy is not smart enough here
>       raise exception_class(message, screen, stacktrace)
E       selenium.common.exceptions.TimeoutException: Message: script timeout
E         (Session info: headless chrome=102.0.5005.61)
E       Stacktrace:
E       #0 0x564bf5efdf33 <unknown>
E       #1 0x564bf5c47faf <unknown>
E       #2 0x564bf5cb02d2 <unknown>
E       #3 0x564bf5c9bf72 <unknown>
E       #4 0x564bf5caf2e4 <unknown>
E       #5 0x564bf5c9be63 <unknown>
E       #6 0x564bf5c7182a <unknown>
E       #7 0x564bf5c72985 <unknown>
E       #8 0x564bf5f424cd <unknown>
E       #9 0x564bf5f465ec <unknown>
E       #10 0x564bf5f2c71e <unknown>
E       #11 0x564bf5f47238 <unknown>
E       #12 0x564bf5f21870 <unknown>
E       #13 0x564bf5f63608 <unknown>
E       #14 0x564bf5f63788 <unknown>
E       #15 0x564bf5f7df1d <unknown>
E       #16 0x7f0ff0164fa3 <unknown>

/usr/local/lib/python3.10/site-packages/selenium/webdriver/remote/errorhandler.py:247: TimeoutException
```
</details>

This switches to `--tb=short` option (example below),

<details>

```
src/tests/test_pyodide.py:399: in test_run_python_async_toplevel_await
    selenium.run_js(
pyodide-test-runner/pyodide_test_runner/browser.py:270: in run_js
    return self.run_js_inner(code, check_code)
pyodide-test-runner/pyodide_test_runner/browser.py:370: in run_js_inner
    retval = self.driver.execute_async_script(wrapper % (code, check_code))
/usr/local/lib/python3.10/site-packages/selenium/webdriver/remote/webdriver.py:900: in execute_async_script
    return self.execute(command, {
/usr/local/lib/python3.10/site-packages/selenium/webdriver/remote/webdriver.py:424: in execute
    self.error_handler.check_response(response)
/usr/local/lib/python3.10/site-packages/selenium/webdriver/remote/errorhandler.py:247: in check_response
    raise exception_class(message, screen, stacktrace)
E   selenium.common.exceptions.TimeoutException: Message: script timeout
E     (Session info: headless chrome=102.0.5005.61)
E   Stacktrace:
E   #0 0x55f99967ef33 <unknown>
E   #1 0x55f9993c8faf <unknown>
E   #2 0x55f9994312d2 <unknown>
E   #3 0x55f99941cf72 <unknown>
E   #4 0x55f9994302e4 <unknown>
E   #5 0x55f99941ce63 <unknown>
E   #6 0x55f9993f282a <unknown>
E   #7 0x55f9993f3985 <unknown>
E   #8 0x55f9996c34cd <unknown>
E   #9 0x55f9996c75ec <unknown>
E   #10 0x55f9996ad71e <unknown>
E   #11 0x55f9996c8238 <unknown>
E   #12 0x55f9996a2870 <unknown>
E   #13 0x55f9996e4608 <unknown>
E   #14 0x55f9996e4788 <unknown>
E   #15 0x55f9996fef1d <unknown>
E   #16 0x7f91f47aafa3 <unknown>
```
</details>



which displays the traceback with only the line number + the line in question (not the the full source code of the function) which I think is probably sufficient, and makes the pytest log more useful when there are multiple failures as in https://github.com/pyodide/pyodide/pull/2578