### PR TITLE
Use -sSIDE_MODULE=2 when compiling rust

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -155,7 +155,7 @@ export PYO3_CONFIG_FILE=$(PYODIDE_ROOT)/tools/pyo3_config.ini
 export RUSTFLAGS= \
 	-C relocation-model=pic \
 	-C target-feature=+mutable-globals \
-	-C link-arg=-sSIDE_MODULE=1 \
+	-C link-arg=-sSIDE_MODULE=2 \
 	-C link-arg=-sWASM_BIGINT
 
 .output_vars:

--- a/tools/rust_emcc_wrapper.py
+++ b/tools/rust_emcc_wrapper.py
@@ -4,9 +4,6 @@ import sys
 
 
 def update_args(args):
-    # https://github.com/emscripten-core/emscripten/issues/17109
-    args.insert(0, "-Wl,--no-whole-archive")
-
     # Remove -s ASSERTIONS=1
     # See https://github.com/rust-lang/rust/pull/97928
     for i in range(len(args)):

--- a/tools/rust_emcc_wrapper.py
+++ b/tools/rust_emcc_wrapper.py
@@ -22,9 +22,6 @@ def update_args(args):
     # contains symbols that should come from the main module.
     # https://github.com/emscripten-core/emscripten/issues/17202
     args.append("-sERROR_ON_UNDEFINED_SYMBOLS=0")
-    # Seems like --no-entry should be implied by SIDE_MODULE but apparently it
-    # isn't?
-    args.append("-Wl,--no-entry")
     # Without this, the dylink section seems to get deleted which causes trouble
     # at load time.
     args.append("-Wl,--no-gc-sections")


### PR DESCRIPTION
instead of passing `-Wl,no-whole-archive`. This should reduce the size of the generated package (?)
and also doesn't require the compiler wrapper to insert the argument.