### PR TITLE
Use nightly rust and simplify rust_emcc_wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ emsdk/emsdk/.complete:
 rust:
 	wget https://sh.rustup.rs -O /rustup.sh
 	sh /rustup.sh -y
+	source $(HOME)/.cargo/env && rustup toolchain install nightly-2022-06-14 && rustup default nightly
 	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain stable
 
 

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ rust:
 	wget https://sh.rustup.rs -O /rustup.sh
 	sh /rustup.sh -y
 	source $(HOME)/.cargo/env && rustup toolchain install nightly-2022-06-14 && rustup default nightly
-	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain stable
+	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-06-14
 
 
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ emsdk/emsdk/.complete:
 rust:
 	wget https://sh.rustup.rs -O /rustup.sh
 	sh /rustup.sh -y
-	source $(HOME)/.cargo/env && rustup toolchain install nightly-2022-06-14 && rustup default nightly
+	source $(HOME)/.cargo/env && rustup toolchain install nightly-2022-06-14 && rustup default nightly-2022-06-14
 	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-06-14
 
 

--- a/tools/rust_emcc_wrapper.py
+++ b/tools/rust_emcc_wrapper.py
@@ -4,27 +4,11 @@ import sys
 
 
 def update_args(args):
-    # Remove -s ASSERTIONS=1
-    # See https://github.com/rust-lang/rust/pull/97928
-    for i in range(len(args)):
-        if "ASSERTIONS" in args[i]:
-            del args[i - 1 : i + 1]
-            break
-
     # remove -lc. Not sure if it makes a difference but -lc doesn't belong here.
     # https://github.com/emscripten-core/emscripten/issues/17191
     for i in reversed(range(len(args))):
         if args[i] == "c" and args[i - 1] == "-l":
             del args[i - 1 : i + 1]
-
-    # Prevent a bunch of errors caused by buggy behavior in
-    # `esmcripten/tools/building.py:lld_flags_for_executable` REQUIRED_EXPORTS
-    # contains symbols that should come from the main module.
-    # https://github.com/emscripten-core/emscripten/issues/17202
-    args.append("-sERROR_ON_UNDEFINED_SYMBOLS=0")
-    # Without this, the dylink section seems to get deleted which causes trouble
-    # at load time.
-    args.append("-Wl,--no-gc-sections")
 
     return args
 


### PR DESCRIPTION
This PR:
https://github.com/rust-lang/rust/pull/97928/files
allows us to simplify `rust_emcc_wrapper`.
Hopefully I can make another fix to Rust that will fix the libc problem and allow us to get rid of the wrapper entirely.