### PR TITLE
Fix typo in scipy f2py wrapper for nrm2

### DIFF
--- a/packages/scipy/patches/0008-make-int-return-values.patch
+++ b/packages/scipy/patches/0008-make-int-return-values.patch
@@ -1,4 +1,4 @@
-From fb6fb30ac1d4f106c7fef514ed924a50f848819a Mon Sep 17 00:00:00 2001
+From e96f9c5c27ac6dee8e793b334517a0799b8a3f15 Mon Sep 17 00:00:00 2001
 From: Joe Marshall <joe.marshall@nottingham.ac.uk>
 Date: Wed, 6 Apr 2022 21:25:13 -0700
 Subject: [PATCH 08/14] make int return values
@@ -113,7 +113,7 @@ index 9974ae0f3..f74c379df 100644
  {
      /*
 diff --git a/scipy/linalg/fblas_l1.pyf.src b/scipy/linalg/fblas_l1.pyf.src
-index 89e50a990..1f134a296 100644
+index 89e50a990..0476e6a26 100644
 --- a/scipy/linalg/fblas_l1.pyf.src
 +++ b/scipy/linalg/fblas_l1.pyf.src
 @@ -279,14 +279,16 @@ end subroutine <prefix>axpy
@@ -218,7 +218,7 @@ index 89e50a990..1f134a296 100644
 -  callstatement (*f2py_func)(&<prefix4>nrm2, &n,x+offx,&incx)
 -  callprotoargument <ctypereal4>*,F_INT*,<ctype4>*,F_INT*
 +  double precision <prefix4>nrm2
-+  <ftype4> n2
++  <ftypereal4> n2
 +  fortranname F_FUNC(<prefix4>nrm2,<S,D>NRM2)
 +  ! This following line is to avoid Fortran wrappers - fix for CLAPACK
 +  intent(c) <prefix4>nrm2

--- a/packages/scipy/patches/0008-make-int-return-values.patch
+++ b/packages/scipy/patches/0008-make-int-return-values.patch
@@ -1,4 +1,4 @@
-From b540dfc763970a818b70b520b7b1e0b365bc3825 Mon Sep 17 00:00:00 2001
+From fb6fb30ac1d4f106c7fef514ed924a50f848819a Mon Sep 17 00:00:00 2001
 From: Joe Marshall <joe.marshall@nottingham.ac.uk>
 Date: Wed, 6 Apr 2022 21:25:13 -0700
 Subject: [PATCH 08/14] make int return values
@@ -113,7 +113,7 @@ index 9974ae0f3..f74c379df 100644
  {
      /*
 diff --git a/scipy/linalg/fblas_l1.pyf.src b/scipy/linalg/fblas_l1.pyf.src
-index 89e50a990..b7c77115d 100644
+index 89e50a990..1f134a296 100644
 --- a/scipy/linalg/fblas_l1.pyf.src
 +++ b/scipy/linalg/fblas_l1.pyf.src
 @@ -279,14 +279,16 @@ end subroutine <prefix>axpy
@@ -193,7 +193,7 @@ index 89e50a990..b7c77115d 100644
  function <prefix3>nrm2(n,x,offx,incx) result(n2)
  
 -  <ftypereal3> <prefix3>nrm2, n2
-+  <ftypereal3> nm2
++  <ftypereal3> n2
 +  double precision <prefix3>nrm2
  
 -  callstatement (*f2py_func)(&<prefix3>nrm2, &n,x+offx,&incx)

--- a/packages/scipy/patches/0009-Rename-_page_trend_test.py-to-prevent-test-unvendori.patch
+++ b/packages/scipy/patches/0009-Rename-_page_trend_test.py-to-prevent-test-unvendori.patch
@@ -1,4 +1,4 @@
-From a39c83fbabb2b0387ac74580edf2daf66daec9ea Mon Sep 17 00:00:00 2001
+From aa5efca2d530f6b8be78151a5873595514b75bf3 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sun, 26 Dec 2021 07:34:40 -0800
 Subject: [PATCH 09/14] Rename _page_trend_test.py to prevent test unvendoring

--- a/packages/scipy/patches/0009-Rename-_page_trend_test.py-to-prevent-test-unvendori.patch
+++ b/packages/scipy/patches/0009-Rename-_page_trend_test.py-to-prevent-test-unvendori.patch
@@ -1,4 +1,4 @@
-From 2597c12ed2438518e826fbb6721cc266af30de2f Mon Sep 17 00:00:00 2001
+From a39c83fbabb2b0387ac74580edf2daf66daec9ea Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sun, 26 Dec 2021 07:34:40 -0800
 Subject: [PATCH 09/14] Rename _page_trend_test.py to prevent test unvendoring

--- a/packages/scipy/patches/0010-sasum-returns-double-not-float.patch
+++ b/packages/scipy/patches/0010-sasum-returns-double-not-float.patch
@@ -1,4 +1,4 @@
-From 670c576b3e7996ea8a103201fb4036d49a722c41 Mon Sep 17 00:00:00 2001
+From 5201d52021f584d625bf92dc8bf3094d879d0ad5 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 18 Dec 2021 12:31:51 -0800
 Subject: [PATCH 10/14] sasum returns double not float

--- a/packages/scipy/patches/0010-sasum-returns-double-not-float.patch
+++ b/packages/scipy/patches/0010-sasum-returns-double-not-float.patch
@@ -1,4 +1,4 @@
-From b41cd9f3f5302c30281d6b8ed6c068586ecbe683 Mon Sep 17 00:00:00 2001
+From 670c576b3e7996ea8a103201fb4036d49a722c41 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 18 Dec 2021 12:31:51 -0800
 Subject: [PATCH 10/14] sasum returns double not float

--- a/packages/scipy/patches/0011-skip-fortran-fails-to-link.patch
+++ b/packages/scipy/patches/0011-skip-fortran-fails-to-link.patch
@@ -1,4 +1,4 @@
-From d032a1ca7e9c973e7186a546688a60b49e59b8ea Mon Sep 17 00:00:00 2001
+From 4a428bf011ab49fb44aeff962cc7bef63d9aa8a6 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 25 Dec 2021 15:08:18 -0800
 Subject: [PATCH 11/14] skip fortran fails to link

--- a/packages/scipy/patches/0011-skip-fortran-fails-to-link.patch
+++ b/packages/scipy/patches/0011-skip-fortran-fails-to-link.patch
@@ -1,4 +1,4 @@
-From d2107ce2e3edcd33adf41cf682bfc56358f52f00 Mon Sep 17 00:00:00 2001
+From d032a1ca7e9c973e7186a546688a60b49e59b8ea Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 25 Dec 2021 15:08:18 -0800
 Subject: [PATCH 11/14] skip fortran fails to link

--- a/packages/scipy/patches/0012-Disable-lapack-detection.patch
+++ b/packages/scipy/patches/0012-Disable-lapack-detection.patch
@@ -1,4 +1,4 @@
-From 9fec66e063979b32135a856dd5680433589ed88d Mon Sep 17 00:00:00 2001
+From 1e8a128867f7655c7e516be38fba6bdcc4990143 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 6 Apr 2022 21:52:29 -0700
 Subject: [PATCH 12/14] Disable lapack detection

--- a/packages/scipy/patches/0012-Disable-lapack-detection.patch
+++ b/packages/scipy/patches/0012-Disable-lapack-detection.patch
@@ -1,4 +1,4 @@
-From 2a48cdef1a686053891880a4f97283f0fba94488 Mon Sep 17 00:00:00 2001
+From 9fec66e063979b32135a856dd5680433589ed88d Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 6 Apr 2022 21:52:29 -0700
 Subject: [PATCH 12/14] Disable lapack detection

--- a/packages/scipy/patches/0013-Add-extra-END-to-prini.f.patch
+++ b/packages/scipy/patches/0013-Add-extra-END-to-prini.f.patch
@@ -1,4 +1,4 @@
-From 54d12ee5fc4012720c648ef0868bcbf61b67fe3d Mon Sep 17 00:00:00 2001
+From 1bfafd7da4804e5d386159332365ae5e8090341a Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 7 Apr 2022 10:41:26 -0700
 Subject: [PATCH 13/14] Add extra END to prini.f

--- a/packages/scipy/patches/0013-Add-extra-END-to-prini.f.patch
+++ b/packages/scipy/patches/0013-Add-extra-END-to-prini.f.patch
@@ -1,4 +1,4 @@
-From ca3f2eb55d8b076d02a126863c94d6b2169965ae Mon Sep 17 00:00:00 2001
+From 54d12ee5fc4012720c648ef0868bcbf61b67fe3d Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 7 Apr 2022 10:41:26 -0700
 Subject: [PATCH 13/14] Add extra END to prini.f

--- a/packages/scipy/patches/0014-BUG-Fix-signature-of-D_IIR_forback-1-2.patch
+++ b/packages/scipy/patches/0014-BUG-Fix-signature-of-D_IIR_forback-1-2.patch
@@ -1,4 +1,4 @@
-From 48493e305cfd78a6b823cc92e916d8b79340877d Mon Sep 17 00:00:00 2001
+From dd3108c44199bd43ba72909508b516a8005b8940 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 7 Apr 2022 11:02:29 -0700
 Subject: [PATCH 14/14] BUG Fix signature of D_IIR_forback(1,2)

--- a/packages/scipy/patches/0014-BUG-Fix-signature-of-D_IIR_forback-1-2.patch
+++ b/packages/scipy/patches/0014-BUG-Fix-signature-of-D_IIR_forback-1-2.patch
@@ -1,4 +1,4 @@
-From dd3108c44199bd43ba72909508b516a8005b8940 Mon Sep 17 00:00:00 2001
+From 2fd75af054a9bb8324a3bd50957c3e059868eb07 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 7 Apr 2022 11:02:29 -0700
 Subject: [PATCH 14/14] BUG Fix signature of D_IIR_forback(1,2)


### PR DESCRIPTION
This is a one character change: nm2 ==> n2.