### PR TITLE
using javascript native response.json()

### DIFF
--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -130,8 +130,7 @@ class FetchResponse:
         return await self.js_response.text()
 
     async def json(self) -> Any:
-        """Return the response body as a Javascript JSON object.
-        """
+        """Return the response body as a Javascript JSON object."""
         self._raise_if_failed()
         return await self.js_response.json()
 

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -1,4 +1,3 @@
-import json
 from io import StringIO
 from typing import Any, BinaryIO, TextIO
 
@@ -130,14 +129,11 @@ class FetchResponse:
         self._raise_if_failed()
         return await self.js_response.text()
 
-    async def json(self, **kwargs: Any) -> Any:
+    async def json(self) -> Any:
         """Return the response body as a Javascript JSON object.
-
-        Any keyword arguments are passed to `json.loads
-        <https://docs.python.org/3.8/library/json.html#json.loads>`_.
         """
         self._raise_if_failed()
-        return json.loads(await self.string(), **kwargs)
+        return await self.js_response.json()
 
     async def memoryview(self) -> memoryview:
         """Return the response body as a memoryview object"""


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

For large responses converting to string and then back to json adds a lot of overhead.
Instead the json can be directly fetched from the javascript fetch response object.
https://developer.mozilla.org/en-US/docs/Web/API/Response/json 

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
