### PR TITLE
MAINT Use the patched version of setuptools-rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ rust:
 	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-06-14
 	# Install setuptools-rust with a fix for Wasm targets
 	# TODO: Remove this when they release the next version.
-	pip install -t HOSTSITEPACKAGES git+https://github.com/PyO3/setuptools-rust.git@$(SETUPTOOLS_RUST_COMMIT)
+	pip install -t $(HOSTSITEPACKAGES) git+https://github.com/PyO3/setuptools-rust.git@$(SETUPTOOLS_RUST_COMMIT)
 
 
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -239,11 +239,15 @@ emsdk/emsdk/.complete:
 	date +"[%F %T] done building emsdk."
 
 
+SETUPTOOLS_RUST_COMMIT=5e8c380429aba1e5df5815dcf921025c599cecec
 rust:
 	wget https://sh.rustup.rs -O /rustup.sh
 	sh /rustup.sh -y
 	source $(HOME)/.cargo/env && rustup toolchain install nightly-2022-06-14 && rustup default nightly-2022-06-14
 	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-06-14
+	# Install setuptools-rust with a fix for Wasm targets
+	# TODO: Remove this when they release the next version.
+	pip install -t HOSTSITEPACKAGES git+https://github.com/PyO3/setuptools-rust.git@$(SETUPTOOLS_RUST_COMMIT)
 
 
 FORCE:

--- a/cpython/adjust_sysconfig.py
+++ b/cpython/adjust_sysconfig.py
@@ -23,7 +23,7 @@ def adjust_sysconfig(config_vars: dict[str, str]):
         MAINCC="cc",
         LDSHARED="cc",
         LINKCC="cc",
-        BLDSHARED="emcc -sSIDE_MODULE=1",  # setuptools-rust looks at this
+        BLDSHARED="cc",
         CXX="c++",
         LDCXXSHARED="c++",
     )

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -249,5 +249,7 @@ def get_unisolated_packages():
         config = parse_package_config(pkg, check=False)
         if config.get("build", {}).get("cross-build-env", False):
             unisolated_packages.append(config["package"]["name"])
+    # TODO: remove setuptools_rust from this when they release the next version.
+    unisolated_packages.append("setuptools_rust")
     os.environ["UNISOLATED_PACKAGES"] = json.dumps(unisolated_packages)
     return unisolated_packages

--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -31,8 +31,7 @@ def symlink_unisolated_packages(env: IsolatedEnv) -> None:
     )
     shutil.copy(sysconfigdata_path, env_site_packages)
     host_site_packages = Path(get_hostsitepackages())
-    # TODO: remove setuptools_rust from this when they release the next version.
-    for name in get_unisolated_packages() + ["setuptools_rust"]:
+    for name in get_unisolated_packages():
         for path in chain(
             host_site_packages.glob(f"{name}*"), host_site_packages.glob(f"_{name}*")
         ):

--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -31,7 +31,8 @@ def symlink_unisolated_packages(env: IsolatedEnv) -> None:
     )
     shutil.copy(sysconfigdata_path, env_site_packages)
     host_site_packages = Path(get_hostsitepackages())
-    for name in get_unisolated_packages():
+    # TODO: remove setuptools_rust from this when they release the next version.
+    for name in get_unisolated_packages() + ["setuptools_rust"]:
         for path in chain(
             host_site_packages.glob(f"{name}*"), host_site_packages.glob(f"_{name}*")
         ):

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -10,7 +10,6 @@ cross-compiling and then pass the command long to emscripten.
 """
 import json
 import os
-import shutil
 import sys
 
 IS_MAIN = __name__ == "__main__"
@@ -540,13 +539,6 @@ def handle_command(
     returncode = subprocess.run(new_args).returncode
     if returncode != 0:
         sys.exit(returncode)
-
-    # Rust gives output files a `.wasm` suffix, but we need them to have a `.so`
-    # suffix.
-    if line[0:2] == ["cargo", "rustc"]:
-        p = Path(args.builddir)
-        for x in p.glob("**/*.wasm"):
-            shutil.move(x, x.with_suffix(".so"))
 
     sys.exit(returncode)
 


### PR DESCRIPTION
This allows us to remove a few workarounds for setuptools-rust bugs that are now fixed.