### PR TITLE
Fix micropip.list() error when there is a package loaded from a custom url

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -166,6 +166,10 @@ substitutions:
   packages into a `repodata.json` file.
   {pr}`2581`
 
+- {{ Fix }} `micropip.list` now works correctly when there are packages
+  that are installed via `pyodide.loadPackage` from a custom URL.
+  {pr}`2743`
+
 ### Packages
 
 - {{ Enhancement }} Pillow now supports WEBP image format {pr}`2407`.

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -604,10 +604,15 @@ def _list():
         if name in packages:
             continue
 
-        version = BUILTIN_PACKAGES[name]["version"]
-        source_ = "pyodide"
-        if pkg_source != "default channel":
-            # Pyodide package loaded from a custom URL
+        if name in BUILTIN_PACKAGES:
+            version = BUILTIN_PACKAGES[name]["version"]
+            source_ = "pyodide"
+            if pkg_source != "default channel":
+                # Pyodide package loaded from a custom URL
+                source_ = pkg_source
+        else:
+            # TODO: calculate version from wheel metadata
+            version = "unknown"
             source_ = pkg_source
         packages[name] = PackageMetadata(name=name, version=version, source=source_)
     return packages

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -595,6 +595,24 @@ async def test_list_wheel_name_mismatch(mock_fetch: mock_fetch_cls) -> None:
     assert pkg_list[dummy_pkg_name].source.lower() == dummy_url
 
 
+def test_list_load_package_from_url(selenium_standalone_micropip):
+    with spawn_web_server(Path(__file__).parent / "test") as server:
+        server_hostname, server_port, _ = server
+        base_url = f"http://{server_hostname}:{server_port}/"
+        url = base_url + "snowballstemmer-2.0.0-py2.py3-none-any.whl"
+
+        selenium = selenium_standalone_micropip
+        selenium.run_js(
+            f"""
+            await pyodide.loadPackage({url!r});
+            await pyodide.runPythonAsync(`
+                import micropip
+                assert "snowballstemmer" in micropip.list()
+            `);
+            """
+        )
+
+
 def test_list_pyodide_package(selenium_standalone_micropip):
     selenium = selenium_standalone_micropip
     selenium.run_js(


### PR DESCRIPTION
### Description

There is a bug in `micropip.list()` when there is a package loaded from a custom url by `pyodide.loadPackage()`.

#### Steps to Reproduce

```python
import pyodide_js
await pyodide_js.loadPackage("https://files.pythonhosted.org/packages/7d/4b/cdf1113a0e88b641893b814e9c36f69a6fda28cd88b62c7f0d858cde3166/snowballstemmer-2.0.0-py2.py3-none-any.whl")
import micropip
micropip.list()
```

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/lib/python3.10/site-packages/micropip/_micropip.py", line 607, in _list
    version = BUILTIN_PACKAGES[name]["version"]
KeyError: 'snowballstemmer'
```


### Checklists

- [x] Add / update tests
