### PR TITLE
Bumped version in meta.yaml for python-sat.

### DIFF
--- a/packages/python-sat/meta.yaml
+++ b/packages/python-sat/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: python-sat
-  version: 0.1.7.dev17
+  version: 0.1.7.dev18
 
 source:
-  sha256: d8c2a41e4d37e936a9eb96be921796ea76582df221cffaa62f85499f14c914c4
-  url: https://files.pythonhosted.org/packages/54/be/ee88df6a4cfcc93c6f69aa8544d7718674ed90418023177a785979dc2a60/python-sat-0.1.7.dev17.tar.gz
+  sha256: 2a9e0d61b62f535ccbe35f09bc0f2981994fbc6c786cf6a8e7572001929d8a00
+  url: https://files.pythonhosted.org/packages/21/a5/782af1c9c9ae64cead20be08f0239ccf24f374cc4c86ca9ead72d53e6db7/python-sat-0.1.7.dev18.tar.gz
 
   patches:
     - patches/force_malloc.patch


### PR DESCRIPTION
The changes only include updating the meta-information for the "python-sat" package (version bump). Nothing else is affected.