### PR TITLE
API Rename packages.json to repodata.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: check \
 	dist/console.html \
 	dist/distutils.tar \
 	dist/test.tar \
-	dist/packages.json \
+	dist/repodata.json \
 	dist/pyodide_py.tar \
 	dist/test.html \
 	dist/module_test.html \
@@ -227,7 +227,7 @@ $(CPYTHONLIB): emsdk/emsdk/.complete
 	date +"[%F %T] done building cpython..."
 
 
-dist/packages.json: FORCE
+dist/repodata.json: FORCE
 	date +"[%F %T] Building packages..."
 	make -C packages
 	date +"[%F %T] done building packages..."

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -246,7 +246,7 @@ build. We automate the following steps:
   `<package name>-tests.zip`
 - Repack the wheel with `python -m wheel pack`
 
-Lastly, a `packages.json` file is created containing the dependency tree of all
+Lastly, a `repodata.json` file is created containing the dependency tree of all
 packages, so {any}`pyodide.loadPackage` can load a package's dependencies
 automatically.
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -62,7 +62,7 @@ substitutions:
 - {{ Feature }} Added `pyodide.run_js` API.
   {pr}`2426`
 
-- {{ Enhancement }} Add SHA-256 hash of package to entries in `packages.json`
+- {{ Enhancement }} Add SHA-256 hash of package to entries in `repodata.json`
   {pr}`2455`
 
 - {{ Fix }} BigInt's between 2^{32\*n - 1} and 2^{32\*n} no longer get
@@ -115,6 +115,9 @@ substitutions:
 
 - {{ Enhancement }} Pyodide now builds with `-sWASM_BIGINT`..
   {pr}`2643`
+- {{ API }} `packages.json` which contains the dependency graph for packages
+  was renamed to `repodata.json` to avoid confusion with `package.json` used
+  in JavaScript packages.
 
 ### REPL
 
@@ -160,7 +163,7 @@ substitutions:
   {pr}`2591`
 
 - {{ Enhancement }} Added `micropip.freeze` to record the current set of loaded
-  packages into a `packages.json` file.
+  packages into a `repodata.json` file.
   {pr}`2581`
 
 ### Packages

--- a/packages/micropip/src/micropip/_compat.py
+++ b/packages/micropip/src/micropip/_compat.py
@@ -2,7 +2,7 @@ from pyodide._core import IN_BROWSER
 
 if IN_BROWSER:
     from ._compat_in_pyodide import (
-        BUILTIN_PACKAGES,
+        REPODATA_PACKAGES,
         fetch_bytes,
         fetch_string,
         loadDynlib,
@@ -11,7 +11,7 @@ if IN_BROWSER:
     )
 else:
     from ._compat_not_in_pyodide import (
-        BUILTIN_PACKAGES,
+        REPODATA_PACKAGES,
         fetch_bytes,
         fetch_string,
         loadDynlib,
@@ -22,7 +22,7 @@ else:
 __all__ = [
     "fetch_bytes",
     "fetch_string",
-    "BUILTIN_PACKAGES",
+    "REPODATA_PACKAGES",
     "loadedPackages",
     "loadDynlib",
     "loadPackage",

--- a/packages/micropip/src/micropip/_compat_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_in_pyodide.py
@@ -6,7 +6,7 @@ try:
     from pyodide_js import loadedPackages, loadPackage
     from pyodide_js._api import loadDynlib  # type: ignore[import]
 
-    BUILTIN_PACKAGES = pyodide_js._api.packages.to_py()
+    REPODATA_PACKAGES = pyodide_js._api.repodata_packages.to_py()
 except ImportError:
     if IN_BROWSER:
         raise
@@ -24,7 +24,7 @@ async def fetch_string(url: str, kwargs: dict[str, str]) -> str:
 __all__ = [
     "fetch_bytes",
     "fetch_string",
-    "BUILTIN_PACKAGES",
+    "REPODATA_PACKAGES",
     "loadedPackages",
     "loadDynlib",
     "loadPackage",

--- a/packages/micropip/src/micropip/_compat_not_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_not_in_pyodide.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-BUILTIN_PACKAGES: dict[str, dict[str, Any]] = {}
+REPODATA_PACKAGES: dict[str, dict[str, Any]] = {}
 
 
 class loadedPackages:
@@ -37,7 +37,7 @@ __all__ = [
     "loadDynlib",
     "fetch_bytes",
     "fetch_string",
-    "BUILTIN_PACKAGES",
+    "REPODATA_PACKAGES",
     "loadedPackages",
     "loadPackage",
 ]

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -513,7 +513,7 @@ def _generate_package_hash(data: BytesIO) -> str:
 
 def freeze() -> str:
     """Produce a json string which can be used as the contents of the
-    ``packages.json`` lockfile.
+    ``repodata.json`` lockfile.
 
     If you later load pyodide with this lock file, you can use
     :any:`pyodide.loadPackage` to load packages that were loaded with `micropip` this

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -22,7 +22,7 @@ from pyodide import to_js
 from pyodide._package_loader import get_dynlibs, wheel_dist_info_dir
 
 from ._compat import (
-    BUILTIN_PACKAGES,
+    REPODATA_PACKAGES,
     fetch_bytes,
     fetch_string,
     loadDynlib,
@@ -333,10 +333,10 @@ class Transaction:
 
         # If there's a Pyodide package that matches the version constraint, use
         # the Pyodide package instead of the one on PyPI
-        if req.name in BUILTIN_PACKAGES and req.specifier.contains(
-            BUILTIN_PACKAGES[req.name]["version"], prereleases=True
+        if req.name in REPODATA_PACKAGES and req.specifier.contains(
+            REPODATA_PACKAGES[req.name]["version"], prereleases=True
         ):
-            version = BUILTIN_PACKAGES[req.name]["version"]
+            version = REPODATA_PACKAGES[req.name]["version"]
             self.pyodide_packages.append(
                 PackageMetadata(name=req.name, version=str(version), source="pyodide")
             )
@@ -487,7 +487,7 @@ async def install(
     pyodide_packages = transaction.pyodide_packages
     if len(pyodide_packages):
         # Note: branch never happens in out-of-browser testing because in
-        # that case BUILTIN_PACKAGES is empty.
+        # that case REPODATA_PACKAGES is empty.
         wheel_promises.append(
             asyncio.ensure_future(
                 loadPackage(to_js([name for [name, _, _] in pyodide_packages]))
@@ -522,7 +522,7 @@ def freeze() -> str:
     """
     from copy import deepcopy
 
-    packages = deepcopy(BUILTIN_PACKAGES)
+    packages = deepcopy(REPODATA_PACKAGES)
     for dist in importlib_distributions():
         name = dist.name
         version = dist.version
@@ -604,7 +604,7 @@ def _list():
         if name in packages:
             continue
 
-        version = BUILTIN_PACKAGES[name]["version"]
+        version = REPODATA_PACKAGES[name]["version"]
         source_ = "pyodide"
         if pkg_source != "default channel":
             # Pyodide package loaded from a custom URL

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -677,9 +677,9 @@ async def test_load_binary_wheel1(
 @run_in_pyodide(packages=["micropip"])
 async def test_load_binary_wheel2(selenium):
     import micropip
-    from pyodide_js._api import packages
+    from pyodide_js._api import repodata_packages
 
-    await micropip.install(packages.regex.file_name)
+    await micropip.install(repodata_packages.regex.file_name)
     import regex  # noqa: F401
 
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -497,7 +497,7 @@ def _generate_package_hash(full_path: Path) -> str:
     return sha256_hash.hexdigest()
 
 
-def generate_packages_json(
+def generate_repodata(
     output_dir: Path, pkg_map: dict[str, BasePackage]
 ) -> dict[str, dict[str, Any]]:
     """Generate the package.json file"""
@@ -603,9 +603,9 @@ def build_packages(
         pkg.unvendored_tests = pkg.tests_path()
 
     copy_packages_to_dist_dir(pkg_map.values(), output_dir)
-    package_data = generate_packages_json(output_dir, pkg_map)
+    package_data = generate_repodata(output_dir, pkg_map)
 
-    with open(output_dir / "packages.json", "w") as fd:
+    with open(output_dir / "repodata.json", "w") as fd:
         json.dump(package_data, fd)
         fd.write("\n")
 

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -52,7 +52,7 @@ def test_generate_dependency_graph_disabled(monkeypatch):
     assert set(pkg_map.keys()) == set()
 
 
-def test_generate_packages_json(tmp_path):
+def test_generate_repodata(tmp_path):
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, {"pkg_1", "pkg_2"})
     for pkg in pkg_map.values():
         pkg.file_name = pkg.file_name or pkg.name + ".file"
@@ -60,7 +60,7 @@ def test_generate_packages_json(tmp_path):
         with open(tmp_path / pkg.file_name, "w") as f:
             f.write(pkg.name)
 
-    package_data = buildall.generate_packages_json(tmp_path, pkg_map)
+    package_data = buildall.generate_repodata(tmp_path, pkg_map)
     assert set(package_data.keys()) == {"info", "packages"}
     assert set(package_data["info"].keys()) == {"arch", "platform", "version"}
     assert package_data["info"]["arch"] == "wasm32"

--- a/pyodide-test-runner/pyodide_test_runner/utils.py
+++ b/pyodide-test-runner/pyodide_test_runner/utils.py
@@ -91,11 +91,11 @@ def maybe_skip_test(item, dist_dir, delayed=False):
 
 @functools.cache
 def built_packages(dist_dir: Path) -> list[str]:
-    """Returns the list of built package names from packages.json"""
-    packages_json_path = dist_dir / "packages.json"
-    if not packages_json_path.exists():
+    """Returns the list of built package names from repodata.json"""
+    repodata_path = dist_dir / "repodata.json"
+    if not repodata_path.exists():
         return []
-    return list(json.loads(packages_json_path.read_text())["packages"].keys())
+    return list(json.loads(repodata_path.read_text())["packages"].keys())
 
 
 def package_is_built(package_name: str, dist_dir: Path) -> bool:

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -149,7 +149,7 @@ export async function loadPackagesFromImports(
  *
  *    let result = await pyodide.runPythonAsync(`
  *        from js import fetch
- *        response = await fetch("./packages.json")
+ *        response = await fetch("./repodata.json")
  *        packages = await response.json()
  *        # If final statement is an expression, its value is returned to JavaScript
  *        len(packages.packages.object_keys())

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -14,7 +14,7 @@ import { PyProxy, isPyProxy } from "./pyproxy.gen";
 let baseURL: string;
 /**
  * Initialize the packages index. This is called as early as possible in
- * loadPyodide so that fetching packages.json can occur in parallel with other
+ * loadPyodide so that fetching repodata.json can occur in parallel with other
  * operations.
  * @param indexURL
  * @private
@@ -25,16 +25,16 @@ export async function initializePackageIndex(indexURL: string) {
   if (IN_NODE) {
     await initNodeModules();
     const package_string = await nodeFsPromisesMod.readFile(
-      `${indexURL}packages.json`
+      `${indexURL}repodata.json`
     );
     package_json = JSON.parse(package_string);
   } else {
-    let response = await fetch(`${indexURL}packages.json`);
+    let response = await fetch(`${indexURL}repodata.json`);
     package_json = await response.json();
   }
   if (!package_json.packages) {
     throw new Error(
-      "Loaded packages.json does not contain the expected key 'packages'."
+      "Loaded repodata.json does not contain the expected key 'packages'."
     );
   }
   API.packages = package_json.packages;
@@ -150,7 +150,7 @@ function recursiveDependencies(
 
 /**
  * Download a package. If `channel` is `DEFAULT_CHANNEL`, look up the wheel URL
- * relative to baseURL from `packages.json`, otherwise use the URL specified by
+ * relative to baseURL from `repodata.json`, otherwise use the URL specified by
  * `channel`.
  * @param name The name of the package
  * @param channel Either `DEFAULT_CHANNEL` or the absolute URL to the

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -57,7 +57,7 @@
   },
   "files": [
     "pyodide*",
-    "packages.json",
+    "repodata.json",
     "distutils.tar",
     "console.html"
   ],

--- a/src/tests/test_asyncio.py
+++ b/src/tests/test_asyncio.py
@@ -407,7 +407,7 @@ def test_await_pyproxy_eval_async(selenium):
         """
         let c = pyodide.pyodide_py.eval_code_async(`
             from js import fetch
-            await (await fetch('packages.json')).json()
+            await (await fetch('repodata.json')).json()
         `);
         let result = await c;
         c.destroy();
@@ -422,7 +422,7 @@ def test_await_pyproxy_async_def(selenium):
         let packages = await pyodide.runPythonAsync(`
             from js import fetch
             async def temp():
-                return await (await fetch('packages.json')).json()
+                return await (await fetch('repodata.json')).json()
             await temp()
         `);
         return (!!packages.packages) && (!!packages.info);

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -455,14 +455,14 @@ def test_import_invocation(selenium):
     from pyodide import create_once_callable
 
     js.setTimeout(create_once_callable(temp), 100)
-    js.fetch("packages.json")
+    js.fetch("repodata.json")
 
 
 @run_in_pyodide
 def test_import_bind(selenium):
     from js import fetch
 
-    fetch("packages.json")
+    fetch("repodata.json")
 
 
 @run_in_pyodide

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -258,7 +258,7 @@ def test_test_unvendoring(selenium_standalone):
 
     assert selenium.run_js(
         """
-        return pyodide._api.packages['regex'].unvendored_tests;
+        return pyodide._api.repodata_packages['regex'].unvendored_tests;
         """
     )
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -400,7 +400,7 @@ def test_run_python_async_toplevel_await(selenium):
         """
         await pyodide.runPythonAsync(`
             from js import fetch
-            resp = await fetch("packages.json")
+            resp = await fetch("repodata.json")
             json = (await resp.json()).to_py()["packages"]
             assert "micropip" in json
         `);


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide/issues/2747

 - renames  packages.json to repodata.json
 - also rename the corresponding JS and Python variables to be a bit more explicit.

Tangentially related to https://github.com/pyodide/pyodide/issues/795