### PR TITLE
Fix micropip error when a package contains invalid version

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -170,6 +170,9 @@ substitutions:
   that are installed via `pyodide.loadPackage` from a custom URL.
   {pr}`2743`
 
+- {{ Fix }} micropip now skips package versions which do not follow PEP440.
+  {pr}`2754`
+
 ### Packages
 
 - {{ Enhancement }} Pillow now supports WEBP image format {pr}`2407`.

--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import importlib
 import json
+import warnings
 from asyncio import gather
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError
@@ -202,6 +203,13 @@ def find_wheel(metadata: dict[str, Any], req: Requirement) -> WheelInfo:
         reverse=True,
     )
     for ver in candidate_versions:
+        if str(ver) not in releases:
+            pkg_name = metadata.get("info", {}).get("name", "UNKNOWN")
+            warnings.warn(
+                f"The package '{pkg_name}' contains an invalid version: '{ver}'. This version will be skipped"
+            )
+            continue
+
         release = releases[str(ver)]
         for fileinfo in release:
             url = fileinfo["url"]

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -550,7 +550,7 @@ async def test_install_version_invalid_pep440(
     mock_fetch: mock_fetch_cls,
     version_invalid: str,
 ) -> None:
-    # Micropip should skip package versions that doesn't follow PEP 440.
+    # Micropip should skip package versions which do not follow PEP 440.
     #
     #     [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
     #

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -544,6 +544,27 @@ async def test_install_pre(
 
 
 @pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::Warning")
+@pytest.mark.parametrize("version_invalid", ["1.2.3-1", "2.3.1-post1", "3.2.1-pre1"])
+async def test_install_version_invalid_pep440(
+    mock_fetch: mock_fetch_cls,
+    version_invalid: str,
+) -> None:
+    # Micropip should skip package versions that doesn't follow PEP 440.
+    #
+    #     [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
+    #
+
+    dummy = "dummy"
+    version_stable = "1.0.0"
+
+    mock_fetch.add_pkg_version(dummy, version_stable)
+    mock_fetch.add_pkg_version(dummy, version_invalid)
+    await micropip.install(dummy)
+    assert micropip.list()[dummy].version == version_stable
+
+
+@pytest.mark.asyncio
 async def test_fetch_wheel_fail(monkeypatch, wheel_base):
     pytest.importorskip("packaging")
     from micropip import _micropip


### PR DESCRIPTION
### Description

This PR makes micropip skip a version if the version string does not follow PEP440.

Fix #2752 

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
