### PR TITLE
Fix micropip package loading from file:// in node

### DIFF
--- a/packages/micropip/src/micropip/_compat_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_in_pyodide.py
@@ -4,7 +4,7 @@ from pyodide.http import pyfetch
 try:
     import pyodide_js
     from pyodide_js import loadedPackages, loadPackage
-    from pyodide_js._api import loadDynlib  # type: ignore[import]
+    from pyodide_js._api import loadBinaryFile, loadDynlib  # type: ignore[import]
 
     REPODATA_PACKAGES = pyodide_js._api.repodata_packages.to_py()
 except ImportError:
@@ -14,6 +14,8 @@ except ImportError:
 
 
 async def fetch_bytes(url: str, kwargs: dict[str, str]) -> bytes:
+    if url.startswith("file://"):
+        return (await loadBinaryFile("", url)).to_bytes()
     return await (await pyfetch(url, **kwargs)).bytes()
 
 

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -252,15 +252,30 @@ def test_install_custom_url(selenium_standalone_micropip, base_url):
 
         selenium.run_js(
             f"""
-            let url = '{url}';
-            let resp = await fetch(url);
             await pyodide.runPythonAsync(`
                 import micropip
-                await micropip.install('${{url}}')
+                await micropip.install('{url}')
                 import snowballstemmer
             `);
             """
         )
+
+
+@pytest.mark.xfail_browsers(chrome="node only", firefox="node only")
+def test_install_file_protocol_node(selenium_standalone_micropip):
+    selenium = selenium_standalone_micropip
+    from conftest import DIST_PATH
+
+    pyparsing_wheel_name = list(DIST_PATH.glob("pyparsing*.whl"))[0].name
+    selenium.run_js(
+        f"""
+        await pyodide.runPythonAsync(`
+            import micropip
+            await micropip.install('file://{pyparsing_wheel_name}')
+            import pyparsing
+        `);
+        """
+    )
 
 
 def create_transaction(Transaction):

--- a/pyodide-test-runner/pyodide_test_runner/node_test_driver.js
+++ b/pyodide-test-runner/pyodide_test_runner/node_test_driver.js
@@ -9,6 +9,7 @@ let baseUrl = process.argv[2];
 let distDir = process.argv[3];
 
 let { loadPyodide } = require(`${distDir}/pyodide`);
+process.chdir(distDir);
 
 // node requires full paths.
 function fetch(path) {

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -6,8 +6,11 @@ import "./module.ts";
 import { loadPackage, loadedPackages } from "./load-package";
 import { isPyProxy, PyBuffer, PyProxy, TypedArray } from "./pyproxy.gen";
 import { PythonError } from "./error_handling.gen";
+import { loadBinaryFile } from "./compat";
 export { loadPackage, loadedPackages, isPyProxy };
 import "./error_handling.gen.js";
+
+API.loadBinaryFile = loadBinaryFile;
 
 /**
  * An alias to the Python :py:mod:`pyodide` package.

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -134,15 +134,15 @@ async function browser_loadBinaryFile(
 }
 
 /** @private */
-export let _loadBinaryFile: (
+export let loadBinaryFile: (
   indexURL: string,
   path: string,
   file_sub_resource_hash?: string | undefined
 ) => Promise<Uint8Array>;
 if (IN_NODE) {
-  _loadBinaryFile = node_loadBinaryFile;
+  loadBinaryFile = node_loadBinaryFile;
 } else {
-  _loadBinaryFile = browser_loadBinaryFile;
+  loadBinaryFile = browser_loadBinaryFile;
 }
 
 /**

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -5,7 +5,7 @@ declare var API: any;
 import {
   IN_NODE,
   nodeFsPromisesMod,
-  _loadBinaryFile,
+  loadBinaryFile,
   initNodeModules,
 } from "./compat.js";
 import { PyProxy, isPyProxy } from "./pyproxy.gen";
@@ -176,7 +176,7 @@ async function downloadPackage(
     file_sub_resource_hash = undefined;
   }
   try {
-    return await _loadBinaryFile(baseURL, file_name, file_sub_resource_hash);
+    return await loadBinaryFile(baseURL, file_name, file_sub_resource_hash);
   } catch (e) {
     if (!IN_NODE) {
       throw e;
@@ -187,7 +187,7 @@ async function downloadPackage(
   );
   // If we are IN_NODE, download the package from the cdn, then stash it into
   // the node_modules directory for future use.
-  let binary = await _loadBinaryFile(cdnURL, file_name);
+  let binary = await loadBinaryFile(cdnURL, file_name);
   console.log(
     `Package ${file_name} loaded from ${cdnURL}, caching the wheel in node_modules for future use.`
   );

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -2,7 +2,7 @@
  * The main bootstrap code for loading pyodide.
  */
 import ErrorStackParser from "error-stack-parser";
-import { loadScript, _loadBinaryFile, initNodeModules } from "./compat";
+import { loadScript, loadBinaryFile, initNodeModules } from "./compat";
 
 import { createModule, setStandardStreams, setHomeDirectory } from "./module";
 
@@ -249,7 +249,7 @@ export async function loadPyodide(
     config.indexURL += "/";
   }
   await initNodeModules();
-  const pyodide_py_tar_promise = _loadBinaryFile(
+  const pyodide_py_tar_promise = loadBinaryFile(
     config.indexURL,
     "pyodide_py.tar"
   );


### PR DESCRIPTION
The node native fetch doesn't support `file://` yet but we want micropip to support it anyways.