### PR TITLE
Add noop "bind" function to PyProxyCallableMethods

### DIFF
--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1140,6 +1140,11 @@ export class PyProxyCallableMethods {
     }
     return Module.callPyObjectKwargs(_getPtr(this), ...jsargs);
   }
+
+  /**
+  * No-op bind function for compatibility with existing libraries
+  */
+  bind(placeholder: any) {}
 }
 // @ts-ignore
 PyProxyCallableMethods.prototype.prototype = Function.prototype;

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1144,7 +1144,9 @@ export class PyProxyCallableMethods {
   /**
    * No-op bind function for compatibility with existing libraries
    */
-  bind(placeholder: any) { return this; }
+  bind(placeholder: any) {
+    return this;
+  }
 }
 // @ts-ignore
 PyProxyCallableMethods.prototype.prototype = Function.prototype;

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1142,8 +1142,8 @@ export class PyProxyCallableMethods {
   }
 
   /**
-  * No-op bind function for compatibility with existing libraries
-  */
+   * No-op bind function for compatibility with existing libraries
+   */
   bind(placeholder: any) {}
 }
 // @ts-ignore

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1144,7 +1144,7 @@ export class PyProxyCallableMethods {
   /**
    * No-op bind function for compatibility with existing libraries
    */
-  bind(placeholder: any) {}
+  bind(placeholder: any) { return this; }
 }
 // @ts-ignore
 PyProxyCallableMethods.prototype.prototype = Function.prototype;

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -889,7 +889,7 @@ def test_pyproxy_call(selenium):
         selenium.run_js("f.callKwargs(76, {x : 6})")
 
     assert_call("f.bind({})()", [2, 3])
-    assert_call("f.bind({}).$$ == f.$$", True)
+    assert_call("f.bind({}).$$ === f.$$", True)
 
     selenium.run_js("f.destroy()")
 

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -889,6 +889,7 @@ def test_pyproxy_call(selenium):
         selenium.run_js("f.callKwargs(76, {x : 6})")
 
     assert_call("f.bind({})()", [2, 3])
+    assert_call("f.bind({}).$$ == f.$$", True)
 
     selenium.run_js("f.destroy()")
 

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -888,6 +888,8 @@ def test_pyproxy_call(selenium):
     with pytest.raises(selenium.JavascriptException, match=msg):
         selenium.run_js("f.callKwargs(76, {x : 6})")
 
+    assert_call("f.bind({})()", [2, 3])
+
     selenium.run_js("f.destroy()")
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This pull request adds a noop "bind" function to `PyProxyCallableMethods` in pyproxy.ts. Some libraries like Vue will call "bind" on functions passed as event handlers. Adding a no-op bind will not change the functionality of the proxy, but will prevent this error.

Fixes #2757

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
