### PR TITLE
Update libffi tag

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -26,7 +26,7 @@ BZIP2URL=https://sourceware.org/pub/bzip2/bzip2-1.0.2.tar.gz
 
 FFIBUILD=$(ROOT)/build/libffi
 LIBFFIREPO=https://github.com/hoodmane/libffi-emscripten
-LIBFFI_TAG=2022-04-03
+LIBFFI_TAG=2022-06-23
 
 all: $(INSTALL)/lib/$(LIB) $(INSTALL)/lib/libffi.a
 


### PR DESCRIPTION
Since the Emscripten update, libffi can support closures with up to 1000 arguments.