### PR TITLE
Don't log every exception.

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -219,6 +219,7 @@ finally:
   return jserror;
 }
 
+#ifdef DEBUG_F
 EM_JS(void, log_python_error, (JsRef jserror), {
   // If a js error occurs in here, it's a weird edge case. This will probably
   // never happen, but for maximum paranoia let's double check.
@@ -229,6 +230,7 @@ EM_JS(void, log_python_error, (JsRef jserror), {
     API.fatal_error(e);
   }
 });
+#endif
 
 /**
  * Convert the current Python error to a javascript error and throw it.
@@ -237,7 +239,9 @@ void _Py_NO_RETURN
 pythonexc2js()
 {
   JsRef jserror = wrap_exception();
+#ifdef DEBUG_F
   log_python_error(jserror);
+#endif
   // hiwire_throw_error steals jserror
   hiwire_throw_error(jserror);
 }


### PR DESCRIPTION
We don't need to emit a console warning every time a Python exception is wrapped in a JavaScript exception. Users can catch and log the exception themselves if they need to log it.

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Background: I'm trying to implement cancellation via `KeyboardInterrupt` and this exception gets logged every time something gets cancelled and it causes unnecessary noise in the logs since cancellation is frequent in this particular application. I tried catching the KeyboardInterrupt in Python code, but since I'm using a `SharedArrayBuffer` to trigger the interrupt, there is always race condition where the interrupt can be triggered and the exception raised before the `try:` block is entered or after the `try:` block has ended (even if there is no code to run before or after the try block, the interpreter can still check for pending exceptions).

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- ~Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry~
- ~Add / update tests~
- ~Add new / update outdated documentation~
