### PR TITLE
Micropip: Improve error message when attempting to load wheel with wrong platform

### DIFF
--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -21,6 +21,8 @@ except ImportError:
 
 from pyodide_build import common
 
+cpver = f"cp{sys.version_info.major}{sys.version_info.minor}"
+
 
 @pytest.fixture
 def mock_platform(monkeypatch):
@@ -80,9 +82,9 @@ def make_wheel_filename(name: str, version: str, platform: str = "generic") -> s
     if platform == "generic":
         platform_str = "py3-none-any"
     elif platform == "emscripten":
-        platform_str = f"cp310-cp310-{common.platform()}"
+        platform_str = f"{cpver}-{cpver}-{common.platform()}"
     elif platform == "native":
-        platform_str = "cp310-cp310-manylinux_2_31_x86_64"
+        platform_str = f"{cpver}-{cpver}-manylinux_2_31_x86_64"
     else:
         platform_str = platform
 
@@ -454,7 +456,7 @@ async def test_install_non_pure_python_wheel():
     pytest.importorskip("packaging")
     from micropip._micropip import Transaction
 
-    msg = "not a pure Python 3 wheel"
+    msg = "Wheel platform 'macosx_10_9_intel' is not compatible with Pyodide's platform"
     with pytest.raises(ValueError, match=msg):
         url = "http://a/scikit_learn-0.22.2.post1-cp35-cp35m-macosx_10_9_intel.whl"
         transaction = create_transaction(Transaction)
@@ -849,15 +851,15 @@ def raiseValueError(msg):
             "cp35m",
             "emscripten_3_1_14_wasm32",
             raiseValueError(
-                "Wheel abi 'cp35m' .* Supported abis are 'abi3' and 'cp310'."
+                f"Wheel abi 'cp35m' .* Supported abis are 'abi3' and '{cpver}'."
             ),
         ),
         ("cp35", "abi3", "emscripten_3_1_14_wasm32", does_not_raise()),
-        ("cp310", "abi3", "emscripten_3_1_14_wasm32", does_not_raise()),
-        ("cp310", "cp310", "emscripten_3_1_14_wasm32", does_not_raise()),
+        (cpver, "abi3", "emscripten_3_1_14_wasm32", does_not_raise()),
+        (cpver, cpver, "emscripten_3_1_14_wasm32", does_not_raise()),
         (
             "cp35",
-            "cp310",
+            cpver,
             "emscripten_3_1_14_wasm32",
             raiseValueError("Wheel interpreter version 'cp35' is not supported."),
         ),

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -827,6 +827,10 @@ def raiseValueError(msg):
     return pytest.raises(ValueError, match=msg)
 
 
+PLATFORM = common.platform()
+EMSCRIPTEN_VER = common.emscripten_version()
+
+
 @pytest.mark.parametrize(
     "interp, abi, arch,ctx",
     [
@@ -835,7 +839,7 @@ def raiseValueError(msg):
             "cp35m",
             "macosx_10_9_intel",
             raiseValueError(
-                "Wheel platform 'macosx_10_9_intel' .* Pyodide's platform 'emscripten_3_1_14_wasm32'"
+                f"Wheel platform 'macosx_10_9_intel' .* Pyodide's platform '{PLATFORM}'"
             ),
         ),
         (
@@ -843,30 +847,30 @@ def raiseValueError(msg):
             "cp35m",
             "emscripten_2_0_27_wasm32",
             raiseValueError(
-                r"Emscripten v2.0.27 but Pyodide was built with Emscripten v3.1.14"
+                f"Emscripten v2.0.27 but Pyodide was built with Emscripten v{EMSCRIPTEN_VER}"
             ),
         ),
         (
             "cp35",
             "cp35m",
-            "emscripten_3_1_14_wasm32",
+            PLATFORM,
             raiseValueError(
                 f"Wheel abi 'cp35m' .* Supported abis are 'abi3' and '{cpver}'."
             ),
         ),
-        ("cp35", "abi3", "emscripten_3_1_14_wasm32", does_not_raise()),
-        (cpver, "abi3", "emscripten_3_1_14_wasm32", does_not_raise()),
-        (cpver, cpver, "emscripten_3_1_14_wasm32", does_not_raise()),
+        ("cp35", "abi3", PLATFORM, does_not_raise()),
+        (cpver, "abi3", PLATFORM, does_not_raise()),
+        (cpver, cpver, PLATFORM, does_not_raise()),
         (
             "cp35",
             cpver,
-            "emscripten_3_1_14_wasm32",
+            PLATFORM,
             raiseValueError("Wheel interpreter version 'cp35' is not supported."),
         ),
         (
             "cp391",
             "abi3",
-            "emscripten_3_1_14_wasm32",
+            PLATFORM,
             raiseValueError("Wheel interpreter version 'cp391' is not supported."),
         ),
     ],

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -12,6 +12,10 @@ from packaging.utils import parse_wheel_filename
 from .io import parse_package_config
 
 
+def emscripten_version():
+    return get_make_flag("PYODIDE_EMSCRIPTEN_VERSION")
+
+
 def platform():
     emscripten_version = get_make_flag("PYODIDE_EMSCRIPTEN_VERSION")
     version = emscripten_version.replace(".", "_")


### PR DESCRIPTION
If the wheel is an Emscripten wheel of the wrong version, give the expected version and the wheel version. Otherwise, complain about platform mismatch.  