### PR TITLE
Update Rust nightly version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,8 +243,8 @@ SETUPTOOLS_RUST_COMMIT=5e8c380429aba1e5df5815dcf921025c599cecec
 rust:
 	wget https://sh.rustup.rs -O /rustup.sh
 	sh /rustup.sh -y
-	source $(HOME)/.cargo/env && rustup toolchain install nightly-2022-06-14 && rustup default nightly-2022-06-14
-	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain nightly-2022-06-14
+	source $(HOME)/.cargo/env && rustup toolchain install $(RUST_TOOLCHAIN) && rustup default $(RUST_TOOLCHAIN)
+	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain $(RUST_TOOLCHAIN)
 	# Install setuptools-rust with a fix for Wasm targets
 	# TODO: Remove this when they release the next version.
 	pip install -t $(HOSTSITEPACKAGES) git+https://github.com/PyO3/setuptools-rust.git@$(SETUPTOOLS_RUST_COMMIT)

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -149,10 +149,11 @@ export CARGO_HOME ?= $(HOME)/.cargo
 export CARGO_BUILD_TARGET=wasm32-unknown-emscripten
 export CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_LINKER=emcc
 export PYO3_CONFIG_FILE=$(PYODIDE_ROOT)/tools/pyo3_config.ini
+export RUST_TOOLCHAIN=nightly-2022-06-25
+
 
 # idealy we could automatically include all SIDE_MODULE_LDFLAGS here
 export RUSTFLAGS= \
-	-C relocation-model=pic \
 	-C link-arg=-sSIDE_MODULE=2 \
 	-C link-arg=-sWASM_BIGINT \
 	-Z link-native-libraries=no

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -149,7 +149,7 @@ export CARGO_HOME ?= $(HOME)/.cargo
 export CARGO_BUILD_TARGET=wasm32-unknown-emscripten
 export CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_LINKER=emcc
 export PYO3_CONFIG_FILE=$(PYODIDE_ROOT)/tools/pyo3_config.ini
-export RUST_TOOLCHAIN=nightly-2022-06-25
+export RUST_TOOLCHAIN=nightly-2022-06-26
 
 
 # idealy we could automatically include all SIDE_MODULE_LDFLAGS here


### PR DESCRIPTION
Yesterday's nightly includes https://github.com/rust-lang/rust/pull/98149 which allows us to remove the PIC setting. This also means we won't ever have to put `-Zbuild-std` back in.