### PR TITLE
Add macros to extract common logic for calling into Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ src/js/pyproxy.gen.ts : src/core/pyproxy.* src/core/*.h
 	echo "// Do not edit it directly!" >> $@
 	cat src/core/pyproxy.ts | \
 		sed '/^\/\/\s*pyodide-skip/,/^\/\/\s*end-pyodide-skip/d' | \
-		$(CC) -E -C -P -imacros src/core/pyproxy.c $(MAIN_MODULE_CFLAGS) - \
+		$(CC) -E -C -P -imacros src/core/pyproxy.c -imacros src/core/pyproxy.ts.h $(MAIN_MODULE_CFLAGS) - \
 		>> $@
 
 dist/test.html: src/templates/test.html

--- a/src/core/pyproxy.ts.h
+++ b/src/core/pyproxy.ts.h
@@ -1,0 +1,24 @@
+#define PY(x, y...) x y
+
+#define ENTER(arg1, rest...)                                                   \
+  try {                                                                        \
+    Module.HEAP32[Module._entry_depth]++;                                      \
+    arg1;                                                                      \
+    rest;                                                                      \
+    Module.HEAP32[Module._entry_depth]--;                                      \
+  } catch (e) {                                                                \
+    API.fatal_error(e);                                                        \
+  }
+
+#define WHILE(cond, body...)                                                   \
+  while (cond) {                                                               \
+    body;                                                                      \
+  }
+
+#define DO(args...) args
+
+#define FINALLY(args...)                                                       \
+  finally                                                                      \
+  {                                                                            \
+    args                                                                       \
+  }


### PR DESCRIPTION
This makes new macros to extract the common logic for try, catch, finally blocks when calling into Python. The main reason to do this is so that we can easily adjust all of these entry points at the same time. In particular, I want to add a counter that tracks the entry depth so that we can have special handling for certain errors (for instance, `SystemExit`) when exiting the outermost Python layer.