### PR TITLE
Implement interpreter shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ src/js/pyproxy.gen.ts : src/core/pyproxy.* src/core/*.h
 	echo "// Do not edit it directly!" >> $@
 	cat src/core/pyproxy.ts | \
 		sed '/^\/\/\s*pyodide-skip/,/^\/\/\s*end-pyodide-skip/d' | \
-		$(CC) -E -C -P -imacros src/core/pyproxy.c $(MAIN_MODULE_CFLAGS) - \
+		$(CC) -E -C -P -imacros src/core/pyproxy.c -imacros src/core/pyproxy.ts.h $(MAIN_MODULE_CFLAGS) - \
 		>> $@
 
 dist/test.html: src/templates/test.html

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -105,6 +105,7 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s EXPORT_ALL=1 \
 	-s POLYFILL \
+	-s EXIT_RUNTIME=1 \
 	\
 	-lpython$(PYMAJOR).$(PYMINOR) \
 	-lffi \

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -166,6 +166,12 @@ finally:
   return result;
 }
 
+int entry_depth = 0;
+int may_exit = 1;
+
+int
+_Py_HandleSystemExit(int*);
+
 /**
  * Wrap the exception in a JavaScript PythonError object.
  *
@@ -189,6 +195,12 @@ wrap_exception()
   PyObject* traceback = NULL;
   PyObject* pystr = NULL;
   JsRef jserror = NULL;
+  if (entry_depth == 0) {
+    int exitcode;
+    if (may_exit && _Py_HandleSystemExit(&exitcode)) {
+      Py_Exit(exitcode);
+    }
+  }
   fetch_and_normalize_exception(&type, &value, &traceback);
   store_sys_last_exception(type, value, traceback);
 

--- a/src/core/pyproxy.ts.h
+++ b/src/core/pyproxy.ts.h
@@ -1,0 +1,24 @@
+#define PY(x, y...) x y
+
+#define ENTER(arg1, rest...)                                                   \
+  try {                                                                        \
+    Module.HEAP32[Module._entry_depth]++;                                      \
+    arg1;                                                                      \
+    rest;                                                                      \
+    Module.HEAP32[Module._entry_depth]--;                                      \
+  } catch (e) {                                                                \
+    API.fatal_error(e);                                                        \
+  }
+
+#define WHILE(cond, body...)                                                   \
+  while (cond) {                                                               \
+    body;                                                                      \
+  }
+
+#define DO(args...) args
+
+#define FINALLY(args...)                                                       \
+  finally                                                                      \
+  {                                                                            \
+    args                                                                       \
+  }


### PR DESCRIPTION
This is on top of #2795. It adds an option `exitMode` which can be set to:
* "no-exit": current behavior.
* "throw": Shut down interpreter then throw an error
* "quit-process": in browser, is the same as "throw". In node, `sys.exit(returncode)` will exit the node process with the given return code.

"quit-process" will be useful when running pytest.

TODO: close out `pyodide` API after shutdown.

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
