### PR TITLE
Package: add termcolor

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -203,7 +203,7 @@ substitutions:
   svgwrite, jsonschema, tskit {pr}`2506`, xarray {pr}`2538`, demes, libgsl, newick,
   ruamel, msprime {pr}`2548`, gmpy2 {pr}`2665`, xgboost {pr}`2537`, galpy {pr}`2676`,
   shapely, geos {pr}`2725`, suitesparse, sparseqr {pr}`2685`, libtiff {pr}`2762`,
-  pytest-benchmark {pr}`2799`,
+  pytest-benchmark {pr}`2799`, termcolor {pr}`2809`
 
 ### Miscellaneous
 

--- a/packages/termcolor/meta.yaml
+++ b/packages/termcolor/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: termcolor
+  version: 1.1.0
+source:
+  url: https://files.pythonhosted.org/packages/8a/48/a76be51647d0eb9f10e2a4511bf3ffb8cc1e6b14e9e4fab46173aa79f981/termcolor-1.1.0.tar.gz
+  sha256: 1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b
+test:
+  imports:
+    - termcolor
+about:
+  home: http://pypi.python.org/pypi/termcolor
+  PyPI: https://pypi.org/project/termcolor
+  summary: ANSII Color formatting for output in terminal.
+  license: MIT

--- a/packages/termcolor/test_termcolor.py
+++ b/packages/termcolor/test_termcolor.py
@@ -1,0 +1,20 @@
+from pyodide_test_runner.decorator import run_in_pyodide
+
+
+@run_in_pyodide(packages=["termcolor"])
+def test_termcolor(selenium):
+    import sys
+    from termcolor import colored, cprint
+
+    text = colored('Hello, World!', 'red', attrs=['reverse', 'blink'])
+    print(text)
+    cprint('Hello, World!', 'green', 'on_red')
+
+    print_red_on_cyan = lambda x: cprint(x, 'red', 'on_cyan')
+    print_red_on_cyan('Hello, World!')
+    print_red_on_cyan('Hello, Universe!')
+
+    for i in range(10):
+        cprint(i, 'magenta', end=' ')
+
+    cprint("Attention!", 'red', attrs=['bold'], file=sys.stderr)

--- a/packages/termcolor/test_termcolor.py
+++ b/packages/termcolor/test_termcolor.py
@@ -5,7 +5,7 @@ from pyodide_test_runner.decorator import run_in_pyodide
 def test_termcolor(selenium):
     import sys
 
-    from termcolor import colored, cprint
+    from termcolor import colored, cprint  # type: ignore[import]
 
     text = colored("Hello, World!", "red", attrs=["reverse", "blink"])
     print(text)

--- a/packages/termcolor/test_termcolor.py
+++ b/packages/termcolor/test_termcolor.py
@@ -4,17 +4,18 @@ from pyodide_test_runner.decorator import run_in_pyodide
 @run_in_pyodide(packages=["termcolor"])
 def test_termcolor(selenium):
     import sys
+
     from termcolor import colored, cprint
 
-    text = colored('Hello, World!', 'red', attrs=['reverse', 'blink'])
+    text = colored("Hello, World!", "red", attrs=["reverse", "blink"])
     print(text)
-    cprint('Hello, World!', 'green', 'on_red')
+    cprint("Hello, World!", "green", "on_red")
 
-    print_red_on_cyan = lambda x: cprint(x, 'red', 'on_cyan')
-    print_red_on_cyan('Hello, World!')
-    print_red_on_cyan('Hello, Universe!')
+    print_red_on_cyan = lambda x: cprint(x, "red", "on_cyan")
+    print_red_on_cyan("Hello, World!")
+    print_red_on_cyan("Hello, Universe!")
 
     for i in range(10):
-        cprint(i, 'magenta', end=' ')
+        cprint(i, "magenta", end=" ")
 
-    cprint("Attention!", 'red', attrs=['bold'], file=sys.stderr)
+    cprint("Attention!", "red", attrs=["bold"], file=sys.stderr)


### PR DESCRIPTION
Termcolor doesn't have a wheel on pypi and doesn't look very maintained. It is used by `pytest-sugar`.