### PR TITLE
Add plotly package

### DIFF
--- a/packages/plotly/meta.yaml
+++ b/packages/plotly/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: plotly
+  version: 5.9.0
+source:
+  url: https://files.pythonhosted.org/packages/2d/6a/2c2e9ed190066646bbf1620c0b67f8e363e0024ee7bf0d3ea1fdcc9af3ae/plotly-5.9.0-py2.py3-none-any.whl
+  sha256: 9acf168915101caac82ed6da3390840c622d9d4e4a78cbe1260f52501efc3117
+test:
+  imports:
+    - plotly
+about:
+  home: https://plotly.com/python/
+  PyPI: https://pypi.org/project/plotly
+  summary: An open-source, interactive data visualization library for Python
+  license: MIT

--- a/packages/plotly/test_plotly.py
+++ b/packages/plotly/test_plotly.py
@@ -1,0 +1,12 @@
+from pyodide_test_runner import run_in_pyodide
+
+
+@run_in_pyodide(packages=["plotly"])
+def test_plotly(selenium):
+    import plotly.express as px
+
+    df = px.data.gapminder().query("country=='Canada'")
+    fig = px.line(df, x="year", y="lifeExp", title='Life expectancy in Canada')
+    fig.show()
+
+    

--- a/packages/plotly/test_plotly.py
+++ b/packages/plotly/test_plotly.py
@@ -6,7 +6,5 @@ def test_plotly(selenium):
     import plotly.express as px
 
     df = px.data.gapminder().query("country=='Canada'")
-    fig = px.line(df, x="year", y="lifeExp", title='Life expectancy in Canada')
+    fig = px.line(df, x="year", y="lifeExp", title="Life expectancy in Canada")
     fig.show()
-
-    


### PR DESCRIPTION
### Description
Adds `plotly` to the provided packages. This package offers several additional types of charts and visualizations and complements `bokeh`, which is already included in `pyodide`. Makes it easier to start producing charts without having to install the package in code (because it can be loaded directly using `loadPackagesFromImports`).


### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation
