### PR TITLE
Drop deprecated usage of APIs

### DIFF
--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -49,7 +49,6 @@ API.runPythonInternal = function (code: string): any {
   return API._pyodide._base.eval_code(code, API.runPythonInternal_dict);
 };
 
-let runPythonPositionalGlobalsDeprecationWarned = false;
 /**
  * Runs a string of Python code from JavaScript, using :any:`pyodide.code.eval_code`
  * to evaluate the code. If the last statement in the Python code is an
@@ -74,15 +73,6 @@ export function runPython(
   code: string,
   options: { globals?: PyProxy } = {}
 ): any {
-  if (API.isPyProxy(options)) {
-    options = { globals: options as PyProxy };
-    if (!runPythonPositionalGlobalsDeprecationWarned) {
-      console.warn(
-        "Passing a PyProxy as the second argument to runPython is deprecated and will be removed in v0.21. Use 'runPython(code, {globals : some_dict})' instead."
-      );
-      runPythonPositionalGlobalsDeprecationWarned = true;
-    }
-  }
   if (!options.globals) {
     options.globals = API.globals;
   }
@@ -184,15 +174,6 @@ export async function runPythonAsync(
   code: string,
   options: { globals?: PyProxy } = {}
 ): Promise<any> {
-  if (API.isPyProxy(options)) {
-    options = { globals: options as PyProxy };
-    if (!runPythonPositionalGlobalsDeprecationWarned) {
-      console.warn(
-        "Passing a PyProxy as the second argument to runPythonAsync is deprecated and will be removed in v0.21. Use 'runPythonAsync(code, {globals : some_dict})' instead."
-      );
-      runPythonPositionalGlobalsDeprecationWarned = true;
-    }
-  }
   if (!options.globals) {
     options.globals = API.globals;
   }
@@ -344,7 +325,6 @@ export function pyimport(mod_name: string): PyProxy {
   return API.importlib.import_module(mod_name);
 }
 
-let unpackArchivePositionalExtractDirDeprecationWarned = false;
 /**
  * Unpack an archive into a target directory.
  *
@@ -372,15 +352,6 @@ export function unpackArchive(
     extractDir?: string;
   } = {}
 ) {
-  if (typeof options === "string") {
-    if (!unpackArchivePositionalExtractDirDeprecationWarned) {
-      console.warn(
-        "Passing a string as the third argument to unpackArchive is deprecated and will be removed in v0.21. Instead use { extract_dir : 'some_path' }"
-      );
-      unpackArchivePositionalExtractDirDeprecationWarned = true;
-    }
-    options = { extractDir: options };
-  }
   if (
     !ArrayBuffer.isView(buffer) &&
     Object.prototype.toString.call(buffer) !== "[object ArrayBuffer]"

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -183,33 +183,6 @@ def test_eval_code_locals():
     eval_code("invalidate_caches()", globals, locals)
 
 
-def test_deprecations(selenium_standalone):
-    selenium = selenium_standalone
-    selenium.run_js(
-        """
-        let d = pyodide.runPython("{}");
-        pyodide.runPython("x=2", d);
-        pyodide.runPython("y=2", d);
-        assert(() => d.get("x") === 2);
-        d.destroy();
-        """
-    )
-    dep_msg = "Passing a PyProxy as the second argument to runPython is deprecated and will be removed in v0.21. Use 'runPython(code, {globals : some_dict})' instead."
-    assert selenium.logs.count(dep_msg) == 1
-    selenium.run_js(
-        """
-        pyodide.runPython(`
-            import shutil
-            shutil.make_archive("blah", "zip")
-        `);
-        pyodide.unpackArchive(pyodide.FS.readFile("blah.zip"), "zip", "abc");
-        pyodide.unpackArchive(pyodide.FS.readFile("blah.zip"), "zip", "abc");
-        """
-    )
-    dep_msg = "Passing a string as the third argument to unpackArchive is deprecated and will be removed in v0.21. Instead use { extract_dir : 'some_path' }"
-    assert selenium.logs.count(dep_msg) == 1
-
-
 def test_unpack_archive(selenium_standalone):
     selenium = selenium_standalone
     js_error = selenium.run_js(


### PR DESCRIPTION
Following the [deprecation timeline](https://github.com/pyodide/pyodide/blob/main/docs/project/deprecation-timeline.md#0210).