### PR TITLE
Fix GHA timeout on firefox test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,8 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -r requirements.txt
-          pip install playwright && python -m playwright install
+          # FIXME: playwright 1.23.0 has unknown performance issue on firefox
+          pip install playwright<1.23.0 && python -m playwright install
 
       - name: run core tests
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           # FIXME: playwright 1.23.0 has unknown performance issue on firefox
-          pip install playwright<1.23.0 && python -m playwright install
+          pip install "playwright<1.23.0" && python -m playwright install
 
       - name: run core tests
         env:

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -14,7 +14,7 @@ from pyodide_test_runner.hypothesis import (
 
 
 @given(s=text())
-@settings(deadline=15000)
+@settings(deadline=4000)
 def test_string_conversion(selenium_module_scope, s):
     @run_in_pyodide
     def main(selenium, sbytes):

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -14,7 +14,7 @@ from pyodide_test_runner.hypothesis import (
 
 
 @given(s=text())
-@settings(deadline=4000)
+@settings(deadline=15000)
 def test_string_conversion(selenium_module_scope, s):
     @run_in_pyodide
     def main(selenium, sbytes):


### PR DESCRIPTION
For some reason, the recent playwright-python update (`v.1.23.0`) made this test slower on firefox, which results in a CI timeout.