### PR TITLE
Respect symbol visibility in export calculation

### DIFF
--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -402,7 +402,12 @@ def calculate_object_exports(objects):
     # llvm-readobj output is almost valid JSON...
     output = '[{"Sections":' + completedprocess.stdout.partition('"Sections":')[-1]
     result = []
-    for x in json.loads(output)[1]["Symbols"]:
+    try:
+        parsed_json = json.loads(output)
+    except json.decoder.JSONDecodeError:
+        print(output)
+        raise
+    for x in parsed_json[1]["Symbols"]:
         symbol = x["Symbol"]
         flags = [x["Name"] for x in symbol["Flags"]["Flags"]]
         if (

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -428,7 +428,6 @@ def calculate_object_exports(objects):
                         "Didn't find symbol's name:\n" + "\n".join(symbol_lines)
                     )
                 result.append(name)
-    print(result)
     return result
 
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -122,9 +122,7 @@ def get_build_env(
     args["exports"] = exports
 
     with TemporaryDirectory() as symlink_dir_str:
-        symlink_dir_str = ".pyodide_build_env"
         symlink_dir = Path(symlink_dir_str)
-        symlink_dir.mkdir(exist_ok=True)
         env = dict(env)
         make_command_wrapper_symlinks(symlink_dir, env)
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -393,7 +393,7 @@ def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
         if line.startswith("Name:"):
             name = line.removeprefix("Name:").strip()
         if (
-            line.startswith("BINDING_LOCAL")
+            line.startswith(("BINDING_LOCAL", "UNDEFINED", "VISIBILITY_HIDDEN"))
             or line.startswith("UNDEFINED")
             or line.startswith("VISIBILITY_HIDDEN")
         ):
@@ -428,7 +428,7 @@ def calculate_exports(line: list[str], export_all: bool) -> Iterable[str]:
     then return all public symbols. If not, return only the public symbols that
     begin with `PyInit`.
     """
-    objects = [arg for arg in line if arg.endswith(".a") or arg.endswith(".o")]
+    objects = [arg for arg in line if arg.endswith((".a", ".o"))]
     exports = None
     # Using emnm is simpler but it cannot handle bitcode. If we're only
     # exporting the PyInit symbols, save effort by using nm.

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -392,11 +392,7 @@ def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
         symbol_lines.append(line)
         if line.startswith("Name:"):
             name = line.removeprefix("Name:").strip()
-        if (
-            line.startswith(("BINDING_LOCAL", "UNDEFINED", "VISIBILITY_HIDDEN"))
-            or line.startswith("UNDEFINED")
-            or line.startswith("VISIBILITY_HIDDEN")
-        ):
+        if line.startswith(("BINDING_LOCAL", "UNDEFINED", "VISIBILITY_HIDDEN")):
             export = False
         if line == "}":
             insymbol = False

--- a/pyodide-build/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide-build/pyodide_build/tests/test_pywasmcross.py
@@ -182,18 +182,20 @@ def test_environment_var_substitution(monkeypatch):
 
 def test_exports_node(tmp_path):
     template = """
+        int l();
+
         __attribute__((visibility("hidden")))
         int f%s() {
-            return 0;
+            return l();
         }
 
         __attribute__ ((visibility ("default")))
         int g%s() {
-            return 0;
+            return l();
         }
 
         int h%s(){
-            return 0;
+            return l();
         }
         """
     (tmp_path / "f1.c").write_text(template % (1, 1, 1))


### PR DESCRIPTION
We shouldn't export symbols with `__attribute__((visibility("hidden")))`. Numpy has a test to check that symbols with this attribute aren't exported. This fixes that test.