### PR TITLE
Fix pywasmcross when pyodide_build is installed out of tree

### DIFF
--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -15,9 +15,10 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 PYWASMCROSS_ARGS: dict[str, Any] = {}
+IS_COMPILER_INVOCATION: bool = False
 
 
-def _compiler_setup() -> bool:
+def _compiler_setup() -> None:
     import __main__
 
     env_folder = Path(__main__.__file__).parent
@@ -25,7 +26,10 @@ def _compiler_setup() -> bool:
     if env_folder.name in ["pyodide_build", "bin"]:
         # ENV_FOLDER.name == "pyodide_build": we are being run via `python -m pyodide_build`,
         # ENV_FOLDER.name == "bin": we are being run via a console entrypoint
-        return False
+        return
+
+    global IS_COMPILER_INVOCATION
+    IS_COMPILER_INVOCATION = True
 
     global PYWASMCROSS_ARGS
     # If possible load from environment variable, if necessary load from disk.
@@ -40,10 +44,9 @@ def _compiler_setup() -> bool:
     # restore __name__ so that relative imports work as we expect
     global __name__
     __name__ = PYWASMCROSS_ARGS.pop("orig__name__")
-    return True
 
 
-IS_MAIN = _compiler_setup()
+_compiler_setup()
 del _compiler_setup
 
 import re
@@ -633,7 +636,7 @@ def environment_substitute_args(
     return subbed_args
 
 
-def main():
+def compiler_main():
     REPLAY_ARGS = ReplayArgs(**PYWASMCROSS_ARGS)
 
     basename = Path(sys.argv[0]).name
@@ -645,5 +648,5 @@ def main():
         raise Exception(f"Unexpected invocation '{basename}'")
 
 
-if IS_MAIN:
-    main()
+if IS_COMPILER_INVOCATION:
+    compiler_main()

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -18,32 +18,30 @@ PYWASMCROSS_ARGS: dict[str, Any] = {}
 IS_COMPILER_INVOCATION: bool = False
 
 
-def _get_pywasmcross_args(env_folder: Path) -> dict[str, Any]:
-    # If possible load from environment variable, if necessary load from disk.
-    if "PYWASMCROSS_ARGS" in os.environ:
-        return json.loads(os.environ["PYWASMCROSS_ARGS"])
-    try:
-        with open(env_folder / "pywasmcross_env.json") as f:
-            return json.load(f)
-    except FileNotFoundError:
-        raise RuntimeError(f"Unexpected invocation. Parent directory: {env_folder}")
-
-
 def _compiler_setup() -> None:
     import __main__
 
     env_folder = Path(__main__.__file__).parent
 
-    if env_folder.name in ["pyodide_build", "bin"]:
-        # ENV_FOLDER.name == "pyodide_build": we are being run via `python -m pyodide_build`,
-        # ENV_FOLDER.name == "bin": we are being run via a console entrypoint
+    # Known cases where we aren't a compiler invocation
+    if env_folder.name in ["pyodide_build", "bin", "sphinx"]:
         return
+
+    global PYWASMCROSS_ARGS
+    # If possible load from environment variable, if necessary load from disk.
+    if "PYWASMCROSS_ARGS" in os.environ:
+        PYWASMCROSS_ARGS = json.loads(os.environ["PYWASMCROSS_ARGS"])
+    try:
+        with open(env_folder / "pywasmcross_env.json") as f:
+            PYWASMCROSS_ARGS = json.load(f)
+    except FileNotFoundError:
+        raise RuntimeError(
+            "Invalid invocation: can't find PYWASMCROSS_ARGS."
+            f" Invoked from {env_folder}."
+        )
 
     global IS_COMPILER_INVOCATION
     IS_COMPILER_INVOCATION = True
-
-    global PYWASMCROSS_ARGS
-    PYWASMCROSS_ARGS = _get_pywasmcross_args(env_folder)
 
     sys.path = PYWASMCROSS_ARGS.pop("PYTHONPATH")
     os.environ["PATH"] = PYWASMCROSS_ARGS.pop("PATH")

--- a/pyodide-build/setup.py
+++ b/pyodide-build/setup.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     setuptools.setup(
         entry_points={
             "console_scripts": [
-                "_pywasmcross = pyodide_build.pywasmcross:main",
+                "_pywasmcross = pyodide_build.pywasmcross:compiler_main",
             ]
         }
     )

--- a/pyodide-build/setup.py
+++ b/pyodide-build/setup.py
@@ -2,4 +2,10 @@
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(
+        entry_points={
+            "console_scripts": [
+                "_pywasmcross = pyodide_build.pywasmcross:entry",
+            ]
+        }
+    )

--- a/pyodide-build/setup.py
+++ b/pyodide-build/setup.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     setuptools.setup(
         entry_points={
             "console_scripts": [
-                "_pywasmcross = pyodide_build.pywasmcross:entry",
+                "_pywasmcross = pyodide_build.pywasmcross:main",
             ]
         }
     )


### PR DESCRIPTION
Symlinking `cc` to `pywasmcross.py` only works if `pywasmcross.py` has execute permissions. When we install the package with `pip`, it will not set execute permissions on `pywasmcross.py`. It does set execute flags on entrypoints. Thus, define an entrypoint called `_pywasmcross` which calls `pywasmcross.main`. If a script called `_pywasmcross` exists, we are using an out-of-tree install so symlink cc to `_pywasmcross`. Otherwise, we should be in tree and `pywasmcross.py` should have the execute flag set, so symlink cc to `pywasmcross.py`.

On the other side, if `__main__.__file__` is in a folder named `pyodide_build` or `bin` we are being invoked normally, otherwise we are being invoked via a symlink.

Split off from #2823.