### PR TITLE
Write built packages to a file in package build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,9 @@ jobs:
             source pyodide_env.sh
 
             ccache -z
-            PYODIDE_PACKAGES="core" make
+            PYODIDE_PACKAGES="core" \
+              WRITE_BUILT_PACKAGES=$CIRCLE_JOB \
+              make
             ccache -s
 
       - run:
@@ -145,7 +147,9 @@ jobs:
             touch -m -d '1 Jan 2021 12:00' emsdk/emsdk/.emscripten
 
             ccache -z
-            PYODIDE_PACKAGES='<< parameters.packages >>' make -C packages
+            PYODIDE_PACKAGES='<< parameters.packages >>' \
+              WRITE_BUILT_PACKAGES=$CIRCLE_JOB \
+              make -C packages
             ccache -s
           environment:
             PYODIDE_JOBS: 5

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -8,11 +8,18 @@ else
 	ONLY_PACKAGES=--only "$(PYODIDE_PACKAGES)"
 endif
 
+ifeq ($(strip $(WRITE_BUILT_PACKAGES)),)
+else
+	WRITE_BUILT_PACKAGES_FLAG=--write-built-packages ./build-logs/$(WRITE_BUILT_PACKAGES)
+endif
+
+
 all: pyodide-build
 	mkdir -p $(HOSTINSTALLDIR) $(WASM_LIBRARY_DIR)
 	PYODIDE_ROOT=$(PYODIDE_ROOT) python -m pyodide_build buildall . $(PYODIDE_ROOT)/dist \
-	$(ONLY_PACKAGES) --n-jobs $${PYODIDE_JOBS:-4} \
-	--log-dir=./build-logs
+		$(ONLY_PACKAGES) --n-jobs $${PYODIDE_JOBS:-4} \
+		--log-dir=./build-logs \
+		$(WRITE_BUILT_PACKAGES_FLAG)
 
 pyodide-build: ../pyodide-build/pyodide_build/**
 	$(HOSTPYTHON) -m pip install -e ../pyodide-build


### PR DESCRIPTION
This is partial work towards splitting up the package test jobs into several different pieces so that it isn't necessary to wait for scipy and open-cv to build to test packages that don't depend on numpy.