### PR TITLE
Refactor hiwire.[ch] to divide functions declarations into better groups

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -280,7 +280,6 @@ EM_JS_NUM(int, hiwire_init, (), {
   return 0;
 });
 
-
 EM_JS(JsRef, hiwire_incref, (JsRef idval), {
   if (idval & 1) {
     // least significant bit unset ==> idval is a singleton.
@@ -778,7 +777,6 @@ EM_JS_REF(JsRef, hiwire_subarray, (JsRef idarr, int start, int end), {
   return Hiwire.new_value(jssub);
 });
 
-
 // ==================== JsArray API  ====================
 
 EM_JS_BOOL(bool, JsArray_Check, (JsRef idobj), {
@@ -927,7 +925,6 @@ JsString_FromId(Js_Identifier* id)
   }
   return id->object;
 }
-
 
 // ==================== JsMap API  ====================
 

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -18,8 +18,6 @@ const JsRef Js_null = ((JsRef)(8));
 // For when the return value would be Option<JsRef>
 const JsRef Js_novalue = ((JsRef)(10));
 
-
-
 JsRef
 hiwire_from_bool(bool boolean)
 {

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -18,6 +18,8 @@ const JsRef Js_null = ((JsRef)(8));
 // For when the return value would be Option<JsRef>
 const JsRef Js_novalue = ((JsRef)(10));
 
+
+
 JsRef
 hiwire_from_bool(bool boolean)
 {
@@ -280,19 +282,6 @@ EM_JS_NUM(int, hiwire_init, (), {
   return 0;
 });
 
-EM_JS_REF(JsRef, JsString_InternFromCString, (const char* str), {
-  let jsstring = UTF8ToString(str);
-  return Hiwire.intern_object(jsstring);
-})
-
-JsRef
-JsString_FromId(Js_Identifier* id)
-{
-  if (!id->object) {
-    id->object = JsString_InternFromCString(id->string);
-  }
-  return id->object;
-}
 
 EM_JS(JsRef, hiwire_incref, (JsRef idval), {
   if (idval & 1) {
@@ -369,120 +358,6 @@ EM_JS_REF(JsRef, hiwire_string_ascii, (const char* ptr), {
 
 EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
   throw Hiwire.pop_value(iderr);
-});
-
-EM_JS_BOOL(bool, JsArray_Check, (JsRef idobj), {
-  let obj = Hiwire.get_value(idobj);
-  if (Array.isArray(obj)) {
-    return true;
-  }
-  let typeTag = Object.prototype.toString.call(obj);
-  // We want to treat some standard array-like objects as Array.
-  // clang-format off
-  if(typeTag === "[object HTMLCollection]" || typeTag === "[object NodeList]"){
-    // clang-format on
-    return true;
-  }
-  // What if it's a TypedArray?
-  // clang-format off
-  if (ArrayBuffer.isView(obj) && obj.constructor.name !== "DataView") {
-    // clang-format on
-    return true;
-  }
-  return false;
-});
-
-// clang-format off
-EM_JS_REF(JsRef, JsArray_New, (), {
-  return Hiwire.new_value([]);
-});
-// clang-format on
-
-EM_JS_NUM(errcode, JsArray_Push, (JsRef idarr, JsRef idval), {
-  Hiwire.get_value(idarr).push(Hiwire.get_value(idval));
-});
-
-EM_JS(int, JsArray_Push_unchecked, (JsRef idarr, JsRef idval), {
-  const arr = Hiwire.get_value(idarr);
-  arr.push(Hiwire.get_value(idval));
-  return arr.length - 1;
-});
-
-// clang-format off
-EM_JS_REF(JsRef, JsObject_New, (), {
-  return Hiwire.new_value({});
-});
-// clang-format on
-
-EM_JS_REF(JsRef, JsObject_GetString, (JsRef idobj, const char* ptrkey), {
-  let jsobj = Hiwire.get_value(idobj);
-  let jskey = UTF8ToString(ptrkey);
-  let result = jsobj[jskey];
-  // clang-format off
-  if (result === undefined && !(jskey in jsobj)) {
-    // clang-format on
-    return ERROR_REF;
-  }
-  return Hiwire.new_value(result);
-});
-
-// clang-format off
-EM_JS_NUM(errcode,
-          JsObject_SetString,
-          (JsRef idobj, const char* ptrkey, JsRef idval),
-{
-  let jsobj = Hiwire.get_value(idobj);
-  let jskey = UTF8ToString(ptrkey);
-  let jsval = Hiwire.get_value(idval);
-  jsobj[jskey] = jsval;
-});
-// clang-format on
-
-EM_JS_NUM(errcode, JsObject_DeleteString, (JsRef idobj, const char* ptrkey), {
-  let jsobj = Hiwire.get_value(idobj);
-  let jskey = UTF8ToString(ptrkey);
-  delete jsobj[jskey];
-});
-
-EM_JS_REF(JsRef, JsArray_Get, (JsRef idobj, int idx), {
-  let obj = Hiwire.get_value(idobj);
-  let result = obj[idx];
-  // clang-format off
-  if (result === undefined && !(idx in obj)) {
-    // clang-format on
-    return ERROR_REF;
-  }
-  return Hiwire.new_value(result);
-});
-
-EM_JS_NUM(errcode, JsArray_Set, (JsRef idobj, int idx, JsRef idval), {
-  Hiwire.get_value(idobj)[idx] = Hiwire.get_value(idval);
-});
-
-EM_JS_NUM(errcode, JsArray_Delete, (JsRef idobj, int idx), {
-  let obj = Hiwire.get_value(idobj);
-  // Weird edge case: allow deleting an empty entry, but we raise a key error if
-  // access is attempted.
-  if (idx < 0 || idx >= obj.length) {
-    return ERROR_NUM;
-  }
-  obj.splice(idx, 1);
-});
-
-EM_JS_REF(JsRef, JsObject_Dir, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  let result = [];
-  do {
-    // clang-format off
-    result.push(... Object.getOwnPropertyNames(jsobj).filter(
-      s => {
-        let c = s.charCodeAt(0);
-        return c < 48 || c > 57; /* Filter out integer array indices */
-      }
-    ));
-    // clang-format on
-  } while (jsobj = Object.getPrototypeOf(jsobj));
-  return Hiwire.new_value(result);
 });
 
 static JsRef
@@ -838,21 +713,6 @@ EM_JS_REF(JsRef, hiwire_get_iterator, (JsRef idobj), {
   return Hiwire.new_value(jsobj[Symbol.iterator]());
 })
 
-EM_JS_REF(JsRef, JsObject_Entries, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  return Hiwire.new_value(Object.entries(jsobj));
-});
-
-EM_JS_REF(JsRef, JsObject_Keys, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  return Hiwire.new_value(Object.keys(jsobj));
-});
-
-EM_JS_REF(JsRef, JsObject_Values, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  return Hiwire.new_value(Object.values(jsobj));
-});
-
 EM_JS_BOOL(bool, hiwire_is_typedarray, (JsRef idobj), {
   let jsobj = Hiwire.get_value(idobj);
   // clang-format off
@@ -920,6 +780,159 @@ EM_JS_REF(JsRef, hiwire_subarray, (JsRef idarr, int start, int end), {
   return Hiwire.new_value(jssub);
 });
 
+
+// ==================== JsArray API  ====================
+
+EM_JS_BOOL(bool, JsArray_Check, (JsRef idobj), {
+  let obj = Hiwire.get_value(idobj);
+  if (Array.isArray(obj)) {
+    return true;
+  }
+  let typeTag = Object.prototype.toString.call(obj);
+  // We want to treat some standard array-like objects as Array.
+  // clang-format off
+  if(typeTag === "[object HTMLCollection]" || typeTag === "[object NodeList]"){
+    // clang-format on
+    return true;
+  }
+  // What if it's a TypedArray?
+  // clang-format off
+  if (ArrayBuffer.isView(obj) && obj.constructor.name !== "DataView") {
+    // clang-format on
+    return true;
+  }
+  return false;
+});
+
+// clang-format off
+EM_JS_REF(JsRef, JsArray_New, (), {
+  return Hiwire.new_value([]);
+});
+// clang-format on
+
+EM_JS_NUM(errcode, JsArray_Push, (JsRef idarr, JsRef idval), {
+  Hiwire.get_value(idarr).push(Hiwire.get_value(idval));
+});
+
+EM_JS(int, JsArray_Push_unchecked, (JsRef idarr, JsRef idval), {
+  const arr = Hiwire.get_value(idarr);
+  arr.push(Hiwire.get_value(idval));
+  return arr.length - 1;
+});
+
+EM_JS_REF(JsRef, JsArray_Get, (JsRef idobj, int idx), {
+  let obj = Hiwire.get_value(idobj);
+  let result = obj[idx];
+  // clang-format off
+  if (result === undefined && !(idx in obj)) {
+    // clang-format on
+    return ERROR_REF;
+  }
+  return Hiwire.new_value(result);
+});
+
+EM_JS_NUM(errcode, JsArray_Set, (JsRef idobj, int idx, JsRef idval), {
+  Hiwire.get_value(idobj)[idx] = Hiwire.get_value(idval);
+});
+
+EM_JS_NUM(errcode, JsArray_Delete, (JsRef idobj, int idx), {
+  let obj = Hiwire.get_value(idobj);
+  // Weird edge case: allow deleting an empty entry, but we raise a key error if
+  // access is attempted.
+  if (idx < 0 || idx >= obj.length) {
+    return ERROR_NUM;
+  }
+  obj.splice(idx, 1);
+});
+
+// ==================== JsObject API  ====================
+
+// clang-format off
+EM_JS_REF(JsRef, JsObject_New, (), {
+  return Hiwire.new_value({});
+});
+// clang-format on
+
+EM_JS_REF(JsRef, JsObject_GetString, (JsRef idobj, const char* ptrkey), {
+  let jsobj = Hiwire.get_value(idobj);
+  let jskey = UTF8ToString(ptrkey);
+  let result = jsobj[jskey];
+  // clang-format off
+  if (result === undefined && !(jskey in jsobj)) {
+    // clang-format on
+    return ERROR_REF;
+  }
+  return Hiwire.new_value(result);
+});
+
+// clang-format off
+EM_JS_NUM(errcode,
+          JsObject_SetString,
+          (JsRef idobj, const char* ptrkey, JsRef idval),
+{
+  let jsobj = Hiwire.get_value(idobj);
+  let jskey = UTF8ToString(ptrkey);
+  let jsval = Hiwire.get_value(idval);
+  jsobj[jskey] = jsval;
+});
+// clang-format on
+
+EM_JS_NUM(errcode, JsObject_DeleteString, (JsRef idobj, const char* ptrkey), {
+  let jsobj = Hiwire.get_value(idobj);
+  let jskey = UTF8ToString(ptrkey);
+  delete jsobj[jskey];
+});
+
+EM_JS_REF(JsRef, JsObject_Dir, (JsRef idobj), {
+  let jsobj = Hiwire.get_value(idobj);
+  let result = [];
+  do {
+    // clang-format off
+    result.push(... Object.getOwnPropertyNames(jsobj).filter(
+      s => {
+        let c = s.charCodeAt(0);
+        return c < 48 || c > 57; /* Filter out integer array indices */
+      }
+    ));
+    // clang-format on
+  } while (jsobj = Object.getPrototypeOf(jsobj));
+  return Hiwire.new_value(result);
+});
+
+EM_JS_REF(JsRef, JsObject_Entries, (JsRef idobj), {
+  let jsobj = Hiwire.get_value(idobj);
+  return Hiwire.new_value(Object.entries(jsobj));
+});
+
+EM_JS_REF(JsRef, JsObject_Keys, (JsRef idobj), {
+  let jsobj = Hiwire.get_value(idobj);
+  return Hiwire.new_value(Object.keys(jsobj));
+});
+
+EM_JS_REF(JsRef, JsObject_Values, (JsRef idobj), {
+  let jsobj = Hiwire.get_value(idobj);
+  return Hiwire.new_value(Object.values(jsobj));
+});
+
+// ==================== JsString API  ====================
+
+EM_JS_REF(JsRef, JsString_InternFromCString, (const char* str), {
+  let jsstring = UTF8ToString(str);
+  return Hiwire.intern_object(jsstring);
+})
+
+JsRef
+JsString_FromId(Js_Identifier* id)
+{
+  if (!id->object) {
+    id->object = JsString_InternFromCString(id->string);
+  }
+  return id->object;
+}
+
+
+// ==================== JsMap API  ====================
+
 // clang-format off
 EM_JS_REF(JsRef, JsMap_New, (), {
   return Hiwire.new_value(new Map());
@@ -932,6 +945,8 @@ EM_JS_NUM(errcode, JsMap_Set, (JsRef mapid, JsRef keyid, JsRef valueid), {
   let value = Hiwire.get_value(valueid);
   map.set(key, value);
 })
+
+// ==================== JsSet API  ====================
 
 // clang-format off
 EM_JS_REF(JsRef, JsSet_New, (), {

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -582,6 +582,15 @@ JsRef
 JsObject_Values(JsRef idobj);
 
 
+// ==================== JsString API  ====================
+
+JsRef
+JsString_InternFromCString(const char* str);
+
+JsRef
+JsString_FromId(Js_Identifier* id);
+
+
 // ==================== JsMap API  ====================
 
 /**

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -78,6 +78,8 @@ typedef struct Js_Identifier
     x = NULL;                                                                  \
   } while (0)
 
+// ==================== hiwire API  ====================
+
 /**
  * Initialize the variables and functions required for hiwire.
  */
@@ -183,88 +185,12 @@ hiwire_from_bool(bool boolean);
 bool
 hiwire_to_bool(JsRef value);
 
-bool
-JsArray_Check(JsRef idobj);
-
-/**
- * Create a new JavaScript Array.
- *
- * Returns: New reference
- */
-JsRef
-JsArray_New();
-
-/**
- * Push a value to the end of a JavaScript array.
- */
-errcode WARN_UNUSED
-JsArray_Push(JsRef idobj, JsRef idval);
-
-/**
- * Same as JsArray_Push but panics on failure
- */
-int
-JsArray_Push_unchecked(JsRef idobj, JsRef idval);
-
-/**
- * Create a new JavaScript object.
- *
- * Returns: New reference
- */
-JsRef
-JsObject_New();
-
 /**
  * Throw a javascript Error object.
  * Steals a reference to the argument.
  */
 void _Py_NO_RETURN
 hiwire_throw_error(JsRef iderr);
-
-/**
- * Get an object member by string.
- *
- *
- * Returns: New reference
- */
-JsRef
-JsObject_GetString(JsRef idobj, const char* ptrname);
-
-/**
- * Set an object member by string.
- */
-errcode WARN_UNUSED
-JsObject_SetString(JsRef idobj, const char* ptrname, JsRef idval);
-
-/**
- * Delete an object member by string.
- */
-errcode WARN_UNUSED
-JsObject_DeleteString(JsRef idobj, const char* ptrname);
-
-/**
- * Get an object member by integer.
- *
- * Returns: New reference
- */
-JsRef
-JsArray_Get(JsRef idobj, int idx);
-
-/**
- * Set an object member by integer.
- */
-errcode WARN_UNUSED
-JsArray_Set(JsRef idobj, int idx, JsRef idval);
-
-errcode WARN_UNUSED
-JsArray_Delete(JsRef idobj, int idx);
-
-/**
- * Get the methods on an object, both on itself and what it inherits.
- *
- */
-JsRef
-JsObject_Dir(JsRef idobj);
 
 /**
  * Call a js function
@@ -509,24 +435,6 @@ JsRef
 hiwire_get_iterator(JsRef idobj);
 
 /**
- * Returns `Object.entries(obj)`
- */
-JsRef
-JsObject_Entries(JsRef idobj);
-
-/**
- * Returns `Object.keys(obj)`
- */
-JsRef
-JsObject_Keys(JsRef idobj);
-
-/**
- * Returns `Object.values(obj)`
- */
-JsRef
-JsObject_Values(JsRef idobj);
-
-/**
  * Returns 1 if the value is a typedarray.
  */
 bool
@@ -574,6 +482,108 @@ hiwire_get_buffer_info(JsRef idobj,
 JsRef
 hiwire_subarray(JsRef idarr, int start, int end);
 
+// ==================== JsArray API  ====================
+
+bool
+JsArray_Check(JsRef idobj);
+
+/**
+ * Create a new JavaScript Array.
+ *
+ * Returns: New reference
+ */
+JsRef
+JsArray_New();
+
+/**
+ * Push a value to the end of a JavaScript array.
+ */
+errcode WARN_UNUSED
+JsArray_Push(JsRef idobj, JsRef idval);
+
+/**
+ * Same as JsArray_Push but panics on failure
+ */
+int
+JsArray_Push_unchecked(JsRef idobj, JsRef idval);
+
+/**
+ * Get an object member by integer.
+ *
+ * Returns: New reference
+ */
+JsRef
+JsArray_Get(JsRef idobj, int idx);
+
+/**
+ * Set an object member by integer.
+ */
+errcode WARN_UNUSED
+JsArray_Set(JsRef idobj, int idx, JsRef idval);
+
+errcode WARN_UNUSED
+JsArray_Delete(JsRef idobj, int idx);
+
+
+// ==================== JsObject API  ====================
+
+/**
+ * Create a new JavaScript object.
+ *
+ * Returns: New reference
+ */
+JsRef
+JsObject_New();
+
+/**
+ * Get an object member by string.
+ *
+ *
+ * Returns: New reference
+ */
+JsRef
+JsObject_GetString(JsRef idobj, const char* ptrname);
+
+/**
+ * Set an object member by string.
+ */
+errcode WARN_UNUSED
+JsObject_SetString(JsRef idobj, const char* ptrname, JsRef idval);
+
+/**
+ * Delete an object member by string.
+ */
+errcode WARN_UNUSED
+JsObject_DeleteString(JsRef idobj, const char* ptrname);
+
+/**
+ * Get the methods on an object, both on itself and what it inherits.
+ *
+ */
+JsRef
+JsObject_Dir(JsRef idobj);
+
+/**
+ * Returns `Object.entries(obj)`
+ */
+JsRef
+JsObject_Entries(JsRef idobj);
+
+/**
+ * Returns `Object.keys(obj)`
+ */
+JsRef
+JsObject_Keys(JsRef idobj);
+
+/**
+ * Returns `Object.values(obj)`
+ */
+JsRef
+JsObject_Values(JsRef idobj);
+
+
+// ==================== JsMap API  ====================
+
 /**
  * Create a new Map.
  */
@@ -586,6 +596,9 @@ JsMap_New();
 errcode WARN_UNUSED
 JsMap_Set(JsRef mapid, JsRef keyid, JsRef valueid);
 
+
+// ==================== JsSet API  ====================
+
 /**
  * Create a new Set.
  */
@@ -597,5 +610,6 @@ JsSet_New();
  */
 errcode WARN_UNUSED
 JsSet_Add(JsRef mapid, JsRef keyid);
+
 
 #endif /* HIWIRE_H */

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -524,7 +524,6 @@ JsArray_Set(JsRef idobj, int idx, JsRef idval);
 errcode WARN_UNUSED
 JsArray_Delete(JsRef idobj, int idx);
 
-
 // ==================== JsObject API  ====================
 
 /**
@@ -581,7 +580,6 @@ JsObject_Keys(JsRef idobj);
 JsRef
 JsObject_Values(JsRef idobj);
 
-
 // ==================== JsString API  ====================
 
 JsRef
@@ -589,7 +587,6 @@ JsString_InternFromCString(const char* str);
 
 JsRef
 JsString_FromId(Js_Identifier* id);
-
 
 // ==================== JsMap API  ====================
 
@@ -605,7 +602,6 @@ JsMap_New();
 errcode WARN_UNUSED
 JsMap_Set(JsRef mapid, JsRef keyid, JsRef valueid);
 
-
 // ==================== JsSet API  ====================
 
 /**
@@ -619,6 +615,5 @@ JsSet_New();
  */
 errcode WARN_UNUSED
 JsSet_Add(JsRef mapid, JsRef keyid);
-
 
 #endif /* HIWIRE_H */


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

The functions inside `hiwire.h` and `hiwire.c` were defined in some inconsistent order. This PR shuffle things around so that they are clearly divided into multiple groups, one for each "namespace" (in the C sense):
- `hiwire_*`
- `JsObject_*`
- `JsArray_*`
- `JsString_*`
- `JsMap_*`
- `JaString_*`

This makes it easier to navigate inside the file, and will make it easier to add future functions "at the right place".


