### PR TITLE
TST Replace deprecated get_event_loop with asyncio.run

### DIFF
--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -137,11 +137,14 @@ def test_interactive_console():
                 == 'Traceback (most recent call last):\n  File "<console>", line 1, in <module>\nException: hi\n'
             )
 
-    asyncio.get_event_loop().run_until_complete(test())
+    asyncio.run(test())
 
 
 def test_top_level_await():
     from asyncio import Queue, sleep
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     q: Queue[int] = Queue()
     shell = Console(locals())
@@ -153,7 +156,7 @@ def test_top_level_await():
         await q.put(5)
         assert await fut == 5
 
-    asyncio.get_event_loop().run_until_complete(test())
+    loop.run_until_complete(test())
 
 
 @pytest.fixture
@@ -211,7 +214,7 @@ def test_persistent_redirection(safe_sys_redirections):
         assert await get_result("1+1") == 2
         assert my_stdout == "foo\nfoobar\nfoobar\n"
 
-    asyncio.get_event_loop().run_until_complete(test())
+    asyncio.run(test())
 
     my_stderr = ""
 
@@ -276,7 +279,7 @@ def test_nonpersistent_redirection(safe_sys_redirections):
         assert await get_result("sys.stdout.isatty()")
         assert await get_result("sys.stderr.isatty()")
 
-    asyncio.get_event_loop().run_until_complete(test())
+    asyncio.run(test())
 
 
 @pytest.mark.skip_refcount_check


### PR DESCRIPTION
`asyncio.get_event_loop` is deprecated and was raising deprecated warnings in `test-python` CI job.

```
src/tests/test_console.py::test_persistent_redirection
  /root/repo/src/tests/test_console.py:214: DeprecationWarning: There is no current event loop
    asyncio.get_event_loop().run_until_complete(test())
```

There are two warnings left regarding asyncio, which I think Hood was fixing in #2788.

```
src/tests/test_console.py::test_top_level_await
  /src/src/py/pyodide/console.py:179: DeprecationWarning: There is no current event loop
    super().__init__(loop=loop)

src/tests/test_console.py::test_top_level_await
  /src/src/py/pyodide/console.py:361: DeprecationWarning: There is no current event loop
    ensure_future(self.runcode(source, code)).add_done_callback(done_cb)
```