### PR TITLE
CI Split up package test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,11 +234,6 @@ jobs:
               --durations 50 \
               << parameters.test-params >> \
               -o cache_dir=$CACHE_DIR
-          post-steps:
-            - persist_to_workspace:
-                root: .
-                paths:
-                  - ./.test_cache
       - store_test_results:
           path: test-results
 
@@ -572,6 +567,11 @@ workflows:
           filters:
             tags:
               only: /.*/
+          post-steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - ./.test_cache
 
       - test-main:
           name: test-packages-chrome
@@ -593,6 +593,11 @@ workflows:
           filters:
             tags:
               only: /.*/
+          post-steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - ./.test_cache
 
       - test-main:
           name: test-packages-firefox
@@ -614,6 +619,11 @@ workflows:
           filters:
             tags:
               only: /.*/
+          post-steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - ./.test_cache
 
       - test-main:
           name: test-packages-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,14 @@ jobs:
       test-params:
         description: The tests to run.
         type: string
+      test-result-file:
+        description: The path to save test results.
+        type: string
+        default: ""
     <<: *defaults
     resource_class: medium+
+    environment:
+      TEST_RESULT_FILE: << parameters.test-result-file >>
     steps:
       - attach_workspace:
           at: .
@@ -218,11 +224,20 @@ jobs:
             mkdir test-results
             pip install ./pyodide-test-runner
             npm install -g node-fetch@2
+            if [ -z "${TEST_RESULT_FILE}" ]; then
+              export TEST_RESULT_FILE="lasttestresult_$(echo $RANDOM | md5sum | head -c 10)"
+            fi
             tools/pytest_wrapper.py \
               --junitxml=test-results/junit.xml \
               --verbose \
               --durations 50 \
-              << parameters.test-params >>
+              << parameters.test-params >> \
+              --test-result-file ${TEST_RESULT_FILE}
+          post-steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - ./.pytest_cache/v/cache/${TEST_RESULT_FILE}
       - store_test_results:
           path: test-results
 
@@ -548,27 +563,57 @@ workflows:
               only: /.*/
 
       - test-main:
-          name: test-packages-chrome
-          test-params: -k chrome packages/test* packages/*/test*
+          name: test-packages-no-numpy-dependents-chrome
+          test-params: -k chrome packages/test* packages/*/test* --test-result-file pkgtest_chrome
           requires:
+            - build-packages-no-numpy-dependents
+          filters:
+            tags:
+              only: /.*/
+
+      - test-main:
+          name: test-packages-chrome
+          test-params: -k chrome packages/test* packages/*/test* --skip-passed --test-result-file pkgtest_chrome
+          requires:
+            - test-packages-no-numpy-dependents-chrome
             - build-packages
+          filters:
+            tags:
+              only: /.*/
+
+      - test-main:
+          name: test-packages-no-numpy-dependents-firefox
+          test-params: -k firefox packages/test* packages/*/test* --test-result-file pkgtest_firefox
+          requires:
+            - build-packages-no-numpy-dependents
           filters:
             tags:
               only: /.*/
 
       - test-main:
           name: test-packages-firefox
-          test-params: -k firefox packages/test* packages/*/test*
+          test-params: -k firefox packages/test* packages/*/test* --skip-passed --test-result-file pkgtest_firefox
           requires:
+            - test-packages-no-numpy-dependents-firefox
             - build-packages
           filters:
             tags:
               only: /.*/
 
       - test-main:
-          name: test-packages-node
-          test-params: -k node packages/test* packages/*/test*
+          name: test-packages-no-numpy-dependents-node
+          test-params: -k node packages/test* packages/*/test* --test-result-file pkgtest_node
           requires:
+            - build-packages-no-numpy-dependents
+          filters:
+            tags:
+              only: /.*/
+
+      - test-main:
+          name: test-packages-node
+          test-params: -k node packages/test* packages/*/test* --skip-passed --test-result-file pkgtest_node
+          requires:
+            - test-packages-no-numpy-dependents-node
             - build-packages
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,14 +206,14 @@ jobs:
       test-params:
         description: The tests to run.
         type: string
-      test-result-file:
-        description: The path to save test results.
+      cache-dir:
+        description: pytest-cache-dir.
         type: string
         default: ""
     <<: *defaults
     resource_class: medium+
     environment:
-      TEST_RESULT_FILE: << parameters.test-result-file >>
+      CACHE_DIR: << parameters.cache-dir >>
     steps:
       - attach_workspace:
           at: .
@@ -224,20 +224,21 @@ jobs:
             mkdir test-results
             pip install ./pyodide-test-runner
             npm install -g node-fetch@2
-            if [ -z "${TEST_RESULT_FILE}" ]; then
-              export TEST_RESULT_FILE="lasttestresult_$(echo $RANDOM | md5sum | head -c 10)"
+            if [ -z "${CACHE_DIR}" ]; then
+              export CACHE_DIR=".test_cache/.pytest_cache_$(echo $RANDOM | md5sum | head -c 10)"
             fi
+            echo "pytest cache dir: $CACHE_DIR"
             tools/pytest_wrapper.py \
               --junitxml=test-results/junit.xml \
               --verbose \
               --durations 50 \
               << parameters.test-params >> \
-              --test-result-file ${TEST_RESULT_FILE}
+              -o cache_dir=$CACHE_DIR
           post-steps:
             - persist_to_workspace:
                 root: .
                 paths:
-                  - ./.pytest_cache/v/cache/${TEST_RESULT_FILE}
+                  - ./.test_cache
       - store_test_results:
           path: test-results
 
@@ -564,7 +565,8 @@ workflows:
 
       - test-main:
           name: test-packages-no-numpy-dependents-chrome
-          test-params: -k chrome packages/test* packages/*/test* --test-result-file pkgtest_chrome
+          test-params: -k chrome packages/test* packages/*/test*
+          cache-dir: .pytest_cache_chrome
           requires:
             - build-packages-no-numpy-dependents
           filters:
@@ -573,7 +575,8 @@ workflows:
 
       - test-main:
           name: test-packages-chrome
-          test-params: -k chrome packages/test* packages/*/test* --skip-passed --test-result-file pkgtest_chrome
+          test-params: -k chrome packages/test* packages/*/test* --skip-passed
+          cache-dir: .pytest_cache_chrome
           requires:
             - test-packages-no-numpy-dependents-chrome
             - build-packages
@@ -583,7 +586,8 @@ workflows:
 
       - test-main:
           name: test-packages-no-numpy-dependents-firefox
-          test-params: -k firefox packages/test* packages/*/test* --test-result-file pkgtest_firefox
+          test-params: -k firefox packages/test* packages/*/test*
+          cache-dir: .pytest_cache_firefox
           requires:
             - build-packages-no-numpy-dependents
           filters:
@@ -592,7 +596,8 @@ workflows:
 
       - test-main:
           name: test-packages-firefox
-          test-params: -k firefox packages/test* packages/*/test* --skip-passed --test-result-file pkgtest_firefox
+          test-params: -k firefox packages/test* packages/*/test* --skip-passed
+          cache-dir: .pytest_cache_firefox
           requires:
             - test-packages-no-numpy-dependents-firefox
             - build-packages
@@ -602,7 +607,8 @@ workflows:
 
       - test-main:
           name: test-packages-no-numpy-dependents-node
-          test-params: -k node packages/test* packages/*/test* --test-result-file pkgtest_node
+          test-params: -k node packages/test* packages/*/test*
+          cache-dir: .pytest_cache_node
           requires:
             - build-packages-no-numpy-dependents
           filters:
@@ -611,7 +617,8 @@ workflows:
 
       - test-main:
           name: test-packages-node
-          test-params: -k node packages/test* packages/*/test* --skip-passed --test-result-file pkgtest_node
+          test-params: -k node packages/test* packages/*/test* --skip-passed
+          cache-dir: .pytest_cache_node
           requires:
             - test-packages-no-numpy-dependents-node
             - build-packages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         stages: [manual]
 
   - repo: https://github.com/psf/black
-    rev: "22.3.0"
+    rev: "22.6.0"
     hooks:
       - id: black
 
@@ -68,7 +68,7 @@ repos:
         additional_dependencies: *mypy-deps
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v14.0.5"
+    rev: "v14.0.6"
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]

--- a/conftest.py
+++ b/conftest.py
@@ -93,17 +93,16 @@ def pytest_terminal_summary(terminalreporter):
 
     test_result = {}
     for status in tr.stats:
-        if status == "warnings":
+        if status in ("warnings", "deselected"):
             continue
 
         for test in tr.stats[status]:
             try:
-                if test.longrepr[2] in "previously passed":
+                if test.longrepr and test.longrepr[2] in "previously passed":
                     test_result[test.nodeid] = "skip_passed"
                 else:
                     test_result[test.nodeid] = test.outcome
             except Exception:
-                # Doctest, etc...
                 pass
 
     result_file = tr.config.getoption("--test-result-file")

--- a/conftest.py
+++ b/conftest.py
@@ -97,10 +97,14 @@ def pytest_terminal_summary(terminalreporter):
             continue
 
         for test in tr.stats[status]:
-            if test.longrepr[2] in "previously passed":
-                test_result[test.nodeid] = "skip_passed"
-            else:
-                test_result[test.nodeid] = test.outcome
+            try:
+                if test.longrepr[2] in "previously passed":
+                    test_result[test.nodeid] = "skip_passed"
+                else:
+                    test_result[test.nodeid] = test.outcome
+            except Exception:
+                # Doctest, etc...
+                pass
 
     result_file = tr.config.getoption("--test-result-file")
     cache.set(f"cache/{result_file}", test_result)

--- a/conftest.py
+++ b/conftest.py
@@ -32,11 +32,6 @@ def pytest_addoption(parser):
             "CAUTION: this will skip tests even if tests are modified"
         ),
     )
-    group.addoption(
-        "--test-result-file",
-        default="lasttestresult",
-        help="File to store test results in",
-    )
 
 
 def pytest_configure(config):
@@ -72,8 +67,7 @@ def pytest_collection_modifyitems(config, items):
     prev_test_result = {}
     if config.getoption("--skip-passed"):
         cache = config.cache
-        result_file = config.getoption("--test-result-file")
-        prev_test_result = cache.get(f"cache/{result_file}", {})
+        prev_test_result = cache.get("cache/lasttestresult", {})
 
     for item in items:
         if prev_test_result.get(item.nodeid) in ("passed", "warnings", "skip_passed"):
@@ -105,8 +99,7 @@ def pytest_terminal_summary(terminalreporter):
             except Exception:
                 pass
 
-    result_file = tr.config.getoption("--test-result-file")
-    cache.set(f"cache/{result_file}", test_result)
+    cache.set("cache/lasttestresult", test_result)
 
 
 @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION
### Description

This PR splits package test in CI so that `no-numpy-dependents` packages can be tested earlier.

In detail, pytest will now save test results into its cache directory, and if `--skip-passed` option is given, it will skip previously successful tests.

@hoodmane 