### PR TITLE
Fix doc for building package with pyodide_build

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -119,7 +119,7 @@ build:
 ### 2. Building the package and investigating issues
 
 Once the `meta.yaml` file is ready, build the package with the following
-commands
+command
 
 ```sh
 python -m pyodide_build buildall --only 'package-name' packages dist

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -119,7 +119,7 @@ build:
 ### 2. Building the package and investigating issues
 
 Once the `meta.yaml` file is ready, build the package with the following
-commands from inside the package directory `packages/<package-name>`
+commands
 
 ```sh
 python -m pyodide_build buildall --only 'package-name' packages dist


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Fixes the documentation issue in #2853 
In the old instructions to build package it was written that you should run `pyodide_build buildall` from the `packages/<package-name>` folder. However, the command that comes next assumes you are in the root (like the previous commands, i.e. to create the meta.yml template). Fixed by removing the reference to the folder.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add new / update outdated documentation
