### PR TITLE
Change out of tree build entrypoint name from pywasm to pyodide

### DIFF
--- a/pyodide-build/setup.py
+++ b/pyodide-build/setup.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     setuptools.setup(
         entry_points={
             "console_scripts": [
-                "pywasm = pyodide_build.out_of_tree.__main__:main",
+                "pyodide = pyodide_build.out_of_tree.__main__:main",
                 "_pywasmcross = pyodide_build.pywasmcross:compiler_main",
             ]
         }


### PR DESCRIPTION
As recommended by @rth in a comment on #2823.