### PR TITLE
CI Remove package source files after build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,11 @@ jobs:
             tar --exclude="node_modules" -cjf pyodide-build.tar.gz dist
             tar cjf build-logs.tar.gz  packages/build-logs
 
+      - run:
+          name: Clean up package source files
+          command: |
+            cd packages && find **/build ! -name '.packaged' -type f -exec rm -f {} +
+
       - store_artifacts:
           path: /root/repo/pyodide-build.tar.gz
 


### PR DESCRIPTION
### Description

Clean up package source files after build in order to reduce the size of data shared between CI jobs. 
This reduces the running time of CI jobs such as `test-packages-chrome`, around 3 minutes.
