### PR TITLE
Use CircleCI security context for S3 deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -719,6 +719,8 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\w+$/
+          context:
+            - s3-deployment
       - deploy-dev:
           requires:
             - test-python
@@ -728,3 +730,5 @@ workflows:
           filters:
             branches:
               only: main
+          context:
+            - s3-deployment


### PR DESCRIPTION
This switches to using [CircleCI contexts](https://circleci.com/docs/contexts) for better securing of env variables. This allows,
  - to restrict the CI jobs which see the sensitive env variables
  - make this env variable available only to workflows triggered by the core team members. They were previously restricted to running on the upstream more, and since only core members can push there, it should be more or less equivalent.

Previously I was a bit reluctant to add tools such as codecov for code coverage, as it essentially runs an arbitrary script from some server, and if it's compromised it would be able to compromise these env variables (as happened in [2021 for other projects](https://about.codecov.io/security-update/)). With this change, we should be able to start using codecov.

This PR makes this change for S3 env variables, once we merge it and it works, we should do the same for NPM and Github tokens.

It's a bit hard to test, so we will know if it works once we test it.