### PR TITLE
Update MacOS setup steps

### DIFF
--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -99,9 +99,7 @@ To build on MacOS, you need:
 - cmake (`brew install cmake`)
 - pkg-config (`brew install pkg-config`)
 - openssl (`brew install openssl`)
-- autoconf (`brew install autoconf`)
-- automake (`brew install automake`)
-- libtool (`brew install libtool`)
+- autoconf, automaker & libtool (`brew install autoconf automaker libtool`)
 - gfortran (`brew cask install gfortran`)
 - f2c: Install wget (`brew install wget`), and then run the buildf2c script from
   the root directory (`sudo ./tools/buildf2c`)

--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -99,6 +99,9 @@ To build on MacOS, you need:
 - cmake (`brew install cmake`)
 - pkg-config (`brew install pkg-config`)
 - openssl (`brew install openssl`)
+- autoconf (`brew install autoconf`)
+- automake (`brew install automake`)
+- libtool (`brew install libtool`)
 - gfortran (`brew cask install gfortran`)
 - f2c: Install wget (`brew install wget`), and then run the buildf2c script from
   the root directory (`sudo ./tools/buildf2c`)


### PR DESCRIPTION
Update MacOS setup steps in `building-from-sources.md`

### Description

When trying to build `pyodide` locally in MacOS with `make` it was noticed that some further tools are required but not documented in the setup steps, they are now added to the `building-from-sources.md` file under the MacOS section.

Thanks to these tools the build is not failing until the issue reported in https://github.com/pyodide/pyodide/issues/2449

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation
