### PR TITLE
Fix Windows Node errors on loading pyodide

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -107,6 +107,9 @@ substitutions:
   empty container. Otherwise it returns `True`.
   {pr}`2803`
 
+- {{ Fix }} Fix `loadPyodide` errors for the Windows Node environment.
+  {pr}`2888`
+
 ### REPL
 
 - {{ Enhancement }} Add a spinner while the REPL is loading

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -8,7 +8,7 @@ export const IN_NODE =
   typeof process.browser ===
     "undefined"; /* This last condition checks if we run the browser shim of process */
 
-let nodePathMod: any;
+let nodeUrlMod: any;
 let nodeFetch: any;
 let nodeVmMod: any;
 /** @private */
@@ -30,7 +30,7 @@ export async function initNodeModules() {
     return;
   }
   // @ts-ignore
-  nodePathMod = (await import("path")).default;
+  nodeUrlMod = (await import("url")).default;
   nodeFsPromisesMod = await import("fs/promises");
   if (globalThis.fetch) {
     nodeFetch = fetch;
@@ -194,6 +194,6 @@ async function nodeLoadScript(url: string) {
   } else {
     // Otherwise, hopefully it is a relative path we can load from the file
     // system.
-    await import(nodePathMod.resolve(url));
+    await import(nodeUrlMod.pathToFileURL(url).href);
   }
 }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -171,6 +171,9 @@ function calculateIndexURL(): string {
   const indexOfLastSlash = fileName.includes("/")
     ? fileName.lastIndexOf("/")
     : fileName.lastIndexOf("\\");
+  if (indexOfLastSlash === -1) {
+    throw new Error("Could not extract indexURL path from pyodide module location");
+  }
   return fileName.slice(0, indexOfLastSlash);
 }
 

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -168,7 +168,8 @@ function calculateIndexURL(): string {
     err = e as Error;
   }
   let fileName = ErrorStackParser.parse(err)[0].fileName!;
-  return fileName.slice(0, fileName.lastIndexOf("/"));
+  const indexOfLastSlash = fileName.includes("/") ? fileName.lastIndexOf("/") : fileName.lastIndexOf("\\");
+  return fileName.slice(0, indexOfLastSlash);
 }
 
 /**

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -172,7 +172,9 @@ function calculateIndexURL(): string {
     ? fileName.lastIndexOf("/")
     : fileName.lastIndexOf("\\");
   if (indexOfLastSlash === -1) {
-    throw new Error("Could not extract indexURL path from pyodide module location");
+    throw new Error(
+      "Could not extract indexURL path from pyodide module location"
+    );
   }
   return fileName.slice(0, indexOfLastSlash);
 }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -168,7 +168,9 @@ function calculateIndexURL(): string {
     err = e as Error;
   }
   let fileName = ErrorStackParser.parse(err)[0].fileName!;
-  const indexOfLastSlash = fileName.includes("/") ? fileName.lastIndexOf("/") : fileName.lastIndexOf("\\");
+  const indexOfLastSlash = fileName.includes("/")
+    ? fileName.lastIndexOf("/")
+    : fileName.lastIndexOf("\\");
   return fileName.slice(0, indexOfLastSlash);
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Fixes #2882 

There were two separate issues:

1. There's a difference in Node's handling of imports across OSes. You can find more info + the recommended solution in this issue: https://github.com/nodejs/node/issues/31710
2. `calculateIndexURL()` did not handle the case where the filename had backslashes on Windows instead of forward slashes. Since the `fileName.lastIndexOf("/")` evaluated to `-1`, the calculated indexURL value was `${/path/to/pyodide}/pyodide.j`

I recommend adding error handling to the `calculateIndexURL()` function to throw when no forward slashes or backslashes are found. I can add that as part of this PR or I can defer if y'all don't want me to add it.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
