### PR TITLE
Set initialization script for pyodide-test-runner

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,22 +20,20 @@ from pyodide_test_runner.utils import parse_xfail_browsers
 # There are a bunch of global objects that occasionally enter the hiwire cache
 # but never leave. The refcount checks get angry about them if they aren't preloaded.
 # We need to go through and touch them all once to keep everything okay.
-os.environ[
-    "PYTEST_PYODIDE_INITIALIZE_SCRIPT"
-] = """
-    pyodide.globals.get;
-    pyodide._api.pyodide_code.eval_code;
-    pyodide._api.pyodide_code.eval_code_async;
-    pyodide._api.pyodide_code.find_imports;
-    pyodide._api.pyodide_ffi.register_js_module;
-    pyodide._api.pyodide_ffi.unregister_js_module;
-    pyodide._api.importlib.invalidate_caches;
-    pyodide._api.package_loader.unpack_buffer;
-    pyodide._api.package_loader.get_dynlibs;
-    pyodide._api.package_loader.sub_resource_hash;
-    pyodide.runPython("");
-    pyodide.pyimport("pyodide.ffi.wrappers").destroy();
-    """
+os.environ["PYTEST_PYODIDE_INITIALIZE_SCRIPT"] = (
+    "pyodide.globals.get;"
+    "pyodide._api.pyodide_code.eval_code;"
+    "pyodide._api.pyodide_code.eval_code_async;"
+    "pyodide._api.pyodide_code.find_imports;"
+    "pyodide._api.pyodide_ffi.register_js_module;"
+    "pyodide._api.pyodide_ffi.unregister_js_module;"
+    "pyodide._api.importlib.invalidate_caches;"
+    "pyodide._api.package_loader.unpack_buffer;"
+    "pyodide._api.package_loader.get_dynlibs;"
+    "pyodide._api.package_loader.sub_resource_hash;"
+    "pyodide.runPython('');"
+    "pyodide.pyimport('pyodide.ffi.wrappers').destroy();"
+)
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 """
 Various common utilities for testing.
 """
+import os
 import pathlib
 import sys
 
@@ -15,6 +16,26 @@ sys.path.append(str(ROOT_PATH / "src" / "py"))
 from pyodide_test_runner.utils import maybe_skip_test
 from pyodide_test_runner.utils import package_is_built as _package_is_built
 from pyodide_test_runner.utils import parse_xfail_browsers
+
+# There are a bunch of global objects that occasionally enter the hiwire cache
+# but never leave. The refcount checks get angry about them if they aren't preloaded.
+# We need to go through and touch them all once to keep everything okay.
+os.environ[
+    "PYTEST_PYODIDE_INITIALIZE_SCRIPT"
+] = """
+    pyodide.globals.get;
+    pyodide._api.pyodide_code.eval_code;
+    pyodide._api.pyodide_code.eval_code_async;
+    pyodide._api.pyodide_code.find_imports;
+    pyodide._api.pyodide_ffi.register_js_module;
+    pyodide._api.pyodide_ffi.unregister_js_module;
+    pyodide._api.importlib.invalidate_caches;
+    pyodide._api.package_loader.unpack_buffer;
+    pyodide._api.package_loader.get_dynlibs;
+    pyodide._api.package_loader.sub_resource_hash;
+    pyodide.runPython("");
+    pyodide.pyimport("pyodide.ffi.wrappers").destroy();
+    """
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 """
 Various common utilities for testing.
 """
-import os
 import pathlib
 import sys
 
@@ -13,6 +12,7 @@ DIST_PATH = ROOT_PATH / "dist"
 sys.path.append(str(ROOT_PATH / "pyodide-build"))
 sys.path.append(str(ROOT_PATH / "src" / "py"))
 
+import pyodide_test_runner.browser
 from pyodide_test_runner.utils import maybe_skip_test
 from pyodide_test_runner.utils import package_is_built as _package_is_built
 from pyodide_test_runner.utils import parse_xfail_browsers
@@ -20,20 +20,20 @@ from pyodide_test_runner.utils import parse_xfail_browsers
 # There are a bunch of global objects that occasionally enter the hiwire cache
 # but never leave. The refcount checks get angry about them if they aren't preloaded.
 # We need to go through and touch them all once to keep everything okay.
-os.environ["PYTEST_PYODIDE_INITIALIZE_SCRIPT"] = (
-    "pyodide.globals.get;"
-    "pyodide._api.pyodide_code.eval_code;"
-    "pyodide._api.pyodide_code.eval_code_async;"
-    "pyodide._api.pyodide_code.find_imports;"
-    "pyodide._api.pyodide_ffi.register_js_module;"
-    "pyodide._api.pyodide_ffi.unregister_js_module;"
-    "pyodide._api.importlib.invalidate_caches;"
-    "pyodide._api.package_loader.unpack_buffer;"
-    "pyodide._api.package_loader.get_dynlibs;"
-    "pyodide._api.package_loader.sub_resource_hash;"
-    "pyodide.runPython('');"
-    "pyodide.pyimport('pyodide.ffi.wrappers').destroy();"
-)
+pyodide_test_runner.browser.INITIALIZE_SCRIPT = """
+    pyodide.globals.get;
+    pyodide._api.pyodide_code.eval_code;
+    pyodide._api.pyodide_code.eval_code_async;
+    pyodide._api.pyodide_code.find_imports;
+    pyodide._api.pyodide_ffi.register_js_module;
+    pyodide._api.pyodide_ffi.unregister_js_module;
+    pyodide._api.importlib.invalidate_caches;
+    pyodide._api.package_loader.unpack_buffer;
+    pyodide._api.package_loader.get_dynlibs;
+    pyodide._api.package_loader.sub_resource_hash;
+    pyodide.runPython("");
+    pyodide.pyimport("pyodide.ffi.wrappers").destroy();
+"""
 
 
 def pytest_addoption(parser):

--- a/pyodide-test-runner/pyodide_test_runner/browser.py
+++ b/pyodide-test-runner/pyodide_test_runner/browser.py
@@ -1,5 +1,4 @@
 import json
-import os
 import textwrap
 from pathlib import Path
 
@@ -83,6 +82,8 @@ globalThis.assertThrowsAsync = async function (cb, errname, pattern) {
     checkError(err, errname, pattern, pat_str, thiscallstr);
 };
 """.strip()
+
+INITIALIZE_SCRIPT = "pyodide.runPython('');"
 
 
 class JavascriptException(Exception):
@@ -173,11 +174,7 @@ class BrowserWrapper:
         )
 
     def initialize_pyodide(self):
-        initialize_script = os.environ.get(
-            "PYTEST_PYODIDE_INITIALIZE_SCRIPT",
-            "pyodide.runPython('')",
-        )
-        self.run_js(initialize_script)
+        self.run_js(INITIALIZE_SCRIPT)
 
     @property
     def pyodide_loaded(self):

--- a/pyodide-test-runner/pyodide_test_runner/browser.py
+++ b/pyodide-test-runner/pyodide_test_runner/browser.py
@@ -175,9 +175,7 @@ class BrowserWrapper:
     def initialize_pyodide(self):
         initialize_script = os.environ.get(
             "PYTEST_PYODIDE_INITIALIZE_SCRIPT",
-            """
-            pyodide.runPython("");
-            """,
+            "pyodide.runPython('')",
         )
         self.run_js(initialize_script)
 


### PR DESCRIPTION
Take out `initialize_global_hiwire_objects` from pytest-pyodide (pyodide-test-runner) to conftest.py.

The purpose of this PR is to loosen the dependency between pytest-pyodide and pyodide so we can update pyodide API without modifying pytest-pyodide.