### PR TITLE
add meta.yaml for z3solver to package directory

### DIFF
--- a/packages/z3-solver/meta.yaml
+++ b/packages/z3-solver/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: z3-solver
+  name: z3_solver
   version: 4.9.1.0
 source:
   url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-solver-4.9.1.0.tar.gz

--- a/packages/z3-solver/meta.yaml
+++ b/packages/z3-solver/meta.yaml
@@ -12,4 +12,4 @@ about:
   PyPI: https://pypi.org/project/z3-solver
   summary: an efficient SMT solver library
   license: MIT License
-  
+

--- a/packages/z3-solver/meta.yaml
+++ b/packages/z3-solver/meta.yaml
@@ -5,11 +5,10 @@ source:
   url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-solver-4.9.1.0.tar.gz
   sha256: 5ed51c9748a23b6e21af9a526fa21f7ff0a76fd696aff436676300f162e10ddc
 test:
-  imports:
+  imports:pre-commit run --all-files
     - z3-solver
 about:
   home: https://github.com/Z3Prover/z3
   PyPI: https://pypi.org/project/z3-solver
   summary: an efficient SMT solver library
   license: MIT License
-

--- a/packages/z3-solver/meta.yaml
+++ b/packages/z3-solver/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: z3-solver
+  version: 4.9.1.0
+source:
+  url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-sol
+ver-4.9.1.0.tar.gz
+  sha256: 5ed51c9748a23b6e21af9a526fa21f7ff0a76fd696aff436676300f162e10ddc
+test:
+  imports:
+    - z3-solver
+about:
+  home: https://github.com/Z3Prover/z3
+  PyPI: https://pypi.org/project/z3-solver
+  summary: an efficient SMT solver library
+  license: MIT License

--- a/packages/z3-solver/meta.yaml
+++ b/packages/z3-solver/meta.yaml
@@ -5,7 +5,7 @@ source:
   url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-solver-4.9.1.0.tar.gz
   sha256: 5ed51c9748a23b6e21af9a526fa21f7ff0a76fd696aff436676300f162e10ddc
 test:
-  imports:pre-commit run --all-files
+  imports:
     - z3-solver
 about:
   home: https://github.com/Z3Prover/z3

--- a/packages/z3-solver/meta.yaml
+++ b/packages/z3-solver/meta.yaml
@@ -2,8 +2,7 @@ package:
   name: z3-solver
   version: 4.9.1.0
 source:
-  url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-sol
-ver-4.9.1.0.tar.gz
+  url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-solver-4.9.1.0.tar.gz
   sha256: 5ed51c9748a23b6e21af9a526fa21f7ff0a76fd696aff436676300f162e10ddc
 test:
   imports:
@@ -13,3 +12,4 @@ about:
   PyPI: https://pypi.org/project/z3-solver
   summary: an efficient SMT solver library
   license: MIT License
+  

--- a/packages/z3solver/meta.yaml
+++ b/packages/z3solver/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: z3_solver
+  name: z3solver
   version: 4.9.1.0
 source:
   url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-solver-4.9.1.0.tar.gz

--- a/packages/z3solver/meta.yaml
+++ b/packages/z3solver/meta.yaml
@@ -4,8 +4,11 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-solver-4.9.1.0.tar.gz
   sha256: 5ed51c9748a23b6e21af9a526fa21f7ff0a76fd696aff436676300f162e10ddc
+requirements:
+  run:
+    - setuptools
 build:
-  ldflags: -s SIDE_MODULE=1
+  exports: whole_archive
 test:
   imports:
     - z3

--- a/packages/z3solver/meta.yaml
+++ b/packages/z3solver/meta.yaml
@@ -6,7 +6,7 @@ source:
   sha256: 5ed51c9748a23b6e21af9a526fa21f7ff0a76fd696aff436676300f162e10ddc
 test:
   imports:
-    - z3-solver
+    - z3solver
 about:
   home: https://github.com/Z3Prover/z3
   PyPI: https://pypi.org/project/z3-solver

--- a/packages/z3solver/meta.yaml
+++ b/packages/z3solver/meta.yaml
@@ -4,6 +4,8 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/91/be/d247b751fd779e2e6abb175347cf97893e8606a19deaeab4ed26581b81a0/z3-solver-4.9.1.0.tar.gz
   sha256: 5ed51c9748a23b6e21af9a526fa21f7ff0a76fd696aff436676300f162e10ddc
+build:
+  ldflags: -s SIDE_MODULE=1
 test:
   imports:
     - z3

--- a/packages/z3solver/meta.yaml
+++ b/packages/z3solver/meta.yaml
@@ -6,7 +6,7 @@ source:
   sha256: 5ed51c9748a23b6e21af9a526fa21f7ff0a76fd696aff436676300f162e10ddc
 test:
   imports:
-    - z3solver
+    - z3
 about:
   home: https://github.com/Z3Prover/z3
   PyPI: https://pypi.org/project/z3-solver

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -8,6 +8,7 @@ def test_z3_socrates(selenium):
     """test to see if z3 is alive"""
 
     import z3
+    
     obj = z3.DeclareSort("Object")
     human = z3.Function("Human", obj, z3.BoolSort())
     mortal = z3.Function("Mortal", obj, z3.BoolSort())

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -5,30 +5,19 @@ from pyodide_test_runner import run_in_pyodide
     packages=["z3solver"],
 )
 def test_z3_socrates(selenium):
-    import io
-
-    from z3 import *
-
-    Object = DeclareSort('Object')
-    Human = Function('Human', Object, BoolSort())
-    Mortal = Function('Mortal', Object, BoolSort())
-
+    """ test to see if z3 is alive """
+    import z3solver as z3
+    sObject = z3.DeclareSort('Object')
+    fHuman = z3.Function('Human', sObject, z3.BoolSort())
+    fMortal = z3.Function('Mortal', sObject, z3.BoolSort())
     # a well known philosopher
-    socrates = Const('socrates', Object)
-
+    socrates = z3.Const('socrates', sObject)
     # free variables used in forall must be declared Const in python
-    x = Const('x', Object)
-
-    axioms = [ForAll([x], Implies(Human(x), Mortal(x))), Human(socrates)]
-
-    s = Solver()
+    x = z3.Const('x', sObject)
+    axioms = [z3.ForAll([x], z3.Implies(fHuman(x), fMortal(x))), fHuman(socrates)]
+    s = z3.Solver()
     s.add(axioms)
-
     print(s.check()) # prints sat so axioms are coherent
-
     # classical refutation
-    s.add(Not(Mortal(socrates)))
-
+    s.add(z3.Not(fMortal(socrates)))
     print(s.check()) # prints unsat so socrates is Mortal
-
-

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -6,7 +6,7 @@ from pyodide_test_runner import run_in_pyodide
 )
 def test_z3_socrates(selenium):
     """ test to see if z3 is alive """
-    import z3solver as z3
+    import z3
     sObject = z3.DeclareSort('Object')
     fHuman = z3.Function('Human', sObject, z3.BoolSort())
     fMortal = z3.Function('Mortal', sObject, z3.BoolSort())

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -18,7 +18,7 @@ def test_z3_socrates(selenium):
     axioms = [z3.ForAll([x], z3.Implies(human(x), mortal(x))), human(socrates)]
     s = z3.Solver()
     s.add(axioms)
-    print(s.check())  
+    print(s.check())
     # prints sat so axioms are coherent
     assert z3.sat == s.check()
     # classical refutation
@@ -26,5 +26,5 @@ def test_z3_socrates(selenium):
     is_sat = s.check()
     print(is_sat)
     assert is_sat == z3.unsat
-    # prints unsat so socrates is Mortal    
+    # prints unsat so socrates is Mortal
     print(is_sat)

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -5,23 +5,27 @@ from pyodide_test_runner import run_in_pyodide
     packages=["z3solver"],
 )
 def test_z3_socrates(selenium):
-    """ test to see if z3 is alive """
+    """test to see if z3 is alive"""
+
     import z3
-    obj = z3.DeclareSort('Object')
-    human = z3.Function('Human', obj, z3.BoolSort())
-    mortal = z3.Function('Mortal', obj, z3.BoolSort())
+    obj = z3.DeclareSort("Object")
+    human = z3.Function("Human", obj, z3.BoolSort())
+    mortal = z3.Function("Mortal", obj, z3.BoolSort())
     # a well known philosopher
-    socrates = z3.Const('socrates', obj)
+    socrates = z3.Const("socrates", obj)
     # free variables used in forall must be declared Const in python
-    x = z3.Const('x', obj)
+    x = z3.Const("x", obj)
     axioms = [z3.ForAll([x], z3.Implies(human(x), mortal(x))), human(socrates)]
     s = z3.Solver()
     s.add(axioms)
-    print(s.check()) # prints sat so axioms are coherent
-    assert(z3.sat == s.check())
+    print(s.check())  
+    # prints sat so axioms are coherent
+    assert z3.sat == s.check()
     # classical refutation
     s.add(z3.Not(mortal(socrates)))
     is_sat = s.check()
     print(is_sat)
-    assert(is_sat == z3.unsat)
-    print(is_sat) # prints unsat so socrates is Mortal
+    assert is_sat == z3.unsat
+    # prints unsat so socrates is Mortal    
+    print(is_sat) 
+

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -7,22 +7,21 @@ from pyodide_test_runner import run_in_pyodide
 def test_z3_socrates(selenium):
     """ test to see if z3 is alive """
     import z3
-    sObject = z3.DeclareSort('Object')
-    fHuman = z3.Function('Human', sObject, z3.BoolSort())
-    fMortal = z3.Function('Mortal', sObject, z3.BoolSort())
+    obj = z3.DeclareSort('Object')
+    human = z3.Function('Human', obj, z3.BoolSort())
+    mortal = z3.Function('Mortal', obj, z3.BoolSort())
     # a well known philosopher
-    socrates = z3.Const('socrates', sObject)
+    socrates = z3.Const('socrates', obj)
     # free variables used in forall must be declared Const in python
-    x = z3.Const('x', sObject)
-    axioms = [z3.ForAll([x], z3.Implies(fHuman(x), fMortal(x))), fHuman(socrates)]
+    x = z3.Const('x', obj)
+    axioms = [z3.ForAll([x], z3.Implies(human(x), mortal(x))), human(socrates)]
     s = z3.Solver()
     s.add(axioms)
     print(s.check()) # prints sat so axioms are coherent
     assert(z3.sat == s.check())
     # classical refutation
-    s.add(z3.Not(fMortal(socrates)))
+    s.add(z3.Not(mortal(socrates)))
     is_sat = s.check()
     print(is_sat)
     assert(is_sat == z3.unsat)
     print(is_sat) # prints unsat so socrates is Mortal
-

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -18,6 +18,11 @@ def test_z3_socrates(selenium):
     s = z3.Solver()
     s.add(axioms)
     print(s.check()) # prints sat so axioms are coherent
+    assert(z3.sat == s.check())
     # classical refutation
     s.add(z3.Not(fMortal(socrates)))
-    print(s.check()) # prints unsat so socrates is Mortal
+    is_sat = s.check()
+    print(is_sat)
+    assert(is_sat == z3.unsat)
+    print(is_sat) # prints unsat so socrates is Mortal
+

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -1,0 +1,34 @@
+from pyodide_test_runner import run_in_pyodide
+
+
+@run_in_pyodide(
+    packages=["z3solver"],
+)
+def test_z3_socrates(selenium):
+    import io
+
+    from z3 import *
+
+    Object = DeclareSort('Object')
+    Human = Function('Human', Object, BoolSort())
+    Mortal = Function('Mortal', Object, BoolSort())
+
+    # a well known philosopher
+    socrates = Const('socrates', Object)
+
+    # free variables used in forall must be declared Const in python
+    x = Const('x', Object)
+
+    axioms = [ForAll([x], Implies(Human(x), Mortal(x))), Human(socrates)]
+
+    s = Solver()
+    s.add(axioms)
+
+    print(s.check()) # prints sat so axioms are coherent
+
+    # classical refutation
+    s.add(Not(Mortal(socrates)))
+
+    print(s.check()) # prints unsat so socrates is Mortal
+
+

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -14,6 +14,7 @@ def test_z3_socrates(selenium):
     mortal = z3.Function("Mortal", obj, z3.BoolSort())
     # a well known philosopher
     socrates = z3.Const("socrates", obj)
+
     # free variables used in forall must be declared Const in python
     x = z3.Const("x", obj)
     axioms = [z3.ForAll([x], z3.Implies(human(x), mortal(x))), human(socrates)]

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -27,5 +27,4 @@ def test_z3_socrates(selenium):
     print(is_sat)
     assert is_sat == z3.unsat
     # prints unsat so socrates is Mortal    
-    print(is_sat) 
-
+    print(is_sat)

--- a/packages/z3solver/test_z3solver.py
+++ b/packages/z3solver/test_z3solver.py
@@ -8,7 +8,7 @@ def test_z3_socrates(selenium):
     """test to see if z3 is alive"""
 
     import z3
-    
+
     obj = z3.DeclareSort("Object")
     human = z3.Function("Human", obj, z3.BoolSort())
     mortal = z3.Function("Mortal", obj, z3.BoolSort())


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Please consider merging the following pull request.
It adds a package description for [z3-solver](https://github.com/z3prover/z3). 
I have built in for wasm in the latest pyodide docker image, so I hope it works.
We would like to use pyodide to run the python bindings to z3 in a browser to make it easier for users to 
learn and experiment with. You can find a preliminary place-holder [here](https://microsoft.github.io/z3guide/docs/Programming%20Z3/Using%20Z3%20from%20Python/Introduction)
