### PR TITLE
Rename out of tree CLI entrypoint

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ autosummary_generate = True
 autodoc_default_flags = ["members", "inherited-members"]
 
 # Add modules to be mocked.
-mock_modules = ["ruamel.yaml", "tomli"]
+mock_modules = ["ruamel.yaml", "tomli", "build"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ autosummary_generate = True
 autodoc_default_flags = ["members", "inherited-members"]
 
 # Add modules to be mocked.
-mock_modules = ["ruamel.yaml", "tomli", "build"]
+mock_modules = ["ruamel.yaml", "tomli", "build", "build.__main__", "build.env"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/pyodide-build/pyodide_build/__main__.py
+++ b/pyodide-build/pyodide_build/__main__.py
@@ -4,12 +4,13 @@ import sys
 
 from . import buildall, buildpkg, create_xbuildenv, install_xbuildenv, mkpkg, serve
 from .common import init_environment
+from .out_of_tree import __main__ as out_of_tree
 
 
 def make_parser() -> argparse.ArgumentParser:
     """Create an argument parser with argparse"""
 
-    main_parser = argparse.ArgumentParser(prog="pyodide")
+    main_parser = argparse.ArgumentParser(prog="pyodide-build")
     main_parser.description = "A command line interface (CLI) for pyodide_build"
     subparsers = main_parser.add_subparsers(help="action")
 
@@ -20,6 +21,7 @@ def make_parser() -> argparse.ArgumentParser:
         ("mkpkg", mkpkg),
         ("create_xbuildenv", create_xbuildenv),
         ("install_xbuildenv", install_xbuildenv),
+        ("out_of_tree", out_of_tree),
     ):
         if "sphinx" in sys.modules and command_name in [
             "buildpkg",

--- a/pyodide-build/setup.py
+++ b/pyodide-build/setup.py
@@ -5,7 +5,6 @@ if __name__ == "__main__":
     setuptools.setup(
         entry_points={
             "console_scripts": [
-                "pyodide-xbuild = pyodide_build.out_of_tree.__main__:main",
                 "_pywasmcross = pyodide_build.pywasmcross:compiler_main",
             ]
         }

--- a/pyodide-build/setup.py
+++ b/pyodide-build/setup.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     setuptools.setup(
         entry_points={
             "console_scripts": [
-                "pyodide = pyodide_build.out_of_tree.__main__:main",
+                "pyodide-xbuild = pyodide_build.out_of_tree.__main__:main",
                 "_pywasmcross = pyodide_build.pywasmcross:compiler_main",
             ]
         }


### PR DESCRIPTION
Related: #2879

This PR renames the `pyodide` CLI entrypoint used for out-of-tree build to `pyodide-xbuild` (no strong opinion, please suggest a better name), so we can reserve the `pyodide` entrypoint for the future.

@hoodmane 