### PR TITLE
Remove pymalloc check

### DIFF
--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -39,7 +39,6 @@ if IS_COMPILER_INVOCATION:
     __name__ = PYWASMCROSS_ARGS.pop("orig__name__")
 
 
-import re
 import shutil
 import subprocess
 from collections import namedtuple
@@ -592,9 +591,6 @@ def handle_command_generate_args(
     used_libs: set[str] = set()
     # Go through and adjust arguments
     for arg in line[1:]:
-        # The native build is possibly multithreaded, but the emscripten one
-        # definitely isn't
-        arg = re.sub(r"/python([0-9]\.[0-9]+)m", r"/python\1", arg)
         if arg in optflags_valid and optflag is not None:
             # There are multiple contradictory optflags provided, use the one
             # from cflags/cxxflags/ldflags


### PR DESCRIPTION
This check was added 4 years ago. I think it was dealing with [Python built with `--with-pymalloc` case](https://peps.python.org/pep-3149/), which has been removed [since Python3.8](https://docs.python.org/3/whatsnew/3.8.html#build-and-c-api-changes).

I'm not sure what the comment is about.