### PR TITLE
TST Fix test skip check

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -106,10 +106,11 @@ def pytest_terminal_summary(terminalreporter):
 
     test_result = {}
     for status in tr.stats:
-        if status in ("warnings", "deselected"):
+        if status in ("warnings", "deselected", ""):
             continue
 
         for test in tr.stats[status]:
+            assert test.when == "call"
             try:
                 if test.longrepr and test.longrepr[2] in "previously passed":
                     test_result[test.nodeid] = "skip_passed"

--- a/conftest.py
+++ b/conftest.py
@@ -106,11 +106,14 @@ def pytest_terminal_summary(terminalreporter):
 
     test_result = {}
     for status in tr.stats:
-        if status in ("warnings", "deselected", ""):
+        if status in ("warnings", "deselected"):
             continue
 
         for test in tr.stats[status]:
-            assert test.when == "call"
+
+            if test.when != "call":  # discard results from setup/teardown
+                continue
+
             try:
                 if test.longrepr and test.longrepr[2] in "previously passed":
                     test_result[test.nodeid] = "skip_passed"

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -14,7 +14,7 @@ from pyodide_test_runner.hypothesis import (
 
 
 @given(s=text())
-@settings(deadline=4000)
+@settings(deadline=10000)
 @example("\ufeff")
 def test_string_conversion(selenium_module_scope, s):
     @run_in_pyodide


### PR DESCRIPTION
`--skip-passed` flag sometimes skips some tests that were not actually passed. This fixes it.