### PR TITLE
MAINT Rename pytest_pyodide wrappers

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -9,8 +9,8 @@ from time import time
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from pytest_pyodide import (  # noqa: E402
-    SeleniumChromeWrapper,
-    SeleniumFirefoxWrapper,
+    SeleniumChromeRunner,
+    SeleniumFirefoxRunner,
     spawn_web_server,
 )
 
@@ -180,8 +180,8 @@ def main():
     results = {}
     selenium_backends = {}
     browser_cls = [
-        ("firefox", SeleniumFirefoxWrapper),
-        ("chrome", SeleniumChromeWrapper),
+        ("firefox", SeleniumFirefoxRunner),
+        ("chrome", SeleniumChromeRunner),
     ]
 
     with spawn_web_server(args.dist_dir) as (hostname, port, log_path):

--- a/packages/test_packages_common.py
+++ b/packages/test_packages_common.py
@@ -2,7 +2,7 @@ import functools
 import os
 
 import pytest
-from pytest_pyodide import SeleniumWrapper
+from pytest_pyodide.runner import _BrowserBaseRunner
 
 from conftest import ROOT_PATH, package_is_built
 from pyodide_build.io import parse_package_config
@@ -44,7 +44,7 @@ def test_parse_package(name: str) -> None:
 @pytest.mark.skip_refcount_check
 @pytest.mark.driver_timeout(60)
 @pytest.mark.parametrize("name", registered_packages())
-def test_import(name: str, selenium_standalone: SeleniumWrapper) -> None:
+def test_import(name: str, selenium_standalone: _BrowserBaseRunner) -> None:
     if not package_is_built(name):
         raise AssertionError(
             "Implementation error. Test for an unbuilt package "


### PR DESCRIPTION
-  Rename `Wrapper` ==> `Runner`, according to (https://github.com/pyodide/pytest-pyodide/issues/8)
-  Handling `xfail_browsers` has been moved to pytest-pyodide, so delete it (https://github.com/pyodide/pytest-pyodide/pull/15)