### PR TITLE
Make GH sponsors more visible

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: # TODO Replace with up to 4 GitHub Sponsors-enabled username: pyodide
+github: pyodide
 open_collective: pyodide


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide/issues/2917

It should show [GH sponsors](https://github.com/sponsors/pyodide)  in the list I think

![image](https://user-images.githubusercontent.com/630936/182599170-10c32d64-20e2-4029-a60d-6ad7fa4686d9.png)
