### PR TITLE
Be more careful about different array variants

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -41,17 +41,19 @@
 #include "structmember.h"
 
 // clang-format off
-#define IS_ITERABLE  (1<<0)
-#define IS_ITERATOR  (1<<1)
-#define HAS_LENGTH   (1<<2)
-#define HAS_GET      (1<<3)
-#define HAS_SET      (1<<4)
-#define HAS_HAS      (1<<5)
-#define HAS_INCLUDES (1<<6)
-#define IS_AWAITABLE (1<<7)
-#define IS_BUFFER    (1<<8)
-#define IS_CALLABLE  (1<<9)
-#define IS_ARRAY     (1<<10)
+#define IS_ITERABLE   (1<<0)
+#define IS_ITERATOR   (1<<1)
+#define HAS_LENGTH    (1<<2)
+#define HAS_GET       (1<<3)
+#define HAS_SET       (1<<4)
+#define HAS_HAS       (1<<5)
+#define HAS_INCLUDES  (1<<6)
+#define IS_AWAITABLE  (1<<7)
+#define IS_BUFFER     (1<<8)
+#define IS_CALLABLE   (1<<9)
+#define IS_ARRAY      (1<<10)
+#define IS_NODE_LIST  (1<<11)
+#define IS_TYPEDARRAY (1<<12)
 // clang-format on
 
 _Py_IDENTIFIER(get_event_loop);
@@ -491,6 +493,36 @@ finally:
 }
 
 /**
+ * __getitem__ for proxies of Js TypedArrays, controlled by IS_TYPEDARRAY
+ */
+static PyObject*
+JsTypedArray_subscript(PyObject* o, PyObject* item)
+{
+  if (PySlice_Check(item)) {
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "Slice subscripting isn't implemented for typed arrays");
+    return NULL;
+  }
+  return JsArray_subscript(o, item);
+}
+
+/**
+ * __getitem__ for proxies of HTMLCollection or NodeList, controlled by
+ * IS_NODE_LIST
+ */
+static PyObject*
+JsNodeList_subscript(PyObject* o, PyObject* item)
+{
+  if (PySlice_Check(item)) {
+    PyErr_SetString(
+      PyExc_NotImplementedError,
+      "Slice subscripting isn't implemented for HTMLCollection or NodeList");
+    return NULL;
+  }
+  return JsArray_subscript(o, item);
+}
+
+/**
  * __setitem__ and __delitem__ for proxies of Js Arrays, controlled by IS_ARRAY
  */
 static int
@@ -585,6 +617,25 @@ finally:
   Py_CLEAR(seq);
   hiwire_CLEAR(idvalue);
   return success ? 0 : -1;
+}
+
+/**
+ * __setitem__ and __delitem__ for proxies of TypedArrays, controlled by
+ * IS_TYPED_ARRAY
+ */
+static int
+JsTypedArray_ass_subscript(PyObject* o, PyObject* item, PyObject* pyvalue)
+{
+  if (pyvalue == NULL) {
+    PyErr_SetString(PyExc_ValueError, "cannot delete array elements");
+    return -1;
+  }
+  if (PySlice_Check(item)) {
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "Slice assignment isn't implemented for typed arrays");
+    return -1;
+  }
+  return JsArray_ass_subscript(o, item, pyvalue);
 }
 
 static PyObject*
@@ -2133,6 +2184,17 @@ JsProxy_create_subtype(int flags)
                                        .pfunc = (void*)JsArray_inplace_concat };
     methods[cur_method++] = JsArray_extend_MethodDef;
   }
+  if (flags & IS_TYPEDARRAY) {
+    slots[cur_slot++] = (PyType_Slot){ .slot = Py_mp_subscript,
+                                       .pfunc = (void*)JsTypedArray_subscript };
+    slots[cur_slot++] =
+      (PyType_Slot){ .slot = Py_mp_ass_subscript,
+                     .pfunc = (void*)JsTypedArray_ass_subscript };
+  }
+  if (flags & IS_NODE_LIST) {
+    slots[cur_slot++] = (PyType_Slot){ .slot = Py_mp_subscript,
+                                       .pfunc = (void*)JsNodeList_subscript };
+  }
   if (flags & IS_BUFFER) {
     methods[cur_method++] = JsBuffer_assign_MethodDef;
     methods[cur_method++] = JsBuffer_assign_to_MethodDef;
@@ -2227,6 +2289,32 @@ finally:
   return (PyTypeObject*)type;
 }
 
+EM_JS_NUM(int, JsProxy_array_detect, (JsRef idobj), {
+  try {
+    let obj = Hiwire.get_value(idobj);
+    let result = 0;
+    if (Array.isArray(obj)) {
+      return IS_ARRAY;
+    }
+    let typeTag = Object.prototype.toString.call(obj);
+    // We want to treat some standard array-like objects as Array.
+    // clang-format off
+    if(typeTag === "[object HTMLCollection]" || typeTag === "[object NodeList]"){
+      // clang-format on
+      return IS_NODE_LIST;
+    }
+    // What if it's a TypedArray?
+    // clang-format off
+    if (ArrayBuffer.isView(obj) && obj.constructor.name !== "DataView") {
+      // clang-format on
+      return IS_TYPEDARRAY;
+    }
+    return 0;
+  } catch (e) {
+    return 0;
+  }
+});
+
 ////////////////////////////////////////////////////////////
 // Public functions
 
@@ -2284,9 +2372,8 @@ JsProxy_create_with_this(JsRef object, JsRef this)
   if (hiwire_is_promise(object)) {
     type_flags |= IS_AWAITABLE;
   }
-  if (JsArray_Check(object)) {
-    type_flags |= IS_ARRAY;
-  }
+  type_flags |= JsProxy_array_detect(object);
+
 done_feature_detecting:
 
   type = JsProxy_get_subtype(type_flags);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -621,7 +621,7 @@ finally:
 
 /**
  * __setitem__ and __delitem__ for proxies of TypedArrays, controlled by
- * IS_TYPED_ARRAY
+ * IS_TYPEDARRAY
  */
 static int
 JsTypedArray_ass_subscript(PyObject* o, PyObject* item, PyObject* pyvalue)
@@ -2292,7 +2292,6 @@ finally:
 EM_JS_NUM(int, JsProxy_array_detect, (JsRef idobj), {
   try {
     let obj = Hiwire.get_value(idobj);
-    let result = 0;
     if (Array.isArray(obj)) {
       return IS_ARRAY;
     }

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1720,3 +1720,62 @@ def test_array_extend(selenium_module_scope, l1, l2):
 
     assert l1 == l1js1.to_py()
     assert l1 == l1js2.to_py()
+
+
+@run_in_pyodide
+def test_typed_array(selenium):
+    from pyodide.code import run_js
+
+    a = run_js("self.a = new Uint8Array([1,2,3,4]); a")
+    assert a[0] == 1
+    assert a[-1] == 4
+    a[-2] = 7
+    assert run_js("self.a[2]") == 7
+
+    import pytest
+
+    with pytest.raises(ValueError, match="cannot delete array elements"):
+        del a[0]
+
+    msg = "Slice subscripting isn't implemented for typed arrays"
+    with pytest.raises(NotImplementedError, match=msg):
+        a[:]
+
+    msg = "Slice assignment isn't implemented for typed arrays"
+    with pytest.raises(NotImplementedError, match=msg):
+        a[:] = [-1, -2, -3, -4]
+
+    assert not hasattr(a, "extend")
+    with pytest.raises(TypeError):
+        a += [1, 2, 3]
+
+
+@pytest.mark.xfail_browsers(node="No document in node")
+@run_in_pyodide
+def test_html_array(selenium):
+    from pyodide.code import run_js
+
+    x = run_js("document.querySelectorAll('*')")
+    assert run_js(
+        """
+        (a, b) => {
+            a === b[0]
+        }
+        """
+    )(x[0], x)
+
+    assert run_js(
+        """
+        (a, b) => {
+            a === Array.from(b).pop()
+        }
+        """
+    )(x[-1], x)
+
+    import pytest
+
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        x[0] = 0
+
+    with pytest.raises(TypeError, match="does not support item deletion"):
+        del x[0]

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1761,8 +1761,8 @@ def test_html_array(selenium):
 
     import pytest
 
-    with pytest.raises(TypeError, match="does not support item assignment"):
+    with pytest.raises(TypeError, match="does ?n[o']t support item assignment"):
         x[0] = 0
 
-    with pytest.raises(TypeError, match="does not support item deletion"):
+    with pytest.raises(TypeError, match="does ?n[o']t support item deletion"):
         del x[0]

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1756,21 +1756,8 @@ def test_html_array(selenium):
     from pyodide.code import run_js
 
     x = run_js("document.querySelectorAll('*')")
-    assert run_js(
-        """
-        (a, b) => {
-            a === b[0]
-        }
-        """
-    )(x[0], x)
-
-    assert run_js(
-        """
-        (a, b) => {
-            a === Array.from(b).pop()
-        }
-        """
-    )(x[-1], x)
+    assert run_js("(a, b) => a === b[0]")(x[0], x)
+    assert run_js("(a, b) => a === Array.from(b).pop()")(x[-1], x)
 
     import pytest
 


### PR DESCRIPTION
This fixes a few problems introduced in #2907. The slicing doesn't work correctly for `TypedArray` or `NodeList` and there are several possible routes to take with `TypedArray` so I think it's better to leave it not implemented for now. Also, `extend` and `+=` don't work for `TypedArray` and `NodeList`. This also gives a better error if you attempt `del a[0]` when `a` is a `TypedArray` or `NodeList`. The former have a fixed length, the latter are immutable.

### Checklists

- [x] Add / update tests
