### PR TITLE
Report checksum when checksum doesn't match in a package build

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -209,7 +209,7 @@ def check_checksum(archive: Path, source_metadata: dict[str, Any]) -> None:
             if len(chunk) < CHUNK_SIZE:
                 break
     if h.hexdigest() != checksum:
-        raise ValueError(f"Invalid {checksum_algorithm} checksum")
+        raise ValueError(f"Invalid {checksum_algorithm} checksum: {h.hexdigest()}")
 
 
 def trim_archive_extension(tarballname: str) -> str:


### PR DESCRIPTION
This is a convenience modification. If I am updating a url I often want to update the checksum to force the new url to be accepted when the check fails. This makes it easy to copy the correct checksum from the error message.