### PR TITLE
DOC fix changelog badges

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -1,11 +1,11 @@
 ---
 substitutions:
-API: "<span class='badge badge-warning'>API Change</span>"
-Enhancement: "<span class='badge badge-info'>Enhancement</span>"
-Feature: "<span class='badge badge-success'>Feature</span>"
-Fix: "<span class='badge badge-danger'>Fix</span>"
-Update: "<span class='badge badge-success'>Update</span>"
-Breaking: "<span class='badge badge-danger'>BREAKING CHANGE</span>"
+  API: "<span class='badge badge-warning'>API Change</span>"
+  Enhancement: "<span class='badge badge-info'>Enhancement</span>"
+  Feature: "<span class='badge badge-success'>Feature</span>"
+  Fix: "<span class='badge badge-danger'>Fix</span>"
+  Update: "<span class='badge badge-success'>Update</span>"
+  Breaking: "<span class='badge badge-danger'>BREAKING CHANGE</span>"
 ---
 
 (changelog)=


### PR DESCRIPTION
### Description

This PR reverts the indentation change introduced in #2909, to make sure badges are displayed correctly.

I've checked at https://pyodide.org/en/latest/project/changelog.html and badges are, in fact, temporarily broken.

