### PR TITLE
Add an Emscripten version check for out of tree builds

### DIFF
--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -34,7 +34,7 @@ def check_emscripten_version() -> None:
     installed_version = None
     try:
         for x in reversed(version_info.partition("\n")[0].split(" ")):
-            if re.match(r"[0-9]+\.[0-9]+.[0-9]+", x):
+            if re.match(r"[0-9]+\.[0-9]+\.[0-9]+", x):
                 installed_version = x
                 break
     except Exception:

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -1,6 +1,7 @@
 import contextlib
 import functools
 import os
+import re
 import subprocess
 import sys
 from collections.abc import Generator, Iterable, Iterator, Mapping
@@ -15,6 +16,35 @@ from .io import parse_package_config
 
 def emscripten_version() -> str:
     return get_make_flag("PYODIDE_EMSCRIPTEN_VERSION")
+
+
+def get_emscripten_version_info() -> str:
+    """Extracted for testing purposes."""
+    return subprocess.run(["emcc", "-v"], capture_output=True, encoding="utf8").stderr
+
+
+def check_emscripten_version() -> None:
+    needed_version = emscripten_version()
+    try:
+        version_info = get_emscripten_version_info()
+    except FileNotFoundError:
+        raise RuntimeError(
+            f"No Emscripten compiler found. Need Emscripten version {needed_version}"
+        ) from None
+    installed_version = None
+    try:
+        for x in reversed(version_info.partition("\n")[0].split(" ")):
+            if re.match(r"[0-9]+\.[0-9]+.[0-9]+", x):
+                installed_version = x
+                break
+    except Exception:
+        raise RuntimeError("Failed to determine Emscripten version.")
+    if installed_version is None:
+        raise RuntimeError("Failed to determine Emscripten version.")
+    if installed_version != needed_version:
+        raise RuntimeError(
+            f"Incorrect Emscripten version {installed_version}. Need Emscripten version {needed_version}"
+        )
 
 
 def platform() -> str:

--- a/pyodide-build/pyodide_build/out_of_tree/build.py
+++ b/pyodide-build/pyodide_build/out_of_tree/build.py
@@ -26,6 +26,7 @@ def run(exports, args):
 
 
 def main(parser_args: argparse.Namespace) -> None:
+    common.check_emscripten_version()
     run(parser_args.exports, parser_args.backend_args)
 
 

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -130,3 +130,58 @@ def test_search_pyodide_root(tmp_path):
     pyproject_file.unlink()
     with pytest.raises(FileNotFoundError):
         search_pyodide_root(tmp_path)
+
+
+def test_check_emscripten_version(monkeypatch):
+    from pyodide_build import common
+
+    s = None
+
+    def get_emscripten_version_info():
+        return s
+
+    needed_version = common.emscripten_version()
+    monkeypatch.setattr(
+        common, "get_emscripten_version_info", get_emscripten_version_info
+    )
+    s = """\
+emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.4 (14cd48e6ead13b02a79f47df1a252abc501a3269)
+clang version 15.0.0 (https://github.com/llvm/llvm-project ce5588fdf478b6af724977c11a405685cebc3d26)
+Target: wasm32-unknown-emscripten
+Thread model: posix
+"""
+    with pytest.raises(
+        RuntimeError,
+        match=f"Incorrect Emscripten version 3.1.4. Need Emscripten version {needed_version}",
+    ):
+        common.check_emscripten_version()
+
+    s = """\
+emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 1.39.20
+clang version 12.0.0 (/b/s/w/ir/cache/git/chromium.googlesource.com-external-github.com-llvm-llvm--project 55fa315b0352b63454206600d6803fafacb42d5e)
+"""
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"Incorrect Emscripten version 1.39.20. Need Emscripten version {needed_version}",
+    ):
+        common.check_emscripten_version()
+
+    s = """\
+emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 3.1.14 (4343cbec72b7db283ea3bda1adc6cb1811ae9a73)
+clang version 15.0.0 (https://github.com/llvm/llvm-project 7effcbda49ba32991b8955821b8fdbd4f8f303e2)
+"""
+    common.check_emscripten_version()
+
+    def get_emscripten_version_info():  # type: ignore[no-redef]
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(
+        common, "get_emscripten_version_info", get_emscripten_version_info
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"No Emscripten compiler found. Need Emscripten version {needed_version}",
+    ):
+        common.check_emscripten_version()


### PR DESCRIPTION
The out of tree build system applies an abi tag based on `PYODIDE_EMSCRIPTEN_VERSION` in `Makefile.envs`. Prior to this PR, it will happily accept the version of emscripten (say 3.1.18) and produce a wheel tagged like it was produced from the expected Emscripten version (say 3.1.14). This causes confusing errors due to ABI mismatch see https://github.com/igraph/python-igraph/issues/560. This error message should help prevent such confusion.