### PR TITLE
loadPackage should say that packages downloaded from pypi come from pypi

### DIFF
--- a/packages/micropip/src/micropip/_micropip.py
+++ b/packages/micropip/src/micropip/_micropip.py
@@ -208,6 +208,9 @@ class WheelInfo:
             self.write_dist_info(
                 "PYODIDE_REQUIRES", json.dumps(sorted(x.name for x in self._requires))
             )
+        name = self.project_name
+        assert name
+        setattr(loadedPackages, name, wheel_source)
 
     async def load_libraries(self, target: Path) -> None:
         assert self.data
@@ -215,18 +218,14 @@ class WheelInfo:
         await gather(*map(lambda dynlib: loadDynlib(dynlib, False), dynlibs))
 
     async def install(self, target: Path) -> None:
-        url = self.url
         if not self.data:
             raise RuntimeError(
                 "Micropip internal error: attempted to install wheel before downloading it?"
             )
         self.validate()
         self.extract(target)
-        self.set_installer()
         await self.load_libraries(target)
-        name = self.project_name
-        assert name
-        setattr(loadedPackages, name, url)
+        self.set_installer()
 
 
 FAQ_URLS = {


### PR DESCRIPTION
If micropip loads a package, we put it into `pyodide.loadedPackages` so that `loadPackage` will know about it. Currently, if one installs via `micropip` and then via `loadPackage`:
```py
from pyodide_js import loadPackage
import micropip
await micropip.install("pytest==7.1.1")
await loadPackage("pytest")
```
it will say `pytest already loaded from https://pythonhosted.org/longstuff`. This makes it say `pytest already loaded from pypi`.