### PR TITLE
Rename released bundle from pyodide-build.tar.gz to pyodide.tar.gz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run:
           name: Zip build directory
           command: |
-            tar cjf pyodide-build.tar.gz dist
+            tar cjf pyodide.tar.gz dist
 
       - persist_to_workspace:
           root: .
@@ -107,7 +107,7 @@ jobs:
           path: /root/repo/dist/
 
       - store_artifacts:
-          path: /root/repo/pyodide-build.tar.gz
+          path: /root/repo/pyodide.tar.gz
 
       - store_artifacts:
           path: /root/repo/packages/build-logs
@@ -162,7 +162,7 @@ jobs:
       - run:
           name: Zip build directory
           command: |
-            tar --exclude="node_modules" -cjf pyodide-build.tar.gz dist
+            tar --exclude="node_modules" -cjf pyodide.tar.gz dist
             tar cjf build-logs.tar.gz  packages/build-logs
 
       - run:
@@ -171,7 +171,7 @@ jobs:
             cd packages && find **/build ! -name '.packaged' -type f -exec rm -f {} +
 
       - store_artifacts:
-          path: /root/repo/pyodide-build.tar.gz
+          path: /root/repo/pyodide.tar.gz
 
       - store_artifacts:
           path: /root/repo/build-logs.tar.gz
@@ -341,7 +341,7 @@ jobs:
             cp -r dist /tmp/ghr/pyodide
             cp -r xbuildenv /tmp/ghr/xbuildenv
             cd /tmp/ghr
-            tar cjf dist/pyodide-build-${CIRCLE_TAG}.tar.bz2  pyodide/
+            tar cjf dist/pyodide-${CIRCLE_TAG}.tar.bz2  pyodide/
             tar cjf dist/xbuildenv-${CIRCLE_TAG}.tar.bz2  xbuildenv/
             ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" \
               -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" \

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -31,6 +31,10 @@ substitutions:
 - {{ Fix }} Pyodide works in Safari v14 again. It was broken in v0.21.0
   {pr}`2994`
 
+- {{ Enhancement }} The releases are now called `pyodide-{version}.tar.gz`
+  rather than `pyodide-build-{version}.tar.gz`
+  {pr}`2996`
+
 ## Version 0.21.0
 
 _August 9, 2022_


### PR DESCRIPTION
It's confusing that we call the release `pyodide-build.tar.gz`. This renames it to `pyodide.tar.gz`.