### PR TITLE
DOC Switch to Plausible analytics in the docs

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,8 @@
+{# Import the theme's layout. #} {% extends '!layout.html' %} {%- block
+extrahead %} {{ super() }}
+<script
+  defer
+  data-domain="pyodide.org"
+  src="https://plausible.io/js/plausible.js"
+></script>
+{%- endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,4 @@
-{# Import the theme's layout. #} {% extends '!layout.html' %} {%- block
-extrahead %} {{ super() }}
+{% extends '!layout.html' %} {%- block extrahead %} {{ super() }}
 <script
   defer
   data-domain="pyodide.org"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,7 +154,7 @@ if IN_READTHEDOCS:
             # insert the analytics script after the `pyodide.js` script
             console_html.insert(
                 idx,
-                '<script defer data-domain="pyodide.org" src="https://plausible.io/js/plausible.js"></script>"\n',
+                '<script defer data-domain="pyodide.org" src="https://plausible.io/js/plausible.js"></script>\n',
             )
             break
     else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,21 @@ if IN_READTHEDOCS:
         encoding="utf-8",
     )
     print(res)
+    # insert the Plausible analytics script to console.html
+    console_path = Path("_build/html/console.html")
+    console_html = console_path.read_text().splitlines(keepends=True)
+    for idx, line in enumerate(list(console_html)):
+        if 'pyodide.js">' in line:
+            # insert the analytics script after the `pyodide.js` script
+            console_html.insert(
+                idx,
+                '<script defer data-domain="pyodide.org" src="https://plausible.io/js/plausible.js"></script>"\n',
+            )
+            break
+    else:
+        raise ValueError("Could not find pyodide.js in the <head> section")
+    console_path.write_text("".join(console_html))
+
 
 if IN_SPHINX:
     # Compatibility shims. sphinx-js and sphinxcontrib-napoleon have not been updated for Python 3.10


### PR DESCRIPTION
Due to the same reasons as in https://github.com/pyodide/pyodide-blog/pull/33

Also adds analytics to console.html (only when it's deployed as part of the docs).

The Google Analytics is  configured in readthedocs, so I'll disable it once this is merged.