### PR TITLE
Remove socketmodule from ssl

### DIFF
--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -10,13 +10,11 @@ build:
     mkdir dist
     export DISTDIR=$(pwd)/dist
     cd $CPYTHONBUILD
-    emcc $STDLIB_MODULE_CFLAGS -c Modules/socketmodule.c -o Modules/socketmodule.o
     emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \
       $(pkg-config --cflags --dont-define-prefix openssl) \
       $(pkg-config --libs --dont-define-prefix openssl) \
       -DOPENSSL_THREADS # This declares that OPENSSL is threadsafe. We are single threaded so everything is threadsafe.
     emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS $(pkg-config --libs --dont-define-prefix openssl)
-    emcc Modules/socketmodule.o -o $DISTDIR/socketmodule.so $SIDE_MODULE_LDFLAGS
 
     cp Lib/ssl.py $DISTDIR
 


### PR DESCRIPTION
### Description

I don't see why we are building socketmodule in ssl. We already have `_socket` vendored.

