### PR TITLE
Fix loadPackage on relative urls

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -32,6 +32,11 @@ substitutions:
   rather than `pyodide-build-{version}.tar.gz`
   {pr}`2996`
 
+- {{ Fix }} If a wheel path is passed to {any}`pyodide.loadPackage`, it will now
+  be resolved relative to `document.location` (in browser) or relative to the
+  current working directory (in Node) rather than relative to `indexURL`.
+  {pr}`3013`, {issue}`3011`
+
 ### Build System
 
 - {{ Enhancement }} Added `requirements/host` key to the `meta.yaml` spec to allow

--- a/packages/micropip/src/micropip/_compat_in_pyodide.py
+++ b/packages/micropip/src/micropip/_compat_in_pyodide.py
@@ -23,7 +23,7 @@ async def fetch_bytes(url: str, kwargs: dict[str, str]) -> IO[bytes]:
     if parsed_url.scheme == "emfs":
         return open(parsed_url.path, "rb")
     if parsed_url.scheme == "file":
-        result_bytes = (await loadBinaryFile("", parsed_url.path)).to_bytes()
+        result_bytes = (await loadBinaryFile(parsed_url.path)).to_bytes()
     else:
         result_bytes = await (await pyfetch(url, **kwargs)).bytes()
     return BytesIO(result_bytes)

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -11,6 +11,7 @@ export const IN_NODE =
 let nodeUrlMod: any;
 let nodeFetch: any;
 let nodeVmMod: any;
+let nodePath: any;
 /** @private */
 export let nodeFsPromisesMod: any;
 
@@ -40,6 +41,8 @@ export async function initNodeModules() {
   }
   // @ts-ignore
   nodeVmMod = (await import("vm")).default;
+  nodePath = await import("path");
+
   if (typeof require !== "undefined") {
     return;
   }
@@ -66,6 +69,21 @@ export async function initNodeModules() {
   (globalThis as any).require = function (mod: string): any {
     return node_modules[mod];
   };
+}
+
+function node_resolvePath(path: string, base?: string): string {
+  return nodePath.resolve(base || ".", path);
+}
+
+function browser_resolvePath(path: string, base?: string): string {
+  return new URL(path, base).toString();
+}
+
+export let resolvePath: (rest: string, base?: string) => string;
+if (IN_NODE) {
+  resolvePath = node_resolvePath;
+} else {
+  resolvePath = browser_resolvePath;
 }
 
 /**

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -78,16 +78,9 @@ export async function initNodeModules() {
  * @private
  */
 async function node_loadBinaryFile(
-  indexURL: string,
   path: string,
   _file_sub_resource_hash?: string | undefined // Ignoring sub resource hash. See issue-2431.
 ): Promise<Uint8Array> {
-  if (!path.startsWith("/") && !path.includes("://")) {
-    // If path starts with a "/" or starts with a protocol "blah://", we
-    // interpret it as an absolute path, otherwise "resolve" it by
-    // joining it with indexURL.
-    path = `${indexURL}${path}`;
-  }
   if (path.startsWith("file://")) {
     // handle file:// with filesystem operations rather than with fetch.
     path = path.slice("file://".length);
@@ -110,20 +103,17 @@ async function node_loadBinaryFile(
  * Load a binary file, only for use in browser. Resolves relative paths against
  * indexURL.
  *
- * @param indexURL base path to resolve relative paths
  * @param path the path to load
  * @param subResourceHash the sub resource hash for fetch() integrity check
  * @returns A Uint8Array containing the binary data
  * @private
  */
 async function browser_loadBinaryFile(
-  indexURL: string,
   path: string,
   subResourceHash: string | undefined
 ): Promise<Uint8Array> {
   // @ts-ignore
-  const base = new URL(indexURL, location);
-  const url = new URL(path, base);
+  const url = new URL(path, location);
   let options = subResourceHash ? { integrity: subResourceHash } : {};
   // @ts-ignore
   let response = await fetch(url, options);
@@ -135,7 +125,6 @@ async function browser_loadBinaryFile(
 
 /** @private */
 export let loadBinaryFile: (
-  indexURL: string,
   path: string,
   file_sub_resource_hash?: string | undefined
 ) => Promise<Uint8Array>;

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -7,6 +7,7 @@ import {
   nodeFsPromisesMod,
   loadBinaryFile,
   initNodeModules,
+  resolvePath,
 } from "./compat.js";
 import { PyProxy, isPyProxy } from "./pyproxy.gen";
 
@@ -166,7 +167,7 @@ async function downloadPackage(
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.repodata_packages[name].file_name;
-    uri = new URL(file_name, API.config.indexURL).toString();
+    uri = resolvePath(file_name, API.config.indexURL);
     file_sub_resource_hash = API.package_loader.sub_resource_hash(
       API.repodata_packages[name].sha256
     );

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -160,43 +160,37 @@ async function downloadPackage(
   name: string,
   channel: string
 ): Promise<Uint8Array> {
-  let file_name, file_sub_resource_hash;
+  let file_name, uri, file_sub_resource_hash;
   if (channel === DEFAULT_CHANNEL) {
     if (!(name in API.repodata_packages)) {
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.repodata_packages[name].file_name;
+    uri = API.config.indexURL + file_name;
     file_sub_resource_hash = API.package_loader.sub_resource_hash(
       API.repodata_packages[name].sha256
     );
   } else {
-    file_name = channel;
+    uri = channel;
     file_sub_resource_hash = undefined;
   }
   try {
-    return await loadBinaryFile(
-      API.config.indexURL,
-      file_name,
-      file_sub_resource_hash
-    );
+    return await loadBinaryFile(uri, file_sub_resource_hash);
   } catch (e) {
-    if (!IN_NODE) {
+    if (!IN_NODE || channel !== DEFAULT_CHANNEL) {
       throw e;
     }
   }
   console.log(
-    `Didn't find package ${file_name}, attempting to load from ${cdnURL}`
+    `Didn't find package ${file_name} locally, attempting to load from ${cdnURL}`
   );
   // If we are IN_NODE, download the package from the cdn, then stash it into
   // the node_modules directory for future use.
-  let binary = await loadBinaryFile(cdnURL, file_name);
+  let binary = await loadBinaryFile(cdnURL + file_name);
   console.log(
     `Package ${file_name} loaded from ${cdnURL}, caching the wheel in node_modules for future use.`
   );
-  await nodeFsPromisesMod.writeFile(
-    `${API.config.indexURL}${file_name}`,
-    binary
-  );
+  await nodeFsPromisesMod.writeFile(uri, binary);
   return binary;
 }
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -166,7 +166,7 @@ async function downloadPackage(
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.repodata_packages[name].file_name;
-    uri = API.config.indexURL + file_name;
+    uri = new URL(file_name, API.config.indexURL).toString();
     file_sub_resource_hash = API.package_loader.sub_resource_hash(
       API.repodata_packages[name].sha256
     );

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -271,8 +271,7 @@ export async function loadPyodide(
   const config = Object.assign(default_config, options) as ConfigType;
   await initNodeModules();
   const pyodide_py_tar_promise = loadBinaryFile(
-    config.indexURL,
-    "pyodide_py.tar"
+    config.indexURL + "pyodide_py.tar"
   );
 
   const Module = createModule();

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -84,6 +84,8 @@ def test_load_relative_url(request, runtime, web_server_main, playwright_browser
         ) as selenium, set_webdriver_script_timeout(
             selenium, script_timeout=parse_driver_timeout(request.node)
         ):
+            if selenium.browser == "node":
+                selenium.run_js(f"process.chdir('{directory.resolve()}')")
             selenium.load_package(pytz1_wheel)
             selenium.run(
                 "import pytz; from pyodide_js import loadedPackages; print(loadedPackages.pytz1)"

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -61,35 +61,33 @@ def test_load_from_url(selenium_standalone, web_server_secondary, active_server)
     selenium.run("import pytz")
 
 
-def test_load_relative_url(request, runtime, web_server_main, playwright_browsers):
-    from tempfile import TemporaryDirectory
+def test_load_relative_url(
+    request, runtime, web_server_main, playwright_browsers, tmp_path
+):
+    url, port, _ = web_server_main
+    test_html = (ROOT_PATH / "src/templates/test.html").read_text()
+    test_html = test_html.replace("./pyodide.js", f"http://{url}:{port}/pyodide.js")
+    (tmp_path / "test.html").write_text(test_html)
+    pytz_wheel = get_pytz_wheel_name()
+    pytz1_wheel = pytz_wheel.replace("pytz", "pytz1")
+    shutil.copy(DIST_PATH / pytz_wheel, tmp_path / pytz1_wheel)
 
-    with TemporaryDirectory() as temp, spawn_web_server(temp) as web_server:
-        directory = Path(temp)
-        url, port, _ = web_server_main
-        test_html = (ROOT_PATH / "src/templates/test.html").read_text()
-        test_html = test_html.replace("./pyodide.js", f"http://{url}:{port}/pyodide.js")
-        (directory / "test.html").write_text(test_html)
-        pytz_wheel = get_pytz_wheel_name()
-        pytz1_wheel = pytz_wheel.replace("pytz", "pytz1")
-        shutil.copy(DIST_PATH / pytz_wheel, directory / pytz1_wheel)
-
-        with selenium_common(
-            request,
-            runtime,
-            web_server,
-            load_pyodide=True,
-            browsers=playwright_browsers,
-            script_type="classic",
-        ) as selenium, set_webdriver_script_timeout(
-            selenium, script_timeout=parse_driver_timeout(request.node)
-        ):
-            if selenium.browser == "node":
-                selenium.run_js(f"process.chdir('{directory.resolve()}')")
-            selenium.load_package(pytz1_wheel)
-            selenium.run(
-                "import pytz; from pyodide_js import loadedPackages; print(loadedPackages.pytz1)"
-            )
+    with spawn_web_server(tmp_path) as web_server, selenium_common(
+        request,
+        runtime,
+        web_server,
+        load_pyodide=True,
+        browsers=playwright_browsers,
+        script_type="classic",
+    ) as selenium, set_webdriver_script_timeout(
+        selenium, script_timeout=parse_driver_timeout(request.node)
+    ):
+        if selenium.browser == "node":
+            selenium.run_js(f"process.chdir('{tmp_path.resolve()}')")
+        selenium.load_package(pytz1_wheel)
+        selenium.run(
+            "import pytz; from pyodide_js import loadedPackages; print(loadedPackages.pytz1)"
+        )
 
 
 def test_list_loaded_urls(selenium_standalone):

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -2,15 +2,18 @@ import shutil
 from pathlib import Path
 
 import pytest
+from pytest_pyodide.fixture import selenium_common
+from pytest_pyodide.server import spawn_web_server
+from pytest_pyodide.utils import parse_driver_timeout, set_webdriver_script_timeout
 
-from conftest import DIST_PATH
+from conftest import DIST_PATH, ROOT_PATH
 
 
-def get_pyparsing_wheel_name():
+def get_pyparsing_wheel_name() -> str:
     return list(DIST_PATH.glob("pyparsing*.whl"))[0].name
 
 
-def get_pytz_wheel_name():
+def get_pytz_wheel_name() -> str:
     return list(DIST_PATH.glob("pytz*.whl"))[0].name
 
 
@@ -58,10 +61,33 @@ def test_load_from_url(selenium_standalone, web_server_secondary, active_server)
     selenium.run("import pytz")
 
 
-def test_load_relative_url(selenium_standalone):
-    print(get_pytz_wheel_name())
-    selenium_standalone.load_package(f"./{get_pytz_wheel_name()}")
-    selenium_standalone.run("import pytz")
+def test_load_relative_url(request, runtime, web_server_main, playwright_browsers):
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as temp, spawn_web_server(temp) as web_server:
+        directory = Path(temp)
+        url, port, _ = web_server_main
+        test_html = (ROOT_PATH / "src/templates/test.html").read_text()
+        test_html = test_html.replace("./pyodide.js", f"http://{url}:{port}/pyodide.js")
+        (directory / "test.html").write_text(test_html)
+        pytz_wheel = get_pytz_wheel_name()
+        pytz1_wheel = pytz_wheel.replace("pytz", "pytz1")
+        shutil.copy(DIST_PATH / pytz_wheel, directory / pytz1_wheel)
+
+        with selenium_common(
+            request,
+            runtime,
+            web_server,
+            load_pyodide=True,
+            browsers=playwright_browsers,
+            script_type="classic",
+        ) as selenium, set_webdriver_script_timeout(
+            selenium, script_timeout=parse_driver_timeout(request.node)
+        ):
+            selenium.load_package(pytz1_wheel)
+            selenium.run(
+                "import pytz; from pyodide_js import loadedPackages; print(loadedPackages.pytz1)"
+            )
 
 
 def test_list_loaded_urls(selenium_standalone):


### PR DESCRIPTION
### Description

This fixes #3011.

We attempted to make a test for this, but in all of our tests `document.location === indexURL`. Our logic incorrectly used `indexURL` instead of `document.location`.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
