### PR TITLE
Don't install standard library into the site-packages directory

### DIFF
--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -74,7 +74,7 @@ function unpackPyodidePy(Module: any, pyodide_py_tar: Uint8Array) {
 from sys import version_info
 pyversion = f"python{version_info.major}.{version_info.minor}"
 import shutil
-shutil.unpack_archive("/pyodide_py.tar", f"/lib/{pyversion}/site-packages/")
+shutil.unpack_archive("/pyodide_py.tar", f"/lib/{pyversion}/")
 del shutil
 import importlib
 importlib.invalidate_caches()

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -411,7 +411,7 @@ def test_console_html(console_html_fixture):
         ).strip()
     )
     result = re.sub(r"line \d+, in repr_shorten", "line xxx, in repr_shorten", result)
-    result = re.sub(r"/lib/python3.\d+/site-packages", "...", result)
+    result = re.sub(r"/lib/python3.\d+", "/lib/pythonxxx", result)
 
     answer = dedent(
         """
@@ -422,7 +422,7 @@ def test_console_html(console_html_fixture):
 
             >>> Test()
             [[;;;terminal-error]Traceback (most recent call last):
-              File \".../pyodide/console.py\", line xxx, in repr_shorten
+              File \"/lib/pythonxxx/pyodide/console.py\", line xxx, in repr_shorten
                 text = repr(value)
               File \"<console>\", line 3, in __repr__
             TypeError: hi]

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -767,6 +767,7 @@ def test_fatal_error(selenium_standalone):
         x = re.sub(".*@https?://[0-9.:]*/.*\n", "", x)
         x = re.sub(".*@debugger.*\n", "", x)
         x = re.sub(".*@chrome.*\n", "", x)
+        x = re.sub("line [0-9]*", "line xxx", x)
         x = x.replace("\n\n", "\n")
         return x
 
@@ -785,8 +786,8 @@ def test_fatal_error(selenium_standalone):
                   File "<exec>", line 6 in g
                   File "<exec>", line 4 in f
                   File "<exec>", line 9 in <module>
-                  File "/lib/pythonxxx/site-packages/pyodide/_base.py", line 242 in run
-                  File "/lib/pythonxxx/site-packages/pyodide/_base.py", line 344 in eval_code
+                  File "/lib/pythonxxx/pyodide/_base.py", line 242 in run
+                  File "/lib/pythonxxx/pyodide/_base.py", line 344 in eval_code
                 """
             )
         ).strip()


### PR DESCRIPTION
Usually the Python standard library is not installed into site-packages. This is important because if we use a virtual environment, then `/lib/python3.10/site-packages` directory will not be on the import path but `/lib/python3.10` will be.

Split off from #2976.

### Checklists

- [x] Add / update tests
