### PR TITLE
Handle case when Python startup code calls exit

### DIFF
--- a/src/js/module.ts
+++ b/src/js/module.ts
@@ -3,7 +3,7 @@ export interface Module {
   noImageDecoding: boolean;
   noAudioDecoding: boolean;
   noWasmDecoding: boolean;
-  quit: (a: any, b: any) => void;
+  quit: (status: number, toThrow: Error) => void;
   preRun: { (): void }[];
   print: (a: string) => void;
   printErr: (a: string) => void;
@@ -24,7 +24,7 @@ export function createModule(): any {
   Module.noWasmDecoding = false; // we preload wasm using the built in plugin now
   Module.preloadedWasm = {};
   Module.preRun = [];
-  Module.quit = (status: any, toThrow: any) => {
+  Module.quit = (status: number, toThrow: Error) => {
     Module.exited = { status, toThrow };
     throw toThrow;
   };

--- a/src/js/module.ts
+++ b/src/js/module.ts
@@ -3,6 +3,7 @@ export interface Module {
   noImageDecoding: boolean;
   noAudioDecoding: boolean;
   noWasmDecoding: boolean;
+  quit: (a: any, b: any) => void;
   preRun: { (): void }[];
   print: (a: string) => void;
   printErr: (a: string) => void;
@@ -23,6 +24,10 @@ export function createModule(): any {
   Module.noWasmDecoding = false; // we preload wasm using the built in plugin now
   Module.preloadedWasm = {};
   Module.preRun = [];
+  Module.quit = (status: any, toThrow: any) => {
+    Module.exited = { status, toThrow };
+    throw toThrow;
+  };
   return Module;
 }
 

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -296,6 +296,10 @@ export async function loadPyodide(
   // There is some work to be done between the module being "ready" and postRun
   // being called.
   await moduleLoaded;
+  // Handle early exit
+  if (Module.exited) {
+    throw Module.exited.toThrow;
+  }
 
   // Disable further loading of Emscripten file_packager stuff.
   Module.locateFile = (path: string) => {


### PR DESCRIPTION
If Python startup code calls `exit` (for instance because `--version` or `--help` was passed), then Emscripten calls `quit` which throws the error. The enclosing environment catches that error and burns the evidence. This modifies `quit` to record the fact that `exit` was called and rethrow the error (which will include the exit code). Otherwise, trying to run the command line runner with `python --version` will segfault.