### PR TITLE
TST Benchmark package load time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,8 @@ jobs:
               --junitxml=test-results/junit.xml \
               --verbose \
               --durations 50 \
+              --benchmark-json=benchmark-time.json \
+              --benchmark-columns=mean,min,max,stddev \
               << parameters.test-params >> \
               -o cache_dir=$CACHE_DIR
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,7 @@ jobs:
             make npm-link
             mkdir test-results
             pip install pytest-pyodide
+            pip install -r requirements.txt
             npm install -g node-fetch@2
             if [ -z "<< parameters.cache-dir >>" ]; then
               export CACHE_DIR=".test_cache/.pytest_cache_$(echo $RANDOM | md5sum | head -c 10)"

--- a/packages/_tests/test_packages_common.py
+++ b/packages/_tests/test_packages_common.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import time
 from typing import Any
 
 import pytest
@@ -48,6 +49,7 @@ def test_parse_package(name: str) -> None:
 @pytest.mark.benchmark(
     max_time=3,
     min_rounds=1,
+    timer=time.time,
 )
 def test_import(
     name: str, selenium_standalone: _BrowserBaseRunner, benchmark: Any

--- a/packages/_tests/test_packages_common.py
+++ b/packages/_tests/test_packages_common.py
@@ -45,6 +45,10 @@ def test_parse_package(name: str) -> None:
 @pytest.mark.skip_refcount_check
 @pytest.mark.driver_timeout(60)
 @pytest.mark.parametrize("name", registered_packages())
+@pytest.mark.benchmark(
+    max_time=3,
+    min_rounds=1,
+)
 def test_import(
     name: str, selenium_standalone: _BrowserBaseRunner, benchmark: Any
 ) -> None:

--- a/packages/_tests/test_packages_common.py
+++ b/packages/_tests/test_packages_common.py
@@ -1,5 +1,6 @@
 import functools
 import os
+from typing import Any
 
 import pytest
 from pytest_pyodide.runner import _BrowserBaseRunner
@@ -44,7 +45,9 @@ def test_parse_package(name: str) -> None:
 @pytest.mark.skip_refcount_check
 @pytest.mark.driver_timeout(60)
 @pytest.mark.parametrize("name", registered_packages())
-def test_import(name: str, selenium_standalone: _BrowserBaseRunner) -> None:
+def test_import(
+    name: str, selenium_standalone: _BrowserBaseRunner, benchmark: Any
+) -> None:
     if not package_is_built(name):
         raise AssertionError(
             "Implementation error. Test for an unbuilt package "
@@ -70,30 +73,35 @@ def test_import(name: str, selenium_standalone: _BrowserBaseRunner) -> None:
         ))
         """
     )
-    for import_name in meta.get("test", {}).get("imports", []):
-        selenium_standalone.run_async("import %s" % import_name)
-        # Make sure that even after importing, there are no additional .pyc
-        # files
-        assert (
-            selenium_standalone.run(
-                """
-                len(list(glob.glob(
-                    site.getsitepackages()[0] + '/**/*.pyc',
-                    recursive=True)
-                ))
-                """
-            )
-            == baseline_pyc
+
+    def _import_all():
+        for import_name in meta.get("test", {}).get("imports", []):
+            selenium_standalone.run_async("import %s" % import_name)
+
+    benchmark(_import_all())
+
+    # Make sure that even after importing, there are no additional .pyc
+    # files
+    assert (
+        selenium_standalone.run(
+            """
+            len(list(glob.glob(
+                site.getsitepackages()[0] + '/**/*.pyc',
+                recursive=True)
+            ))
+            """
         )
-        # Make sure no exe files were loaded!
-        assert (
-            selenium_standalone.run(
-                """
-                len(list(glob.glob(
-                    site.getsitepackages()[0] + '/**/*.exe',
-                    recursive=True)
-                ))
-                """
-            )
-            == 0
+        == baseline_pyc
+    )
+    # Make sure no exe files were loaded!
+    assert (
+        selenium_standalone.run(
+            """
+            len(list(glob.glob(
+                site.getsitepackages()[0] + '/**/*.exe',
+                recursive=True)
+            ))
+            """
         )
+        == 0
+    )

--- a/packages/_tests/test_packages_common.py
+++ b/packages/_tests/test_packages_common.py
@@ -74,11 +74,11 @@ def test_import(
         """
     )
 
-    def _import_all():
+    def _import_pkg():
         for import_name in meta.get("test", {}).get("imports", []):
             selenium_standalone.run_async("import %s" % import_name)
 
-    benchmark(_import_all())
+    benchmark(_import_pkg)
 
     # Make sure that even after importing, there are no additional .pyc
     # files

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@
   pytest-asyncio
   pytest-cov
   pytest-httpserver
+  pytest-benchmark


### PR DESCRIPTION
benchmark test load time in import tests in `test_packages_common.py`. This PR aims to measure how #3020 affects the package load time.

Note that since package import tests take too long to run, I set the minimal number of repentance to 1.