### PR TITLE
Fix incorrect package name of ruamel.yaml

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -67,13 +67,13 @@ def maybe_skip_test(item, delayed=False):
     if match and not is_common_test:
         package_name = match.group("name")
         if not package_is_built(package_name) and re.match(
-            rf"test_[\w\-]+\[({browsers})[^\]]*\]", item.name
+            rf"test_[\w\-\.]+\[({browsers})[^\]]*\]", item.name
         ):
             skip_msg = f"package '{package_name}' is not built."
 
     # Common package import test. Skip it if the package is not built.
     if skip_msg is None and is_common_test and item.name.startswith("test_import"):
-        match = re.match(rf"test_import\[({browsers})-(?P<name>[\w-]+)\]", item.name)
+        match = re.match(rf"test_import\[({browsers})-(?P<name>[\w\-\.]+)\]", item.name)
         if match:
             package_name = match.group("name")
             if not package_is_built(package_name):

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -41,6 +41,9 @@ substitutions:
   used by Pyodide's event loop.
   {pr}`2997`
 
+- {{ Fix }} Fix the incorrect package name `ruamel` to `ruamel.yaml`.
+  {pr}`3036`
+
 ### Build System
 
 - {{ Enhancement }} Added `requirements/host` key to the `meta.yaml` spec to allow

--- a/packages/demes/meta.yaml
+++ b/packages/demes/meta.yaml
@@ -7,7 +7,7 @@ source:
 requirements:
   run:
     - attrs
-    - ruamel
+    - ruamel.yaml
 test:
   imports:
     - demes

--- a/packages/ruamel.yaml/meta.yaml
+++ b/packages/ruamel.yaml/meta.yaml
@@ -1,12 +1,12 @@
 package:
-  name: ruamel
+  name: ruamel.yaml
   version: 0.17.21
 source:
   url: https://files.pythonhosted.org/packages/9e/cb/938214ac358fbef7058343b3765c79a1b7ed0c366f7f992ce7ff38335652/ruamel.yaml-0.17.21-py3-none-any.whl
   sha256: 742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7
 test:
   imports:
-    - ruamel
+    - ruamel.yaml
 about:
   home: https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree
   PyPI: https://pypi.org/project/ruamel.yaml

--- a/packages/ruamel.yaml/meta.yaml
+++ b/packages/ruamel.yaml/meta.yaml
@@ -6,6 +6,7 @@ source:
   sha256: 742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7
 test:
   imports:
+    - ruamel
     - ruamel.yaml
 about:
   home: https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -100,7 +100,7 @@ class Package(BasePackage):
         self.library = self.meta["build"].get("library", False)
         self.shared_library = self.meta["build"].get("sharedlibrary", False)
 
-        assert self.name == pkgdir.stem
+        assert self.name == pkgdir.name, f"{self.name} != {pkgdir.name}"
 
         self.run_dependencies = self.meta["requirements"].get("run", [])
         self.host_dependencies = self.meta["requirements"].get("host", [])


### PR DESCRIPTION
### Description

Fix the incorrect package name ruamel to ruamel.yaml

(Splited out from #3006)

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
