### PR TITLE
Scipy 1.9.1

### DIFF
--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: scipy
-  version: 1.8.1
+  version: 1.9.1
 
 # See extra explanation in info.md
 #
@@ -13,8 +13,8 @@ package:
 # subroutine. Try deleting it.
 
 source:
-  url: https://files.pythonhosted.org/packages/26/b5/9330f004b9a3b2b6a31f59f46f1617ce9ca15c0e7fe64288c20385a05c9d/scipy-1.8.1.tar.gz
-  sha256: 9e3fb1b0e896f14a85aa9a28d5f755daaeeb54c897b746df7a55ccb02b340f33
+  url: https://files.pythonhosted.org/packages/db/af/16906139f52bc6866c43401869ce247662739ad71afa11c6f18505eb0546/scipy-1.9.1.tar.gz
+  sha256: 26d28c468900e6d5fdb37d2812ab46db0ccd22c63baa095057871faa3a498bc9
 
   patches:
     - patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
@@ -30,8 +30,7 @@ source:
     - patches/0011-skip-fortran-fails-to-link.patch
     - patches/0012-Disable-lapack-detection.patch
     - patches/0013-Add-extra-END-to-prini.f.patch
-    - patches/0014-BUG-Fix-signature-of-D_IIR_forback-1-2.patch
-    - patches/0015-Change-qh_eachvoronoi_all-FILE-type.patch
+    - patches/0014-Change-qh_eachvoronoi_all-FILE-type.patch
 
 build:
   cflags: |
@@ -48,6 +47,8 @@ build:
   # Scipy has a bunch of custom logic implemented in
   # pyodide-build/pyodide_build/_f2c_fixes.py.
   script: |
+    set -x
+    export PKG_CONFIG_LIBDIR=$WASM_PKG_CONFIG_PATH
     pip install -t $HOSTSITEPACKAGES pythran
     # We get linker errors because the following 36 functions are missing
     # Copying them from a more recent LAPACK seems to work fine.
@@ -66,7 +67,7 @@ build:
     cd ../..
 
     # Change many functions that return void into functions that return int
-    find scipy -name "*.c*" | xargs sed -i 's/extern void F_FUNC/extern int F_FUNC/g'
+    find scipy -name "*.c*" -type f | xargs sed -i 's/extern void F_FUNC/extern int F_FUNC/g'
 
     sed -i 's/void F_FUNC/int F_FUNC/g' scipy/odr/__odrpack.c
     sed -i 's/^void/int/g' scipy/odr/odrpack.h

--- a/packages/scipy/patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
+++ b/packages/scipy/patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
@@ -1,7 +1,7 @@
-From 90a2cac7e8812f0a3e64c6bbc45fb1ece8d5f4d1 Mon Sep 17 00:00:00 2001
+From 3536f68975e1ba59681b1c2b29537d0df0cf40ad Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 18 Mar 2022 16:25:39 -0700
-Subject: [PATCH 01/15] Fix dstevr in special/lapack_defs.h
+Subject: [PATCH 01/14] Fix dstevr in special/lapack_defs.h
 
 ---
  scipy/special/lapack_defs.h | 5 ++---

--- a/packages/scipy/patches/0002-loadDynamicLibrary-flapack.patch
+++ b/packages/scipy/patches/0002-loadDynamicLibrary-flapack.patch
@@ -1,7 +1,7 @@
-From 9e6c2ad31267a5ed0c30645e70a0b290b3973dd1 Mon Sep 17 00:00:00 2001
+From 9a4a3a14f8292d1ca3297b9774b4d432d293c8d4 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 2 Apr 2022 14:20:25 -0700
-Subject: [PATCH 02/15] loadDynamicLibrary flapack
+Subject: [PATCH 02/14] loadDynamicLibrary flapack
 
 We are using CLAPACK for our LAPACK, but CLAPACK only supports
 LAPACK v3.2 since starting in v3.3 LAPACK started adding fortran
@@ -30,10 +30,10 @@ So we have to call loadDynamicLibrary on it, hence this patch.
  1 file changed, 11 insertions(+)
 
 diff --git a/scipy/linalg/lapack.py b/scipy/linalg/lapack.py
-index 9850d80c4..a28c3c6ca 100644
+index d4427d044..05ba6aacd 100644
 --- a/scipy/linalg/lapack.py
 +++ b/scipy/linalg/lapack.py
-@@ -809,6 +809,17 @@ All functions
+@@ -800,6 +800,17 @@ All functions
     ilaver
  
  """

--- a/packages/scipy/patches/0003-Add-lapack_extras-to-linalg-setup.py.patch
+++ b/packages/scipy/patches/0003-Add-lapack_extras-to-linalg-setup.py.patch
@@ -1,14 +1,14 @@
-From f6e479ea524c286f0a96d5df60d1f8edb595f643 Mon Sep 17 00:00:00 2001
+From 14208cd3dfda9396792254ebd90ca558a333936e Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 31 Dec 2021 22:27:07 -0800
-Subject: [PATCH 03/15] Add lapack_extras to linalg/setup.py
+Subject: [PATCH 03/14] Add lapack_extras to linalg/setup.py
 
 ---
  scipy/linalg/setup.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scipy/linalg/setup.py b/scipy/linalg/setup.py
-index 2f0ef0a48..d384081a2 100644
+index b84085a7c..20192f4cf 100644
 --- a/scipy/linalg/setup.py
 +++ b/scipy/linalg/setup.py
 @@ -43,7 +43,7 @@ def configuration(parent_package='', top_path=None):
@@ -18,8 +18,8 @@ index 2f0ef0a48..d384081a2 100644
 -    sources = ['flapack.pyf.src']
 +    sources = ['flapack.pyf.src', 'lapack_extras.f']
      sources += get_g77_abi_wrappers(lapack_opt)
-     dep_pfx = join('src', 'lapack_deprecations')
-     deprecated_lapack_routines = [join(dep_pfx, c + 'gegv.f') for c in 'cdsz']
+     depends = ['flapack_gen.pyf.src',
+                'flapack_gen_banded.pyf.src',
 -- 
 2.25.1
 

--- a/packages/scipy/patches/0004-int-to-string.patch
+++ b/packages/scipy/patches/0004-int-to-string.patch
@@ -1,7 +1,7 @@
-From 3c0ad123668366e82b64f459941eb36943745c43 Mon Sep 17 00:00:00 2001
+From 4ee1a3a58325adf45798c6be5bbad0b0f23d16d0 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 25 Dec 2021 18:04:18 -0800
-Subject: [PATCH 04/15] int to string
+Subject: [PATCH 04/14] int to string
 
 f2c does not handle implicit casts of function arguments correctly. The msg
 argument of `xerrwv` is defined to be an `int *`, and then implicitly cast

--- a/packages/scipy/patches/0005-disable-blas-detection.patch
+++ b/packages/scipy/patches/0005-disable-blas-detection.patch
@@ -1,7 +1,7 @@
-From 25612fa1854608cbbdcb994abb8486fc6f4a0736 Mon Sep 17 00:00:00 2001
+From 665e3d2e94224c7ae394158a0a5992a72efa4221 Mon Sep 17 00:00:00 2001
 From: Roman Yurchak <rth.yurchak@gmail.com>
 Date: Wed, 6 Apr 2022 21:19:55 -0700
-Subject: [PATCH 05/15] disable blas detection
+Subject: [PATCH 05/14] disable blas detection
 
 BLAS and LAPACK aren't available on host because we only cross compile these
 libraries (see CLAPACK/meta.yaml). Scipy tries to detect these libraries and
@@ -12,10 +12,10 @@ correctly for our target, so we just disable this detection mechanism.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/setup.py b/setup.py
-index a5ccaa159..8c3eb13c3 100755
+index e4ba8f669..a1a7c4e25 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -507,7 +507,7 @@ def configuration(parent_package='', top_path=None):
+@@ -415,7 +415,7 @@ def configuration(parent_package='', top_path=None):
  
      lapack_opt = get_info('lapack_opt')
  

--- a/packages/scipy/patches/0006-fix-fotran-files-minpack.patch
+++ b/packages/scipy/patches/0006-fix-fotran-files-minpack.patch
@@ -1,7 +1,7 @@
-From 84a590dd8d7563306c09f1f3ba5299e68c9bd359 Mon Sep 17 00:00:00 2001
+From a4c641af121cb2ed562e1c4ab018f7a17cf26dd2 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 6 Apr 2022 21:21:53 -0700
-Subject: [PATCH 06/15] fix fotran files minpack
+Subject: [PATCH 06/14] fix fotran files minpack
 
 ---
  scipy/optimize/minpack/chkder.f | 3 +--

--- a/packages/scipy/patches/0007-gemm_-no-const.patch
+++ b/packages/scipy/patches/0007-gemm_-no-const.patch
@@ -1,7 +1,7 @@
-From e3140b25165537ddc731f1d72e46ec9059faa6d6 Mon Sep 17 00:00:00 2001
+From 7fab490dc4e7081633a553f2ed394fa06e36e521 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 18 Dec 2021 11:41:15 -0800
-Subject: [PATCH 07/15] gemm_ no const
+Subject: [PATCH 07/14] gemm_ no const
 
 cgemm, dgemm, sgemm, and zgemm are declared with `const` in slu_cdefs.h, but
 other places don't have the cosnt causing compile errors.

--- a/packages/scipy/patches/0008-make-int-return-values.patch
+++ b/packages/scipy/patches/0008-make-int-return-values.patch
@@ -1,7 +1,7 @@
-From 3187f7c7b940c7d3a74bf8a30db74a1e0214bace Mon Sep 17 00:00:00 2001
+From e36f73ce3c92683a8bc05ea2b5265d71459dbbf4 Mon Sep 17 00:00:00 2001
 From: Joe Marshall <joe.marshall@nottingham.ac.uk>
 Date: Wed, 6 Apr 2022 21:25:13 -0700
-Subject: [PATCH 08/15] make int return values
+Subject: [PATCH 08/14] make int return values
 
 The return values of f2c functions are insignificant in most cases, so often it
 is treated as returning void, when it really should return int (values are
@@ -24,7 +24,7 @@ to be consistent.
  scipy/_build_utils/src/wrap_dummy_g77_abi.f   | 16 ----
  scipy/integrate/_odepackmodule.c              |  8 +-
  scipy/linalg/fblas_l1.pyf.src                 | 78 +++++++++++++------
- scipy/linalg/setup.py                         |  7 +-
+ scipy/linalg/setup.py                         |  1 +
  scipy/odr/__odrpack.c                         |  2 +-
  scipy/optimize/_lsq/setup.py                  |  2 +-
  .../linalg/_dsolve/SuperLU/SRC/cgsrfs.c       |  7 --
@@ -48,7 +48,7 @@ to be consistent.
  scipy/sparse/linalg/_dsolve/_superlu_utils.c  |  4 +-
  .../linalg/_eigen/arpack/ARPACK/SRC/debug.h   | 20 ++---
  .../linalg/_eigen/arpack/ARPACK/SRC/stat.h    | 26 +++----
- 27 files changed, 111 insertions(+), 147 deletions(-)
+ 27 files changed, 108 insertions(+), 144 deletions(-)
 
 diff --git a/scipy/_build_utils/src/wrap_dummy_g77_abi.f b/scipy/_build_utils/src/wrap_dummy_g77_abi.f
 index caf99ac63..73cdebd96 100644
@@ -85,7 +85,7 @@ index caf99ac63..73cdebd96 100644
        COMPLEX            X, Y
        EXTERNAL           CLADIV
 diff --git a/scipy/integrate/_odepackmodule.c b/scipy/integrate/_odepackmodule.c
-index 9974ae0f3..26046ab71 100644
+index 2b2189f0b..17f3f9348 100644
 --- a/scipy/integrate/_odepackmodule.c
 +++ b/scipy/integrate/_odepackmodule.c
 @@ -154,17 +154,17 @@ static PyObject *odepack_error;
@@ -277,25 +277,19 @@ index 89e50a990..0476e6a26 100644
    <ftype4> dimension(*), intent(in) :: x
    <ftypereal4> <prefix4>asum,s
 diff --git a/scipy/linalg/setup.py b/scipy/linalg/setup.py
-index d384081a2..d318fa8b8 100644
+index 20192f4cf..55a23ba7f 100644
 --- a/scipy/linalg/setup.py
 +++ b/scipy/linalg/setup.py
-@@ -45,9 +45,10 @@ def configuration(parent_package='', top_path=None):
+@@ -45,6 +45,7 @@ def configuration(parent_package='', top_path=None):
      # flapack:
      sources = ['flapack.pyf.src', 'lapack_extras.f']
      sources += get_g77_abi_wrappers(lapack_opt)
--    dep_pfx = join('src', 'lapack_deprecations')
--    deprecated_lapack_routines = [join(dep_pfx, c + 'gegv.f') for c in 'cdsz']
--    sources += deprecated_lapack_routines
-+#   CLAPACK still has these routines (with conflicting signatures)
-+#    dep_pfx = join('src', 'lapack_deprecations')
-+#    deprecated_lapack_routines = [join(dep_pfx, c + 'gegv.f') for c in 'cdsz']
-+#    sources += deprecated_lapack_routines
++
      depends = ['flapack_gen.pyf.src',
                 'flapack_gen_banded.pyf.src',
                 'flapack_gen_tri.pyf.src',
 diff --git a/scipy/odr/__odrpack.c b/scipy/odr/__odrpack.c
-index bd7100fb4..ec6f0ed69 100644
+index c806e33fb..c4b822eb9 100644
 --- a/scipy/odr/__odrpack.c
 +++ b/scipy/odr/__odrpack.c
 @@ -13,7 +13,7 @@

--- a/packages/scipy/patches/0009-Rename-_page_trend_test.py-to-prevent-test-unvendori.patch
+++ b/packages/scipy/patches/0009-Rename-_page_trend_test.py-to-prevent-test-unvendori.patch
@@ -1,33 +1,47 @@
-From 3c3ada887e548b868ecb796741dd1a769a245b9a Mon Sep 17 00:00:00 2001
+From 300688d3472b62beefa44e4a93ec5f2abd57762d Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sun, 26 Dec 2021 07:34:40 -0800
-Subject: [PATCH 09/15] Rename _page_trend_test.py to prevent test unvendoring
+Subject: [PATCH 09/14] Rename _page_trend_test.py to prevent test unvendoring
 
 unvendor_tests will unvendor any file that ends in _test.py.
 Prevent that by changing the name of this file.
 ---
  scipy/stats/__init__.py                                   | 2 +-
  scipy/stats/{_page_trend_test.py => _page_trend_test_.py} | 0
- 2 files changed, 1 insertion(+), 1 deletion(-)
+ scipy/stats/meson.build                                   | 2 +-
+ 3 files changed, 2 insertions(+), 2 deletions(-)
  rename scipy/stats/{_page_trend_test.py => _page_trend_test_.py} (100%)
 
 diff --git a/scipy/stats/__init__.py b/scipy/stats/__init__.py
-index f416e1a4f..2268caa3e 100644
+index 70a527849..8ce1ae379 100644
 --- a/scipy/stats/__init__.py
 +++ b/scipy/stats/__init__.py
-@@ -466,7 +466,7 @@ from ._bootstrap import bootstrap, BootstrapDegenerateDistributionWarning
+@@ -480,7 +480,7 @@ from ._resampling import bootstrap, monte_carlo_test, permutation_test
  from ._entropy import *
  from ._hypotests import *
- from ._rvs_sampling import rvs_ratio_uniforms, NumericalInverseHermite  # noqa
+ from ._rvs_sampling import rvs_ratio_uniforms, NumericalInverseHermite
 -from ._page_trend_test import page_trend_test
 +from ._page_trend_test_ import page_trend_test
  from ._mannwhitneyu import mannwhitneyu
+ from ._fit import fit
  
- # Deprecated namespaces, to be removed in v2.0.0
 diff --git a/scipy/stats/_page_trend_test.py b/scipy/stats/_page_trend_test_.py
 similarity index 100%
 rename from scipy/stats/_page_trend_test.py
 rename to scipy/stats/_page_trend_test_.py
+diff --git a/scipy/stats/meson.build b/scipy/stats/meson.build
+index 9539a26cb..e5d702158 100644
+--- a/scipy/stats/meson.build
++++ b/scipy/stats/meson.build
+@@ -204,7 +204,7 @@ py3.install_sources([
+     '_mstats_basic.py',
+     '_mstats_extras.py',
+     '_multivariate.py',
+-    '_page_trend_test.py',
++    '_page_trend_test_.py',
+     '_qmc.py',
+     '_relative_risk.py',
+     '_resampling.py',
 -- 
 2.25.1
 

--- a/packages/scipy/patches/0010-sasum-returns-double-not-float.patch
+++ b/packages/scipy/patches/0010-sasum-returns-double-not-float.patch
@@ -1,7 +1,7 @@
-From 8901c3e687a46ee2e13b9357b5122c679b1fcf06 Mon Sep 17 00:00:00 2001
+From 648b59e79d5d823e981cd227fdaf94c1f0dff911 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 18 Dec 2021 12:31:51 -0800
-Subject: [PATCH 10/15] sasum returns double not float
+Subject: [PATCH 10/14] sasum returns double not float
 
 ---
  scipy/sparse/linalg/_dsolve/SuperLU/SRC/slacon2.c | 2 +-

--- a/packages/scipy/patches/0011-skip-fortran-fails-to-link.patch
+++ b/packages/scipy/patches/0011-skip-fortran-fails-to-link.patch
@@ -1,7 +1,7 @@
-From 5b7d4751308016d821c2f6dfadc53e870eb4ed91 Mon Sep 17 00:00:00 2001
+From 23106c8c06d57305ad61e1c217721690699eea25 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 25 Dec 2021 15:08:18 -0800
-Subject: [PATCH 11/15] skip fortran fails to link
+Subject: [PATCH 11/14] skip fortran fails to link
 
 These are tests and they have both void vs int return value problems and implicit
 function argument cast problems. Not worth fixing for tests.

--- a/packages/scipy/patches/0012-Disable-lapack-detection.patch
+++ b/packages/scipy/patches/0012-Disable-lapack-detection.patch
@@ -1,14 +1,14 @@
-From 57a1a2f471d5f6ad25578cdc3472261254309785 Mon Sep 17 00:00:00 2001
+From 2307b669a1c63b760a635989d5dd07f2b2ce4b9c Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 6 Apr 2022 21:52:29 -0700
-Subject: [PATCH 12/15] Disable lapack detection
+Subject: [PATCH 12/14] Disable lapack detection
 
 ---
  scipy/sparse/linalg/_propack/setup.py | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/scipy/sparse/linalg/_propack/setup.py b/scipy/sparse/linalg/_propack/setup.py
-index b593cbca9..824980e24 100644
+index 5c8f252ac..232af31b6 100644
 --- a/scipy/sparse/linalg/_propack/setup.py
 +++ b/scipy/sparse/linalg/_propack/setup.py
 @@ -21,7 +21,7 @@ def configuration(parent_package='', top_path=None):

--- a/packages/scipy/patches/0013-Add-extra-END-to-prini.f.patch
+++ b/packages/scipy/patches/0013-Add-extra-END-to-prini.f.patch
@@ -1,22 +1,21 @@
-From ce60b3e7c5d1327c9b4fe00dbfc2292ffef6456f Mon Sep 17 00:00:00 2001
+From 2e0510793eb6a2d8aebb3594becf86da61f8a2a5 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 7 Apr 2022 10:41:26 -0700
-Subject: [PATCH 13/15] Add extra END to prini.f
+Subject: [PATCH 13/14] Add extra END to prini.f
 
 ---
  scipy/linalg/src/id_dist/src/prini.f | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/scipy/linalg/src/id_dist/src/prini.f b/scipy/linalg/src/id_dist/src/prini.f
-index 33a0bc8d3..f93289925 100644
+index 679590d84..fb883fae6 100644
 --- a/scipy/linalg/src/id_dist/src/prini.f
 +++ b/scipy/linalg/src/id_dist/src/prini.f
-@@ -110,4 +110,5 @@ C
-      1     WRITE(IQ,1800) (MES(I),I=1,I1)
+@@ -111,3 +111,4 @@ C
   1800 FORMAT(1X,80A1)
           RETURN
-+         END
           END
++         END
 \ No newline at end of file
 -- 
 2.25.1

--- a/packages/scipy/patches/0014-Change-qh_eachvoronoi_all-FILE-type.patch
+++ b/packages/scipy/patches/0014-Change-qh_eachvoronoi_all-FILE-type.patch
@@ -1,0 +1,51 @@
+From bcb6b8b4fa424ca7c16994c0fec03a9798039a93 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Mon, 29 Aug 2022 16:45:21 -0700
+Subject: [PATCH 14/14] Change qh_eachvoronoi_all FILE type
+
+---
+ scipy/spatial/_qhull.pyx | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/scipy/spatial/_qhull.pyx b/scipy/spatial/_qhull.pyx
+index 8c9135adc..5726cc704 100644
+--- a/scipy/spatial/_qhull.pyx
++++ b/scipy/spatial/_qhull.pyx
+@@ -18,6 +18,7 @@ from . cimport _qhull
+ from . cimport setlist
+ from libc cimport stdlib
+ from scipy._lib.messagestream cimport MessageStream
++from libc.stdio cimport FILE
+ 
+ import os
+ import sys
+@@ -185,7 +186,7 @@ cdef extern from "qhull_src/src/io_r.h":
+ 
+     ctypedef void printvridgeT(qhT *, void *fp, vertexT *vertex, vertexT *vertexA,
+                                setT *centers, boolT unbounded)
+-    int qh_eachvoronoi_all(qhT *, void *fp, void* printvridge,
++    int qh_eachvoronoi_all(qhT *, FILE *fp, void* printvridge,
+                            boolT isUpper, qh_RIDGE innerouter,
+                            boolT inorder) nogil
+ 
+@@ -830,7 +831,7 @@ cdef class _Qhull:
+         self._ridge_points = np.empty((10, 2), np.intc)
+         self._ridge_vertices = []
+ 
+-        qh_eachvoronoi_all(self._qh, <void*>self, &_visit_voronoi, self._qh[0].UPPERdelaunay,
++        qh_eachvoronoi_all(self._qh, <FILE*>self, &_visit_voronoi, self._qh[0].UPPERdelaunay,
+                            qh_RIDGEall, 1)
+ 
+         self._ridge_points = self._ridge_points[:self._nridges]
+@@ -992,7 +993,7 @@ cdef class _Qhull:
+         return extremes_arr
+ 
+ 
+-cdef void _visit_voronoi(qhT *_qh, void *ptr, vertexT *vertex, vertexT *vertexA,
++cdef void _visit_voronoi(qhT *_qh, FILE *ptr, vertexT *vertex, vertexT *vertexA,
+                          setT *centers, boolT unbounded):
+     cdef _Qhull qh = <_Qhull>ptr
+     cdef int point_1, point_2, ix
+-- 
+2.25.1
+

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -466,6 +466,7 @@ def compile(
 
         from .pypabuild import build
 
+        os.environ["PYODIDE_BUILD_PACKAGE"] = name
         try:
             build(build_env, backend_flags)
         except BaseException:

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -122,7 +122,9 @@ def get_build_env(
     args["exports"] = exports
 
     with TemporaryDirectory() as symlink_dir_str:
+        symlink_dir_str = "/tmp/symlinks"
         symlink_dir = Path(symlink_dir_str)
+        symlink_dir.mkdir(exist_ok=True)
         env = dict(env)
         make_command_wrapper_symlinks(symlink_dir, env)
 

--- a/tools/emscripten.meson.cross
+++ b/tools/emscripten.meson.cross
@@ -1,0 +1,21 @@
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+fortran='gfortran'
+
+cmake = ['emmake', 'cmake']
+sdl2-config = ['emconfigure', 'sdl2-config']
+
+#exe_wrapper = 'node'
+
+[properties]
+# Emscripten always needs an exe wrapper. Again,
+# maybe Meson could just know this.
+needs_exe_wrapper = true
+
+[host_machine]
+system = 'wasm'
+cpu_family = 'wasm'
+cpu = 'wasm'
+endian = 'little'


### PR DESCRIPTION
WIP. This seems like it will be quite hard. Meson detects the fact that an Emscripten compiler is being used and wants to be told that it is cross compiling. It might be possible to figure out (e.g., from the arguments) that meson is trying to detect the compiler and lie about it, but the better way is to use a proper cross compiling toolchain. Unfortunately, mesonpy does not allow cross compilation or really any modification of the meson parameters at all so I forked it and inserted our cross toolchain:
https://github.com/hoodmane/meson-python/commit/ff68f2a8ed8d30a21fca17e9377ebd34b56c1d16

Currently the error seems to be something about pkg-config. I get an error message like:
```
A full log can be found at /src/packages/scipy/build/scipy-1.9.1/.mesonpy-udi3w61t/build/meson-logs/meson-log.txt
```
Aggravatingly, this log file does not actually exist. Probably `mesonpy` is deleting it, and I should remove that deletion in my fork.

I had `exe_wrapper = 'node'` in the toolchain but that led to it detecting that our fortran compiler doesn't work. I am not sure why exactly.

Currently I'm stuck with blas/lapack detection. This part might be too hard for me to fix so I'll probably have to hope that @ryanking13 decides to look into it at some point.

Alternatively maybe we can just stay on scipy 1.8 until we get a working Fortran compiler.

@rgommers @tylerjereddy