### PR TITLE
Initialize loadedPackages from importlib distributions

### DIFF
--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -334,6 +334,7 @@ export async function loadPyodide(
   if (API.repodata_info.version !== pyodide.version) {
     throw new Error("Lock file version doesn't match Pyodide version");
   }
+  API.package_loader.init_loaded_packages();
   if (config.fullStdLib) {
     await pyodide.loadPackage(API._pyodide._importhook.UNVENDORED_STDLIBS);
   }

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -6,6 +6,8 @@ import sysconfig
 import tarfile
 from collections.abc import Iterable
 from importlib.machinery import EXTENSION_SUFFIXES
+from importlib.metadata import Distribution
+from importlib.metadata import distributions as importlib_distributions
 from pathlib import Path
 from site import getsitepackages
 from tempfile import NamedTemporaryFile
@@ -297,6 +299,34 @@ def get_dynlibs(archive: IO[bytes], suffix: str, target_dir: Path) -> list[str]:
         for path in dynlib_paths_iter
         if should_load_dynlib(path)
     ]
+
+
+def get_dist_source(dist: Distribution) -> str | None:
+    source = dist.read_text("PYODIDE_SOURCE")
+    if source == "pyodide":
+        return "default channel"
+    if source:
+        return source
+    direct_url = dist.read_text("direct_url.json")
+    if direct_url:
+        import json
+
+        return json.loads(direct_url)["url"]
+    installer = dist.read_text("INSTALLER")
+    if installer:
+        installer = installer.strip()
+    if installer == "pip":
+        return "pip (index unknown)"
+    return None
+
+
+def init_loaded_packages() -> None:
+    from pyodide_js import loadedPackages
+
+    for dist in importlib_distributions():
+        source = get_dist_source(dist)
+        if source:
+            setattr(loadedPackages, dist.name, source)
 
 
 def sub_resource_hash(sha_256: str) -> str:

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -14,6 +14,11 @@ from tempfile import NamedTemporaryFile
 from typing import IO, Any, Literal
 from zipfile import ZipFile
 
+try:
+    from pyodide_js import loadedPackages
+except ImportError:
+    loadedPackages = None
+
 from ._core import IN_BROWSER, JsProxy, to_js
 
 SITE_PACKAGES = Path(getsitepackages()[0])
@@ -315,14 +320,11 @@ def get_dist_source(dist: Distribution) -> str | None:
     installer = dist.read_text("INSTALLER")
     if installer:
         installer = installer.strip()
-    if installer == "pip":
-        return "pip (index unknown)"
+        return f"{installer} (index unknown)"
     return None
 
 
 def init_loaded_packages() -> None:
-    from pyodide_js import loadedPackages
-
     for dist in importlib_distributions():
         source = get_dist_source(dist)
         if source:

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -306,7 +306,12 @@ def get_dynlibs(archive: IO[bytes], suffix: str, target_dir: Path) -> list[str]:
     ]
 
 
-def get_dist_source(dist: Distribution) -> str | None:
+def get_dist_source(dist: Distribution) -> str:
+    """Get a description of the source of a package.
+
+    This is used in loadPackage to explain where the package came from. Purely
+    for informative purposes.
+    """
     source = dist.read_text("PYODIDE_SOURCE")
     if source == "pyodide":
         return "default channel"
@@ -321,14 +326,18 @@ def get_dist_source(dist: Distribution) -> str | None:
     if installer:
         installer = installer.strip()
         return f"{installer} (index unknown)"
-    return None
+    return "Unknown"
 
 
 def init_loaded_packages() -> None:
+    """Initialize pyodide.loadedPackages with the packages that are already
+    present.
+
+    This ensures that `pyodide.loadPackage` knows that they are around and
+    doesn't install over them.
+    """
     for dist in importlib_distributions():
-        source = get_dist_source(dist)
-        if source:
-            setattr(loadedPackages, dist.name, source)
+        setattr(loadedPackages, dist.name, get_dist_source(dist))
 
 
 def sub_resource_hash(sha_256: str) -> str:

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from pathlib import Path
 
@@ -416,6 +417,90 @@ def test_get_dynlibs():
         x2.close()
         t.flush()
         assert sorted(get_dynlibs(t, ".zip", Path("/p"))) == so_files
+
+
+class DummyDistribution:
+    def __init__(
+        self,
+        name: str,
+        source: str | None = None,
+        direct_url: dict[str, str] | None = None,
+        installer: str | None = None,
+    ):
+        self.name = name
+        direct_url_json = json.dumps(direct_url) if direct_url else None
+        self._files: dict[str, str | None] = {
+            "PYODIDE_SOURCE": source,
+            "direct_url.json": direct_url_json,
+            "INSTALLER": installer,
+        }
+
+    def read_text(self, key: str) -> str | None:
+        return self._files.get(key)
+
+    def __repr__(self):
+        return self.name
+
+
+result_dist_pairs = [
+    ("default channel", DummyDistribution("A", source="pyodide")),
+    (
+        "default channel",
+        DummyDistribution(
+            "B",
+            source="pyodide",
+            direct_url={"url": "http://some.pkg.src/a/b/c.whl"},
+            installer="pip",
+        ),
+    ),
+    (
+        "http://some.pkg.src/a/b/c.whl",
+        DummyDistribution("C", source="http://some.pkg.src/a/b/c.whl"),
+    ),
+    (
+        "http://some.pkg.src/a/b/c.whl",
+        DummyDistribution(
+            "D",
+            source="http://some.pkg.src/a/b/c.whl",
+            direct_url={"url": "http://a.b.c/x/y/z.whl"},
+            installer="pip",
+        ),
+    ),
+    (
+        "http://a.b.c/x/y/z.whl",
+        DummyDistribution(
+            "E", direct_url={"url": "http://a.b.c/x/y/z.whl"}, installer="pip"
+        ),
+    ),
+    ("pip (index unknown)", DummyDistribution("F", installer="pip")),
+    ("other (index unknown)", DummyDistribution("G", installer="other")),
+    (None, DummyDistribution("H")),
+]
+
+
+@pytest.mark.parametrize("result,dist", result_dist_pairs)
+def test_get_dist_source(result, dist):
+    from pyodide._package_loader import get_dist_source
+
+    assert result == get_dist_source(dist)
+
+
+def test_init_loaded_packages(monkeypatch):
+    from pyodide import _package_loader
+
+    class loadedPackagesCls:
+        pass
+
+    loadedPackages = loadedPackagesCls()
+    monkeypatch.setattr(_package_loader, "loadedPackages", loadedPackages)
+    dists = [dist for [_, dist] in result_dist_pairs]
+    monkeypatch.setattr(_package_loader, "importlib_distributions", lambda: dists)
+    _package_loader.init_loaded_packages()
+
+    for [result, dist] in result_dist_pairs:
+        assert hasattr(loadedPackages, dist.name) == bool(result)
+        if result:
+            assert getattr(loadedPackages, dist.name) == result
 
 
 @pytest.mark.xfail_browsers(node="Some fetch trouble")

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -474,7 +474,7 @@ result_dist_pairs = [
     ),
     ("pip (index unknown)", DummyDistribution("F", installer="pip")),
     ("other (index unknown)", DummyDistribution("G", installer="other")),
-    (None, DummyDistribution("H")),
+    ("Unknown", DummyDistribution("H")),
 ]
 
 
@@ -498,9 +498,8 @@ def test_init_loaded_packages(monkeypatch):
     _package_loader.init_loaded_packages()
 
     for [result, dist] in result_dist_pairs:
-        assert hasattr(loadedPackages, dist.name) == bool(result)
-        if result:
-            assert getattr(loadedPackages, dist.name) == result
+        assert hasattr(loadedPackages, dist.name)
+        assert getattr(loadedPackages, dist.name) == result
 
 
 @pytest.mark.xfail_browsers(node="Some fetch trouble")


### PR DESCRIPTION
This initializes `pyodide.loadedPackages` from the file system `importlib.metadata.distributions`. This makes it possible to handle the case when the `site_packages` is persistent or packages are preinstalled there (say with `--preload-file`).

Split off from #2976.

### Checklists

- [x] Add / update tests
