### PR TITLE
DOCS Add more info on Rust compilation

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -386,3 +386,27 @@ Currently it is necessary to run `source $CARGO_HOME/env` in the build script [a
 but other than that there may be no other issues if you are lucky.
 
 As mentioned [here](https://github.com/pyodide/pyodide/issues/2706#issuecomment-1154655224), by default certain wasm-related `RUSTFLAGS` are set during `build.script` and can be removed with `export RUSTFLAGS=""`.
+
+#### Setting up Rust in the docker container
+
+This part is for developers who use the docker image and wish to compile Python packages containing Rust code.
+If you clone the Pyodide repo from Github the docker container will not have `rust` installed. For this you'd need to install `rust` using the preferred method described [here](https://www.rust-lang.org/tools/install). 
+
+```
+apt update
+apt install curl
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+After install, you'll need to switch to the nighly build, as a certain flag `-Z` -which is used to compile `cryptography`- is only available in the nighly builds. 
+```
+"$HOME/.cargo/env"
+rustup default nightly
+```
+Finally, you'd need to add the `wasm32-unknown-emscripten` target.
+
+```
+rustup target add wasm32-unknown-emscripten
+```
+
+After these steps you'll be able to compile `cryptography` and other PyO3 based projects.

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -390,7 +390,7 @@ As mentioned [here](https://github.com/pyodide/pyodide/issues/2706#issuecomment-
 #### Setting up Rust in the docker container
 
 This part is for developers who use the docker image and wish to compile Python packages containing Rust code.
-If you clone the Pyodide repo from Github the docker container will not have `rust` installed. For this you'd need to install `rust` using the preferred method described [here](https://www.rust-lang.org/tools/install). 
+If you clone the Pyodide repo from Github the docker container will not have `rust` installed. For this you'd need to install `rust` using the preferred method described [here](https://www.rust-lang.org/tools/install).
 
 ```
 apt update
@@ -398,11 +398,13 @@ apt install curl
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-After install, you'll need to switch to the nighly build, as a certain flag `-Z` -which is used to compile `cryptography`- is only available in the nighly builds. 
+After install, you'll need to switch to the nighly build, as a certain flag `-Z` -which is used to compile `cryptography`- is only available in the nighly builds.
+
 ```
 "$HOME/.cargo/env"
 rustup default nightly
 ```
+
 Finally, you'd need to add the `wasm32-unknown-emscripten` target.
 
 ```


### PR DESCRIPTION
### Description
I was having a hard time getting the cryptography package compiled on the latest version in the docker container because of the special requirements to get Rust working.  
Added a small section to the documentation describing the steps I took to make it work.

### Checklists
- [X] Add new / update outdated documentation
