### PR TITLE
MAINT Remove custom setuptools_rust commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,15 +189,10 @@ emsdk/emsdk/.complete:
 	date +"[%F %T] done building emsdk."
 
 
-SETUPTOOLS_RUST_COMMIT=5e8c380429aba1e5df5815dcf921025c599cecec
 rust:
 	wget -q -O - https://sh.rustup.rs | sh -s -- -y
 	source $(HOME)/.cargo/env && rustup toolchain install $(RUST_TOOLCHAIN) && rustup default $(RUST_TOOLCHAIN)
 	source $(HOME)/.cargo/env && rustup target add wasm32-unknown-emscripten --toolchain $(RUST_TOOLCHAIN)
-	# Install setuptools-rust with a fix for Wasm targets
-	# TODO: Remove this when they release the next version.
-	pip install -t $(HOSTSITEPACKAGES) git+https://github.com/PyO3/setuptools-rust.git@$(SETUPTOOLS_RUST_COMMIT)
-
 
 FORCE:
 

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -295,8 +295,6 @@ def get_unisolated_packages() -> list[str]:
             config = parse_package_config(pkg, check=False)
             if config.get("build", {}).get("cross-build-env", False):
                 unisolated_packages.append(config["package"]["name"])
-        # TODO: remove setuptools_rust from this when they release the next version.
-        unisolated_packages.append("setuptools_rust")
     os.environ["UNISOLATED_PACKAGES"] = json.dumps(unisolated_packages)
     return unisolated_packages
 


### PR DESCRIPTION
Now that `setuptools_rust` has been released with the emscripten fixes, we don't need this anymore.