### PR TITLE
Minor build optimizations for libraries

### DIFF
--- a/packages/geos/meta.yaml
+++ b/packages/geos/meta.yaml
@@ -16,6 +16,7 @@ build:
       -DBUILD_TESTING=OFF \
       -DBUILD_BENCHMARKS=OFF \
       -DBUILD_DOCUMENTATION=OFF \
+      -DBUILD_GEOSOP=OFF \
       -DCMAKE_C_FLAGS="-fPIC" \
       -DCMAKE_CXX_FLAGS="-fPIC" \
       -DCMAKE_PROJECT_INCLUDE=SupportSharedLib.cmake \

--- a/packages/glpk/meta.yaml
+++ b/packages/glpk/meta.yaml
@@ -11,6 +11,7 @@ build:
   script: |
     CFLAGS="-fPIC" emconfigure ./configure \
       --prefix=${WASM_LIBRARY_DIR} \
+      --disable-dependency-tracking \
       --disable-shared \
       --enable-static
     emmake make -j ${PYODIDE_JOBS:-3}

--- a/packages/glpk/meta.yaml
+++ b/packages/glpk/meta.yaml
@@ -9,6 +9,9 @@ source:
 build:
   library: true
   script: |
-    CFLAGS="-fPIC" emconfigure ./configure  --prefix=${WASM_LIBRARY_DIR}
+    CFLAGS="-fPIC" emconfigure ./configure \
+      --prefix=${WASM_LIBRARY_DIR} \
+      --disable-shared \
+      --enable-static
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libgmp/meta.yaml
+++ b/packages/libgmp/meta.yaml
@@ -11,9 +11,10 @@ build:
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
+        --disable-dependency-tracking \
         --host none \
-        --enable-shared=no \
-        --enable-static=yes \
+        --disable-shared \
+        --enable-static \
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libgmp/meta.yaml
+++ b/packages/libgmp/meta.yaml
@@ -12,6 +12,8 @@ build:
     emconfigure ./configure \
         CFLAGS="-fPIC" \
         --host none \
+        --enable-shared=no \
+        --enable-static=yes \
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libgsl/meta.yaml
+++ b/packages/libgsl/meta.yaml
@@ -10,6 +10,7 @@ build:
     emconfigure ./configure \
         CFLAGS="-fPIC" \
         --prefix=${WASM_LIBRARY_DIR} \
+        --disable-dependency-tracking \
         --disable-shared
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/liblzma/meta.yaml
+++ b/packages/liblzma/meta.yaml
@@ -19,6 +19,7 @@ build:
         --disable-scripts \
         --disable-doc \
         --enable-shared=no \
+        --disable-dependency-tracking \
         --prefix=${WASM_LIBRARY_DIR}
 
     emmake make -j ${PYODIDE_JOBS:-3}

--- a/packages/libmagic/meta.yaml
+++ b/packages/libmagic/meta.yaml
@@ -20,8 +20,7 @@ build:
     cp magic/magic.mgc dist
     # build libmagic.so
     emconfigure ./configure \
-      CFLAGS="${SIDE_MODULE_CFLAGS}" \
-      --disable-dependency-tracking
+      CFLAGS="${SIDE_MODULE_CFLAGS}"
     cd src
     emmake make -j ${PYODIDE_JOBS:-3} libmagic.la \
       LDFLAGS="-Xcompiler '${SIDE_MODULE_LDFLAGS}'"

--- a/packages/libmagic/meta.yaml
+++ b/packages/libmagic/meta.yaml
@@ -20,7 +20,8 @@ build:
     cp magic/magic.mgc dist
     # build libmagic.so
     emconfigure ./configure \
-      CFLAGS="${SIDE_MODULE_CFLAGS}"
+      CFLAGS="${SIDE_MODULE_CFLAGS}" \
+      --disable-dependency-tracking
     cd src
     emmake make -j ${PYODIDE_JOBS:-3} libmagic.la \
       LDFLAGS="-Xcompiler '${SIDE_MODULE_LDFLAGS}'"

--- a/packages/libmpc/meta.yaml
+++ b/packages/libmpc/meta.yaml
@@ -16,7 +16,7 @@ build:
     emconfigure ./configure \
         CFLAGS="-fPIC" \
         --disable-dependency-tracking \
-        --disabled-shared \
+        --disable-shared \
         --with-gmp="${WASM_LIBRARY_DIR}" \
         --with-mpfr="${WASM_LIBRARY_DIR}" \
         --prefix=${WASM_LIBRARY_DIR}

--- a/packages/libmpc/meta.yaml
+++ b/packages/libmpc/meta.yaml
@@ -15,6 +15,8 @@ build:
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
+        --disable-dependency-tracking \
+        --disabled-shared \
         --with-gmp="${WASM_LIBRARY_DIR}" \
         --with-mpfr="${WASM_LIBRARY_DIR}" \
         --prefix=${WASM_LIBRARY_DIR}

--- a/packages/libmpfr/meta.yaml
+++ b/packages/libmpfr/meta.yaml
@@ -15,6 +15,8 @@ build:
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
+        --disable-dependency-tracking \
+        --disabled-shared \
         --with-gmp="${WASM_LIBRARY_DIR}" \
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}

--- a/packages/libmpfr/meta.yaml
+++ b/packages/libmpfr/meta.yaml
@@ -16,7 +16,7 @@ build:
     emconfigure ./configure \
         CFLAGS="-fPIC" \
         --disable-dependency-tracking \
-        --disabled-shared \
+        --disable-shared \
         --with-gmp="${WASM_LIBRARY_DIR}" \
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}

--- a/packages/libtiff/meta.yaml
+++ b/packages/libtiff/meta.yaml
@@ -13,7 +13,7 @@ build:
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
-        --disabled-shared \
+        --disable-shared \
         --disable-dependency-tracking \
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}

--- a/packages/libtiff/meta.yaml
+++ b/packages/libtiff/meta.yaml
@@ -13,6 +13,8 @@ build:
   script: |
     emconfigure ./configure \
         CFLAGS="-fPIC" \
+        --disabled-shared \
+        --disable-dependency-tracking \
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/libyaml/meta.yaml
+++ b/packages/libyaml/meta.yaml
@@ -11,7 +11,10 @@ build:
   script: |
     export INSTALL_DIR=${WASM_LIBRARY_DIR}
 
-    CFLAGS="-fPIC" emcmake cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .
+    CFLAGS="-fPIC" emcmake cmake \
+      -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+      -DBUILD_TESTING=OFF \
+      .
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
     rm -f ${INSTALL_DIR}/lib/libyaml.a

--- a/packages/suitesparse/meta.yaml
+++ b/packages/suitesparse/meta.yaml
@@ -32,12 +32,12 @@ build:
       INSTALL=${WASM_LIBRARY_DIR}
     mkdir -p dist
 
-    cp ${WASM_LIBRARY_DIR}/lib/libsuitesparseconfig* \
-       ${WASM_LIBRARY_DIR}/lib/libamd* \
-       ${WASM_LIBRARY_DIR}/lib/libcamd* \
-       ${WASM_LIBRARY_DIR}/lib/libccolamd* \
-       ${WASM_LIBRARY_DIR}/lib/libcolamd* \
-       ${WASM_LIBRARY_DIR}/lib/libmetis* \
-       ${WASM_LIBRARY_DIR}/lib/libcholmod* \
-       ${WASM_LIBRARY_DIR}/lib/libspqr* \
+    cp ${WASM_LIBRARY_DIR}/lib/libsuitesparseconfig.so \
+       ${WASM_LIBRARY_DIR}/lib/libamd.so \
+       ${WASM_LIBRARY_DIR}/lib/libcamd.so \
+       ${WASM_LIBRARY_DIR}/lib/libccolamd.so \
+       ${WASM_LIBRARY_DIR}/lib/libcolamd.so \
+       ${WASM_LIBRARY_DIR}/lib/libmetis.so \
+       ${WASM_LIBRARY_DIR}/lib/libcholmod.so \
+       ${WASM_LIBRARY_DIR}/lib/libspqr.so \
        dist/


### PR DESCRIPTION
Minor build optimizations for libraries by:

- Not building executables and test if possible
- Using `--disable-dependency-tracking` flags for libraries that use autoconf