### PR TITLE
[Docs] Fix 'Loading packages' CDN url

### DIFF
--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -134,10 +134,7 @@ installs from PyPI. See [this stack overflow answer](https://stackoverflow.com/q
     <meta charset="utf-8" />
   </head>
   <body>
-    <script
-      type="text/javascript"
-      src="{{PYODIDE_CDN_URL}}pyodide.js"
-    ></script>
+    <script type="text/javascript" src="{{PYODIDE_CDN_URL}}pyodide.js"></script>
     <script type="text/javascript">
       async function main() {
         let pyodide = await loadPyodide();

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -136,7 +136,7 @@ installs from PyPI. See [this stack overflow answer](https://stackoverflow.com/q
   <body>
     <script
       type="text/javascript"
-      src="{{PYODIDE_CDN_URL}}/pyodide.js"
+      src="{{PYODIDE_CDN_URL}}pyodide.js"
     ></script>
     <script type="text/javascript">
       async function main() {


### PR DESCRIPTION
### Description
There's a double shalsh in the CDN url on the [Loading packages](https://pyodide.org/en/stable/usage/loading-packages.html) page.

`PYODIDE_CDN_URL` already ends with a forward-slash, so when building the CDN URL a double slash is added (ie: `https://cdn.jsdelivr.net/pyodide/v0.21.2/full//pyodide.js`) and that is not a valid url. 

No slash is needed between the variable `PYODIDE_CDN_URL` and `pyodide.js`, like in the rest of the docs, so removing that extra shalsh after PYODIDE_CDN_URL creates the valid URL. 

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation
