### PR TITLE
Fix and xfail some flaky tests

### DIFF
--- a/packages/astropy/test_astropy.py
+++ b/packages/astropy/test_astropy.py
@@ -29,6 +29,7 @@ from pytest_pyodide import run_in_pyodide
     ],
 )
 @pytest.mark.skip_refcount_check
+@pytest.mark.driver_timeout(60)
 @run_in_pyodide(packages=["astropy", "pytest", "micropip"])
 async def test_astropy(selenium, package, specific_test):
     import astropy

--- a/src/tests/python_tests.yaml
+++ b/src/tests/python_tests.yaml
@@ -354,7 +354,9 @@
 - test_imaplib:
     xfail: socket
 - test_imghdr
-- test_imp
+- test_imp:
+    xfail:
+      - test_unencodeable # fails perioically
 - test_importlib.builtin.test_finder
 - test_importlib.builtin.test_loader
 - test_importlib.extension.test_case_sensitivity


### PR DESCRIPTION
- `test_imp:test_unencodeable`: fails in firefox periodically.
- `astropy tests`: started to timeout periodically recently, not sure why. I guess it is because astropy tests install pytest plugins dynamically during tests.