### PR TITLE
Add codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,25 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        # Commits pushed to main should not make the overall
+        # project coverage decrease by more than 1%:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # Be tolerant on slight code coverage diff on PRs to limit
+        # noisy red coverage status on github PRs.
+        # Note: The coverage stats are still uploaded
+        # to codecov so that PR reviewers can see uncovered lines
+        target: auto
+        threshold: 1%
+
+codecov:
+  notify:
+    # Prevent coverage status to upload multiple times for parallel and long
+    # running CI pipelines. This configuration is particularly useful on PRs
+    # to avoid confusion.
+    after_n_builds: 1


### PR DESCRIPTION
Coverage and codecov is a bit brittle and can make the CI fail if the computed coverage fluctuates unrelated to code changes (e.g. in https://github.com/pyodide/pyodide/pull/3053). 

This adds a minimal threshold on what decrease in coverage should be considered a CI failure (adapted from scikit-learn)