### PR TITLE
Allow use with (module-type) service workers

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -13,6 +13,7 @@ substitutions:
 # Change Log
 
 ## Unreleased
+- {{ Enhancement }} Users can do a static import of `pyodide/pyodide.asm.js` to avoid issues with dynamic imports. This allows the use of Pyodide with module-type service workers. 
 
 - {{ Enhancement }} Emscripten was updated to Version 3.1.21
   {pr}`2958`, {pr}`2950`, {pr}`3027`, {pr}`3107`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,7 +14,10 @@ substitutions:
 
 ## Unreleased
 
-- {{ Enhancement }} Users can do a static import of `pyodide/pyodide.asm.js` to avoid issues with dynamic imports. This allows the use of Pyodide with module-type service workers.
+- {{ Enhancement }} Users can do a static import of `pyodide/pyodide.asm.js` to
+  avoid issues with dynamic imports. This allows the use of Pyodide with
+  module-type service workers. 
+  {pr}`3070`
 
 - {{ Enhancement }} Emscripten was updated to Version 3.1.21
   {pr}`2958`, {pr}`2950`, {pr}`3027`, {pr}`3107`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -13,7 +13,8 @@ substitutions:
 # Change Log
 
 ## Unreleased
-- {{ Enhancement }} Users can do a static import of `pyodide/pyodide.asm.js` to avoid issues with dynamic imports. This allows the use of Pyodide with module-type service workers. 
+
+- {{ Enhancement }} Users can do a static import of `pyodide/pyodide.asm.js` to avoid issues with dynamic imports. This allows the use of Pyodide with module-type service workers.
 
 - {{ Enhancement }} Emscripten was updated to Version 3.1.21
   {pr}`2958`, {pr}`2950`, {pr}`3027`, {pr}`3107`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,7 +16,7 @@ substitutions:
 
 - {{ Enhancement }} Users can do a static import of `pyodide/pyodide.asm.js` to
   avoid issues with dynamic imports. This allows the use of Pyodide with
-  module-type service workers. 
+  module-type service workers.
   {pr}`3070`
 
 - {{ Enhancement }} Emscripten was updated to Version 3.1.21

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -73,9 +73,17 @@ officially supported.
 ## Web Workers
 
 By default, WebAssembly runs in the main browser thread, and it can make UI
-non-responsive for long-running computations.
+non-responsive for long-running computations. 
 
-To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`.
+To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`. 
+
+## Service Workers
+
+It's also possible to run {ref}`Pyodide in a Service Worker <using_from_service_worker>`. Service workers have some unique capabilities, one of them being running code in response to `fetch` calls on a webpage. 
+
+If you're not sure whether you need web workers or service workers, here's an [overview + comparison of the two][workers overview]. 
+
+[workers overview]: https://web.dev/workers-overview/
 
 ## Node.js
 
@@ -167,4 +175,5 @@ Python says that 1+1= 2
    webworker.md
    loading-custom-python-code.md
    file-system.md
+   service-worker.md
 ```

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -77,9 +77,10 @@ non-responsive for long-running computations.
 
 To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`.
 
-It's also possible to run {ref}`Pyodide in a Service Worker <using_from_service_worker>`. 
+It's also possible to run {ref}`Pyodide in a Service Worker <using_from_service_worker>`.
 
 If you're not sure whether you need web workers or service workers, here's an [overview and comparison of the two](https://web.dev/workers-overview/).
+
 ## Node.js
 
 ```{note}

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -77,14 +77,9 @@ non-responsive for long-running computations.
 
 To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`.
 
-## Service Workers
+It's also possible to run {ref}`Pyodide in a Service Worker <using_from_service_worker>`. 
 
-It's also possible to run {ref}`Pyodide in a Service Worker <using_from_service_worker>`. Service workers have some unique capabilities, one of them being running code in response to `fetch` calls on a webpage.
-
-If you're not sure whether you need web workers or service workers, here's an [overview + comparison of the two][workers overview].
-
-[workers overview]: https://web.dev/workers-overview/
-
+If you're not sure whether you need web workers or service workers, here's an [overview and comparison of the two](https://web.dev/workers-overview/).
 ## Node.js
 
 ```{note}

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -73,15 +73,15 @@ officially supported.
 ## Web Workers
 
 By default, WebAssembly runs in the main browser thread, and it can make UI
-non-responsive for long-running computations. 
+non-responsive for long-running computations.
 
-To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`. 
+To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`.
 
 ## Service Workers
 
-It's also possible to run {ref}`Pyodide in a Service Worker <using_from_service_worker>`. Service workers have some unique capabilities, one of them being running code in response to `fetch` calls on a webpage. 
+It's also possible to run {ref}`Pyodide in a Service Worker <using_from_service_worker>`. Service workers have some unique capabilities, one of them being running code in response to `fetch` calls on a webpage.
 
-If you're not sure whether you need web workers or service workers, here's an [overview + comparison of the two][workers overview]. 
+If you're not sure whether you need web workers or service workers, here's an [overview + comparison of the two][workers overview].
 
 [workers overview]: https://web.dev/workers-overview/
 

--- a/docs/usage/service-worker.md
+++ b/docs/usage/service-worker.md
@@ -1,0 +1,352 @@
+(using_from_service_worker)=
+
+# Using Pyodide in a service worker
+
+This document describes how to use Pyodide to execute Python scripts in a service worker. Compared to typical web workers, service workers are more related to acting as a network proxy, handling background tasks, and things like caching and offline. See [this article](https://web.dev/workers-overview/#use-cases) for more info.
+
+For our example, we'll be talking about how we can use a service worker to intercept a fetch call for some data and modify the data. We will have two parties involved:
+
+- The **service worker** which will be intercepting fetch calls for JSON, and modifying the data before returning it
+- The **consumer** which will be fetching some JSON data
+
+To keep things simple, all we'll do is add a field to a fetched JSON object, but an example of a more interesting use case is transforming fetched tabular data using numpy, and caching the result before returning it.
+
+You might notice we have two different examples on this page. There are two different kinds of service workers, classic and module. For cross-browser compatibility, it might be easier to use classic service workers for now, as Firefox doesn't yet support module-type service workers. That said, module-type service workers may be a better fit if you want to write background service workers for Chromium-based browser extensions.
+
+## Detailed example 1 - classic service workers
+
+### Setup
+
+Setup your project to serve `classic-service-worker.js`. You should also serve
+`pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`, and `.wasm`
+files as well, though this is not strictly required if `pyodide.js` is pointing
+to a site serving current versions of these files.
+The simplest way to serve the required files is to use a CDN,
+such as `https://cdn.jsdelivr.net/pyodide`. This is the solution
+presented here.
+
+Update the `classic-service-worker.js` sample so that it has a valid URL for `pyodide.js`, and sets
+{any}`indexURL <globalThis.loadPyodide>` to the location of the supporting files.
+
+You'll also need to serve `data.json`, a JSON file containing a simple object - a sample is provided below:
+
+```json
+{
+  "name": "Jem"
+}
+```
+
+### Consumers
+
+HTML:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      /* MODIFY PATHS TO POINT TO YOUR ASSETS */
+      const SERVICE_WORKER_PATH = "/classic-service-worker.js";
+      const JSON_FILE_PATH = "./data.json";
+      const REGISTRATION_OPTIONS = {
+        scope: "/",
+      };
+
+      // modified snippet from https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
+      async function registerServiceWorker() {
+        if ("serviceWorker" in navigator) {
+          try {
+            const registration = await navigator.serviceWorker.register(
+              SERVICE_WORKER_PATH,
+              REGISTRATION_OPTIONS
+            );
+            if (registration.installing) {
+              console.log("Service worker installing");
+            } else if (registration.waiting) {
+              console.log("Service worker installed");
+            } else if (registration.active) {
+              console.log("Service worker active");
+            }
+          } catch (error) {
+            console.error(`Registration failed with ${error}`);
+          }
+        }
+      }
+
+      async function fetchAndLogData() {
+        try {
+          console.log(await (await fetch(JSON_FILE_PATH)).json());
+        } catch (e) {
+          console.error("Failed to fetch", e);
+        }
+      }
+
+      registerServiceWorker();
+    </script>
+  </head>
+
+  <body>
+    <button onclick="fetchAndLogData()">Fetch and log data</button>
+  </body>
+</html>
+```
+
+### Service worker
+
+```js
+/* MODIFY IMPORT PATHS TO POINT TO YOUR SCRIPTS */
+importScripts("./xml-http-request.js"); // This script should assign self.XMLHttpRequest to a compatible polyfill, there are many on npm
+importScripts("./pyodide.asm.js"); // This is necessary if you choose to load pyodide after installation of the service worker
+importScripts("./pyodide.js");
+
+let modifyData;
+let pyodide;
+loadPyodide({}).then((_pyodide) => {
+  pyodide = _pyodide;
+  let namespace = pyodide.globals.get("dict")();
+
+  pyodide.runPython(
+    `
+    import json
+
+    counter = 0
+    def modify_data(data):
+        global counter
+        dict = data.to_py()
+        dict['count'] = counter
+        counter += 1
+        return dict
+    `,
+    { globals: namespace }
+  );
+
+  // assign the modify_data function from the Python context to our Javascript variable
+  modifyData = namespace.get("modify_data");
+  namespace.destroy();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.url.endsWith("json")) {
+    if (!modifyData) {
+      // For this example, throw so it's clear that the worker isn't ready to modify responses
+      // This is because we don't want to return a response that isn't modified yet
+      // If your service worker would return the same response as a server (eg. it's just performing calculations closer to home)
+      // then you may want to let the event through without doing anything
+      event.respondWith(
+        Promise.reject("Python code isn't set up yet, try again in a bit")
+      );
+    } else {
+      event.respondWith(
+        // We aren't using the async await syntax because event.respondWith needs to respond synchronously
+        // it can't be executing after an awaited promise within the fetch event handler, otherwise you'll get this
+        // Uncaught (in promise) DOMException: Failed to execute 'respondWith' on 'FetchEvent': The event has already been responded to
+        fetch(event.request)
+          .then((v) => v.json())
+          .then((originalData) => {
+            let proxy = modifyData(originalData);
+            let pyproxies = [];
+
+            // Because toJs gives us a Map, we transform it to a plain Javascript object before changing it to JSON
+            let result = JSON.stringify(
+              Object.fromEntries(
+                proxy.toJs({
+                  pyproxies,
+                })
+              )
+            );
+            // Craft our new JSON response
+            return new Response(result, {
+              headers: { "Content-Type": "application/json" },
+            });
+          })
+      );
+    }
+  }
+});
+
+// Code below is for easy iteration during development, you may want to remove or modify in a prod environment:
+
+// Immediately become the active service worker once installed, so we don't have a stale service worker intercepting requests
+// You can remove this code and achieve a similar thing by enabling "Update on Reload" in devtools, if supported:
+// https://web.dev/service-worker-lifecycle/#update-on-reload
+self.addEventListener("install", function () {
+  self.skipWaiting();
+});
+
+// With this, we won't need to reload the page before the service worker can intercept fetch requests
+// https://developer.mozilla.org/en-US/docs/Web/API/Clients/claim#examples
+self.addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim());
+});
+```
+
+## Detailed example 2 - module service workers
+
+### Setup
+
+Setup your project to serve `module-service-worker.js`. You should also serve
+`pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`, and `.wasm`
+files as well, though this is not strictly required if `pyodide.js` is pointing
+to a site serving current versions of these files.
+The simplest way to serve the required files is to use a CDN,
+such as `https://cdn.jsdelivr.net/pyodide`. This is the solution
+presented here.
+
+Update the `module-service-worker.js` sample so that it has a valid URL for `pyodide.js`, and sets
+{any}`indexURL <globalThis.loadPyodide>` to the location of the supporting files.
+
+You'll also need to serve `data.json`, a JSON file containing a simple object - a sample is provided below:
+
+```json
+{
+  "name": "Jem"
+}
+```
+
+### Consumers
+
+HTML:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      /* MODIFY PATHS TO POINT TO YOUR ASSETS */
+      const SERVICE_WORKER_PATH = "/module-service-worker.js";
+      const JSON_FILE_PATH = "./data.json";
+      const REGISTRATION_OPTIONS = {
+        scope: "/",
+        // Note that specifying the type option can cause errors if the browser doesn't support module-type service workers
+        type: "module",
+      };
+
+      // modified snippet from https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
+      async function registerServiceWorker() {
+        if ("serviceWorker" in navigator) {
+          try {
+            const registration = await navigator.serviceWorker.register(
+              SERVICE_WORKER_PATH,
+              REGISTRATION_OPTIONS
+            );
+            if (registration.installing) {
+              console.log("Service worker installing");
+            } else if (registration.waiting) {
+              console.log("Service worker installed");
+            } else if (registration.active) {
+              console.log("Service worker active");
+            }
+          } catch (error) {
+            console.error(`Registration failed with ${error}`);
+          }
+        }
+      }
+
+      async function fetchAndLogData() {
+        try {
+          console.log(await (await fetch(JSON_FILE_PATH)).json());
+        } catch (e) {
+          console.error("Failed to fetch", e);
+        }
+      }
+
+      registerServiceWorker();
+    </script>
+  </head>
+
+  <body>
+    <button onclick="fetchAndLogData()">Fetch and log data</button>
+  </body>
+</html>
+```
+
+### Service worker
+
+This example is largely the same as the classic service worker example above, the main difference is how we import things. `importScripts` is not supported in module-type workers, we use the ESM import instead.
+
+```js
+/* MODIFY IMPORT PATHS TO POINT TO YOUR SCRIPTS */
+import "./xml-http-request.js"; // This script should assign self.XMLHttpRequest to a compatible polyfill, there are many on npm
+import "./pyodide.asm.js"; // Pyodide detects this and skips dynamically importing it. Dynamic imports fail in a service worker.
+import { loadPyodide } from "./pyodide.mjs";
+
+let modifyData;
+let pyodide;
+loadPyodide({}).then((_pyodide) => {
+  pyodide = _pyodide;
+  let namespace = pyodide.globals.get("dict")();
+
+  pyodide.runPython(
+    `
+    import json
+
+    counter = 0
+    def modify_data(data):
+        global counter
+        dict = data.to_py()
+        dict['count'] = counter
+        counter += 1
+        return dict
+    `,
+    { globals: namespace }
+  );
+
+  // assign the modify_data function from the Python context to our Javascript variable
+  modifyData = namespace.get("modify_data");
+  namespace.destroy();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.url.endsWith("json")) {
+    if (!modifyData) {
+      // For this example, throw so it's clear that the worker isn't ready to modify responses
+      // This is because we don't want to return a response that isn't modified yet
+      // If your service worker would return the same response as a server (eg. it's just performing calculations closer to home)
+      // then you may want to let the event through without doing anything
+      event.respondWith(
+        Promise.reject("Python code isn't set up yet, try again in a bit")
+      );
+    } else {
+      event.respondWith(
+        // We aren't using the async await syntax because event.respondWith needs to respond synchronously
+        // it can't be executing after an awaited promise within the fetch event handler, otherwise you'll get this
+        // Uncaught (in promise) DOMException: Failed to execute 'respondWith' on 'FetchEvent': The event has already been responded to
+        fetch(event.request)
+          .then((v) => v.json())
+          .then((originalData) => {
+            let proxy = modifyData(originalData);
+            let pyproxies = [];
+
+            // Because toJs gives us a Map, we transform it to a plain Javascript object before changing it to JSON
+            let result = JSON.stringify(
+              Object.fromEntries(
+                proxy.toJs({
+                  pyproxies,
+                })
+              )
+            );
+            // Craft our new JSON response
+            return new Response(result, {
+              headers: { "Content-Type": "application/json" },
+            });
+          })
+      );
+    }
+  }
+});
+
+// Code below is for easy iteration during development, you may want to remove or modify in a prod environment:
+
+// Immediately become the active service worker once installed, so we don't have a stale service worker intercepting requests
+// You can remove this code and achieve a similar thing by enabling "Update on Reload" in devtools, if supported:
+// https://web.dev/service-worker-lifecycle/#update-on-reload
+self.addEventListener("install", function () {
+  self.skipWaiting();
+});
+
+// With this, we won't need to reload the page before the service worker can intercept fetch requests
+// https://developer.mozilla.org/en-US/docs/Web/API/Clients/claim#examples
+self.addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim());
+});
+```

--- a/docs/usage/service-worker.md
+++ b/docs/usage/service-worker.md
@@ -67,7 +67,7 @@ provide a button that fetches data and logs it.
         scope: "/",
       };
 
-      // modified snippet from 
+      // modified snippet from
       // https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
       async function registerServiceWorker() {
         if ("serviceWorker" in navigator) {

--- a/docs/usage/service-worker.md
+++ b/docs/usage/service-worker.md
@@ -4,6 +4,8 @@
 
 This document describes how to use Pyodide to execute Python scripts in a service worker. Compared to typical web workers, service workers are more related to acting as a network proxy, handling background tasks, and things like caching and offline. See [this article](https://web.dev/workers-overview/#use-cases) for more info.
 
+## Detailed example
+
 For our example, we'll be talking about how we can use a service worker to intercept a fetch call for some data and modify the data. We will have two parties involved:
 
 - The **service worker** which will be intercepting fetch calls for JSON, and modifying the data before returning it
@@ -11,21 +13,17 @@ For our example, we'll be talking about how we can use a service worker to inter
 
 To keep things simple, all we'll do is add a field to a fetched JSON object, but an example of a more interesting use case is transforming fetched tabular data using numpy, and caching the result before returning it.
 
-You might notice we have two different examples on this page. There are two different kinds of service workers, classic and module. For cross-browser compatibility, it might be easier to use classic service workers for now, as Firefox doesn't yet support module-type service workers. That said, module-type service workers may be a better fit if you want to write background service workers for Chromium-based browser extensions.
-
-## Detailed example 1 - classic service workers
+Please note that service workers will only work on https and localhost, so you will require a server to be running for this example.
 
 ### Setup
 
-Setup your project to serve `classic-service-worker.js`. You should also serve
-`pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`, and `.wasm`
+Setup your project to serve the service worker script `sw.js`, and the XMLHttpRequest polyfill script `xml-http-request.js`. You should also serve `pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`, and `.wasm`
 files as well, though this is not strictly required if `pyodide.js` is pointing
 to a site serving current versions of these files.
 The simplest way to serve the required files is to use a CDN,
-such as `https://cdn.jsdelivr.net/pyodide`. This is the solution
-presented here.
+such as `https://cdn.jsdelivr.net/pyodide`.
 
-Update the `classic-service-worker.js` sample so that it has a valid URL for `pyodide.js`, and sets
+Update the `sw.js` sample so that it has a valid URL for `pyodide.js`, and sets
 {any}`indexURL <globalThis.loadPyodide>` to the location of the supporting files.
 
 You'll also need to serve `data.json`, a JSON file containing a simple object - a sample is provided below:
@@ -36,18 +34,19 @@ You'll also need to serve `data.json`, a JSON file containing a simple object - 
 }
 ```
 
-### Consumers
+### Consumer
 
-HTML:
+In our consumer, we want to register our service worker - in the html below, we're registering a classic-type service worker. For convenience, we also provide a button that fetches data and logs it.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <script>
-      /* MODIFY PATHS TO POINT TO YOUR ASSETS */
-      const SERVICE_WORKER_PATH = "/classic-service-worker.js";
+      /* UPDATE PATHS TO POINT TO YOUR ASSETS */
+      const SERVICE_WORKER_PATH = "/sw.js";
       const JSON_FILE_PATH = "./data.json";
+      /* IF USING MODULE-TYPE SERVICE WORKER, REPLACE THESE OPTIONS */
       const REGISTRATION_OPTIONS = {
         scope: "/",
       };
@@ -58,7 +57,7 @@ HTML:
           try {
             const registration = await navigator.serviceWorker.register(
               SERVICE_WORKER_PATH,
-              REGISTRATION_OPTIONS,
+              REGISTRATION_OPTIONS
             );
             if (registration.installing) {
               console.log("Service worker installing");
@@ -93,11 +92,20 @@ HTML:
 
 ### Service worker
 
+To set up Pyodide in a service worker, you'll need to do the following:
+
+1. Polyfill `XMLHttpRequest` because it isn't available in service workers' global scopes.
+2. Import Pyodide
+3. If you're planning on calling `loadPyodide` after [installation](https://web.dev/service-worker-lifecycle/) of the service worker, import `pyodide.asm.js` too.
+
+After all the required scripts are imported, we call `loadPyodide` to set up Pyodide, then create a Python function called `modify_data`. This function add a `count` property to an object, where `count` is equal to the number of times `modify_data` is called. We will access this function via a handle assigned to the Javascript variable `modifyData`. We also set up a fetch event handler that intercepts requests for json files so that any JSON object that is fetched is modified using `modifyData`.
+
 ```js
-/* MODIFY IMPORT PATHS TO POINT TO YOUR SCRIPTS */
-importScripts("./xml-http-request.js"); // This script should assign self.XMLHttpRequest to a compatible polyfill, there are many on npm
-importScripts("./pyodide.asm.js"); // This is necessary if you choose to load pyodide after installation of the service worker
+/* sw.js */
+/* MODIFY IMPORT PATHS TO POINT TO YOUR SCRIPTS, REPLACE IF USING MODULE-TYPE WORKER */
+importScripts("./xml-http-request.js");
 importScripts("./pyodide.js");
+// importScripts("./pyodide.asm.js"); // if loading Pyodide after installation phase, you'll need to import this too
 
 let modifyData;
 let pyodide;
@@ -112,15 +120,15 @@ loadPyodide({}).then((_pyodide) => {
     counter = 0
     def modify_data(data):
         global counter
+        counter += 1
         dict = data.to_py()
         dict['count'] = counter
-        counter += 1
         return dict
     `,
-    { globals: namespace },
+    { globals: namespace }
   );
 
-  // assign the modify_data function from the Python context to our Javascript variable
+  // assign the modify_data function from the Python context to a Javascript variable
   modifyData = namespace.get("modify_data");
   namespace.destroy();
 });
@@ -133,7 +141,7 @@ self.addEventListener("fetch", (event) => {
       // If your service worker would return the same response as a server (eg. it's just performing calculations closer to home)
       // then you may want to let the event through without doing anything
       event.respondWith(
-        Promise.reject("Python code isn't set up yet, try again in a bit"),
+        Promise.reject("Python code isn't set up yet, try again in a bit")
       );
     } else {
       event.respondWith(
@@ -151,14 +159,14 @@ self.addEventListener("fetch", (event) => {
               Object.fromEntries(
                 proxy.toJs({
                   pyproxies,
-                }),
-              ),
+                })
+              )
             );
-            // Craft our new JSON response
+            // Craft the new JSON response
             return new Response(result, {
               headers: { "Content-Type": "application/json" },
             });
-          }),
+          })
       );
     }
   }
@@ -180,173 +188,230 @@ self.addEventListener("activate", function (event) {
 });
 ```
 
-## Detailed example 2 - module service workers
+### XMLHttpRequest polyfill
+
+This script should be imported into your service worker, to assign `XMLHttpRequest` in the service worker's global scope.
+
+```js
+/* xml-http-request.js */
+/* vendored from https://github.com/apple502j/xhr-shim/blob/master/src/index.js and modified */
+
+const sHeaders = Symbol("headers");
+const sRespHeaders = Symbol("response headers");
+const sAbortController = Symbol("AbortController");
+const sMethod = Symbol("method");
+const sURL = Symbol("URL");
+const sMIME = Symbol("MIME");
+const sDispatch = Symbol("dispatch");
+const sErrored = Symbol("errored");
+const sTimeout = Symbol("timeout");
+const sTimedOut = Symbol("timedOut");
+const sIsResponseText = Symbol("isResponseText");
+
+const XMLHttpRequestShim = class XMLHttpRequest extends EventTarget {
+  constructor() {
+    super();
+    this.readyState = this.constructor.UNSENT;
+    this.response = null;
+    this.responseType = "";
+    this.responseURL = "";
+    this.status = 0;
+    this.statusText = "";
+    this.timeout = 0;
+    this.withCredentials = false;
+    this[sHeaders] = Object.create(null);
+    this[sHeaders].accept = "*/*";
+    this[sRespHeaders] = Object.create(null);
+    this[sAbortController] = new AbortController();
+    this[sMethod] = "";
+    this[sURL] = "";
+    this[sMIME] = "";
+    this[sErrored] = false;
+    this[sTimeout] = 0;
+    this[sTimedOut] = false;
+    this[sIsResponseText] = true;
+  }
+  static get UNSENT() {
+    return 0;
+  }
+  static get OPENED() {
+    return 1;
+  }
+  static get HEADERS_RECEIVED() {
+    return 2;
+  }
+  static get LOADING() {
+    return 3;
+  }
+  static get DONE() {
+    return 4;
+  }
+  get responseText() {
+    if (this[sErrored]) return null;
+    if (this.readyState < this.constructor.HEADERS_RECEIVED) return "";
+    if (this[sIsResponseText]) return this.response;
+    throw new DOMException(
+      "Response type not set to text",
+      "InvalidStateError"
+    );
+  }
+  get responseXML() {
+    throw new Error("XML not supported");
+  }
+  [sDispatch](evt) {
+    const attr = `on${evt.type}`;
+    if (typeof this[attr] === "function") {
+      this.addEventListener(evt.type, this[attr].bind(this), {
+        once: true,
+      });
+    }
+    this.dispatchEvent(evt);
+  }
+  abort() {
+    this[sAbortController].abort();
+    this.status = 0;
+    this.readyState = this.constructor.UNSENT;
+  }
+  open(method, url) {
+    this.status = 0;
+    this[sMethod] = method;
+    this[sURL] = url;
+    this.readyState = this.constructor.OPENED;
+  }
+  setRequestHeader(header, value) {
+    header = String(header).toLowerCase();
+    if (typeof this[sHeaders][header] === "undefined") {
+      this[sHeaders][header] = String(value);
+    } else {
+      this[sHeaders][header] += `, ${value}`;
+    }
+  }
+  overrideMimeType(mimeType) {
+    this[sMIME] = String(mimeType);
+  }
+  getAllResponseHeaders() {
+    if (this[sErrored] || this.readyState < this.constructor.HEADERS_RECEIVED)
+      return "";
+    return Object.entries(this[sRespHeaders])
+      .map(([header, value]) => `${header}: ${value}`)
+      .join("\r\n");
+  }
+  getResponseHeader(headerName) {
+    const value = this[sRespHeaders][String(headerName).toLowerCase()];
+    return typeof value === "string" ? value : null;
+  }
+  send(body = null) {
+    if (this.timeout > 0) {
+      this[sTimeout] = setTimeout(() => {
+        this[sTimedOut] = true;
+        this[sAbortController].abort();
+      }, this.timeout);
+    }
+    const responseType = this.responseType || "text";
+    this[sIsResponseText] = responseType === "text";
+    fetch(this[sURL], {
+      method: this[sMethod] || "GET",
+      signal: this[sAbortController].signal,
+      headers: this[sHeaders],
+      credentials: this.withCredentials ? "include" : "same-origin",
+      body,
+    })
+      .finally(() => {
+        this.readyState = this.constructor.DONE;
+        clearTimeout(this[sTimeout]);
+        this[sDispatch](new CustomEvent("loadstart"));
+      })
+      .then(
+        async (resp) => {
+          this.responseURL = resp.url;
+          this.status = resp.status;
+          this.statusText = resp.statusText;
+          const finalMIME =
+            this[sMIME] || this[sRespHeaders]["content-type"] || "text/plain";
+          Object.assign(this[sRespHeaders], resp.headers);
+          switch (responseType) {
+            case "text":
+              this.response = await resp.text();
+              break;
+            case "blob":
+              this.response = new Blob([await resp.arrayBuffer()], {
+                type: finalMIME,
+              });
+              break;
+            case "arraybuffer":
+              this.response = await resp.arrayBuffer();
+              break;
+            case "json":
+              this.response = await resp.json();
+              break;
+          }
+          this[sDispatch](new CustomEvent("load"));
+        },
+        (err) => {
+          let eventName = "abort";
+          if (err.name !== "AbortError") {
+            this[sErrored] = true;
+            eventName = "error";
+          } else if (this[sTimedOut]) {
+            eventName = "timeout";
+          }
+          this[sDispatch](new CustomEvent(eventName));
+        }
+      )
+      .finally(() => this[sDispatch](new CustomEvent("loadend")));
+  }
+};
+
+self.XMLHttpRequest = XMLHttpRequestShim;
+```
+
+## Using module-type service workers
+
+While classic-type service workers have better cross-browser compatibility at the moment, module-type service workers make it easier to include external libraries in your service workers via ES module imports. There are environments where we can safely assume ES module support in service workers, such as Chromium-based browser extensions' background scripts. With the adjustments outlined below, you should be able to use our example with a module-type service worker.
 
 ### Setup
 
-Setup your project to serve `module-service-worker.js`. You should also serve
-`pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`, and `.wasm`
-files as well, though this is not strictly required if `pyodide.js` is pointing
-to a site serving current versions of these files.
-The simplest way to serve the required files is to use a CDN,
-such as `https://cdn.jsdelivr.net/pyodide`. This is the solution
-presented here.
-
-Update the `module-service-worker.js` sample so that it has a valid URL for `pyodide.js`, and sets
-{any}`indexURL <globalThis.loadPyodide>` to the location of the supporting files.
-
-You'll also need to serve `data.json`, a JSON file containing a simple object - a sample is provided below:
-
-```json
-{
-  "name": "Jem"
-}
-```
+Serve `pyodide.mjs` instead of `pyodide.js`, the rest of the setup remains the same.
 
 ### Consumers
 
-HTML:
+We need to use different registration options on the consumer side. Replace this section of the script:
 
-```html
-<!doctype html>
-<html>
-  <head>
-    <script>
-      /* MODIFY PATHS TO POINT TO YOUR ASSETS */
-      const SERVICE_WORKER_PATH = "/module-service-worker.js";
-      const JSON_FILE_PATH = "./data.json";
-      const REGISTRATION_OPTIONS = {
-        scope: "/",
-        // Note that specifying the type option can cause errors if the browser doesn't support module-type service workers
-        type: "module",
-      };
+```js
+/* IF USING MODULE-TYPE SERVICE WORKER, REPLACE THESE OPTIONS */
+const REGISTRATION_OPTIONS = {
+  scope: "/",
+};
+```
 
-      // modified snippet from https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
-      async function registerServiceWorker() {
-        if ("serviceWorker" in navigator) {
-          try {
-            const registration = await navigator.serviceWorker.register(
-              SERVICE_WORKER_PATH,
-              REGISTRATION_OPTIONS,
-            );
-            if (registration.installing) {
-              console.log("Service worker installing");
-            } else if (registration.waiting) {
-              console.log("Service worker installed");
-            } else if (registration.active) {
-              console.log("Service worker active");
-            }
-          } catch (error) {
-            console.error(`Registration failed with ${error}`);
-          }
-        }
-      }
+With the following:
 
-      async function fetchAndLogData() {
-        try {
-          console.log(await (await fetch(JSON_FILE_PATH)).json());
-        } catch (e) {
-          console.error("Failed to fetch", e);
-        }
-      }
-
-      registerServiceWorker();
-    </script>
-  </head>
-
-  <body>
-    <button onclick="fetchAndLogData()">Fetch and log data</button>
-  </body>
-</html>
+```js
+const REGISTRATION_OPTIONS = {
+  scope: "/",
+  // Note that specifying the type option can cause errors if the browser doesn't support module-type service workers
+  type: "module",
+};
 ```
 
 ### Service worker
 
-This example is largely the same as the classic service worker example above, the main difference is how we import things. `importScripts` is not supported in module-type workers, we use the ESM import instead.
+On the service worker side, we need to change the way we import scripts. Replace the importScripts calls shown below:
 
 ```js
+/* sw.js */
+/* MODIFY IMPORT PATHS TO POINT TO YOUR SCRIPTS, REPLACE IF USING MODULE-TYPE WORKER */
+importScripts("./xml-http-request.js");
+importScripts("./pyodide.js");
+// importScripts("./pyodide.asm.js"); // if loading Pyodide after installation phase, you'll need to import this too
+```
+
+With the following imports:
+
+```js
+/* sw.js */
 /* MODIFY IMPORT PATHS TO POINT TO YOUR SCRIPTS */
-import "./xml-http-request.js"; // This script should assign self.XMLHttpRequest to a compatible polyfill, there are many on npm
-import "./pyodide.asm.js"; // Pyodide detects this and skips dynamically importing it. Dynamic imports fail in a service worker.
-import { loadPyodide } from "./pyodide.mjs";
-
-let modifyData;
-let pyodide;
-loadPyodide({}).then((_pyodide) => {
-  pyodide = _pyodide;
-  let namespace = pyodide.globals.get("dict")();
-
-  pyodide.runPython(
-    `
-    import json
-
-    counter = 0
-    def modify_data(data):
-        global counter
-        dict = data.to_py()
-        dict['count'] = counter
-        counter += 1
-        return dict
-    `,
-    { globals: namespace },
-  );
-
-  // assign the modify_data function from the Python context to our Javascript variable
-  modifyData = namespace.get("modify_data");
-  namespace.destroy();
-});
-
-self.addEventListener("fetch", (event) => {
-  if (event.request.url.endsWith("json")) {
-    if (!modifyData) {
-      // For this example, throw so it's clear that the worker isn't ready to modify responses
-      // This is because we don't want to return a response that isn't modified yet
-      // If your service worker would return the same response as a server (eg. it's just performing calculations closer to home)
-      // then you may want to let the event through without doing anything
-      event.respondWith(
-        Promise.reject("Python code isn't set up yet, try again in a bit"),
-      );
-    } else {
-      event.respondWith(
-        // We aren't using the async await syntax because event.respondWith needs to respond synchronously
-        // it can't be executing after an awaited promise within the fetch event handler, otherwise you'll get this
-        // Uncaught (in promise) DOMException: Failed to execute 'respondWith' on 'FetchEvent': The event has already been responded to
-        fetch(event.request)
-          .then((v) => v.json())
-          .then((originalData) => {
-            let proxy = modifyData(originalData);
-            let pyproxies = [];
-
-            // Because toJs gives us a Map, we transform it to a plain Javascript object before changing it to JSON
-            let result = JSON.stringify(
-              Object.fromEntries(
-                proxy.toJs({
-                  pyproxies,
-                }),
-              ),
-            );
-            // Craft our new JSON response
-            return new Response(result, {
-              headers: { "Content-Type": "application/json" },
-            });
-          }),
-      );
-    }
-  }
-});
-
-// Code below is for easy iteration during development, you may want to remove or modify in a prod environment:
-
-// Immediately become the active service worker once installed, so we don't have a stale service worker intercepting requests
-// You can remove this code and achieve a similar thing by enabling "Update on Reload" in devtools, if supported:
-// https://web.dev/service-worker-lifecycle/#update-on-reload
-self.addEventListener("install", function () {
-  self.skipWaiting();
-});
-
-// With this, we won't need to reload the page before the service worker can intercept fetch requests
-// https://developer.mozilla.org/en-US/docs/Web/API/Clients/claim#examples
-self.addEventListener("activate", function (event) {
-  event.waitUntil(self.clients.claim());
-});
+import "./xml-http-request.js";
+import "./pyodide.asm.js"; // This is compulsory in a module-type service worker, which cannot use importScripts
+import { loadPyodide } from "./pyodide.mjs"; // Note the .mjs extension
 ```

--- a/docs/usage/service-worker.md
+++ b/docs/usage/service-worker.md
@@ -96,7 +96,7 @@ To set up Pyodide in a service worker, you'll need to do the following:
 
 1. Polyfill `XMLHttpRequest` because it isn't available in service workers' global scopes.
 2. Import Pyodide
-3. If you're planning on calling `loadPyodide` after [installation](https://web.dev/service-worker-lifecycle/) of the service worker, import `pyodide.asm.js` too.
+3. We don't need it for this example, but if you're planning on calling `loadPyodide` after [installation](https://web.dev/service-worker-lifecycle/) of the service worker, import `pyodide.asm.js` too.
 
 After all the required scripts are imported, we call `loadPyodide` to set up Pyodide, then create a Python function called `modify_data`. This function add a `count` property to an object, where `count` is equal to the number of times `modify_data` is called. We will access this function via a handle assigned to the Javascript variable `modifyData`. We also set up a fetch event handler that intercepts requests for json files so that any JSON object that is fetched is modified using `modifyData`.
 
@@ -412,6 +412,6 @@ With the following imports:
 /* sw.js */
 /* MODIFY IMPORT PATHS TO POINT TO YOUR SCRIPTS */
 import "./xml-http-request.js";
-import "./pyodide.asm.js"; // This is compulsory in a module-type service worker, which cannot use importScripts
+import "./pyodide.asm.js"; // IMPORTANT: This is compulsory in a module-type service worker, which cannot use importScripts
 import { loadPyodide } from "./pyodide.mjs"; // Note the .mjs extension
 ```

--- a/docs/usage/service-worker.md
+++ b/docs/usage/service-worker.md
@@ -2,31 +2,44 @@
 
 # Using Pyodide in a service worker
 
-This document describes how to use Pyodide to execute Python scripts in a service worker. Compared to typical web workers, service workers are more related to acting as a network proxy, handling background tasks, and things like caching and offline. See [this article](https://web.dev/workers-overview/#use-cases) for more info.
+This document describes how to use Pyodide to execute Python scripts in a
+service worker. Compared to typical web workers, service workers are more
+related to acting as a network proxy, handling background tasks, and things like
+caching and offline. See [this
+article](https://web.dev/workers-overview/#use-cases) for more info.
 
 ## Detailed example
 
-For our example, we'll be talking about how we can use a service worker to intercept a fetch call for some data and modify the data. We will have two parties involved:
+For our example, we'll be talking about how we can use a service worker to
+intercept a fetch call for some data and modify the data. We will have two
+parties involved:
 
-- The **service worker** which will be intercepting fetch calls for JSON, and modifying the data before returning it
+- The **service worker** which will be intercepting fetch calls for JSON, and
+  modifying the data before returning it
 - The **consumer** which will be fetching some JSON data
 
-To keep things simple, all we'll do is add a field to a fetched JSON object, but an example of a more interesting use case is transforming fetched tabular data using numpy, and caching the result before returning it.
+To keep things simple, all we'll do is add a field to a fetched JSON object, but
+an example of a more interesting use case is transforming fetched tabular data
+using numpy, and caching the result before returning it.
 
-Please note that service workers will only work on https and localhost, so you will require a server to be running for this example.
+Please note that service workers will only work on https and localhost, so you
+will require a server to be running for this example.
 
 ### Setup
 
-Setup your project to serve the service worker script `sw.js`, and the XMLHttpRequest polyfill script `xml-http-request.js`. You should also serve `pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`, and `.wasm`
+Setup your project to serve the service worker script `sw.js`, and the
+XMLHttpRequest polyfill script `xml-http-request.js`. You should also serve
+`pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`, and `.wasm`
 files as well, though this is not strictly required if `pyodide.js` is pointing
-to a site serving current versions of these files.
-The simplest way to serve the required files is to use a CDN,
-such as `https://cdn.jsdelivr.net/pyodide`.
+to a site serving current versions of these files. The simplest way to serve the
+required files is to use a CDN, such as `https://cdn.jsdelivr.net/pyodide`.
 
 Update the `sw.js` sample so that it has a valid URL for `pyodide.js`, and sets
-{any}`indexURL <globalThis.loadPyodide>` to the location of the supporting files.
+{any}`indexURL <globalThis.loadPyodide>` to the location of the supporting
+files.
 
-You'll also need to serve `data.json`, a JSON file containing a simple object - a sample is provided below:
+You'll also need to serve `data.json`, a JSON file containing a simple object -
+a sample is provided below:
 
 ```json
 {
@@ -36,7 +49,9 @@ You'll also need to serve `data.json`, a JSON file containing a simple object - 
 
 ### Consumer
 
-In our consumer, we want to register our service worker - in the html below, we're registering a classic-type service worker. For convenience, we also provide a button that fetches data and logs it.
+In our consumer, we want to register our service worker - in the html below,
+we're registering a classic-type service worker. For convenience, we also
+provide a button that fetches data and logs it.
 
 ```html
 <!doctype html>
@@ -94,11 +109,20 @@ In our consumer, we want to register our service worker - in the html below, we'
 
 To set up Pyodide in a service worker, you'll need to do the following:
 
-1. Polyfill `XMLHttpRequest` because it isn't available in service workers' global scopes.
+1. Polyfill `XMLHttpRequest` because it isn't available in service workers'
+   global scopes.
 2. Import Pyodide
-3. We don't need it for this example, but if you're planning on calling `loadPyodide` after [installation](https://web.dev/service-worker-lifecycle/) of the service worker, import `pyodide.asm.js` too.
+3. We don't need it for this example, but if you're planning on calling
+   `loadPyodide` after [installation](https://web.dev/service-worker-lifecycle/)
+   of the service worker, import `pyodide.asm.js` too.
 
-After all the required scripts are imported, we call `loadPyodide` to set up Pyodide, then create a Python function called `modify_data`. This function add a `count` property to an object, where `count` is equal to the number of times `modify_data` is called. We will access this function via a handle assigned to the Javascript variable `modifyData`. We also set up a fetch event handler that intercepts requests for json files so that any JSON object that is fetched is modified using `modifyData`.
+After all the required scripts are imported, we call `loadPyodide` to set up
+Pyodide, then create a Python function called `modify_data`. This function add a
+`count` property to an object, where `count` is equal to the number of times
+`modify_data` is called. We will access this function via a handle assigned to
+the Javascript variable `modifyData`. We also set up a fetch event handler that
+intercepts requests for json files so that any JSON object that is fetched is
+modified using `modifyData`.
 
 ```js
 /* sw.js */
@@ -190,7 +214,8 @@ self.addEventListener("activate", function (event) {
 
 ### XMLHttpRequest polyfill
 
-This script should be imported into your service worker, to assign `XMLHttpRequest` in the service worker's global scope.
+This script should be imported into your service worker, to assign
+`XMLHttpRequest` in the service worker's global scope.
 
 ```js
 /* xml-http-request.js */
@@ -367,15 +392,23 @@ self.XMLHttpRequest = XMLHttpRequestShim;
 
 ## Using module-type service workers
 
-While classic-type service workers have better cross-browser compatibility at the moment, module-type service workers make it easier to include external libraries in your service workers via ES module imports. There are environments where we can safely assume ES module support in service workers, such as Chromium-based browser extensions' background scripts. With the adjustments outlined below, you should be able to use our example with a module-type service worker.
+While classic-type service workers have better cross-browser compatibility at
+the moment, module-type service workers make it easier to include external
+libraries in your service workers via ES module imports. There are environments
+where we can safely assume ES module support in service workers, such as
+Chromium-based browser extensions' background scripts. With the adjustments
+outlined below, you should be able to use our example with a module-type service
+worker.
 
 ### Setup
 
-Serve `pyodide.mjs` instead of `pyodide.js`, the rest of the setup remains the same.
+Serve `pyodide.mjs` instead of `pyodide.js`, the rest of the setup remains the
+same.
 
 ### Consumers
 
-We need to use different registration options on the consumer side. Replace this section of the script:
+We need to use different registration options on the consumer side. Replace this
+section of the script:
 
 ```js
 /* IF USING MODULE-TYPE SERVICE WORKER, REPLACE THESE OPTIONS */
@@ -396,7 +429,8 @@ const REGISTRATION_OPTIONS = {
 
 ### Service worker
 
-On the service worker side, we need to change the way we import scripts. Replace the importScripts calls shown below:
+On the service worker side, we need to change the way we import scripts. Replace
+the importScripts calls shown below:
 
 ```js
 /* sw.js */

--- a/docs/usage/service-worker.md
+++ b/docs/usage/service-worker.md
@@ -41,7 +41,7 @@ You'll also need to serve `data.json`, a JSON file containing a simple object - 
 HTML:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <script>
@@ -58,7 +58,7 @@ HTML:
           try {
             const registration = await navigator.serviceWorker.register(
               SERVICE_WORKER_PATH,
-              REGISTRATION_OPTIONS
+              REGISTRATION_OPTIONS,
             );
             if (registration.installing) {
               console.log("Service worker installing");
@@ -117,7 +117,7 @@ loadPyodide({}).then((_pyodide) => {
         counter += 1
         return dict
     `,
-    { globals: namespace }
+    { globals: namespace },
   );
 
   // assign the modify_data function from the Python context to our Javascript variable
@@ -133,7 +133,7 @@ self.addEventListener("fetch", (event) => {
       // If your service worker would return the same response as a server (eg. it's just performing calculations closer to home)
       // then you may want to let the event through without doing anything
       event.respondWith(
-        Promise.reject("Python code isn't set up yet, try again in a bit")
+        Promise.reject("Python code isn't set up yet, try again in a bit"),
       );
     } else {
       event.respondWith(
@@ -151,14 +151,14 @@ self.addEventListener("fetch", (event) => {
               Object.fromEntries(
                 proxy.toJs({
                   pyproxies,
-                })
-              )
+                }),
+              ),
             );
             // Craft our new JSON response
             return new Response(result, {
               headers: { "Content-Type": "application/json" },
             });
-          })
+          }),
       );
     }
   }
@@ -208,7 +208,7 @@ You'll also need to serve `data.json`, a JSON file containing a simple object - 
 HTML:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <script>
@@ -227,7 +227,7 @@ HTML:
           try {
             const registration = await navigator.serviceWorker.register(
               SERVICE_WORKER_PATH,
-              REGISTRATION_OPTIONS
+              REGISTRATION_OPTIONS,
             );
             if (registration.installing) {
               console.log("Service worker installing");
@@ -288,7 +288,7 @@ loadPyodide({}).then((_pyodide) => {
         counter += 1
         return dict
     `,
-    { globals: namespace }
+    { globals: namespace },
   );
 
   // assign the modify_data function from the Python context to our Javascript variable
@@ -304,7 +304,7 @@ self.addEventListener("fetch", (event) => {
       // If your service worker would return the same response as a server (eg. it's just performing calculations closer to home)
       // then you may want to let the event through without doing anything
       event.respondWith(
-        Promise.reject("Python code isn't set up yet, try again in a bit")
+        Promise.reject("Python code isn't set up yet, try again in a bit"),
       );
     } else {
       event.respondWith(
@@ -322,14 +322,14 @@ self.addEventListener("fetch", (event) => {
               Object.fromEntries(
                 proxy.toJs({
                   pyproxies,
-                })
-              )
+                }),
+              ),
             );
             // Craft our new JSON response
             return new Response(result, {
               headers: { "Content-Type": "application/json" },
             });
-          })
+          }),
       );
     }
   }

--- a/docs/usage/service-worker.md
+++ b/docs/usage/service-worker.md
@@ -39,7 +39,7 @@ You'll also need to serve `data.json`, a JSON file containing a simple object - 
 In our consumer, we want to register our service worker - in the html below, we're registering a classic-type service worker. For convenience, we also provide a button that fetches data and logs it.
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <script>
@@ -57,7 +57,7 @@ In our consumer, we want to register our service worker - in the html below, we'
           try {
             const registration = await navigator.serviceWorker.register(
               SERVICE_WORKER_PATH,
-              REGISTRATION_OPTIONS
+              REGISTRATION_OPTIONS,
             );
             if (registration.installing) {
               console.log("Service worker installing");
@@ -125,7 +125,7 @@ loadPyodide({}).then((_pyodide) => {
         dict['count'] = counter
         return dict
     `,
-    { globals: namespace }
+    { globals: namespace },
   );
 
   // assign the modify_data function from the Python context to a Javascript variable
@@ -141,7 +141,7 @@ self.addEventListener("fetch", (event) => {
       // If your service worker would return the same response as a server (eg. it's just performing calculations closer to home)
       // then you may want to let the event through without doing anything
       event.respondWith(
-        Promise.reject("Python code isn't set up yet, try again in a bit")
+        Promise.reject("Python code isn't set up yet, try again in a bit"),
       );
     } else {
       event.respondWith(
@@ -159,14 +159,14 @@ self.addEventListener("fetch", (event) => {
               Object.fromEntries(
                 proxy.toJs({
                   pyproxies,
-                })
-              )
+                }),
+              ),
             );
             // Craft the new JSON response
             return new Response(result, {
               headers: { "Content-Type": "application/json" },
             });
-          })
+          }),
       );
     }
   }
@@ -252,7 +252,7 @@ const XMLHttpRequestShim = class XMLHttpRequest extends EventTarget {
     if (this[sIsResponseText]) return this.response;
     throw new DOMException(
       "Response type not set to text",
-      "InvalidStateError"
+      "InvalidStateError",
     );
   }
   get responseXML() {
@@ -356,7 +356,7 @@ const XMLHttpRequestShim = class XMLHttpRequest extends EventTarget {
             eventName = "timeout";
           }
           this[sDispatch](new CustomEvent(eventName));
-        }
+        },
       )
       .finally(() => this[sDispatch](new CustomEvent("loadend")));
   }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -320,7 +320,7 @@ export async function loadPyodide(
   // If the pyodide.asm.js script has been imported, we can skip the dynamic import
   // Users can then do a static import of the script in environments where
   // dynamic importing is not allowed or not desirable, like module-type service workers
-  if (!('_createPyodideModule' in globalThis)) {
+  if (!("_createPyodideModule" in globalThis)) {
     const scriptSrc = `${config.indexURL}pyodide.asm.js`;
     await loadScript(scriptSrc);
   }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -320,7 +320,7 @@ export async function loadPyodide(
   // If the pyodide.asm.js script has been imported, we can skip the dynamic import
   // Users can then do a static import of the script in environments where
   // dynamic importing is not allowed or not desirable, like module-type service workers
-  if (!("_createPyodideModule" in globalThis)) {
+  if (typeof _createPyodideModule !== "function") {
     const scriptSrc = `${config.indexURL}pyodide.asm.js`;
     await loadScript(scriptSrc);
   }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -316,8 +316,14 @@ export async function loadPyodide(
   // locateFile tells Emscripten where to find the data files that initialize
   // the file system.
   Module.locateFile = (path: string) => config.indexURL + path;
-  const scriptSrc = `${config.indexURL}pyodide.asm.js`;
-  await loadScript(scriptSrc);
+
+  // If the pyodide.asm.js script has been imported, we can skip the dynamic import
+  // Users can then do a static import of the script in environments where
+  // dynamic importing is not allowed or not desirable, like module-type service workers
+  if (!(_createPyodideModule instanceof Function)) {
+    const scriptSrc = `${config.indexURL}pyodide.asm.js`;
+    await loadScript(scriptSrc);
+  }
 
   // _createPyodideModule is specified in the Makefile by the linker flag:
   // `-s EXPORT_NAME="'_createPyodideModule'"`

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -320,7 +320,7 @@ export async function loadPyodide(
   // If the pyodide.asm.js script has been imported, we can skip the dynamic import
   // Users can then do a static import of the script in environments where
   // dynamic importing is not allowed or not desirable, like module-type service workers
-  if (!(_createPyodideModule instanceof Function)) {
+  if (!('_createPyodideModule' in globalThis)) {
     const scriptSrc = `${config.indexURL}pyodide.asm.js`;
     await loadScript(scriptSrc);
   }

--- a/src/templates/module_static_import_test.html
+++ b/src/templates/module_static_import_test.html
@@ -1,5 +1,5 @@
 <!-- Bootstrap HTML for running the unit tests. -->
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <script type="text/javascript">

--- a/src/templates/module_static_import_test.html
+++ b/src/templates/module_static_import_test.html
@@ -1,0 +1,27 @@
+<!-- Bootstrap HTML for running the unit tests. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="text/javascript">
+      window.logs = [];
+      console.log = function (message) {
+        window.logs.push(message);
+      };
+      console.warn = function (message) {
+        window.logs.push(message);
+      };
+      console.info = function (message) {
+        window.logs.push(message);
+      };
+      console.error = function (message) {
+        window.logs.push(message);
+      };
+    </script>
+    <script type="module">
+      import './pyodide.asm.js';
+      import { loadPyodide } from "./pyodide.mjs";
+      window.loadPyodide = loadPyodide;
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/src/templates/module_static_import_test.html
+++ b/src/templates/module_static_import_test.html
@@ -18,7 +18,7 @@
       };
     </script>
     <script type="module">
-      import './pyodide.asm.js';
+      import "./pyodide.asm.js";
       import { loadPyodide } from "./pyodide.mjs";
       window.loadPyodide = loadPyodide;
     </script>

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1426,9 +1426,8 @@ def test_csp(selenium_standalone_noload):
     finally:
         target_path.unlink()
 
-@pytest.mark.xfail_browsers(
-    node="Browser only"
-)
+
+@pytest.mark.xfail_browsers(node="Browser only")
 def test_static_import(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     target_path = DIST_PATH / "module_static_import_test.html"

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1426,7 +1426,9 @@ def test_csp(selenium_standalone_noload):
     finally:
         target_path.unlink()
 
-
+@pytest.mark.xfail_browsers(
+    node="Browser only"
+)
 def test_static_import(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     target_path = DIST_PATH / "module_static_import_test.html"

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1426,11 +1426,15 @@ def test_csp(selenium_standalone_noload):
     finally:
         target_path.unlink()
 
+
 def test_static_import(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     target_path = DIST_PATH / "module_static_import_test.html"
     try:
-        shutil.copy(get_pyodide_root() / "src/templates/module_static_import_test.html", target_path)
+        shutil.copy(
+            get_pyodide_root() / "src/templates/module_static_import_test.html",
+            target_path,
+        )
         selenium.goto(f"{selenium.base_url}/module_static_import_test.html")
         selenium.javascript_setup()
         selenium.load_pyodide()

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1428,11 +1428,14 @@ def test_csp(selenium_standalone_noload):
     finally:
         target_path.unlink()
 
-
-@pytest.mark.xfail_browsers(node="Browser only")
 def test_static_import(
     request, runtime, web_server_main, playwright_browsers, tmp_path
 ):
+    # the xfail_browsers mark won't work without using a selenium fixture
+    # so we manually xfail the node test
+    if runtime == "node":
+        pytest.xfail("static import test is browser-only")
+
     # copy dist to tmp_path to perform file changes safely
     shutil.copytree(ROOT_PATH / "dist", tmp_path, dirs_exist_ok=True)
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1425,3 +1425,21 @@ def test_csp(selenium_standalone_noload):
         selenium.load_pyodide()
     finally:
         target_path.unlink()
+
+def test_static_import(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+    target_path = DIST_PATH / "module_static_import_test.html"
+    try:
+        shutil.copy(get_pyodide_root() / "src/templates/module_static_import_test.html", target_path)
+        selenium.goto(f"{selenium.base_url}/module_static_import_test.html")
+        selenium.javascript_setup()
+        selenium.load_pyodide()
+        selenium.run_js(
+            """
+            pyodide.runPython(`
+                print('Static import works')
+            `);
+            """
+        )
+    finally:
+        target_path.unlink()

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1428,6 +1428,7 @@ def test_csp(selenium_standalone_noload):
     finally:
         target_path.unlink()
 
+
 def test_static_import(
     request, runtime, web_server_main, playwright_browsers, tmp_path
 ):

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -11,7 +11,6 @@ from pytest_pyodide import run_in_pyodide
 from pytest_pyodide.fixture import selenium_standalone_noload_common
 from pytest_pyodide.server import spawn_web_server
 
-
 from conftest import DIST_PATH, ROOT_PATH
 from pyodide.code import CodeRunner, eval_code, find_imports, should_quiet  # noqa: E402
 from pyodide_build.common import get_pyodide_root
@@ -1440,7 +1439,7 @@ def test_static_import(
     # define the directory to hide the statically imported pyodide.asm.js in
     hiding_dir = "hide_pyodide_asm_for_test"
 
-    # create the directory and move pyodide.asm.js to the directory 
+    # create the directory and move pyodide.asm.js to the directory
     # so that dynamic import won't find it
     (tmp_path / hiding_dir).mkdir()
     shutil.move(tmp_path / "pyodide.asm.js", tmp_path / hiding_dir / "pyodide.asm.js")


### PR DESCRIPTION
### Description
Should solve https://github.com/pyodide/pyodide/issues/2432

Allows users to do a static import of `pyodide.asm.js` to set `globalThis._createPyodideModule`. With this change, users should be able to use Pyodide in module-type service workers by manually importing `pyodide.asm.js` + polyfilling `XMLHttpRequest`, without breaking existing dynamic import behaviour.

Considered removing the dynamic import in favour of a static import, but this might change behaviour of Pyodide in environments where only loading the big (1.6MB) `pyodide.asm.js` file when necessary is important.

I will update documentation with a new section guiding folks on how to use Pyodide with service workers, and I have drafted some content (Intercept a fetch call for some JSON and modify the data). There are 2 types of workers, with different requirements:

- classic - just polyfill `XMLHttpRequest`, setup is otherwise similar to a web worker
- module - import `pyodide.asm.js` + polyfill `XMLHttpRequest`

I'll write up material for both with explanations for the fixes.

### Checklists
- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add new / update outdated documentation
- [x] Add / update tests
