### PR TITLE
Fix creation of PyProxy when CSP without unsafe-eval is used

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -44,6 +44,11 @@ substitutions:
   `indexURL` (this was a regression in v0.21.2).
   {pr}`3077`
 
+- {{ Enhancement }} Pyodide now works with a content security policy that
+  doesn't include `unsafe-eval`. It is still necessary to include
+  `wasm-unsafe-eval` (and probably will always be).
+  {pr}`3075`
+
 ### Build System / Package Loading
 
 - New packages: pycryptodomex {pr}`2966`, pycryptodome {pr}`2965`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -46,7 +46,10 @@ substitutions:
 
 - {{ Enhancement }} Pyodide now works with a content security policy that
   doesn't include `unsafe-eval`. It is still necessary to include
-  `wasm-unsafe-eval` (and probably always will be).
+  `wasm-unsafe-eval` (and probably always will be). Since current Safari
+  versions have no support for `wasm-unsafe-eval`, it is necessary to include
+  `unsafe-eval` in order to work in Safari. This will likely be fixed in the
+  next Safari release: https://bugs.webkit.org/show_bug.cgi?id=235408
   {pr}`3075`
 
 - {{ Fix }} Add `url` to list of pollyfilled packages for webpack compatibility.

--- a/src/templates/test_csp.html
+++ b/src/templates/test_csp.html
@@ -1,0 +1,28 @@
+<!-- Bootstrap HTML for running the unit tests. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>pyodide</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src http: 'wasm-unsafe-eval'"
+    />
+    <script type="text/javascript">
+      window.logs = [];
+      console.log = function (message) {
+        window.logs.push(message);
+      };
+      console.warn = function (message) {
+        window.logs.push(message);
+      };
+      console.info = function (message) {
+        window.logs.push(message);
+      };
+      console.error = function (message) {
+        window.logs.push(message);
+      };
+    </script>
+    <script src="./pyodide.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1359,9 +1359,9 @@ def test_relative_index_url(selenium, tmp_path):
         print_result(result)
 
 
-pytest.mark.xfail_browsers(node="Browser only")
-
-
+@pytest.mark.xfail_browsers(
+    node="Browser only", safari="Safari doesn't support wasm-unsafe-eval"
+)
 def test_csp(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     target_path = DIST_PATH / "test_csp.html"

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 from collections.abc import Sequence
 from pathlib import Path
 from textwrap import dedent
@@ -7,8 +8,9 @@ from typing import Any
 import pytest
 from pytest_pyodide import run_in_pyodide
 
-from conftest import ROOT_PATH
+from conftest import DIST_PATH, ROOT_PATH
 from pyodide.code import CodeRunner, eval_code, find_imports, should_quiet  # noqa: E402
+from pyodide_build.common import get_pyodide_root
 
 
 def _strip_assertions_stderr(messages: Sequence[str]) -> list[str]:
@@ -1304,8 +1306,6 @@ def test_relative_index_url(selenium, tmp_path):
     if version_result.stdout.startswith("v14"):
         extra_node_args.append("--experimental-wasm-bigint")
 
-    import shutil
-
     shutil.copy(ROOT_PATH / "dist/pyodide.js", tmp_dir / "pyodide.js")
     shutil.copytree(ROOT_PATH / "dist/node_modules", tmp_dir / "node_modules")
 
@@ -1346,3 +1346,18 @@ def test_relative_index_url(selenium, tmp_path):
         assert result.stdout.strip().split("\n")[-1] == str(ROOT_PATH / "dist") + "/"
     finally:
         print_result(result)
+
+
+pytest.mark.xfail_browsers(node="Browser only")
+
+
+def test_csp(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+    target_path = DIST_PATH / "test_csp.html"
+    try:
+        shutil.copy(get_pyodide_root() / "src/templates/test_csp.html", target_path)
+        selenium.goto(f"{selenium.base_url}/test_csp.html")
+        selenium.javascript_setup()
+        selenium.load_pyodide()
+    finally:
+        target_path.unlink()


### PR DESCRIPTION
See discussion following https://github.com/pyodide/pyodide/issues/2432#issuecomment-1235646608.

* [x] Add test
* [x] Update changelog