### PR TITLE
fix PATH and ERRNO_CODES failing puppeteer tests

### DIFF
--- a/src/js/test/integration/filesystem.test.js
+++ b/src/js/test/integration/filesystem.test.js
@@ -28,21 +28,21 @@ describe("FS", () => {
 
 describe("PATH", () => {
   it("exists", async () => {
-    chai.assert.exists(pyodide.PATH);
+    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.PATH));
   });
   it("has expected keys", async () => {
-    chai.assert.exists(pyodide.PATH.dirname);
-    chai.assert.exists(pyodide.PATH.normalize);
+    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.PATH.dirname));
+    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.PATH.normalize));
   });
 });
 
 describe("ERRNO_CODES", () => {
   it("exists", async () => {
-    chai.assert.exists(pyodide.ERRNO_CODES);
+    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.ERRNO_CODES));
   });
   it("has expected keys", async () => {
-    chai.assert.exists(pyodide.ERRNO_CODES.ENOENT);
-    chai.assert.exists(pyodide.ERRNO_CODES.EPERM);
-    chai.assert.exists(pyodide.ERRNO_CODES.EEXIST);
+    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.ENOENT));
+    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.EPERM));
+    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.EEXIST));
   });
 });

--- a/src/js/test/integration/filesystem.test.js
+++ b/src/js/test/integration/filesystem.test.js
@@ -28,33 +28,21 @@ describe("FS", () => {
 
 describe("PATH", () => {
   it("exists", async () => {
-    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.PATH));
+    chai.assert.exists(await page.evaluate(() => pyodide.PATH));
   });
   it("has expected keys", async () => {
-    chai.assert.exists(
-      await page.evaluate(() => globalThis.pyodide.PATH.dirname)
-    );
-    chai.assert.exists(
-      await page.evaluate(() => globalThis.pyodide.PATH.normalize)
-    );
+    chai.assert.exists(await page.evaluate(() => pyodide.PATH.dirname));
+    chai.assert.exists(await page.evaluate(() => pyodide.PATH.normalize));
   });
 });
 
 describe("ERRNO_CODES", () => {
   it("exists", async () => {
-    chai.assert.exists(
-      await page.evaluate(() => globalThis.pyodide.ERRNO_CODES)
-    );
+    chai.assert.exists(await page.evaluate(() => pyodide.ERRNO_CODES));
   });
   it("has expected keys", async () => {
-    chai.assert.exists(
-      await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.ENOENT)
-    );
-    chai.assert.exists(
-      await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.EPERM)
-    );
-    chai.assert.exists(
-      await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.EEXIST)
-    );
+    chai.assert.exists(await page.evaluate(() => pyodide.ERRNO_CODES.ENOENT));
+    chai.assert.exists(await page.evaluate(() => pyodide.ERRNO_CODES.EPERM));
+    chai.assert.exists(await page.evaluate(() => pyodide.ERRNO_CODES.EEXIST));
   });
 });

--- a/src/js/test/integration/filesystem.test.js
+++ b/src/js/test/integration/filesystem.test.js
@@ -31,18 +31,30 @@ describe("PATH", () => {
     chai.assert.exists(await page.evaluate(() => globalThis.pyodide.PATH));
   });
   it("has expected keys", async () => {
-    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.PATH.dirname));
-    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.PATH.normalize));
+    chai.assert.exists(
+      await page.evaluate(() => globalThis.pyodide.PATH.dirname)
+    );
+    chai.assert.exists(
+      await page.evaluate(() => globalThis.pyodide.PATH.normalize)
+    );
   });
 });
 
 describe("ERRNO_CODES", () => {
   it("exists", async () => {
-    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.ERRNO_CODES));
+    chai.assert.exists(
+      await page.evaluate(() => globalThis.pyodide.ERRNO_CODES)
+    );
   });
   it("has expected keys", async () => {
-    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.ENOENT));
-    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.EPERM));
-    chai.assert.exists(await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.EEXIST));
+    chai.assert.exists(
+      await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.ENOENT)
+    );
+    chai.assert.exists(
+      await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.EPERM)
+    );
+    chai.assert.exists(
+      await page.evaluate(() => globalThis.pyodide.ERRNO_CODES.EEXIST)
+    );
   });
 });


### PR DESCRIPTION
These tests were failing when I ran `npm run test:browser`, because `globalThis.pyodide` was set in puppeteer's page context. If in node, `page.evaluate` will simply call the function which accesses the node `globalThis` that does have the pyodide property set.