### PR TITLE
Add browser polyfill for node url package.

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -42,6 +42,9 @@ substitutions:
   `indexURL` (this was a regression in v0.21.2).
   {pr}`3077`
 
+- {{ Fix }} Add `url` to list of pollyfilled packages for webpack compatibility.
+  {pr}`3080`
+
 ### Build System / Package Loading
 
 - New packages: pycryptodomex {pr}`2966`, pycryptodome {pr}`2965`

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -67,6 +67,7 @@
     "fs": false,
     "fs/promises": false,
     "path": false,
+    "url": false,
     "vm": false,
     "ws": false
   },


### PR DESCRIPTION
This fixes the error:

```
Module not found: Error: Can't resolve 'url' in '/home/david/work/pybricks/pybricks-code/node_modules/pyodide'
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'
        - install 'url'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "url": false }
```

when using webpack. This package was missed in #2468.

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
