### PR TITLE
Fix webpack warnings and reenable webpack test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
             git clone https://github.com/pyodide/pyodide-webpack-example.git
             export DEV_PYODIDE_PATH=`realpath dist`
             cd pyodide-webpack-example
-            git checkout d17320459f4e48a710bb309f301b0adbf10ad985
+            git checkout c770f7f4f305c5c533b14e952b698c8c48cd4ab4
             ./build.sh
 
   benchmark:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,14 +369,14 @@ jobs:
             npm link ../../dist
             npm run test-types
             npm test
-      # - run:
-      #     name: check if webpack cli works well with load-pyodide.js
-      #     command: |
-      #       git clone https://github.com/pyodide/pyodide-webpack-example.git
-      #       cd pyodide-webpack-example
-      #       npm ci
-      #       cp ../src/js/*.js node_modules/pyodide/
-      #       npx webpack
+      - run:
+          name: check if Pyodide works with Webpack
+          command: |
+            git clone https://github.com/pyodide/pyodide-webpack-example.git
+            export DEV_PYODIDE_PATH=`realpath dist`
+            cd pyodide-webpack-example
+            git checkout d17320459f4e48a710bb309f301b0adbf10ad985
+            ./build.sh
 
   benchmark:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,14 +369,14 @@ jobs:
             npm link ../../dist
             npm run test-types
             npm test
-      - run:
-          name: check if Pyodide works with Webpack
-          command: |
-            git clone https://github.com/pyodide/pyodide-webpack-example.git
-            export DEV_PYODIDE_PATH=`realpath dist`
-            cd pyodide-webpack-example
-            git checkout d17320459f4e48a710bb309f301b0adbf10ad985
-            ./build.sh
+      # - run:
+      #     name: check if webpack cli works well with load-pyodide.js
+      #     command: |
+      #       git clone https://github.com/pyodide/pyodide-webpack-example.git
+      #       cd pyodide-webpack-example
+      #       npm ci
+      #       cp ../src/js/*.js node_modules/pyodide/
+      #       npx webpack
 
   benchmark:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
             git clone https://github.com/pyodide/pyodide-webpack-example.git
             export DEV_PYODIDE_PATH=`realpath dist`
             cd pyodide-webpack-example
-            git checkout 9156357ebc1402ffdccd7e37fb98bd44df31f982
+            git checkout 164054a9c6fbd2176f386b6552ed8d079c6bcc04
             ./build.sh
 
   benchmark:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
             git clone https://github.com/pyodide/pyodide-webpack-example.git
             export DEV_PYODIDE_PATH=`realpath dist`
             cd pyodide-webpack-example
-            git checkout c770f7f4f305c5c533b14e952b698c8c48cd4ab4
+            git checkout 2d4834c5b9840de63b980dc14e2e7af16490b99a
             ./build.sh
 
   benchmark:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
             git clone https://github.com/pyodide/pyodide-webpack-example.git
             export DEV_PYODIDE_PATH=`realpath dist`
             cd pyodide-webpack-example
-            git checkout 2d4834c5b9840de63b980dc14e2e7af16490b99a
+            git checkout 9156357ebc1402ffdccd7e37fb98bd44df31f982
             ./build.sh
 
   benchmark:

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ node_modules/.installed : src/js/package.json src/js/package-lock.json
 
 dist/pyodide.js src/js/_pyodide.out.js: src/js/*.ts src/js/pyproxy.gen.ts src/js/error_handling.gen.ts node_modules/.installed
 	npx rollup -c src/js/rollup.config.js
-	sed -i -E 's!await import\(([a-z0-9._/"-]*?)\)!await import(\1 /* webpack ignore */)!g' pyodide.js
+	sed -i 's!await import(!await import(/* webpackIgnore: true */ !g' dist/pyodide.js
 
 dist/package.json : src/js/package.json
 	cp $< $@

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ node_modules/.installed : src/js/package.json src/js/package-lock.json
 
 dist/pyodide.js src/js/_pyodide.out.js: src/js/*.ts src/js/pyproxy.gen.ts src/js/error_handling.gen.ts node_modules/.installed
 	npx rollup -c src/js/rollup.config.js
+	sed -i -E 's!await import\(([a-z0-9._/"-]*?)\)!await import(\1 /* webpack ignore */)!g' pyodide.js
 
 dist/package.json : src/js/package.json
 	cp $< $@

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ node_modules/.installed : src/js/package.json src/js/package-lock.json
 
 dist/pyodide.js src/js/_pyodide.out.js: src/js/*.ts src/js/pyproxy.gen.ts src/js/error_handling.gen.ts node_modules/.installed
 	npx rollup -c src/js/rollup.config.js
+   # Add /* webpackIgnore: true */ to each dynamic import in `pyodide.js`.
+   # Rollup strips comments so this can't be done via the source file.
+   # We use ! as the sed separator because the replacement text includes /
 	sed -i 's!await import(!await import(/* webpackIgnore: true */ !g' dist/pyodide.js
 
 dist/package.json : src/js/package.json

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -58,6 +58,11 @@ substitutions:
 - {{ Fix }} Add `url` to list of pollyfilled packages for webpack compatibility.
   {pr}`3080`
 
+- {{ Fix }} Fixed warnings like
+  `Critical dependency: the request of a dependency is an expression.`
+  when using Pyodide with webpack.
+  {pr}`3080`
+
 ### Build System / Package Loading
 
 - New packages: pycryptodomex {pr}`2966`, pycryptodome {pr}`2965`

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -182,7 +182,6 @@ if (globalThis.document) {
 } else if (globalThis.importScripts) {
   // webworker
   loadScript = async (url) => {
-    // This is async only for consistency
     try {
       // use importScripts in classic web worker
       globalThis.importScripts(url);
@@ -217,6 +216,7 @@ async function nodeLoadScript(url: string) {
   } else {
     // Otherwise, hopefully it is a relative path we can load from the file
     // system.
-    await import(nodeUrlMod.pathToFileURL(url).href);
+    url = nodeUrlMod.pathToFileURL(url).href;
+    await import(url);
   }
 }

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -182,7 +182,6 @@ if (globalThis.document) {
 } else if (globalThis.importScripts) {
   // webworker
   loadScript = async (url) => {
-    // This is async only for consistency
     try {
       // use importScripts in classic web worker
       globalThis.importScripts(url);

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -182,6 +182,7 @@ if (globalThis.document) {
 } else if (globalThis.importScripts) {
   // webworker
   loadScript = async (url) => {
+    // This is async only for consistency
     try {
       // use importScripts in classic web worker
       globalThis.importScripts(url);
@@ -216,7 +217,6 @@ async function nodeLoadScript(url: string) {
   } else {
     // Otherwise, hopefully it is a relative path we can load from the file
     // system.
-    url = nodeUrlMod.pathToFileURL(url).href;
-    await import(url);
+    await import(nodeUrlMod.pathToFileURL(url).href);
   }
 }

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -51,7 +51,6 @@
       "require": "./pyodide.js",
       "import": "./pyodide.mjs"
     },
-    "./distutils.tar": "./distutils.tar",
     "./pyodide.asm.wasm": "./pyodide.asm.wasm",
     "./pyodide.asm.js": "./pyodide.asm.js",
     "./pyodide.asm.data": "./pyodide.asm.data",


### PR DESCRIPTION
This uses sed to insert `/* webpackIgnore: true */` comments into `pyodide.js`. This resolves #3087. I also enabled a check that a simple webpack config builds without warnings. In the future it would be good to add a test that it also runs without error.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
