### PR TITLE
Add create_index to create a pypa simple index and use it with xbuildenv

### DIFF
--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -365,6 +365,6 @@ def exit_with_stdio(result: subprocess.CompletedProcess[str]) -> NoReturn:
     raise SystemExit(result.returncode)
 
 
-def in_xbuild_env() -> bool:
+def in_xbuildenv() -> bool:
     pyodide_root = get_pyodide_root()
     return pyodide_root.name == "pyodide-root"

--- a/pyodide-build/pyodide_build/create_index.py
+++ b/pyodide-build/pyodide_build/create_index.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+from textwrap import dedent
+from typing import TypedDict
+
+
+class PackageInfo(TypedDict):
+    file_name: str
+    sha256: str
+
+
+def create_index(
+    packages: dict[str, PackageInfo], target_dir: Path, dist_url: str
+) -> None:
+    """Create a pip-compatible package index to be used with a Pyodide virtual
+    environment.
+
+    To use, pass as an `--index-url` or `--extra-index-url` parameter to pip.
+    The argument should be a `file:` url pointing to the `pypi_index` folder (or
+    if you serve `pypi_index` it can be a normal url). It is also used
+    automatically by Pyodide virtual environments created from a release version
+    of Pyodide.
+
+    Parameters
+    ----------
+    packages:
+        A dictionary of packages that we want to index. This should be the
+        "packages" field from repodata.json.
+
+    target_dir:
+        Where to put the pypi index. It will be placed in a subfolder of
+        target_dir called `pypi_index`. `target_dir` should exist but
+        `target_dir/pypi_index` should not exist.
+
+    dist_url:
+        The CDN url to download packages from. This will be hard coded into the
+        generated index. If you wish to install from local files, then prefix
+        with `file:` e.g., `f"file:{pyodide_root}/dist"`.
+    """
+    # We only want to index the wheels
+    packages = {
+        pkgname: pkginfo
+        for (pkgname, pkginfo) in packages.items()
+        if pkginfo["file_name"].endswith(".whl")
+    }
+
+    index_dir = target_dir / "pypi_index"
+    index_dir.mkdir()
+
+    # Create top level index
+    packages_str = "\n".join(f'<a href="{x}/">{x}</a>' for x in packages.keys())
+    index_html = dedent(
+        f"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta name="pypi:repository-version" content="1.0">
+        <title>Simple index</title>
+        </head>
+        <body>
+        {packages_str}
+        </body>
+        </html>
+        """
+    ).strip()
+
+    (index_dir / "index.html").write_text(index_html)
+
+    files_template = dedent(
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta name="pypi:repository-version" content="1.0">
+        <title>Links for {pkgname}</title>
+        </head>
+        <body>
+        <h1>Links for {pkgname}</h1>
+        {links}
+        </body>
+        </html>
+        """
+    ).strip()
+
+    for pkgname, pkginfo in packages.items():
+        pkgdir = index_dir / pkgname
+        filename = pkginfo["file_name"]
+        shasum = pkginfo["sha256"]
+        href = f"{dist_url}{filename}#sha256={shasum}"
+        links_str = f'<a href="{href}">{pkgname}</a>\n'
+        files_html = files_template.format(pkgname=pkgname, links=links_str)
+
+        pkgdir.mkdir()
+        (pkgdir / "index.html").write_text(files_html)

--- a/pyodide-build/pyodide_build/create_pypa_index.py
+++ b/pyodide-build/pyodide_build/create_pypa_index.py
@@ -42,8 +42,12 @@ def create_pypa_index(
         for (pkgname, pkginfo) in packages.items()
         if pkginfo["file_name"].endswith(".whl")
     }
+    if not target_dir.exists():
+        raise RuntimeError(f"target_dir={target_dir} does not exist")
 
     index_dir = target_dir / "pypa_index"
+    if index_dir.exists():
+        raise RuntimeError(f"{index_dir} already exists")
     index_dir.mkdir()
 
     # Create top level index

--- a/pyodide-build/pyodide_build/create_pypa_index.py
+++ b/pyodide-build/pyodide_build/create_pypa_index.py
@@ -8,15 +8,15 @@ class PackageInfo(TypedDict):
     sha256: str
 
 
-def create_index(
+def create_pypa_index(
     packages: dict[str, PackageInfo], target_dir: Path, dist_url: str
 ) -> None:
-    """Create a pip-compatible package index to be used with a Pyodide virtual
+    """Create a pip-compatible Python package (pypa) index to be used with a Pyodide virtual
     environment.
 
     To use, pass as an `--index-url` or `--extra-index-url` parameter to pip.
-    The argument should be a `file:` url pointing to the `pypi_index` folder (or
-    if you serve `pypi_index` it can be a normal url). It is also used
+    The argument should be a `file:` url pointing to the `pypa_index` folder (or
+    if you serve `pypa_index` it can be a normal url). It is also used
     automatically by Pyodide virtual environments created from a release version
     of Pyodide.
 
@@ -27,9 +27,9 @@ def create_index(
         "packages" field from repodata.json.
 
     target_dir:
-        Where to put the pypi index. It will be placed in a subfolder of
-        target_dir called `pypi_index`. `target_dir` should exist but
-        `target_dir/pypi_index` should not exist.
+        Where to put the  index. It will be placed in a subfolder of
+        target_dir called `pypa_index`. `target_dir` should exist but
+        `target_dir/pypa_index` should not exist.
 
     dist_url:
         The CDN url to download packages from. This will be hard coded into the
@@ -43,7 +43,7 @@ def create_index(
         if pkginfo["file_name"].endswith(".whl")
     }
 
-    index_dir = target_dir / "pypi_index"
+    index_dir = target_dir / "pypa_index"
     index_dir.mkdir()
 
     # Create top level index

--- a/pyodide-build/pyodide_build/create_xbuildenv.py
+++ b/pyodide-build/pyodide_build/create_xbuildenv.py
@@ -52,7 +52,13 @@ def copy_wasm_libs(xbuildenv_path: Path) -> None:
         wasm_lib_dir / "CLAPACK",
         wasm_lib_dir / "cmake",
         Path("tools/pyo3_config.ini"),
+        Path("tools/python"),
+        Path("dist/repodata.json"),
+        Path("dist/pyodide_py.tar"),
     ]
+    to_copy.extend(
+        x.relative_to(pyodide_root) for x in (pyodide_root / "dist").glob("pyodide.*")
+    )
     # Some ad-hoc stuff here to moderate size. We'd like to include all of
     # wasm_lib_dir but there's 180mb of it. Better to leave out all the video
     # codecs and stuff.
@@ -84,6 +90,7 @@ def main(args: argparse.Namespace) -> None:
 
     copy_xbuild_files(xbuildenv_path)
     copy_wasm_libs(xbuildenv_path)
+
     res = subprocess.run(
         ["pip", "freeze", "--path", get_make_flag("HOSTSITEPACKAGES")],
         stdout=subprocess.PIPE,

--- a/pyodide-build/pyodide_build/install_xbuildenv.py
+++ b/pyodide-build/pyodide_build/install_xbuildenv.py
@@ -19,11 +19,11 @@ def make_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "Note: this is a private endpoint that should not be used outside of the Pyodide Makefile."
     )
     parser.add_argument("--download", action="store_true", help="Download xbuild env")
-    parser.add_argument("xbuild_env", type=str, nargs=1)
+    parser.add_argument("xbuildenv", type=str, nargs=1)
     return parser
 
 
-def download_xbuild_env(version: str, xbuildenv_path: Path) -> None:
+def download_xbuildenv(version: str, xbuildenv_path: Path) -> None:
     from shutil import rmtree, unpack_archive
     from tempfile import NamedTemporaryFile
 
@@ -36,7 +36,7 @@ def download_xbuild_env(version: str, xbuildenv_path: Path) -> None:
         unpack_archive(f.name, xbuildenv_path)
 
 
-def install_xbuild_env(version: str, xbuildenv_path: Path) -> None:
+def install_xbuildenv(version: str, xbuildenv_path: Path) -> None:
     xbuildenv_path = xbuildenv_path / "xbuildenv"
     pyodide_root = get_pyodide_root()
     xbuildenv_root = xbuildenv_path / "pyodide-root"
@@ -74,8 +74,8 @@ def install_xbuild_env(version: str, xbuildenv_path: Path) -> None:
 def main(args: argparse.Namespace) -> None:
     from . import __version__
 
-    xbuildenv_path = Path(args.xbuild_env[0])
+    xbuildenv_path = Path(args.xbuildenv[0])
     version = __version__
     if args.download:
-        download_xbuild_env(version, xbuildenv_path)
-    install_xbuild_env(version, xbuildenv_path)
+        download_xbuildenv(version, xbuildenv_path)
+    install_xbuildenv(version, xbuildenv_path)

--- a/pyodide-build/pyodide_build/install_xbuildenv.py
+++ b/pyodide-build/pyodide_build/install_xbuildenv.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from urllib.request import urlopen, urlretrieve
 
 from .common import exit_with_stdio, get_make_flag, get_pyodide_root
-from .create_index import create_index
+from .create_pypa_index import create_pypa_index
 
 
 def make_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -74,7 +74,7 @@ def install_xbuildenv(version: str, xbuildenv_path: Path) -> None:
             repodata_bytes = response.read()
     repodata = json.loads(repodata_bytes)
     version = repodata["info"]["version"]
-    create_index(repodata["packages"], xbuildenv_root, cdn_base)
+    create_pypa_index(repodata["packages"], xbuildenv_root, cdn_base)
 
 
 def main(args: argparse.Namespace) -> None:

--- a/pyodide-build/pyodide_build/out_of_tree/__main__.py
+++ b/pyodide-build/pyodide_build/out_of_tree/__main__.py
@@ -12,6 +12,11 @@ def ensure_env_installed(env: Path) -> None:
     from .. import __version__
     from ..install_xbuildenv import download_xbuildenv, install_xbuildenv
 
+    if "dev" in __version__:
+        raise RuntimeError(
+            "To use out of tree builds with development Pyodide, you must explicitly set PYODIDE_ROOT"
+        )
+
     download_xbuildenv(__version__, env)
     install_xbuildenv(__version__, env)
 

--- a/pyodide-build/pyodide_build/out_of_tree/__main__.py
+++ b/pyodide-build/pyodide_build/out_of_tree/__main__.py
@@ -10,10 +10,10 @@ def ensure_env_installed(env: Path) -> None:
     if env.exists():
         return
     from .. import __version__
-    from ..install_xbuildenv import download_xbuild_env, install_xbuild_env
+    from ..install_xbuildenv import download_xbuildenv, install_xbuildenv
 
-    download_xbuild_env(__version__, env)
-    install_xbuild_env(env)
+    download_xbuildenv(__version__, env)
+    install_xbuildenv(__version__, env)
 
 
 def initialize_pyodide_root() -> None:

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -11,7 +11,7 @@ from ..common import (
     exit_with_stdio,
     get_make_flag,
     get_pyodide_root,
-    in_xbuild_env,
+    in_xbuildenv,
 )
 
 
@@ -63,8 +63,8 @@ def create_pip_conf(venv_root: Path) -> None:
 
     This file adds a few options that will always be used by pip install.
     """
-    if in_xbuild_env():
-        # In the xbuild_env, we don't have the packages locally. We will include
+    if in_xbuildenv():
+        # In the xbuildenv, we don't have the packages locally. We will include
         # in the xbuildenv a PEP 503 index for the vendored Pyodide packages
         # https://peps.python.org/pep-0503/
         repo = f'extra-index-url=file:{get_pyodide_root()/"pypi_index"}'

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -67,15 +67,15 @@ def create_pip_conf(venv_root: Path) -> None:
         # In the xbuild_env, we don't have the packages locally. We will include
         # in the xbuildenv a PEP 503 index for the vendored Pyodide packages
         # https://peps.python.org/pep-0503/
-
-        # TODO create the index as part of the xbuildenv
-        repo = f'extra-index-url={get_pyodide_root()/"dist/pypi_index"}'
-        raise NotImplementedError()
+        repo = f'extra-index-url=file:{get_pyodide_root()/"pypi_index"}'
     else:
         # In the Pyodide development environment, the Pyodide dist directory
         # should contain the needed wheels. find-links
         repo = f'find-links={get_pyodide_root()/"dist"}'
 
+    # Prevent attempts to install binary wheels from source.
+    # Maybe some day we can convince pip to invoke `pyodide build` as the build
+    # front end for wheels...
     (venv_root / "pip.conf").write_text(
         dedent(
             f"""
@@ -202,26 +202,23 @@ def create_pyodide_script(venv_bin: Path) -> None:
 
 def install_stdlib(venv_bin: Path) -> None:
     """Install micropip and all unvendored stdlib modules"""
-    # Micropip we can install with pip!
-    toload = ["micropip"]
-    result = subprocess.run(
-        [venv_bin / "pip", "install", *toload],
-        capture_output=True,
-        encoding="utf8",
-    )
-    check_result(result, "ERROR: failed to invoke pip")
+    # Micropip we could install with pip hypothetically, but because we use
+    # `--extra-index-url` it would install the pypi version which we don't want.
 
     # Other stuff we need to load with loadPackage
     # TODO: Also load all shared libs.
+    to_load = ["micropip"]
     result = subprocess.run(
         [
             venv_bin / "python",
             "-c",
             dedent(
-                """
+                f"""
                 from _pyodide._importhook import UNVENDORED_STDLIBS_AND_TEST;
                 from pyodide_js import loadPackage;
-                loadPackage(UNVENDORED_STDLIBS_AND_TEST);
+
+                to_load = [*UNVENDORED_STDLIBS_AND_TEST, *{to_load!r}]
+                loadPackage(to_load);
                 """
             ),
         ],

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -67,7 +67,7 @@ def create_pip_conf(venv_root: Path) -> None:
         # In the xbuildenv, we don't have the packages locally. We will include
         # in the xbuildenv a PEP 503 index for the vendored Pyodide packages
         # https://peps.python.org/pep-0503/
-        repo = f'extra-index-url=file:{get_pyodide_root()/"pypi_index"}'
+        repo = f'extra-index-url=file:{get_pyodide_root()/"pypa_index"}'
     else:
         # In the Pyodide development environment, the Pyodide dist directory
         # should contain the needed wheels. find-links

--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -385,14 +385,16 @@ def test_pip_install_from_pyodide(selenium, venv):
     )
 
 
-def test_install_xbuildenv(tmp_path):
+def test_pypa_index(tmp_path):
+    """Test that installing packages from the python package index works as
+    expected."""
     path = Path(tmp_path)
     version = "0.21.2"  # just need some version that already exists
     download_xbuildenv(version, path)
     install_xbuildenv(version, path)
     pip_opts = [
         "--index-url",
-        "file:" + str((path / "xbuildenv/pyodide-root/pypi_index").resolve()),
+        "file:" + str((path / "xbuildenv/pyodide-root/pypa_index").resolve()),
         "--platform=emscripten_3_1_14_wasm32",
         "--only-binary=:all:",
         "-t",

--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -11,6 +11,7 @@ import pytest
 
 import pyodide
 from pyodide_build.common import emscripten_version, get_pyodide_root
+from pyodide_build.install_xbuildenv import download_xbuildenv, install_xbuildenv
 
 only_node = pytest.mark.xfail_browsers(
     chrome="node only", firefox="node only", safari="node only"
@@ -381,4 +382,43 @@ def test_pip_install_from_pyodide(selenium, venv):
     assert (
         result.stdout
         == "{'word': ['one', 'two', 'three'], 'digits': ['1', '2', '3']}" + "\n"
+    )
+
+
+def test_install_xbuildenv(tmp_path):
+    path = Path(tmp_path)
+    version = "0.21.2"  # just need some version that already exists
+    download_xbuildenv(version, path)
+    install_xbuildenv(version, path)
+    pip_opts = [
+        "--index-url",
+        "file:" + str((path / "xbuildenv/pyodide-root/pypi_index").resolve()),
+        "--platform=emscripten_3_1_14_wasm32",
+        "--only-binary=:all:",
+        "-t",
+        str(path / "temp_lib"),
+    ]
+    to_install = [
+        "numpy",
+        "sharedlib-test-py",
+        "micropip",
+        "attrs",
+    ]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            *pip_opts,
+            *to_install,
+        ],
+        capture_output=True,
+        encoding="utf8",
+    )
+    assert result.returncode == 0
+    stdout = re.sub(r"(?<=[<>=-])([\d+]\.?)+", "*", result.stdout)
+    assert (
+        stdout.strip().rsplit("\n", 1)[-1]
+        == "Successfully installed attrs-* micropip-* numpy-* sharedlib-test-py-*"
     )


### PR DESCRIPTION
Pyodide virtual environments created from release versions of Pyodide
will use this package index to install packages from jsdelivr.

### Checklists

- [x] Add / update tests
