### PR TITLE
Fix `PyProxy.apply` when `args` is undefined

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -71,6 +71,10 @@ substitutions:
   JavaScript and Python Pyodide package does not match.
   {pr}`3074`
 
+- {{ Fix }} `PyProxy.apply` now correctly handles the case when something
+  unexpected is passed as the second argument.
+  {pr}`3101`
+
 ### Build System / Package Loading
 
 - New packages: pycryptodomex {pr}`2966`, pycryptodome {pr}`2965`

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -928,7 +928,7 @@ EM_JS_REF(JsRef, create_once_callable, (PyObject * obj), {
       throw new Error("OnceProxy can only be called once");
     }
     try {
-      return Module.callPyObject(obj, ... args);
+      return Module.callPyObject(obj, args);
     } finally {
       wrapper.destroy();
     }
@@ -1016,7 +1016,7 @@ EM_JS_REF(JsRef, create_promise_handles, (
     checkUsed();
     try {
       if(handle_result){
-        return Module.callPyObject(handle_result, res);
+        return Module.callPyObject(handle_result, [res]);
       }
     } finally {
       done_callback(res);
@@ -1027,7 +1027,7 @@ EM_JS_REF(JsRef, create_promise_handles, (
     checkUsed();
     try {
       if(handle_exception){
-        return Module.callPyObject(handle_exception, err);
+        return Module.callPyObject(handle_exception, [err]);
       }
     } finally {
       done_callback(undefined);

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1129,7 +1129,7 @@ export class PyProxyCallableMethods {
       if (typeof jsargs[Symbol.iterator] === "function") {
         jsargs = Array.from(jsargs);
       } else {
-        throw TypeError("Expected jsargs to be iterable.");
+        throw new TypeError("Expected jsargs to be iterable.");
       }
     }
     return Module.callPyObject(_getPtr(this), jsargs);

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1126,10 +1126,12 @@ export class PyProxyCallableMethods {
     if (jsargs === undefined || jsargs === null) {
       jsargs = [];
     } else if (!Array.isArray(jsargs)) {
-      if (typeof jsargs[Symbol.iterator] === "function") {
+      if (typeof jsargs !== "object") {
+        throw new TypeError("Expected args to an object.");
+      } else if (typeof jsargs[Symbol.iterator] === "function") {
         jsargs = Array.from(jsargs);
       } else {
-        throw new TypeError("Expected jsargs to be iterable.");
+        throw new TypeError("Expected args to be iterable.");
       }
     }
     return Module.callPyObject(_getPtr(this), jsargs);

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1123,17 +1123,11 @@ export type PyProxyCallable = PyProxy &
 
 export class PyProxyCallableMethods {
   apply(jsthis: PyProxyClass, jsargs: any) {
-    if (jsargs === undefined || jsargs === null) {
-      jsargs = [];
-    } else if (!Array.isArray(jsargs)) {
-      if (typeof jsargs !== "object") {
-        throw new TypeError("Expected args to an object.");
-      } else if (typeof jsargs[Symbol.iterator] === "function") {
-        jsargs = Array.from(jsargs);
-      } else {
-        throw new TypeError("Expected args to be iterable.");
-      }
-    }
+    // Convert jsargs to an array using ordinary .apply in order to match the
+    // behavior of .apply very accurately.
+    jsargs = function (...args: any) {
+      return args;
+    }.apply(undefined, jsargs);
     return Module.callPyObject(_getPtr(this), jsargs);
   }
   call(jsthis: PyProxyClass, ...jsargs: any) {

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -963,8 +963,8 @@ def test_pyproxy_apply(selenium):
         }
 
         for(let error_input of [1, "abc", 1n, Symbol.iterator, true]) {
-            assertThrows(() => fjs.apply(undefined, error_input), "TypeError", "CreateListFromArrayLike called on non-object");
-            assertThrows(() => fpy.apply(undefined, error_input), "TypeError", "CreateListFromArrayLike called on non-object");
+            assertThrows(() => fjs.apply(undefined, error_input), "TypeError", "");
+            assertThrows(() => fpy.apply(undefined, error_input), "TypeError", "");
         }
 
         fpy.destroy();

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -935,3 +935,37 @@ def test_coroutine_scheduling(selenium):
         f.destroy();
         """
     )
+
+
+def test_pyproxy_apply(selenium):
+    # Try to match behavior of real .apply
+    selenium.run_js(
+        """
+        pyodide.runPython(`
+            from pyodide.ffi import to_js
+            def f(*args):
+                return to_js(args)
+        `);
+        let fpy = pyodide.globals.get("f");
+        let fjs = function(...args){ return args; };
+        let examples = [
+            undefined,
+            null,
+            {},
+            {0:1, 1:7, 2: -3},
+            { *[Symbol.iterator](){yield 3; yield 5; yield 7;} },
+            {0:1, 1:7, 2: -3, length: 2},
+            [1,7,9,5],
+            function(a,b,c){},
+        ];
+        for(let input of examples){
+            assert(() => JSON.stringify(fpy.apply(undefined, input)) === JSON.stringify(fjs.apply(undefined, input)));
+        }
+
+        assertThrows(() => fpy.apply(undefined, 1), "TypeError", "CreateListFromArrayLike called on non-object");
+        assertThrows(() => fpy.apply(undefined, "abc"), "TypeError", "CreateListFromArrayLike called on non-object");
+        assertThrows(() => fpy.apply(undefined, 1n), "TypeError", "CreateListFromArrayLike called on non-object");
+        assertThrows(() => fpy.apply(undefined, 1n), "TypeError", "CreateListFromArrayLike called on non-object");
+        fpy.destroy();
+        """
+    )

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -962,10 +962,11 @@ def test_pyproxy_apply(selenium):
             assert(() => JSON.stringify(fpy.apply(undefined, input)) === JSON.stringify(fjs.apply(undefined, input)));
         }
 
-        assertThrows(() => fpy.apply(undefined, 1), "TypeError", "CreateListFromArrayLike called on non-object");
-        assertThrows(() => fpy.apply(undefined, "abc"), "TypeError", "CreateListFromArrayLike called on non-object");
-        assertThrows(() => fpy.apply(undefined, 1n), "TypeError", "CreateListFromArrayLike called on non-object");
-        assertThrows(() => fpy.apply(undefined, 1n), "TypeError", "CreateListFromArrayLike called on non-object");
+        for(let error_input of [1, "abc", 1n, Symbol.iterator, true]) {
+            assertThrows(() => fjs.apply(undefined, error_input), "TypeError", "CreateListFromArrayLike called on non-object");
+            assertThrows(() => fpy.apply(undefined, error_input), "TypeError", "CreateListFromArrayLike called on non-object");
+        }
+
         fpy.destroy();
         """
     )


### PR DESCRIPTION
Fixes #3060 which is triggered by calling `PyProxy.apply(this, undefined);`.
I also switched `Module.callPyObject` and `Module.callPyObjectKwargs`
to take `jsargs` as an array not as a spread argument. In most locations
in the code, they are called with an array.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
