### PR TITLE
Fix Robot Raconteur -Wenum-constexpr-conversion build error

### DIFF
--- a/emsdk/patches/0002-library-eventloop-signatures.patch
+++ b/emsdk/patches/0002-library-eventloop-signatures.patch
@@ -1,0 +1,64 @@
+diff --git a/src/library_eventloop.js b/src/library_eventloop.js
+index a8f9c3c18..77b357f0f 100644
+--- a/src/library_eventloop.js
++++ b/src/library_eventloop.js
+@@ -70,6 +70,7 @@ LibraryJSEventLoop = {
+     // emscripten_set_immediate_loop() if application links to both of them.
+   },
+ 
++  emscripten_set_immediate__sig: 'ipp',
+   emscripten_set_immediate__deps: ['$polyfillSetImmediate', '$callUserCallback'],
+   emscripten_set_immediate: function(cb, userData) {
+     polyfillSetImmediate();
+@@ -82,12 +83,14 @@ LibraryJSEventLoop = {
+     });
+   },
+ 
++  emscripten_clear_immediate__sig: 'vi',
+   emscripten_clear_immediate__deps: ['$polyfillSetImmediate'],
+   emscripten_clear_immediate: function(id) {
+     {{{ runtimeKeepalivePop(); }}}
+     emClearImmediate(id);
+   },
+ 
++  emscripten_set_immediate_loop__sig: 'vpp' ,
+   emscripten_set_immediate_loop__deps: ['$polyfillSetImmediate', '$callUserCallback'],
+   emscripten_set_immediate_loop: function(cb, userData) {
+     polyfillSetImmediate();
+@@ -104,6 +107,7 @@ LibraryJSEventLoop = {
+     return emSetImmediate(tick);
+   },
+ 
++  emscripten_set_timeout__sig: 'ipdp',
+   emscripten_set_timeout__deps: ['$callUserCallback'],
+   emscripten_set_timeout: function(cb, msecs, userData) {
+     {{{ runtimeKeepalivePush() }}}
+@@ -115,10 +119,12 @@ LibraryJSEventLoop = {
+     }, msecs);
+   },
+ 
++  emscripten_clear_timeout__sig: 'vi',
+   emscripten_clear_timeout: function(id) {
+     clearTimeout(id);
+   },
+ 
++  emscripten_set_timeout_loop__sig: 'vpdp',
+   emscripten_set_timeout_loop__deps: ['$callUserCallback'],
+   emscripten_set_timeout_loop: function(cb, msecs, userData) {
+     function tick() {
+@@ -139,6 +145,7 @@ LibraryJSEventLoop = {
+     return setTimeout(tick, 0);
+   },
+ 
++  emscripten_set_interval__sig: 'ipdp',
+   emscripten_set_interval__deps: ['$callUserCallback'],
+   emscripten_set_interval: function(cb, msecs, userData) {
+     {{{ runtimeKeepalivePush() }}}
+@@ -149,6 +156,7 @@ LibraryJSEventLoop = {
+     }, msecs);
+   },
+ 
++  emscripten_clear_interval__sig: 'vi',
+   emscripten_clear_interval: function(id) {
+     {{{ runtimeKeepalivePop() }}}
+     clearInterval(id);

--- a/packages/RobotRaconteur/meta.yaml
+++ b/packages/RobotRaconteur/meta.yaml
@@ -1,7 +1,6 @@
 package:
   name: RobotRaconteur
   version: 0.15.1
-  _disabled: true
 
 source:
   url: https://github.com/robotraconteur/robotraconteur_pyodide/releases/download/v0.15.1-pyodide/RobotRaconteur-pyodide-0.15.1-post1-Source.tar.gz
@@ -12,6 +11,7 @@ requirements:
     - numpy
   host:
     - boost-cpp
+    - numpy
 
 build:
   cxxflags: -fexceptions -fPIC -DBOOST_SP_DISABLE_THREADS=1 -O2
@@ -22,7 +22,7 @@ build:
     emcmake cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_PYTHON=ON \
     -DNUMPY_INCLUDE_DIR=$HOSTINSTALLDIR/lib/python$PYMAJOR.$PYMINOR/site-packages/numpy/core/include/ \
     -DPYTHON_INCLUDE_DIR=$PYTHONINCLUDE -DPYTHON_EXECUTABLE=python$PYMAJOR.$PYMINOR \
-    -DCMAKE_CXX_FLAGS="-fPIC -fexceptions -DBOOST_AP_DISABLE_THREADS=1 -O2 -DBOOST_BIND_GLOBAL_PLACEHOLDERS=1" \
+    -DCMAKE_CXX_FLAGS="-fPIC -fexceptions -DBOOST_AP_DISABLE_THREADS=1 -O2 -DBOOST_BIND_GLOBAL_PLACEHOLDERS=1 -Wno-enum-constexpr-conversion" \
     -DBOOST_INCLUDEDIR=$WASM_LIBRARY_DIR/include -DBOOST_LIBRARYDIR=$WASM_LIBRARY_DIR/lib \
     -DBoost_DATE_TIME_LIBRARY_RELEASE=$WASM_LIBRARY_DIR/lib/libboost_date_time.bc \
     -DBoost_DATE_TIME_LIBRARY_DEBUG=$WASM_LIBRARY_DIR/lib/libboost_date_time.bc \


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Fixes build failure in the Robot Raconteur package. This failure was caused by a `-Wenum-constexpr-conversion` error that appears to be in a boost header file. LLVM recently added this error check. This fix disables the error check.

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->
