### PR TITLE
Fix pyodide venv install from local file system for pure Python packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,7 +395,6 @@ jobs:
             cd test
             git clone https://github.com/python-attrs/attrs --depth 1 --branch 22.1.0
             git clone https://github.com/zopefoundation/zope.interface.git --depth 1 --branch 5.4.0
-            git clone https://github.com/nedbat/coveragepy.git --depth 1 --branch coverage-5.5
 
             python3.10 -m venv .venv-host
             source .venv-host/bin/activate
@@ -406,13 +405,8 @@ jobs:
             cd zope.interface
             pyodide build
             pip install dist/*.whl
-            cd ../coveragepy/
-            pyodide build
-            pip install dist/*.whl
             cd ../attrs
-            pyodide build
-            WHEEL_NAME=$(echo dist/*.whl)
-            pip install $WHEEL_NAME[tests]
+            pip install .[tests]
             python -m pytest -k 'not mypy'
 
   benchmark:

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -126,6 +126,9 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         os.environ["_PYTHON_HOST_PLATFORM"] = host_platform
         os.environ["_PYTHON_SYSCONFIGDATA_NAME"] = f'_sysconfigdata_{{sys.abiflags}}_{{sys.platform}}_{{sys.implementation._multiarch}}'
         sys.path.append("{sysconfigdata_dir}")
+        import sysconfig
+        sysconfig.get_config_vars()
+        del os.environ["_PYTHON_SYSCONFIGDATA_NAME"]
         """
     )
 


### PR DESCRIPTION
Currently `pip` can't invoke the Pyodide build backend, but it should still be able to build pure Python packages from source. To allow this, we need to restore `_PYTHON_SYSCONFIGDATA_NAME` so that it isn't inherited by subprocesses. Otherwise, they will fail to import `sysconfig`. Annoyingly, when pip invokes the subprocess it seems to pass `_PYTHON_SYSCONFIGDATA_NAME` down but not `PYTHONPATH` so just setting the `PYTHONPATH` isn't good enough. Also, restoring `_PYTHON_HOST_PLATFORM` breaks installation of Emscripten wheels.

### Checklists

- [x] Add / update tests
