### PR TITLE
Fix pypi deploy for patch releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,12 +478,13 @@ jobs:
           name: Deploy to PyPI
           command: |
             # Ask github actions to deploy for us
+            export PAYLOAD={"ref":"${CIRCLE_TAG}","inputs":{}}
             curl \
               -X POST \
               -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: token ${GITHUB_TOKEN}" \
-              https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/dispatches \
-              -d '{"event_type":"deploy-release","client_payload":{}}'
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/dispatches/deploy-release \
+              -d "$PAYLOAD"
 
       - run:
           name: Set PYODIDE_BASE_URL

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,6 +1,6 @@
 name: deploy-release
 on:
-  repository_dispatch:
+  workflow_dispatch:
     types: [deploy-release]
 jobs:
   deploy-pyodide-build-pypi:


### PR DESCRIPTION
Apparently `repository_dispatch` only works on the main branch and what we need is `workflow_dispatch`. After we merge this, we can backport it to stable and I can do an ad-hoc test by trying to use it to deploy pyodide-build v0.21.3.