### PR TITLE
Keep webpackIgnore comments when building js package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,6 @@ node_modules/.installed : src/js/package.json src/js/package-lock.json
 
 dist/pyodide.js src/js/_pyodide.out.js: src/js/*.ts src/js/pyproxy.gen.ts src/js/error_handling.gen.ts node_modules/.installed
 	npx rollup -c src/js/rollup.config.js
-   # Add /* webpackIgnore: true */ to each dynamic import in `pyodide.js`.
-   # Rollup strips comments so this can't be done via the source file.
-   # We use ! as the sed separator because the replacement text includes /
-	sed -i 's!await import(!await import(/* webpackIgnore: true */ !g' dist/pyodide.js
 
 dist/package.json : src/js/package.json
 	cp $< $@

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -178,7 +178,7 @@ export let loadScript: (url: string) => Promise<void>;
 
 if (globalThis.document) {
   // browser
-  loadScript = async (url) => await import(url);
+  loadScript = async (url) => await import(/* webpackIgnore: true */ url);
 } else if (globalThis.importScripts) {
   // webworker
   loadScript = async (url) => {
@@ -188,7 +188,7 @@ if (globalThis.document) {
     } catch (e) {
       // importScripts throws TypeError in a module type web worker, use import instead
       if (e instanceof TypeError) {
-        await import(url);
+        await import(/* webpackIgnore: true */ url);
       } else {
         throw e;
       }
@@ -216,6 +216,6 @@ async function nodeLoadScript(url: string) {
   } else {
     // Otherwise, hopefully it is a relative path we can load from the file
     // system.
-    await import(nodeUrlMod.pathToFileURL(url).href);
+    await import(/* webpackIgnore: true */ nodeUrlMod.pathToFileURL(url).href);
   }
 }

--- a/src/js/rollup.config.js
+++ b/src/js/rollup.config.js
@@ -35,6 +35,9 @@ function config({ input, output, name, format, minify }) {
         ? terser({
             compress: true,
             mangle: false,
+            format: {
+              comments: /^\s*webpackIgnore/,
+            },
           })
         : undefined,
     ].filter(Boolean),


### PR DESCRIPTION
Fixes:  #3032

It adds terser config to not strip /* webpackIgnore */ comments. I think this is better than using sed after build.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
