### PR TITLE
Add capture_this keyword argument to create_proxy

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -51,8 +51,10 @@ substitutions:
 - {{ Enhancement }} The full test suite is now run in Safari {pr}`2578` {pr}`3095`.
 
 - {{ Enhancement }} It is possible to make a `PyProxy` that takes `this` as the
-  first argument using the {any}`captureThis` method.
-  {pr}`3103`
+  first argument using the {any}`captureThis` method. The {any}`create_proxy`
+  method also has a `capture_this` argument which causes the `PyProxy` to
+  receive `this` as the first argument if set to `True`
+  {pr}`3103`, {pr}`3145`
 
 - {{ Enhancement }} A `JsProxy` of a function now has a `__get__` descriptor
   method, so it's possible to use a JavaScript function as a Python method. When

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1242,7 +1242,7 @@ JsProxy_toPy(PyObject* self,
              PyObject* kwnames)
 {
   static const char* const _keywords[] = { "depth", "default_converter", 0 };
-  static struct _PyArg_Parser _parser = { "|$iO:toPy", _keywords, 0 };
+  static struct _PyArg_Parser _parser = { "|$iO:to_py", _keywords, 0 };
   int depth = -1;
   PyObject* default_converter = NULL;
   if (!_PyArg_ParseStackAndKeywords(

--- a/src/core/pyproxy.h
+++ b/src/core/pyproxy.h
@@ -11,6 +11,9 @@
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
 JsRef
+pyproxy_new_ex(PyObject* obj, bool capture_this);
+
+JsRef
 pyproxy_new(PyObject* obj);
 
 /**

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -235,7 +235,7 @@ class JsProxy:
         ArrayBuffer view.
 
         Example
-        ------------
+        -------
         >>> import pytest; pytest.skip()
         >>> from js import Uint8Array
         >>> x = Uint8Array.new(range(10))
@@ -259,7 +259,7 @@ class JsProxy:
         ArrayBuffer view.
 
         Example
-        ------------
+        -------
         >>> import pytest; pytest.skip()
         >>> from js import Uint8Array
         >>> # the JsProxy need to be pre-allocated
@@ -289,7 +289,7 @@ class JsProxy:
         ArrayBuffer view.
 
         Example
-        ------------
+        -------
         >>> import pytest; pytest.skip()
         >>> from js import Uint8Array
         >>> x = Uint8Array.new(range(10))
@@ -376,11 +376,20 @@ def create_once_callable(obj: Callable[..., Any], /) -> JsProxy:
     return obj  # type: ignore[return-value]
 
 
-def create_proxy(obj: Any, /) -> JsProxy:
+def create_proxy(obj: Any, /, *, capture_this: bool = False) -> JsProxy:
     """Create a ``JsProxy`` of a ``PyProxy``.
 
     This allows explicit control over the lifetime of the ``PyProxy`` from
     Python: call the ``destroy`` API when done.
+
+    Parameters
+    ----------
+    obj: any
+        The object to wrap.
+
+    capture_this : bool, default=False
+        If the object is callable, should `this` be passed as the first argument
+        when calling it from JavaScript.
     """
     return obj
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -601,21 +601,21 @@ def test_create_once_callable(selenium):
 
 @run_in_pyodide
 def test_create_proxy(selenium):
-    from js import testAddListener, testCallListener, testRemoveListener
     from pyodide.code import run_js
     from pyodide.ffi import create_proxy
 
-    run_js(
+    [testAddListener, testCallListener, testRemoveListener] = run_js(
         """
-        self.testAddListener = function(f){
+        function testAddListener(f){
             self.listener = f;
         }
-        self.testCallListener = function(f){
+        function testCallListener(f){
             return self.listener();
         }
-        self.testRemoveListener = function(f){
+        function testRemoveListener(f){
             return self.listener === f;
         }
+        [testAddListener, testCallListener, testRemoveListener]
         """
     )
 
@@ -656,14 +656,13 @@ def test_create_proxy_capture_this(selenium):
     from pyodide.code import run_js
     from pyodide.ffi import create_proxy
 
-    o = run_js("{}")
+    o = run_js("({})")
 
     def f(self):
         assert self == o
 
     o.f = create_proxy(f, capture_this=True)
-    o.f()
-    run_js("(o) => o.f.destroy()")(o)
+    run_js("(o) => { o.f(); o.f.destroy(); }")(o)
 
 
 def test_return_destroyed_value(selenium):


### PR DESCRIPTION
A followup to #3103. Allows creation of proxies from Python with `captureThis` set to `true`.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
