### PR TITLE
Add options to disable integrity check in pyodide.loadPackage

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -60,6 +60,11 @@ substitutions:
   the method is called on.
   {pr}`3130`
 
+- {{ Breaking }} The messageCallback and errorCallback argument to {any}`loadPackage <pyodide.loadPackage>`
+  and {any}`loadPackagesFromImports <pyodide.loadPackagesFromImports>` is now passed as named arguments.
+  The old usage still works with a deprecation warning.
+  {pr}`3149`
+
 ### Build System / Package Loading
 
 - New packages: pycryptodomex {pr}`2966`, pycryptodome {pr}`2965`,

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -74,10 +74,17 @@ substitutions:
   the method is called on.
   {pr}`3130`
 
-- {{ Breaking }} The messageCallback and errorCallback argument to {any}`loadPackage <pyodide.loadPackage>`
-  and {any}`loadPackagesFromImports <pyodide.loadPackagesFromImports>` is now passed as named arguments.
+- {{ Breaking }} The messageCallback and errorCallback argument to
+  {any}`loadPackage <pyodide.loadPackage>` and
+  {any}`loadPackagesFromImports <pyodide.loadPackagesFromImports>`
+  is now passed as named arguments.
   The old usage still works with a deprecation warning.
   {pr}`3149`
+
+- {{ Enhancement }} {any}`loadPackage <pyodide.loadPackage>` and
+  {any}`loadPackagesFromImports <pyodide.loadPackagesFromImports>` now accepts
+  a new option `checkIntegrity`. If set to False, integrity check for Python Packages
+  will be disabled.
 
 - {{ Fix }} Shared libraries with version suffix are now handled correctly.
   {pr}`3154`

--- a/docs/project/deprecation-timeline.md
+++ b/docs/project/deprecation-timeline.md
@@ -10,6 +10,11 @@ state, this list is subject to change and some features can be removed without
 deprecation warnings. More details about each item can often be found in the
 {ref}`changelog`.
 
+## 0.24.0
+
+- The `messageCallback` and `errorCallback` argument to `loadPackage` and `loadPackagesFromImports` will be passed as a
+  named argument only.
+
 ## 0.23.0
 
 Names that used to be in the root `pyodide` module and were moved to submodules

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -87,10 +87,13 @@ let loadPackagesFromImportsPositionalCallbackDeprecationWarned = false;
  * ``pyodide.loadPackage(['numpy'])``.
  *
  * @param code The code to inspect.
- * @param messageCallback The ``messageCallback`` argument of
- * :any:`pyodide.loadPackage` (optional).
- * @param errorCallback The ``errorCallback`` argument of
- * :any:`pyodide.loadPackage` (optional).
+ * @param options Options passed to :any:`pyodide.loadPackage`.
+ * @param options.messageCallback A callback, called with progress messages
+ *    (optional)
+ * @param options.errorCallback A callback, called with error/warning messages
+ *    (optional)
+ * @param options.checkIntegrity If true, check the integrity of the downloaded
+ *    packages (default: true)
  * @async
  */
 export async function loadPackagesFromImports(

--- a/src/test-js/index.test-d.ts
+++ b/src/test-js/index.test-d.ts
@@ -49,29 +49,29 @@ async function main() {
 
   expectType<Promise<void>>(pyodide.loadPackagesFromImports("import some_pkg"));
   expectType<Promise<void>>(
-    pyodide.loadPackagesFromImports("import some_pkg", (x: any) =>
-      console.log(x),
-    ),
+    pyodide.loadPackagesFromImports("import some_pkg", {
+      messageCallback: (x: any) => console.log(x),
+    }),
   );
   expectType<Promise<void>>(
-    pyodide.loadPackagesFromImports(
-      "import some_pkg",
-      (x: any) => console.log(x),
-      (x: any) => console.warn(x),
-    ),
+    pyodide.loadPackagesFromImports("import some_pkg", {
+      messageCallback: (x: any) => console.log(x),
+      errorCallback: (x: any) => console.warn(x),
+    }),
   );
 
   expectType<Promise<void>>(pyodide.loadPackage("blah"));
   expectType<Promise<void>>(pyodide.loadPackage(["blah", "blah2"]));
   expectType<Promise<void>>(
-    pyodide.loadPackage("blah", (x: any) => console.log(x)),
+    pyodide.loadPackage("blah", {
+      messageCallback: (x: any) => console.log(x),
+    }),
   );
   expectType<Promise<void>>(
-    pyodide.loadPackage(
-      ["blah", "blah2"],
-      (x: any) => console.log(x),
-      (x: any) => console.warn(x),
-    ),
+    pyodide.loadPackage(["blah", "blah2"], {
+      messageCallback: (x: any) => console.log(x),
+      errorCallback: (x: any) => console.warn(x),
+    }),
   );
   expectType<Promise<void>>(pyodide.loadPackage(px));
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1229,6 +1229,18 @@ def test_raises_jsexception(selenium):
         raise_jsexception(selenium)
 
 
+def test_deprecations(selenium_standalone):
+    selenium = selenium_standalone
+    selenium.run_js(
+        """
+        pyodide.loadPackage("micropip", (x) => x);
+        pyodide.loadPackagesFromImports("import micropip", (x) => x);
+        """
+    )
+    dep_msg = "Passing a messageCallback or errorCallback as the second or third argument to loadPackage is deprecated and will be removed in v0.24. Instead use { messageCallback : callbackFunc }"
+    assert selenium.logs.count(dep_msg) == 1
+
+
 @run_in_pyodide(packages=["pytest"])
 def test_moved_deprecation_warnings(selenium_standalone):
     import pytest


### PR DESCRIPTION
### Description

Related: #2609 

This PR adds an option to disable integrity check in `pyodide.loadPackage` when it is loading packages registered in repodata.json. In order to make it easier to add more options in `loadPackage` in the future, I changed it to take named arguments.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
