### PR TITLE
DOC Remove warnings about pyodide-cdn2.iodide.io

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,6 +14,9 @@ substitutions:
 
 ## Unreleased
 
+- `pyodide-cdn2.iodide.io` is not available anymore. Please use `https://cdn.jsdelivr.net/pyodide` instead.
+  {pr}`3150`.
+
 - {{ Enhancement }} Added a system for making Pyodide virtual environments. This
   is for testing out of tree builds. For more information, see
   [the documentation](https://pyodide.org/en/stable/development/out-of-tree.html).

--- a/docs/usage/downloading-and-deploying.md
+++ b/docs/usage/downloading-and-deploying.md
@@ -13,10 +13,6 @@ Pyodide is available from the JsDelivr CDN
 | Latest release      | `{{PYODIDE_CDN_URL}}`                        | Recommended, cached by the browser                                                       | [link](https://pyodide.org/en/stable/console.html) |
 | Dev (`main` branch) | `https://cdn.jsdelivr.net/pyodide/dev/full/` | Re-deployed for each commit on main, no browser caching, should only be used for testing | [link](https://pyodide.org/en/latest/console.html) |
 
-```{warning}
-The previous CDN `pyodide-cdn2.iodide.io` is deprecated and should not be used.
-```
-
 ### GitHub releases
 
 You can also download Pyodide packages from [GitHub


### PR DESCRIPTION
Since mozilla took down iodide.io domain recently, I think we don't need the warnings about `pyodide-cdn2.iodide.io` now.