### PR TITLE
Handle shared libraries with version suffix

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -63,6 +63,9 @@ substitutions:
   the method is called on.
   {pr}`3130`
 
+- {{ Fix }} Shared libraries with version suffix are now handled correctly.
+  {pr}`3154`
+
 ### Build System / Package Loading
 
 - New packages: pycryptodomex {pr}`2966`, pycryptodome {pr}`2965`,

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -10,6 +10,7 @@ cross-compiling and then pass the command long to emscripten.
 """
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -227,8 +228,9 @@ def get_library_output(line: list[str]) -> str | None:
     Check if the command is a linker invocation. If so, return the name of the
     output file.
     """
+    SHAREDLIB_REGEX = re.compile(r"(\.dylib|\.so(.\d+)*)$")
     for arg in line:
-        if arg.endswith(".so") and not arg.startswith("-"):
+        if not arg.startswith("-") and SHAREDLIB_REGEX.search(arg):
             return arg
     return None
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -228,7 +228,7 @@ def get_library_output(line: list[str]) -> str | None:
     Check if the command is a linker invocation. If so, return the name of the
     output file.
     """
-    SHAREDLIB_REGEX = re.compile(r"(\.dylib|\.so(.\d+)*)$")
+    SHAREDLIB_REGEX = re.compile(r"\.so(.\d+)*$")
     for arg in line:
         if not arg.startswith("-") and SHAREDLIB_REGEX.search(arg):
             return arg

--- a/pyodide-build/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide-build/pyodide_build/tests/test_pywasmcross.py
@@ -10,6 +10,7 @@ from pyodide_build.pywasmcross import (
     calculate_exports,
     environment_substitute_args,
     get_cmake_compiler_flags,
+    get_library_output,
 )
 
 
@@ -262,3 +263,12 @@ def test_get_cmake_compiler_flags():
 
     for emscripten_compiler in emscripten_compilers:
         assert emscripten_compiler not in cmake_flags
+
+
+def test_get_library_output():
+    assert get_library_output(["test.so"]) == "test.so"
+    assert get_library_output(["test.so.1.2.3"]) == "test.so.1.2.3"
+    assert (
+        get_library_output(["test", "test.a", "test.o", "test.c", "test.cpp", "test.h"])
+        is None
+    )

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -355,6 +355,7 @@ def test_should_load_dynlib():
     assert ext_suffix
     should_load = [
         "a.so",
+        "a.so.1.2.3",
         "a/b.so",
         "b/b.so",
         "a/b/c/d.so",
@@ -375,7 +376,7 @@ def test_should_load_dynlib():
         "q.cpython-38-x86_64-linux-gnu.so",
         "q" + ext_suffix.replace("cpython", "pypy"),
         "q.cpython-32mu.so",
-        "x.so.1",  # Any chance we'd want these at some point?
+        "x.so.a.b.c",
     ]
     for file in should_load:
         assert should_load_dynlib(file)


### PR DESCRIPTION
### Description

Fix handling shared libraries with version suffix such as `libabc.so.11.22.0`. It fixes both building and loading packages.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
