### PR TITLE
Fix cmdline runner when stdout doesn't have columns/rows attributes

### DIFF
--- a/tools/python
+++ b/tools/python
@@ -203,8 +203,8 @@ async function main() {
         from js.process import stdout
         import os
         def get_terminal_size(fallback=(80, 24)):
-            columns = stdout.columns
-            rows = stdout.rows
+            columns = getattr(stdout, "columns", None)
+            rows = getattr(stdout, "rows", None)
             if columns is None:
                 columns = fallback[0]
             if rows is None:


### PR DESCRIPTION
This fixes a bug that came up in https://github.com/numpy/numpy/pull/21895.