### PR TITLE
BLD Retry when package download fails

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import sysconfig
 import textwrap
+import urllib
 from collections.abc import Generator, Iterator
 from contextlib import contextmanager
 from datetime import datetime
@@ -234,7 +235,19 @@ def download_and_extract(
     """
     # We only call this function when the URL is defined
     url = cast(str, src_metadata.url)
-    response = request.urlopen(url)
+    retry_cnt = 3
+    while True:
+        try:
+            response = request.urlopen(url)
+        except urllib.error.URLError as e:
+            if retry_cnt == 0:
+                raise RuntimeError(f"Failed to download {url}") from e
+
+            retry_cnt -= 1
+            continue
+
+        break
+
     _, parameters = cgi.parse_header(response.headers.get("Content-Disposition", ""))
     if "filename" in parameters:
         tarballname = parameters["filename"]

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -235,15 +235,16 @@ def download_and_extract(
     """
     # We only call this function when the URL is defined
     url = cast(str, src_metadata.url)
-    retry_cnt = 3
-    while True:
+    max_retry = 3
+    for retry_cnt in range(max_retry):
         try:
             response = request.urlopen(url)
         except urllib.error.URLError as e:
-            if retry_cnt == 0:
-                raise RuntimeError(f"Failed to download {url}") from e
+            if retry_cnt == max_retry - 1:
+                raise RuntimeError(
+                    f"Failed to download {url} after {max_retry} trials"
+                ) from e
 
-            retry_cnt -= 1
             continue
 
         break


### PR DESCRIPTION
We sometimes encounter `urllib.error.URLError` when downloading packages in CI, which is mostly caused by timeout.
I'm not sure this would fix the situation, but it is better then doing nothing.