### PR TITLE
Add roundtrip parameter to create_proxy

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -64,6 +64,12 @@ substitutions:
   receive `this` as the first argument if set to `True`
   {pr}`3103`, {pr}`3145`
 
+- {{ Enhancement }} `create_proxy` now takes an optional `roundtrip` parameter.
+  If this is set to `True`, then when the proxy is converted back to Python, it
+  is converted back to the same double proxy. This allows the proxy to be
+  destroyed from Python even if no reference is retained.
+  {pr}`3163`
+
 - {{ Enhancement }} Pyodide now shows more helpful error messages when
   importing packages that are included in Pyodide fails.
   {pr}`3137`

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -44,7 +44,7 @@ _js2python_pyproxy(PyObject* val)
 
 EM_JS_REF(PyObject*, js2python, (JsRef id), {
   let value = Hiwire.get_value(id);
-  let result = Module.js2python_convertImmutable(value);
+  let result = Module.js2python_convertImmutable(value, id);
   // clang-format off
   if (result !== undefined) {
     // clang-format on

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -54,6 +54,7 @@
 #define IS_ARRAY      (1<<10)
 #define IS_NODE_LIST  (1<<11)
 #define IS_TYPEDARRAY (1<<12)
+#define IS_DOUBLE_PROXY (1 << 13)
 // clang-format on
 
 _Py_IDENTIFIER(get_event_loop);
@@ -2685,6 +2686,9 @@ JsProxy_create_with_this(JsRef object, JsRef this)
   }
   if (hiwire_is_promise(object)) {
     type_flags |= IS_AWAITABLE;
+  }
+  if (pyproxy_Check(object)) {
+    type_flags |= IS_DOUBLE_PROXY;
   }
   type_flags |= JsProxy_array_detect(object);
 

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2388,6 +2388,24 @@ finally:
   return success ? 0 : -1;
 }
 
+EM_JS_REF(PyObject*, JsDoubleProxy_unwrap_helper, (JsRef id), {
+  return Module.PyProxy_getPtr(Hiwire.get_value(id));
+});
+
+PyObject*
+JsDoubleProxy_unwrap(PyObject* obj, PyObject* _ignored)
+{
+  PyObject* result = JsDoubleProxy_unwrap_helper(JsProxy_JSREF(obj));
+  Py_XINCREF(result);
+  return result;
+}
+
+static PyMethodDef JsDoubleProxy_unwrap_MethodDef = {
+  "unwrap",
+  (PyCFunction)JsDoubleProxy_unwrap,
+  METH_NOARGS,
+};
+
 /**
  * This dynamically creates a subtype of JsProxy using PyType_FromSpecWithBases.
  * It is called from JsProxy_get_subtype(flags) when a type with the given flags
@@ -2520,6 +2538,9 @@ JsProxy_create_subtype(int flags)
     methods[cur_method++] = JsBuffer_write_to_file_MethodDef;
     methods[cur_method++] = JsBuffer_read_from_file_MethodDef;
     methods[cur_method++] = JsBuffer_into_file_MethodDef;
+  }
+  if (flags & IS_DOUBLE_PROXY) {
+    methods[cur_method++] = JsDoubleProxy_unwrap_MethodDef;
   }
   methods[cur_method++] = (PyMethodDef){ 0 };
   members[cur_member++] = (PyMemberDef){ 0 };

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -909,11 +909,14 @@ success:
   return 0;
 }
 
-EM_JS_REF(JsRef, pyproxy_new_ex, (PyObject * ptrobj, bool capture_this), {
-  return Hiwire.new_value(Module.pyproxy_new(ptrobj, {
-    thisInfo : { captureThis : !!capture_this, isBound : false, boundArgs : [] }
-  }));
-});
+EM_JS_REF(JsRef,
+          pyproxy_new_ex,
+          (PyObject * ptrobj, bool capture_this, bool roundtrip),
+          {
+            return Hiwire.new_value(Module.pyproxy_new(ptrobj, {
+              props : { captureThis : !!capture_this, roundtrip : !!roundtrip }
+            }));
+          });
 
 EM_JS_REF(JsRef, pyproxy_new, (PyObject * ptrobj), {
   return Hiwire.new_value(Module.pyproxy_new(ptrobj));
@@ -1054,16 +1057,17 @@ create_proxy(PyObject* self,
              Py_ssize_t nargs,
              PyObject* kwnames)
 {
-  static const char* const _keywords[] = { "", "capture_this", 0 };
-  bool capture_this;
+  static const char* const _keywords[] = { "", "capture_this", "roundtrip", 0 };
+  bool capture_this = false;
+  bool roundtrip = true;
   PyObject* obj;
-  static struct _PyArg_Parser _parser = { "O|$p:create_proxy", _keywords, 0 };
+  static struct _PyArg_Parser _parser = { "O|$pp:create_proxy", _keywords, 0 };
   if (!_PyArg_ParseStackAndKeywords(
-        args, nargs, kwnames, &_parser, &obj, &capture_this)) {
+        args, nargs, kwnames, &_parser, &obj, &capture_this, &roundtrip)) {
     return NULL;
   }
 
-  JsRef ref = pyproxy_new_ex(obj, capture_this);
+  JsRef ref = pyproxy_new_ex(obj, capture_this, roundtrip);
   PyObject* result = JsProxy_create(ref);
   hiwire_decref(ref);
   return result;

--- a/src/core/pyproxy.h
+++ b/src/core/pyproxy.h
@@ -11,7 +11,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
 JsRef
-pyproxy_new_ex(PyObject* obj, bool capture_this);
+pyproxy_new_ex(PyObject* obj, bool capture_this, bool roundtrip);
 
 JsRef
 pyproxy_new(PyObject* obj);

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -362,6 +362,13 @@ class JsProxy:
         Present only if the wrapped Javascript object is an array.
         """
 
+    def unwrap(self) -> Any:
+        """Unwrap a double proxy created with :any:`create_proxy` into the
+        wrapped Python object.
+
+        Only present on double proxies.
+        """
+
 
 # from pyproxy.c
 
@@ -376,7 +383,9 @@ def create_once_callable(obj: Callable[..., Any], /) -> JsProxy:
     return obj  # type: ignore[return-value]
 
 
-def create_proxy(obj: Any, /, *, capture_this: bool = False) -> JsProxy:
+def create_proxy(
+    obj: Any, /, *, capture_this: bool = False, roundtrip: bool = True
+) -> JsProxy:
     """Create a ``JsProxy`` of a ``PyProxy``.
 
     This allows explicit control over the lifetime of the ``PyProxy`` from
@@ -390,6 +399,22 @@ def create_proxy(obj: Any, /, *, capture_this: bool = False) -> JsProxy:
     capture_this : bool, default=False
         If the object is callable, should `this` be passed as the first argument
         when calling it from JavaScript.
+
+    roundtrip: bool, default=True
+        When the proxy is converted back from JavaScript to Python, if this is
+        ``True`` it is converted into a double proxy. If ``False``, it is
+        unwrapped into a Python object. In the case that ``roundtrip`` is
+        ``True`` it is possible to unwrap a double proxy with the :any:`unwrap`
+        method. This is useful to allow easier control of lifetimes from Python:
+
+        .. code-block:: python
+
+            from js import o
+            d = {}
+            o.d = create_proxy(d, roundtrip=True)
+            o.d.destroy() # Destroys the proxy created with create_proxy
+
+        With ``roundtrip=False`` this would be an error.
     """
     return obj
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -665,6 +665,21 @@ def test_create_proxy_capture_this(selenium):
     run_js("(o) => { o.f(); o.f.destroy(); }")(o)
 
 
+@run_in_pyodide
+def test_create_proxy_roundtrip(selenium):
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy, create_proxy
+
+    f = {}  # type: ignore[var-annotated]
+    o = run_js("({})")
+    o.f = create_proxy(f, roundtrip=True)
+    assert isinstance(o.f, JsProxy)
+    o.f.destroy()
+    o.f = create_proxy(f, roundtrip=False)
+    assert isinstance(o.f, dict)
+    run_js("(o) => { o.f.destroy(); }")(o)
+
+
 def test_return_destroyed_value(selenium):
     selenium.run_js(
         r"""

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -674,9 +674,10 @@ def test_create_proxy_roundtrip(selenium):
     o = run_js("({})")
     o.f = create_proxy(f, roundtrip=True)
     assert isinstance(o.f, JsProxy)
+    assert o.f.unwrap() is f
     o.f.destroy()
     o.f = create_proxy(f, roundtrip=False)
-    assert isinstance(o.f, dict)
+    assert o.f is f
     run_js("(o) => { o.f.destroy(); }")(o)
 
 


### PR DESCRIPTION
A typical annoying problem is as follows: if a PyProxy is to be assigned to a JavaScript object from Python:
```py
from js import o
o.f = create_proxy(f)
```
to destroy the proxy it is necessary to do something like:
```py
from pyodide.code import run_js
run_js("(o) => o.f.destroy()")(o)
```
This is because if we say `o.f` in Python we get the unwrapped Python object f rather than the wrapped `PyProxy`, so `o.f.destroy()` will be an `AttributeError`. This PR fixes the problem by setting an internal attribute on the `PyProxy` indicating that when converted to JavaScript it should be wrapped in a `JsProxy` rather than being unwrapped into a normal Python object. This makes it possible to destroy the proxy from Python with `o.f.destroy()`.


### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation
