### PR TITLE
Correctly specify files to be packed in a npm package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,11 @@ jobs:
             git checkout 164054a9c6fbd2176f386b6552ed8d079c6bcc04
             ./build.sh
 
+      - run:
+          name: test npm deploy (dry run)
+          command: |
+            DRY_RUN=1 ./tools/deploy_to_npm.sh
+
   test-cmdline-runner:
     <<: *defaults
     steps:

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -61,7 +61,12 @@
     "./repodata.json": "./repodata.json"
   },
   "files": [
-    "pyodide*",
+    "pyodide.asm.js",
+    "pyodide.asm.wasm",
+    "pyodide_py.tar",
+    "pyodide.mjs",
+    "pyodide.js.map",
+    "pyodide.mjs.map",
     "repodata.json",
     "console.html"
   ],

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -63,10 +63,12 @@
   "files": [
     "pyodide.asm.js",
     "pyodide.asm.wasm",
+    "pyodide.asm.data",
     "pyodide_py.tar",
     "pyodide.mjs",
     "pyodide.js.map",
     "pyodide.mjs.map",
+    "pyodide.d.ts",
     "repodata.json",
     "console.html"
   ],

--- a/tools/deploy_to_npm.sh
+++ b/tools/deploy_to_npm.sh
@@ -4,14 +4,21 @@ set -e
 
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"/..
+
 # FIXME: since we release from dist directory, README file needs to be copied before release
 cp src/js/README.md dist/
+cp src/js/package.json dist/
 
 cd dist/
 
 PACKAGE_NAME=$(node -p "require('./package.json').name")
 JS_VERSION=$(node -p "require('./package.json').version")
-if [[ ${JS_VERSION} =~ [alpha|beta|rc|dev] ]]; then
+if [[ -n "${DRY_RUN}" ]]; then
+    echo "Dry run: npm publish --tag ${JS_VERSION}"
+    npm publish --dry-run
+elif [[ ${JS_VERSION} =~ [alpha|beta|rc|dev] ]]; then
     echo "Publishing an unstable release"
     npm publish --tag next
 else


### PR DESCRIPTION
I found that `pyodide_tblib-1.7.1-py3-none-any.whl` is vendored in pyodide npm package. This fixes it by specifying files to be packed one by one.

I also added dry run option for the npm release script. It will help us to check which files are vendored before releasing npm package.
