### PR TITLE
Bump zlib version to 1.2.13

### DIFF
--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: zlib
-  version: 1.2.12
+  version: 1.2.13
 
 source:
-  sha256: 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
-  url: https://zlib.net/zlib-1.2.12.tar.gz
+  sha256: b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
+  url: https://zlib.net/zlib-1.2.13.tar.gz
 
 build:
   library: true


### PR DESCRIPTION
It looks like zlib yanked the v1.2.12 due to [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434).