### PR TITLE
CI Ignore if codecov fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
               src pyodide-build packages/micropip/ packages/_tests
       - uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   build-core:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I wasn't able to find a way to fix codecov 404 error that happens occasionally... This PR just makes CI pass even if codecov fails.