### PR TITLE
Fix undefined symbol error when loading shared lib

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -92,6 +92,9 @@ substitutions:
   a new option `checkIntegrity`. If set to False, integrity check for Python Packages
   will be disabled.
 
+- {{ Fix }} Fix undefined symbol error when loading shared library
+  {pr}`3193`
+
 - {{ Fix }} Shared libraries with version suffix are now handled correctly.
   {pr}`3154`
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -415,6 +415,7 @@ async function loadDynlib(lib: string, shared: boolean) {
       nodelete: true,
       global: loadGlobally,
       fs: libraryFS,
+      allowUndefined: true,
     });
   } catch (e: any) {
     if (e && e.message && e.message.includes("need to see wasm magic number")) {


### PR DESCRIPTION
The `allowUndefined` parameter passed to `loadDynamicLibrary` was removed by mistake in #2954.

Note that `allowUndefined` needs to be set to true because some shared libs have undefined symbols that are defined in another shared library. For example, `openssl` has two sharedlibs: `libssl`, `libcrypto` and `libssl` requires some symbols defined in `libcrypto`.