### PR TITLE
XGBoost: Fix type mismatch for CSR conversion in c_api

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -95,6 +95,9 @@ substitutions:
 - {{ Fix }} Shared libraries with version suffix are now handled correctly.
   {pr}`3154`
 
+- {{ Fix }} Scipy CSR data is now handled correctly in XGBoost.
+  {pr}`3194`
+
 ### Build System / Package Loading
 
 - New packages: pycryptodomex {pr}`2966`, pycryptodome {pr}`2965`,

--- a/packages/xgboost/meta.yaml
+++ b/packages/xgboost/meta.yaml
@@ -9,6 +9,7 @@ source:
   patches:
     - patches/0001-Add-missing-template-type.patch
     - patches/0002-Add-library-loading-path.patch
+    - patches/0003-Fix-type-mismatch-for-CSR-conversion-in-c_api.patch
 build:
   cflags: |
     -DDMLC_USE_FOPEN64=0

--- a/packages/xgboost/patches/0001-Add-missing-template-type.patch
+++ b/packages/xgboost/patches/0001-Add-missing-template-type.patch
@@ -1,7 +1,7 @@
 From 4ac9a00d9e16b0879b4e734a4b604c7ce672894e Mon Sep 17 00:00:00 2001
 From: Gyeongjae Choi <def6488@gmail.com>
 Date: Mon, 9 May 2022 06:42:07 +0000
-Subject: [PATCH 1/2] Add missing template type
+Subject: [PATCH 1/3] Add missing template type
 
 TODO: Remove this patch when XGBoost version is updated.
 (Upstream PR: https://github.com/dmlc/xgboost/pull/7954)

--- a/packages/xgboost/patches/0002-Add-library-loading-path.patch
+++ b/packages/xgboost/patches/0002-Add-library-loading-path.patch
@@ -1,7 +1,7 @@
 From 54c2a9faeb0b0169172c5ab53367e6092f132c5a Mon Sep 17 00:00:00 2001
 From: Gyeongjae Choi <def6488@gmail.com>
 Date: Mon, 9 May 2022 12:07:44 +0000
-Subject: [PATCH 2/2] Add library loading path
+Subject: [PATCH 2/3] Add library loading path
 
 TODO: Remove this patch when XGBoost version is updated.
 (Upstream PR: https://github.com/dmlc/xgboost/pull/7954)

--- a/packages/xgboost/patches/0003-Fix-type-mismatch-for-CSR-conversion-in-c_api.patch
+++ b/packages/xgboost/patches/0003-Fix-type-mismatch-for-CSR-conversion-in-c_api.patch
@@ -1,4 +1,4 @@
-From 893922cba7ff6c60d0d5e23287c9841a676d623d Mon Sep 17 00:00:00 2001
+From 4ec1b506b424dd9e81fd7127f5712522800a5596 Mon Sep 17 00:00:00 2001
 From: Yizhi Liu <liuyizhi@apache.org>
 Date: Mon, 17 Oct 2022 15:16:45 -0700
 Subject: [PATCH 3/3] Fix type mismatch for CSR conversion in c_api
@@ -7,63 +7,36 @@ TODO: Remove this patch when XGBoost version is updated.
 (Upstream PR: https://github.com/dmlc/xgboost/pull/8369)
 
 ---
- xgboost/include/xgboost/c_api.h | 4 ++--
- xgboost/src/c_api/c_api.cc      | 6 +++---
- 2 files changed, 5 insertions(+), 5 deletions(-)
+ xgboost/core.py | 2 +-
+ xgboost/data.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/xgboost/include/xgboost/c_api.h b/xgboost/include/xgboost/c_api.h
-index 17cd5f4..b76878b 100644
---- a/xgboost/include/xgboost/c_api.h
-+++ b/xgboost/include/xgboost/c_api.h
-@@ -135,7 +135,7 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
-  */
- XGB_DLL int XGDMatrixCreateFromCSR(char const *indptr,
-                                    char const *indices, char const *data,
--                                   bst_ulong ncol,
-+                                   size_t ncol,
-                                    char const* json_config,
-                                    DMatrixHandle* out);
- 
-@@ -998,7 +998,7 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle,
-  */
- XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
-                                     char const *indices, char const *values,
--                                    bst_ulong ncol,
-+                                    size_t ncol,
-                                     char const *c_json_config, DMatrixHandle m,
-                                     bst_ulong const **out_shape,
-                                     bst_ulong *out_dim,
-diff --git a/xgboost/src/c_api/c_api.cc b/xgboost/src/c_api/c_api.cc
-index a11602a..73c10c6 100644
---- a/xgboost/src/c_api/c_api.cc
-+++ b/xgboost/src/c_api/c_api.cc
-@@ -344,7 +344,7 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
- 
- XGB_DLL int XGDMatrixCreateFromCSR(char const *indptr,
-                                    char const *indices, char const *data,
--                                   xgboost::bst_ulong ncol,
-+                                   size_t ncol,
-                                    char const* c_json_config,
-                                    DMatrixHandle* out) {
-   API_BEGIN();
-@@ -861,7 +861,7 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle,
- // A hidden API as cache id is not being supported yet.
- XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
-                                     char const *indices, char const *data,
--                                    xgboost::bst_ulong cols,
-+                                    size_t cols,
-                                     char const *c_json_config, DMatrixHandle m,
-                                     xgboost::bst_ulong const **out_shape,
-                                     xgboost::bst_ulong *out_dim,
-@@ -871,7 +871,7 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
-   std::shared_ptr<xgboost::data::CSRArrayAdapter> x{
-       new xgboost::data::CSRArrayAdapter{StringView{indptr},
-                                          StringView{indices}, StringView{data},
--                                         static_cast<size_t>(cols)}};
-+                                         cols}};
-   std::shared_ptr<DMatrix> p_m {nullptr};
-   if (m) {
-     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
+diff --git a/xgboost/core.py b/xgboost/core.py
+index 36548d8..0246779 100644
+--- a/xgboost/core.py
++++ b/xgboost/core.py
+@@ -2119,7 +2119,7 @@ class Booster:
+                     _array_interface(csr.indptr),
+                     _array_interface(csr.indices),
+                     _array_interface(csr.data),
+-                    ctypes.c_size_t(csr.shape[1]),
++                    c_bst_ulong(csr.shape[1]),
+                     from_pystr_to_cstr(json.dumps(args)),
+                     p_handle,
+                     ctypes.byref(shape),
+diff --git a/xgboost/data.py b/xgboost/data.py
+index 119b354..b958436 100644
+--- a/xgboost/data.py
++++ b/xgboost/data.py
+@@ -88,7 +88,7 @@ def _from_scipy_csr(
+             _array_interface(data.indptr),
+             _array_interface(data.indices),
+             _array_interface(data.data),
+-            ctypes.c_size_t(data.shape[1]),
++            c_bst_ulong(data.shape[1]),
+             config,
+             ctypes.byref(handle),
+         )
 -- 
 2.35.1
 

--- a/packages/xgboost/patches/0003-Fix-type-mismatch-for-CSR-conversion-in-c_api.patch
+++ b/packages/xgboost/patches/0003-Fix-type-mismatch-for-CSR-conversion-in-c_api.patch
@@ -1,0 +1,69 @@
+From 893922cba7ff6c60d0d5e23287c9841a676d623d Mon Sep 17 00:00:00 2001
+From: Yizhi Liu <liuyizhi@apache.org>
+Date: Mon, 17 Oct 2022 15:16:45 -0700
+Subject: [PATCH 3/3] Fix type mismatch for CSR conversion in c_api
+
+TODO: Remove this patch when XGBoost version is updated.
+(Upstream PR: https://github.com/dmlc/xgboost/pull/8369)
+
+---
+ xgboost/include/xgboost/c_api.h | 4 ++--
+ xgboost/src/c_api/c_api.cc      | 6 +++---
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/xgboost/include/xgboost/c_api.h b/xgboost/include/xgboost/c_api.h
+index 17cd5f4..b76878b 100644
+--- a/xgboost/include/xgboost/c_api.h
++++ b/xgboost/include/xgboost/c_api.h
+@@ -135,7 +135,7 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
+  */
+ XGB_DLL int XGDMatrixCreateFromCSR(char const *indptr,
+                                    char const *indices, char const *data,
+-                                   bst_ulong ncol,
++                                   size_t ncol,
+                                    char const* json_config,
+                                    DMatrixHandle* out);
+ 
+@@ -998,7 +998,7 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle,
+  */
+ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
+                                     char const *indices, char const *values,
+-                                    bst_ulong ncol,
++                                    size_t ncol,
+                                     char const *c_json_config, DMatrixHandle m,
+                                     bst_ulong const **out_shape,
+                                     bst_ulong *out_dim,
+diff --git a/xgboost/src/c_api/c_api.cc b/xgboost/src/c_api/c_api.cc
+index a11602a..73c10c6 100644
+--- a/xgboost/src/c_api/c_api.cc
++++ b/xgboost/src/c_api/c_api.cc
+@@ -344,7 +344,7 @@ XGB_DLL int XGDMatrixCreateFromCSREx(const size_t* indptr,
+ 
+ XGB_DLL int XGDMatrixCreateFromCSR(char const *indptr,
+                                    char const *indices, char const *data,
+-                                   xgboost::bst_ulong ncol,
++                                   size_t ncol,
+                                    char const* c_json_config,
+                                    DMatrixHandle* out) {
+   API_BEGIN();
+@@ -861,7 +861,7 @@ XGB_DLL int XGBoosterPredictFromDense(BoosterHandle handle,
+ // A hidden API as cache id is not being supported yet.
+ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
+                                     char const *indices, char const *data,
+-                                    xgboost::bst_ulong cols,
++                                    size_t cols,
+                                     char const *c_json_config, DMatrixHandle m,
+                                     xgboost::bst_ulong const **out_shape,
+                                     xgboost::bst_ulong *out_dim,
+@@ -871,7 +871,7 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
+   std::shared_ptr<xgboost::data::CSRArrayAdapter> x{
+       new xgboost::data::CSRArrayAdapter{StringView{indptr},
+                                          StringView{indices}, StringView{data},
+-                                         static_cast<size_t>(cols)}};
++                                         cols}};
+   std::shared_ptr<DMatrix> p_m {nullptr};
+   if (m) {
+     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);
+-- 
+2.35.1
+

--- a/packages/xgboost/test_xgboost.py
+++ b/packages/xgboost/test_xgboost.py
@@ -319,3 +319,21 @@ def test_pandas_weight(selenium):
     assert data.num_col() == kCols
 
     np.testing.assert_array_equal(data.get_weight(), w)
+
+
+@pytest.mark.driver_timeout(60)
+@run_in_pyodide(packages=["xgboost", "numpy", "scipy"])
+def test_scipy_sparse(selenium):
+    import xgboost as xgb
+    import numpy as np
+    import scipy
+
+    n_rows = 100
+    n_cols = 10
+    X = scipy.sparse.random(n_rows, n_cols, format='csr')
+    y = np.random.randn(n_rows)
+    dtrain = xgb.DMatrix(X, y)
+    booster = xgb.train({}, dtrain, num_boost_round=1)
+    copied_predt = booster.predict(xgb.DMatrix(X))
+    predt = booster.inplace_predict(X)
+    np.testing.assert_allclose(copied_predt, predt)

--- a/packages/xgboost/test_xgboost.py
+++ b/packages/xgboost/test_xgboost.py
@@ -324,13 +324,13 @@ def test_pandas_weight(selenium):
 @pytest.mark.driver_timeout(60)
 @run_in_pyodide(packages=["xgboost", "numpy", "scipy"])
 def test_scipy_sparse(selenium):
-    import xgboost as xgb
     import numpy as np
     import scipy
+    import xgboost as xgb
 
     n_rows = 100
     n_cols = 10
-    X = scipy.sparse.random(n_rows, n_cols, format='csr')
+    X = scipy.sparse.random(n_rows, n_cols, format="csr")
     y = np.random.randn(n_rows)
     dtrain = xgb.DMatrix(X, y)
     booster = xgb.train({}, dtrain, num_boost_round=1)


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description
There was a mismatch between `bst_ulong` in c_api.h and `ctypes.c_size_t` in python. If you run test_scipy_sparse in browser, it would trigger error like,

```
TypeError: Cannot convert 10 to a BigInt
    at ffi_call (pyodide.asm.js:10:189569)
    at pyodide.asm.wasm:0x276cba
    at pyodide.asm.wasm:0x270f9c
    at method_call_trampoline (pyodide.asm.js:10:218037)
    at pyodide.asm.wasm:0x126317
    at pyodide.asm.wasm:0x1e246f
    at pyodide.asm.wasm:0x1e00b3
    at pyodide.asm.wasm:0x1da6a5
    at pyodide.asm.wasm:0x126a07
    at pyodide.asm.wasm:0x1e248c
API.fatal_error @ pyodide.asm.js:10
pyodide.asm.js:10 Stack (most recent call first):
pyodide.asm.js:10   File "/lib/python3.10/site-packages/xgboost/data.py", line 87 in _from_scipy_csr
pyodide.asm.js:10   File "<ipython-input-9-f40ece33f18d>", line 1 in <module>
pyodide.asm.js:10   File "/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3378 in run_code
...
```

In which `10` is the `ncol`.

I've also created an upstream PR https://github.com/dmlc/xgboost/pull/8369

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
