### PR TITLE
TST Fix jsexception test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,7 @@ jobs:
           name: Test docs
           command: |
             mkdir test-results
-            pip install pytest-pyodide
-            pip install -e ./pyodide-build
+            pip install -r requirements.txt
             npm install -g node-fetch@2
             pytest docs/sphinx_pyodide/tests --junitxml=test-results/junit.xml
       - store_test_results:
@@ -269,9 +268,7 @@ jobs:
           command: |
             make npm-link
             mkdir test-results
-            pip install pytest-pyodide
             pip install -r requirements.txt
-            pip install -e pyodide-build
             npm install -g node-fetch@2
             if [ -z "<< parameters.cache-dir >>" ]; then
               export CACHE_DIR=".test_cache/.pytest_cache_$(echo $RANDOM | md5sum | head -c 10)"
@@ -323,15 +320,12 @@ jobs:
             conda create -n pyodide python=3.10 -y
             source activate pyodide
             python -m pip install -r requirements.txt
-            python -m pip install pytest-pyodide
       - run:
           name: test safari
           command: |
             export PATH="$HOME/miniforge3/bin:$PATH"
             source activate pyodide
             mkdir test-results
-            pip install pytest-pyodide
-            pip install -e ./pyodide-build
             if [ -z "<< parameters.cache-dir >>" ]; then
               export CACHE_DIR=".test_cache/.pytest_cache_$(echo $RANDOM | md5sum | head -c 10)"
             else
@@ -356,7 +350,7 @@ jobs:
           name: stack-size
           command: |
             make npm-link
-            pip install pytest-pyodide
+            pip install -r requirements.txt
             npm install -g node-fetch@2
             pytest -s benchmark/stack_usage.py  | sed -n 's/## //pg'
 
@@ -430,11 +424,11 @@ jobs:
           name: install requirements
           command: |
             pip3 install numpy matplotlib pandas
+            pip install -r requirements.txt
+            npm install -g node-fetch@2
       - run:
           name: benchmark
           command: |
-            pip install pytest-pyodide
-            npm install -g node-fetch@2
             python benchmark/benchmark.py all --output dist/benchmarks.json
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,7 @@ jobs:
             conda create -n pyodide python=3.10 -y
             source activate pyodide
             python -m pip install -r requirements.txt
+            pip install -e ./pyodide-build
       - run:
           name: test safari
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
           command: |
             mkdir test-results
             pip install -r requirements.txt
+            pip install -e ./pyodide-build
             npm install -g node-fetch@2
             pytest docs/sphinx_pyodide/tests --junitxml=test-results/junit.xml
       - store_test_results:
@@ -269,6 +270,7 @@ jobs:
             make npm-link
             mkdir test-results
             pip install -r requirements.txt
+            pip install -e ./pyodide-build
             npm install -g node-fetch@2
             if [ -z "<< parameters.cache-dir >>" ]; then
               export CACHE_DIR=".test_cache/.pytest_cache_$(echo $RANDOM | md5sum | head -c 10)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,6 +156,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -r requirements.txt
+          pip install -e ./pyodide-build
           # FIXME: playwright 1.23.0 has unknown performance issue on firefox
           pip install "playwright<1.23.0" && python -m playwright install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -r requirements.txt
-          cd pyodide-build && pip install -e ".[test]" && cd ..
           # FIXME: playwright 1.23.0 has unknown performance issue on firefox
           pip install "playwright<1.23.0" && python -m playwright install
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@
   pytest-cov
   pytest-httpserver
   pytest-benchmark
+  pytest-pyodide==0.23.0

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1252,7 +1252,7 @@ def test_pickle_jsexception(selenium):
 
 
 def test_raises_jsexception(selenium):
-    from pyodide.ffi import JsException
+    from pytest_pyodide.pyodide import JsException
 
     @run_in_pyodide
     def raise_jsexception(selenium):


### PR DESCRIPTION
The host-side JsException class has been changed after: https://github.com/pyodide/pytest-pyodide/pull/44

This PR also pins pytest-pyodide version to prevent CI failure due to pytest-pyodide update.