### PR TITLE
Disable matplotlib benchmark temporarily

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -168,7 +168,9 @@ def main():
     BENCHMARKS = {
         "pystone": get_pystone_benchmarks,
         "numpy": get_numpy_benchmarks,
-        "matplotlib": get_matplotlib_benchmarks,
+        # TODO: matplotlib benchmark occasionally fails after https://github.com/pyodide/pyodide/pull/3130
+        #       but it is not clear why.
+        # "matplotlib": get_matplotlib_benchmarks,
         "pandas": get_pandas_benchmarks,
     }
 


### PR DESCRIPTION
Benchmark CI job is occasionally failing after #3130.

The error seems to happen in `html5_canvas_backend`, but it is hard to analyze. So until we manage to fix it, I think we better disable the matplotlib benchmark...