### PR TITLE
Add _hashlib to unvendored stdlib

### DIFF
--- a/docs/usage/wasm-constraints.md
+++ b/docs/usage/wasm-constraints.md
@@ -22,6 +22,7 @@ Instead, it is better to load individual modules as needed using
 - ssl
 - lzma
 - sqlite3
+- \_hashlib
 - test: it is an exception to the above, since it is not loaded even if `fullStdLib` is set to true.
 
 ### Removed modules

--- a/packages/_hashlib/meta.yaml
+++ b/packages/_hashlib/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: _hashlib
+  version: 1.0.0 # Nonsense
+  _cpython_dynlib: true
+  top-level:
+    - _hashlib
+source:
+  path: empty
+build:
+  sharedlibrary: true
+  script: |
+    mkdir dist
+    export DISTDIR=$(pwd)/dist
+    cd $CPYTHONBUILD
+
+    emcc $STDLIB_MODULE_CFLAGS -c Modules/_hashopenssl.c -o Modules/_hashlib.o \
+      $(pkg-config --cflags --dont-define-prefix libcrypto) -DOPENSSL_THREADS
+
+    emcc Modules/_hashlib.o -o $DISTDIR/_hashlib.so $SIDE_MODULE_LDFLAGS \
+      $(pkg-config --libs --dont-define-prefix libcrypto) -DOPENSSL_THREADS
+
+requirements:
+  run:
+    - openssl
+  host:
+    - openssl

--- a/packages/_hashlib/test_hashlib.py
+++ b/packages/_hashlib/test_hashlib.py
@@ -1,0 +1,72 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["test", "_hashlib"], pytest_assert_rewrites=False)
+def test_hashlib(selenium):
+    from test import libregrtest
+
+    name = "test_hashlib"
+    ignore_tests = [
+        "*threaded*",
+    ]
+
+    try:
+        libregrtest.main([name], ignore_tests=ignore_tests, verbose=True, verbose3=True)
+    except SystemExit as e:
+        if e.code != 0:
+            raise RuntimeError(f"Failed with code: {e.code}") from None
+
+
+@run_in_pyodide(packages=["_hashlib"])
+def test_hashlib_algorithms(selenium):
+    import hashlib
+    from hashlib import algorithms_available
+
+    python_algorithms = {
+        "md5",
+        "blake2s",
+        "sha3_256",
+        "sha256",
+        "sha384",
+        "sha224",
+        "sha3_384",
+        "sha512",
+        "blake2b",
+        "sha3_224",
+        "shake_256",
+        "sha1",
+        "sha3_512",
+        "shake_128",
+    }
+    openssl_algorithms = {
+        "whirlpool",
+        "shake_128",
+        "shake_256",
+        "sha3_384",
+        "sha256",
+        "sha3_512",
+        "sha512",
+        "mdc2",
+        "ripemd160",
+        "md5-sha1",
+        "sm3",
+        "sha512_256",
+        "md5",
+        "md4",
+        "sha3_224",
+        "sha1",
+        "sha224",
+        "blake2s",
+        "sha384",
+        "sha512_224",
+        "sha3_256",
+        "blake2b",
+    } - python_algorithms
+
+    for python_algorithm in python_algorithms:
+        assert python_algorithm in algorithms_available
+    for openssl_algorithm in openssl_algorithms:
+        assert openssl_algorithm in algorithms_available
+
+    for algorithm in algorithms_available:
+        hashlib.new(algorithm).digest_size

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -148,6 +148,7 @@ ALWAYS_PACKAGES = {
     "ssl",
     "lzma",
     "sqlite3",
+    "_hashlib",
 }
 
 CORE_PACKAGES = {

--- a/src/py/_pyodide/_importhook.py
+++ b/src/py/_pyodide/_importhook.py
@@ -138,7 +138,7 @@ def register_js_finder() -> None:
     sys.meta_path.append(jsfinder)
 
 
-UNVENDORED_STDLIBS = ["distutils", "ssl", "lzma", "sqlite3"]
+UNVENDORED_STDLIBS = ["distutils", "ssl", "lzma", "sqlite3", "_hashlib"]
 UNVENDORED_STDLIBS_AND_TEST = UNVENDORED_STDLIBS + ["test"]
 
 


### PR DESCRIPTION
### Description

This adds `_hashlib`, a complied part of stdlib `hashlib`. It was disabled before because it requires OpenSSL. This PR adds _hashlib but unvendors it by default.

Close: #3198

cc: @giacomocaironi

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
