### PR TITLE
Add Py_ENTER and Py_EXIT macros 

### DIFF
--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -11,6 +11,9 @@
 #include "pyproxy.h"
 #include "python2js.h"
 
+#define Py_ENTER()
+#define Py_EXIT()
+
 _Py_IDENTIFIER(result);
 _Py_IDENTIFIER(ensure_future);
 _Py_IDENTIFIER(add_done_callback);

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -46,6 +46,8 @@ declare var PYGEN_RETURN: number;
 declare var PYGEN_ERROR: number;
 
 declare function DEREF_U32(ptr: number, offset: number): number;
+declare function Py_ENTER();
+declare function Py_EXIT();
 // end-pyodide-skip
 
 /**
@@ -69,7 +71,9 @@ if (globalThis.FinalizationRegistry) {
         pyproxy_decref_cache(cache);
       }
       try {
+        Py_ENTER();
         Module._Py_DecRef(ptr);
+        Py_EXIT();
       } catch (e) {
         // I'm not really sure what happens if an error occurs inside of a
         // finalizer...
@@ -351,8 +355,10 @@ Module.pyproxy_destroy = function (proxy: PyProxy, destroyed_msg: string) {
   proxy.$$.destroyed_msg = destroyed_msg;
   pyproxy_decref_cache(proxy.$$.cache);
   try {
+    Py_ENTER();
     Module._Py_DecRef(ptrobj);
     trace_pyproxy_dealloc(proxy);
+    Py_EXIT();
   } catch (e) {
     API.fatal_error(e);
   }
@@ -378,6 +384,7 @@ Module.callPyObjectKwargs = function (
   let idkwnames = Hiwire.new_value(kwargs_names);
   let idresult;
   try {
+    Py_ENTER();
     idresult = Module.__pyproxy_apply(
       ptrobj,
       idargs,
@@ -448,7 +455,9 @@ export class PyProxyClass {
     let ptrobj = _getPtr(this);
     let jsref_repr;
     try {
+      Py_ENTER();
       jsref_repr = Module.__pyproxy_repr(ptrobj);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     }
@@ -552,6 +561,7 @@ export class PyProxyClass {
       default_converter_id = Hiwire.new_value(default_converter);
     }
     try {
+      Py_ENTER();
       idresult = Module._python2js_custom(
         ptrobj,
         depth,
@@ -559,6 +569,7 @@ export class PyProxyClass {
         dict_converter_id,
         default_converter_id,
       );
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     } finally {
@@ -651,7 +662,9 @@ export class PyProxyLengthMethods {
     let ptrobj = _getPtr(this);
     let length;
     try {
+      Py_ENTER();
       length = Module._PyObject_Size(ptrobj);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     }
@@ -680,7 +693,9 @@ export class PyProxyGetItemMethods {
     let idkey = Hiwire.new_value(key);
     let idresult;
     try {
+      Py_ENTER();
       idresult = Module.__pyproxy_getitem(ptrobj, idkey);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     } finally {
@@ -715,7 +730,9 @@ export class PyProxySetItemMethods {
     let idval = Hiwire.new_value(value);
     let errcode;
     try {
+      Py_ENTER();
       errcode = Module.__pyproxy_setitem(ptrobj, idkey, idval);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     } finally {
@@ -738,7 +755,9 @@ export class PyProxySetItemMethods {
     let idkey = Hiwire.new_value(key);
     let errcode;
     try {
+      Py_ENTER();
       errcode = Module.__pyproxy_delitem(ptrobj, idkey);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     } finally {
@@ -768,7 +787,9 @@ export class PyProxyContainsMethods {
     let idkey = Hiwire.new_value(key);
     let result;
     try {
+      Py_ENTER();
       result = Module.__pyproxy_contains(ptrobj, idkey);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     } finally {
@@ -799,10 +820,14 @@ export class PyProxyContainsMethods {
  */
 function* iter_helper(iterptr: number, token: {}): Generator<any> {
   try {
+    Py_ENTER();
     let item;
     while ((item = Module.__pyproxy_iter_next(iterptr))) {
+      Py_EXIT();
       yield Hiwire.pop_value(item);
+      Py_ENTER();
     }
+    Py_EXIT();
   } catch (e) {
     API.fatal_error(e);
   } finally {
@@ -836,7 +861,9 @@ export class PyProxyIterableMethods {
     let token = {};
     let iterptr;
     try {
+      Py_ENTER();
       iterptr = Module._PyObject_GetIter(ptrobj);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     }
@@ -886,7 +913,9 @@ export class PyProxyIteratorMethods {
     let stackTop = Module.stackSave();
     let res_ptr = Module.stackAlloc(4);
     try {
+      Py_ENTER();
       status = Module.__pyproxyGen_Send(_getPtr(this), idarg, res_ptr);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     } finally {
@@ -916,7 +945,9 @@ function python_hasattr(jsobj: PyProxyClass, jskey: any) {
   let idkey = Hiwire.new_value(jskey);
   let result;
   try {
+    Py_ENTER();
     result = Module.__pyproxy_hasattr(ptrobj, idkey);
+    Py_EXIT();
   } catch (e) {
     API.fatal_error(e);
   } finally {
@@ -937,7 +968,9 @@ function python_getattr(jsobj: PyProxyClass, jskey: any) {
   let idresult;
   let cacheId = jsobj.$$.cache.cacheId;
   try {
+    Py_ENTER();
     idresult = Module.__pyproxy_getattr(ptrobj, idkey, cacheId);
+    Py_EXIT();
   } catch (e) {
     API.fatal_error(e);
   } finally {
@@ -957,7 +990,9 @@ function python_setattr(jsobj: PyProxyClass, jskey: any, jsval: any) {
   let idval = Hiwire.new_value(jsval);
   let errcode;
   try {
+    Py_ENTER();
     errcode = Module.__pyproxy_setattr(ptrobj, idkey, idval);
+    Py_EXIT();
   } catch (e) {
     API.fatal_error(e);
   } finally {
@@ -974,7 +1009,9 @@ function python_delattr(jsobj: PyProxyClass, jskey: any) {
   let idkey = Hiwire.new_value(jskey);
   let errcode;
   try {
+    Py_ENTER();
     errcode = Module.__pyproxy_delattr(ptrobj, idkey);
+    Py_EXIT();
   } catch (e) {
     API.fatal_error(e);
   } finally {
@@ -1063,7 +1100,9 @@ let PyProxyHandlers = {
     let ptrobj = _getPtr(jsobj);
     let idresult;
     try {
+      Py_ENTER();
       idresult = Module.__pyproxy_ownKeys(ptrobj);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     }
@@ -1108,11 +1147,13 @@ export class PyProxyAwaitableMethods {
     let reject_handle_id = Hiwire.new_value(rejectHandle);
     let errcode;
     try {
+      Py_ENTER();
       errcode = Module.__pyproxy_ensure_future(
         ptrobj,
         resolve_handle_id,
         reject_handle_id,
       );
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     } finally {
@@ -1416,7 +1457,9 @@ export class PyProxyBufferMethods {
     let this_ptr = _getPtr(this);
     let errcode;
     try {
+      Py_ENTER();
       errcode = Module.__pyproxy_get_buffer(buffer_struct_ptr, this_ptr);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     }
@@ -1509,8 +1552,10 @@ export class PyProxyBufferMethods {
     } finally {
       if (!success) {
         try {
+          Py_ENTER();
           Module._PyBuffer_Release(view_ptr);
           Module._PyMem_Free(view_ptr);
+          Py_EXIT();
         } catch (e) {
           API.fatal_error(e);
         }
@@ -1697,8 +1742,10 @@ export class PyBuffer {
     }
     // Module.bufferFinalizationRegistry.unregister(this);
     try {
+      Py_ENTER();
       Module._PyBuffer_Release(this._view_ptr);
       Module._PyMem_Free(this._view_ptr);
+      Py_EXIT();
     } catch (e) {
       API.fatal_error(e);
     }

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -826,7 +826,7 @@ function* iter_helper(iterptr: number, token: {}): Generator<any> {
       Py_ENTER();
       const item = Module.__pyproxy_iter_next(iterptr);
       if (item === 0) {
-        return;
+        break;
       }
       Py_EXIT();
       yield Hiwire.pop_value(item);

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -392,6 +392,7 @@ Module.callPyObjectKwargs = function (
       idkwnames,
       num_kwargs,
     );
+    Py_EXIT();
   } catch (e) {
     API.fatal_error(e);
   } finally {

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -821,7 +821,6 @@ export class PyProxyContainsMethods {
  */
 function* iter_helper(iterptr: number, token: {}): Generator<any> {
   try {
-    Py_ENTER();
     while (true) {
       Py_ENTER();
       const item = Module.__pyproxy_iter_next(iterptr);

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -46,8 +46,8 @@ declare var PYGEN_RETURN: number;
 declare var PYGEN_ERROR: number;
 
 declare function DEREF_U32(ptr: number, offset: number): number;
-declare function Py_ENTER();
-declare function Py_EXIT();
+declare function Py_ENTER(): void;
+declare function Py_EXIT(): void;
 // end-pyodide-skip
 
 /**
@@ -822,13 +822,15 @@ export class PyProxyContainsMethods {
 function* iter_helper(iterptr: number, token: {}): Generator<any> {
   try {
     Py_ENTER();
-    let item;
-    while ((item = Module.__pyproxy_iter_next(iterptr))) {
+    while (true) {
+      Py_ENTER();
+      const item = Module.__pyproxy_iter_next(iterptr);
+      if (item === 0) {
+        return;
+      }
       Py_EXIT();
       yield Hiwire.pop_value(item);
-      Py_ENTER();
     }
-    Py_EXIT();
   } catch (e) {
     API.fatal_error(e);
   } finally {


### PR DESCRIPTION
These macros can be used to inject extra code that should be done before and after entering Python.

I tried to make a more ambitious change before but @rth vetoed it for being incomprehensible. He has a point. I don't think the current approach will be confusing. I'm going to use it as part of #3210.