### PR TITLE
Fix chrome and chromedriver version mismatch in Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     # Note: when updating the docker image version,
     #       make sure there are no extra old versions lying around.
     #       (e.g. `rg -F --hidden <old_tag>`)
-    - image: sihadan/pyodide-env-test:221102 # FIXME: for test
+    - image: pyodide/pyodide-env:20220629-py310-chrome102-firefox100
   environment:
     - EMSDK_NUM_CORES: 3
       EMCC_CORES: 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     # Note: when updating the docker image version,
     #       make sure there are no extra old versions lying around.
     #       (e.g. `rg -F --hidden <old_tag>`)
-    - image: pyodide/pyodide-env:20220629-py310-chrome102-firefox100
+    - image: sihadan/pyodide-env-test:20221102 # FIXME: for test
   environment:
     - EMSDK_NUM_CORES: 3
       EMCC_CORES: 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     # Note: when updating the docker image version,
     #       make sure there are no extra old versions lying around.
     #       (e.g. `rg -F --hidden <old_tag>`)
-    - image: sihadan/pyodide-env-test:20221102 # FIXME: for test
+    - image: sihadan/pyodide-env-test:221102 # FIXME: for test
   environment:
     - EMSDK_NUM_CORES: 3
       EMCC_CORES: 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
         patch pkg-config swig unzip wget xz-utils \
         autoconf autotools-dev automake texinfo dejagnu \
         build-essential prelink autoconf libtool libltdl-dev \
-        gnupg2 libdbus-glib-1-2 sudo sqlite3 \
+        gnupg2 libdbus-glib-1-2 sudo sqlite3 jq \
   && rm -rf /var/lib/apt/lists/*
 
 ADD docs/requirements-doc.txt requirements.txt /
@@ -64,24 +64,26 @@ RUN if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" 
 #============================================
 
 RUN if [ $CHROME_VERSION = "latest" ]; \
-  then CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"); \
-  else CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}"); \
+  then CHROMEDRIVER_VERSION_FULL=$(wget --no-verbose -O - "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"); \
+  else CHROMEDRIVER_VERSION_FULL=$(wget --no-verbose -O - "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}"); \
   fi \
+  && CHROME_VERSION_MAJOR=$(echo $CHROMEDRIVER_VERSION_FULL | cut -d '.' -f 1) \
+  && CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions" | jq -r '.versions[] | .version' | grep "^${CHROME_VERSION_MAJOR}" | head -n 1) \
   && CHROME_DOWNLOAD_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION_FULL}-1_amd64.deb" \
   && wget --no-verbose -O /tmp/google-chrome.deb ${CHROME_DOWNLOAD_URL} \
   && apt-get update \
   && apt install -qqy /tmp/google-chrome.deb \
   && rm -f /tmp/google-chrome.deb \
   && rm -rf /var/lib/apt/lists/* \
-  && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_VERSION_FULL/chromedriver_linux64.zip \
+  && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION_FULL/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
   && rm /tmp/chromedriver_linux64.zip \
-  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-$CHROME_VERSION_FULL \
-  && chmod 755 /opt/selenium/chromedriver-$CHROME_VERSION_FULL \
-  && ln -fs /opt/selenium/chromedriver-$CHROME_VERSION_FULL /usr/local/bin/chromedriver \
+  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-$CHROMEDRIVER_VERSION_FULL \
+  && chmod 755 /opt/selenium/chromedriver-$CHROMEDRIVER_VERSION_FULL \
+  && ln -fs /opt/selenium/chromedriver-$CHROMEDRIVER_VERSION_FULL /usr/local/bin/chromedriver \
   && echo "Using Chrome version: $(google-chrome --version)" \
-  && echo "Using Chromedriver version: "$CHROME_VERSION_FULL
+  && echo "Using Chromedriver version: "$CHROMEDRIVER_VERSION_FULL
 
 COPY --from=node-image /usr/local/bin/node /usr/local/bin/
 COPY --from=node-image /usr/local/lib/node_modules /usr/local/lib/node_modules


### PR DESCRIPTION
Fix #3217 

It seems like there are cases when the patch version of chromedriver and chrome doesn't match.
So instead of using chromedriver version directly for chrome version, search matching chrome version from [Version History API](https://developer.chrome.com/docs/versionhistory/guide/).

This PR also adds [jq](https://github.com/stedolan/jq) to the docker image, which is used to parse json response.