### PR TITLE
CI Move test-docs job to GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,22 +19,6 @@ orbs:
   macos: circleci/macos@2.2.0
 
 jobs:
-  test-docs:
-    <<: *defaults
-    resource_class: small
-    steps:
-      - checkout
-      - run:
-          name: Test docs
-          command: |
-            mkdir test-results
-            pip install -r requirements.txt
-            pip install -e ./pyodide-build
-            npm install -g node-fetch@2
-            pytest docs/sphinx_pyodide/tests --junitxml=test-results/junit.xml
-      - store_test_results:
-          path: test-results
-
   build-core:
     <<: *defaults
     steps:
@@ -540,11 +524,6 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - test-docs:
-          filters:
-            tags:
-              only: /.*/
-
       - build-core:
           filters:
             tags:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,29 @@ jobs:
           python-version: 3.10.2
       - uses: pre-commit/action@v2.0.3
 
+  test-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.10.2
+      - name: Install requirements
+        shell: bash -l {0}
+        run: |
+          pip install -r requirements.txt -r docs/requirements-doc.txt
+          pip install -e ./pyodide-build
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
+          mkdir -p test-results
+          pytest docs/sphinx_pyodide/tests --junitxml=test-results/junit.xml
+      - name: Test Summary
+        uses: test-summary/action@v1
+        with:
+          paths: "test-results/*.xml"
+        if: always()
+
   test-python:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -r requirements.txt -r docs/requirements-doc.txt
-          pip install -e ./pyodide-build
       - name: Run tests
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
This PR moves the` test-docs` job to GHA, so we can check earlier if the requirements for a document are broken.