### PR TITLE
Fix CLAPACK install path

### DIFF
--- a/packages/CLAPACK/meta.yaml
+++ b/packages/CLAPACK/meta.yaml
@@ -35,6 +35,6 @@ build:
     emmake make -j ${PYODIDE_JOBS:-3} blaslib lapacklib
     mkdir -p dist
     emcc blas_WA.a lapack_WA.a F2CLIBS/libf2c.a ${SIDE_MODULE_LDFLAGS} -o dist/clapack_all.so
-    mkdir -p ${WASM_LIBRARY_DIR}/CLAPACK/LIB
-    cp -r INCLUDE ${WASM_LIBRARY_DIR}/CLAPACK/
-    cp dist/clapack_all.so ${WASM_LIBRARY_DIR}/CLAPACK/LIB
+    mkdir -p ${WASM_LIBRARY_DIR}/{lib,include}
+    cp -r INCLUDE/* ${WASM_LIBRARY_DIR}/include
+    cp dist/clapack_all.so ${WASM_LIBRARY_DIR}/lib

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -37,7 +37,7 @@ source:
 
 build:
   cflags: |
-    -I$(WASM_LIBRARY_DIR)/CLAPACK/INCLUDE
+    -I$(WASM_LIBRARY_DIR)/include
     -I$(HOSTSITEPACKAGES)/pythran/
     -Wno-return-type
     -DUNDERSCORE_G77
@@ -52,8 +52,8 @@ build:
   script: |
     set -x
     export PKG_CONFIG_LIBDIR=$WASM_PKG_CONFIG_PATH
-    export NPY_BLAS_LIBS="-I$WASM_LIBRARY_DIR/CLAPACK/INCLUDE $WASM_LIBRARY_DIR/CLAPACK/LIB/clapack_all.so"
-    export NPY_LAPACK_LIBS="-I$WASM_LIBRARY_DIR/CLAPACK/INCLUDE"
+    export NPY_BLAS_LIBS="-I$WASM_LIBRARY_DIR/include $WASM_LIBRARY_DIR/lib/clapack_all.so"
+    export NPY_LAPACK_LIBS="-I$WASM_LIBRARY_DIR/include"
 
     pip install -t $HOSTSITEPACKAGES pythran
     # We get linker errors because the following 36 functions are missing

--- a/packages/suitesparse/meta.yaml
+++ b/packages/suitesparse/meta.yaml
@@ -23,8 +23,8 @@ build:
 
     emmake make -j ${PYODIDE_JOBS:-3} install \
       LDFLAGS="${SIDE_MODULE_LDFLAGS} -L${WASM_LIBRARY_DIR}/lib " \
-      BLAS="${WASM_LIBRARY_DIR}/CLAPACK/LIB/clapack_all.so" \
-      LAPACK="${WASM_LIBRARY_DIR}/CLAPACK/LIB/clapack_all.so" \
+      BLAS="${WASM_LIBRARY_DIR}/lib/clapack_all.so" \
+      LAPACK="${WASM_LIBRARY_DIR}/lib/clapack_all.so" \
       INSTALL=${WASM_LIBRARY_DIR}
     mkdir -p dist
 

--- a/pyodide-build/pyodide_build/create_xbuildenv.py
+++ b/pyodide-build/pyodide_build/create_xbuildenv.py
@@ -54,7 +54,6 @@ def copy_wasm_libs(xbuildenv_path: Path) -> None:
         pythoninclude,
         sysconfig_dir,
         Path("Makefile.envs"),
-        wasm_lib_dir / "CLAPACK",
         wasm_lib_dir / "cmake",
         Path("tools/pyo3_config.ini"),
         Path("tools/python"),
@@ -68,7 +67,7 @@ def copy_wasm_libs(xbuildenv_path: Path) -> None:
     # Some ad-hoc stuff here to moderate size. We'd like to include all of
     # wasm_lib_dir but there's 180mb of it. Better to leave out all the video
     # codecs and stuff.
-    for pkg in ["ssl", "libcrypto", "zlib", "xml", "mpfr"]:
+    for pkg in ["ssl", "libcrypto", "zlib", "xml", "mpfr", "lapack", "blas", "f2c"]:
         to_copy.extend(
             x.relative_to(pyodide_root)
             for x in (pyodide_root / wasm_lib_dir / "include").glob(f"**/*{pkg}*")


### PR DESCRIPTION
This is split up from #3167.

This change CLAPACK to be installed in the same directory where other libraries are saved.