### PR TITLE
Fixes to package loading from #3229

### DIFF
--- a/src/js/dynload.ts
+++ b/src/js/dynload.ts
@@ -29,10 +29,11 @@ export async function loadDynlib(lib: string, shared: boolean) {
     console.debug(`Loading a dynamic library ${lib}`);
   }
 
+  const libDir = lib.substring(0, lib.lastIndexOf("/"));
   // This is a fake FS-like object to make emscripten
   // load shared libraries from the file system.
   const libraryFS = {
-    _ldLibraryPaths: ["/usr/lib", API.sitepackages],
+    _ldLibraryPaths: ["/usr/lib", API.sitepackages, libDir],
     _resolvePath: (path: string) => {
       if (DEBUG) {
         console.debug(`Searching a library from ${path}, required by ${lib}.`);

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -259,6 +259,7 @@ async function installPackage(
       shared_library: false,
       depends: [],
       imports: [] as string[],
+      target: "site",
     };
   }
   const filename = pkg.file_name;


### PR DESCRIPTION
Add package directory to library search path and set target to 'site' when we `loadPackage` from a wheel.
This fixes two minor bugs I found in #3229 that prevent that package from working correctly.
