### PR TITLE
TST Fix cmdline runner pip test failure

### DIFF
--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -221,6 +221,7 @@ def install_pkg(venv, pkgname):
             venv / "bin/pip",
             "install",
             pkgname,
+            "--disable-pip-version-check",
         ],
         capture_output=True,
         encoding="utf8",


### PR DESCRIPTION
Fix test failure [regarding pip version warning](https://app.circleci.com/pipelines/github/pyodide/pyodide/4968/workflows/4ddb5983-2ab5-4ecc-8c58-bb8e5da482a1/jobs/59765).

```
AssertionError: assert 'ERROR: Could...--upgrade pip' == 'ERROR: Could...nd for psutil'
    ERROR: Could not find a version that satisfies the requirement psutil (from versions: none)
  - ERROR: No matching distribution found for psutil
  + ERROR: No matching distribution found for psutil
  ?                                                 +
  + 
  + [notice] A new release of pip available: 22.3 -> 22.3.1
  + [notice] To update, run: /root/repo/.venv-pyodide-tmp-test/bin/python3.10-host -m pip install --upgrade pip
src/tests/test_cmdline_runner.py:331: in test_pip_install_impure
    assert (
E   AssertionError: assert 'ERROR: Could...--upgrade pip' == 'ERROR: Could...nd for psutil'
E       ERROR: Could not find a version that satisfies the requirement psutil (from versions: none)
E     - ERROR: No matching distribution found for psutil
E     + ERROR: No matching distribution found for psutil
E     ?                                                 +
E     + 
E     + [notice] A new release of pip available: 22.3 -> 22.3.1
E     + [notice] To update, run: /root/repo/.venv-pyodide-tmp-test/bin/python3.10-host -m pip install --upgrade pip
```