### PR TITLE
Fix exit in command line runner

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -21,7 +21,7 @@ substitutions:
   is for testing out of tree builds. For more information, see [the
   documentation](https://pyodide.org/en/stable/development/out-of-tree.html).
   {pr}`2976`, {pr}`3039`, {pr}`3040`, {pr}`3044`, {pr}`3044`, {pr}`3096`,
-  {pr}`3098`, {pr}`3108`, {pr}`3109`
+  {pr}`3098`, {pr}`3108`, {pr}`3109`, {pr}`3241`
 
 - {{ Enhancement }} Users can do a static import of `pyodide/pyodide.asm.js` to
   avoid issues with dynamic imports. This allows the use of Pyodide with

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,8 +20,8 @@ substitutions:
 - {{ Enhancement }} Added a system for making Pyodide virtual environments. This
   is for testing out of tree builds. For more information, see [the
   documentation](https://pyodide.org/en/stable/development/out-of-tree.html).
-  {pr}`2976`, {pr}`3039`, {pr}`3040`, {pr}`3044`, {pr}`3044`, {pr}`3096`,
-  {pr}`3098`, {pr}`3108`, {pr}`3109`, {pr}`3241`
+  {pr}`2976`, {pr}`3039`, {pr}`3040`, {pr}`3044`, {pr}`3096`, {pr}`3098`,
+  {pr}`3108`, {pr}`3109`, {pr}`3241`
 
 - {{ Enhancement }} Users can do a static import of `pyodide/pyodide.asm.js` to
   avoid issues with dynamic imports. This allows the use of Pyodide with

--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -425,3 +425,30 @@ def test_pypa_index(tmp_path):
         stdout.strip().rsplit("\n", 1)[-1]
         == "Successfully installed attrs-* micropip-* numpy-* sharedlib-test-py-*"
     )
+
+
+def test_sys_exit(selenium, venv):
+    result = subprocess.run(
+        [
+            venv / "bin/python",
+            "-c",
+            "import sys; sys.exit(0)"
+        ],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    result = subprocess.run(
+        [
+            venv / "bin/python",
+            "-c",
+            "import sys; sys.exit(12)"
+        ],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""

--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -441,6 +441,6 @@ def test_sys_exit(selenium, venv):
         capture_output=True,
         encoding="utf-8",
     )
-    assert result.returncode == 0
+    assert result.returncode == 12
     assert result.stdout == ""
     assert result.stderr == ""

--- a/tools/python
+++ b/tools/python
@@ -241,8 +241,12 @@ async function main() {
     try {
         errcode = py._module._run_main();
     } catch (e) {
-        // If there is some sort of error, add the Python tracebook in addition
-        // to the JavaScript traceback
+        // If someone called exit, just exit with the right return code.
+        if(e.constructor.name === "ExitStatus"){
+            process.exit(e.status);
+        }
+        // Otherwise if there is some sort of error, include the Python
+        // tracebook in addition to the JavaScript traceback
         py._module._dump_traceback();
         throw e;
     }


### PR DESCRIPTION
Don't set error code to 1 if the program calls `exit(0)`!

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests

