### PR TITLE
Fix docs on loadPyodide

### DIFF
--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -216,12 +216,6 @@ export type ConfigType = {
 /**
  * Load the main Pyodide wasm module and initialize it.
  *
- * Only one copy of Pyodide can be loaded in a given JavaScript global scope
- * because Pyodide uses global variables to load packages. If an attempt is made
- * to load a second copy of Pyodide, :any:`loadPyodide` will throw an error.
- * (This can be fixed once `Firefox adopts support for ES6 modules in webworkers
- * <https://bugzilla.mozilla.org/show_bug.cgi?id=1247687>`_.)
- *
  * @returns The :ref:`js-api-pyodide` module.
  * @memberof globalThis
  * @async


### PR DESCRIPTION
You **can** load several versions of Pyodide since version 0.21.0. We should backport this.