### PR TITLE
Fix Pyodide REPL URL

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python3.10 -m sphinx
+SPHINXBUILD   = python -m sphinx
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Try Pyodide
 -----------
 
 Try Pyodide in a
-`REPL <https://pyodide.org/en/stable/console.html>`_ directly in
+`REPL <./console.html>`_ directly in
 your browser (no installation needed).
 
 

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -142,13 +142,9 @@ you can access the global variable `x` from JavaScript in your browser's
 developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
-You can try it yourself in the browser console. Go to
-
-```text
-{{PYODIDE_CDN_URL}}console.html
-```
-
-and type the following into the browser console:
+You can try it yourself in the browser console. Go to the [Pyodide REPL
+URL](https://pyodide.org/en/latest/console.html) and type the following into
+the browser console:
 
 ```pyodide
 await pyodide.loadPackage("numpy");

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -4,7 +4,7 @@
 
 ## Try it online
 
-Try Pyodide in a [REPL](./console.html) directly in your browser (no installation needed).
+Try Pyodide in a [REPL](../console.html) directly in your browser (no installation needed).
 
 ## Setup
 
@@ -143,7 +143,7 @@ developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
 You can try it yourself in the browser console. Go to the [Pyodide REPL
-URL](./console.html) and type the following into
+URL](../console.html) and type the following into
 the browser console:
 
 ```pyodide

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -4,7 +4,7 @@
 
 ## Try it online
 
-Try Pyodide in a [REPL](https://pyodide.org/en/stable/console.html) directly in your browser (no installation needed).
+Try Pyodide in a [REPL](./console.html) directly in your browser (no installation needed).
 
 ## Setup
 
@@ -143,7 +143,7 @@ developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
 You can try it yourself in the browser console. Go to the [Pyodide REPL
-URL](https://pyodide.org/en/stable/console.html) and type the following into
+URL](./console.html) and type the following into
 the browser console:
 
 ```pyodide

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -4,7 +4,7 @@
 
 ## Try it online
 
-Try Pyodide in a [REPL](https://pyodide.org/en/latest/console.html) directly in your browser (no installation needed).
+Try Pyodide in a [REPL](https://pyodide.org/en/stable/console.html) directly in your browser (no installation needed).
 
 ## Setup
 
@@ -143,7 +143,7 @@ developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
 You can try it yourself in the browser console. Go to the [Pyodide REPL
-URL](https://pyodide.org/en/latest/console.html) and type the following into
+URL](https://pyodide.org/en/stable/console.html) and type the following into
 the browser console:
 
 ```pyodide

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -5,6 +5,7 @@
 ## Try it online
 
 <!-- Use rst to avoid myst_parser trying to resolve ../.console.html and not creating a link  -->
+
 ```{eval-rst}
 Try Pyodide in a `REPL <../console.html>`_ directly in your browser (no installation needed).
 ```
@@ -146,6 +147,7 @@ developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
 <!-- Use rst to avoid myst_parser trying to resolve ../console.html and not creating a link  -->
+
 ```{eval-rst}
 You can try it yourself in the browser console. Go to the `Pyodide REPL URL
 <../console.html>`_ and type the following into the browser console::

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -4,7 +4,8 @@
 
 ## Try it online
 
-Try Pyodide in a [REPL](./console.html) directly in your browser (no installation needed).
+Try Pyodide in a <a href="./console.html">REPL</a> directly in your browser (no
+installation needed).
 
 ## Setup
 
@@ -142,9 +143,9 @@ you can access the global variable `x` from JavaScript in your browser's
 developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
-You can try it yourself in the browser console. Go to the [Pyodide REPL
-URL](./console.html) and type the following into
-the browser console:
+You can try it yourself in the browser console. Go to the
+<a href="./console.html">Pyodide REPL</a> and type the following into the
+browser console:
 
 ```pyodide
 await pyodide.loadPackage("numpy");

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -4,8 +4,7 @@
 
 ## Try it online
 
-Try Pyodide in a <a href="./console.html">REPL</a> directly in your browser (no
-installation needed).
+Try Pyodide in a [REPL](./console.html) directly in your browser (no installation needed).
 
 ## Setup
 
@@ -143,9 +142,9 @@ you can access the global variable `x` from JavaScript in your browser's
 developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
-You can try it yourself in the browser console. Go to the
-<a href="./console.html">Pyodide REPL</a> and type the following into the
-browser console:
+You can try it yourself in the browser console. Go to the [Pyodide REPL
+URL](./console.html) and type the following into
+the browser console:
 
 ```pyodide
 await pyodide.loadPackage("numpy");

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -4,7 +4,10 @@
 
 ## Try it online
 
-Try Pyodide in a [REPL](../console.html) directly in your browser (no installation needed).
+<!-- Use rst to avoid myst_parser trying to resolve ../.console.html and not creating a link  -->
+```{eval-rst}
+Try Pyodide in a `REPL <../console.html>`_ directly in your browser (no installation needed).
+```
 
 ## Setup
 
@@ -142,9 +145,11 @@ you can access the global variable `x` from JavaScript in your browser's
 developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
-You can try it yourself in the browser console. Go to the [Pyodide REPL
-URL](../console.html) and type the following into
-the browser console:
+<!-- Use rst to avoid myst_parser trying to resolve ../console.html and not creating a link  -->
+```{eval-rst}
+You can try it yourself in the browser console. Go to the `Pyodide REPL URL
+<../console.html>`_ and type the following into the browser console::
+```
 
 ```pyodide
 await pyodide.loadPackage("numpy");


### PR DESCRIPTION
### Description

The doc about [accessing Python scope from Javascript](
https://pyodide.org/en/latest/usage/quickstart.html#accessing-python-scope-from-javascript)

![image](https://user-images.githubusercontent.com/1680079/200891363-79014beb-8e27-4e54-ace8-c693e4f3e9d5.png)

mentions the URL https://cdn.jsdelivr.net/pyodide/v0.21.3/full/console.html which ends up on page showing only "Forbidden"
![image](https://user-images.githubusercontent.com/1680079/200891729-aa7b3406-2f6b-4e6b-9c04-ae9d9f841f48.png)

I am guessing this was meant to be pointing to a Pyodide REPL URL instead. I used the `latest` Pyodide REPL URL rather than the `stable` one because this is what is done at the top of the page (both for the `latest` and the `stable` doc).

### Checklists

The following don't really apply to this PR so I checked them all.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation