### PR TITLE
Remove "Python initialization complete" log line

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -112,6 +112,10 @@ substitutions:
 - Add Gitpod configuration to the repository.
   {pr} `3201`
 
+- Removed "Python initialization complete" message printed when loading is
+  finished.
+  {pr}`3247`
+
 ### Build System / Package Loading
 
 - New packages: pycryptodomex {pr}`2966`, pycryptodome {pr}`2965`,

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -119,7 +119,6 @@ hello_python().then((result) => {
 $ node hello_python.js
 Loading distutils
 Loaded distutils
-Python initialization complete
 Python says that 1+1= 2
 ```
 
@@ -135,7 +134,6 @@ undefined
 > let pyodide = await loadPyodide();
 Loading distutils
 Loaded distutils
-Python initialization complete
 undefined
 > await pyodide.runPythonAsync("1+1");
 2
@@ -160,7 +158,6 @@ warning: no blob constructor, cannot create blobs with mimetypes
 warning: no BlobBuilder
 Loading distutils
 Loaded distutils
-Python initialization complete
 Python says that 1+1= 2
 ```
 

--- a/src/js/README.md
+++ b/src/js/README.md
@@ -30,7 +30,6 @@ hello_python().then((result) => {
 $ node hello_python.js
 Loading distutils
 Loaded distutils
-Python initialization complete
 Python says that 1+1= 2
 ```
 
@@ -46,7 +45,6 @@ undefined
 > let pyodide = await loadPyodide();
 Loading distutils
 Loaded distutils
-Python initialization complete
 undefined
 > await pyodide.runPythonAsync("1+1");
 2
@@ -71,7 +69,6 @@ warning: no blob constructor, cannot create blobs with mimetypes
 warning: no BlobBuilder
 Loading distutils
 Loaded distutils
-Python initialization complete
 Python says that 1+1= 2
 ```
 

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -267,6 +267,7 @@ export async function loadPyodide(
     _node_mounts?: string[];
   } = {},
 ): Promise<PyodideInterface> {
+  const t0_init = new Date();
   await initNodeModules();
   let indexURL = options.indexURL || calculateIndexURL();
   indexURL = resolvePath(indexURL); // A relative indexURL causes havoc.
@@ -371,6 +372,10 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
   if (config.fullStdLib) {
     await pyodide.loadPackage(API._pyodide._importhook.UNVENDORED_STDLIBS);
   }
-  pyodide.runPython("print('Python initialization complete')");
+  const init_time = (new Date().getTime() - t0_init.getTime()).toFixed(0);
+
+  pyodide.runPython(
+    `print('Python initialization complete in ${init_time} ms')`,
+  );
   return pyodide;
 }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -267,7 +267,6 @@ export async function loadPyodide(
     _node_mounts?: string[];
   } = {},
 ): Promise<PyodideInterface> {
-  const t0_init = new Date();
   await initNodeModules();
   let indexURL = options.indexURL || calculateIndexURL();
   indexURL = resolvePath(indexURL); // A relative indexURL causes havoc.
@@ -372,10 +371,5 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
   if (config.fullStdLib) {
     await pyodide.loadPackage(API._pyodide._importhook.UNVENDORED_STDLIBS);
   }
-  const init_time = (new Date().getTime() - t0_init.getTime()).toFixed(0);
-
-  pyodide.runPython(
-    `print('Python initialization complete in ${init_time} ms')`,
-  );
   return pyodide;
 }

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -821,7 +821,6 @@ def test_fatal_error(selenium_standalone):
         == dedent(
             strip_stack_trace(
                 """
-                Python initialization complete
                 Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.
                 The cause of the fatal error was:
                 Stack (most recent call first):
@@ -1139,7 +1138,6 @@ def test_custom_stdin_stdout(selenium_standalone_noload):
         """
     )
     assert stdoutstrings[-2:] == [
-        "Python initialization complete",
         "something to stdout",
     ]
     stderrstrings = _strip_assertions_stderr(stderrstrings)

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -1,10 +1,6 @@
 import pytest
 
 
-def test_init(selenium_standalone):
-    assert "Python initialization complete" in selenium_standalone.logs.splitlines()
-
-
 @pytest.mark.xfail_browsers(node="Webbrowser doesn't work in node")
 def test_webbrowser(selenium):
     # Selenium

--- a/src/tests/test_python_esm.py
+++ b/src/tests/test_python_esm.py
@@ -1,10 +1,6 @@
 import pytest
 
 
-def test_init(selenium_esm):
-    assert "Python initialization complete" in selenium_esm.logs.splitlines()
-
-
 def test_print(selenium_esm):
     selenium_esm.run("print('This should be logged')")
     assert "This should be logged" in selenium_esm.logs.splitlines()

--- a/tools/python
+++ b/tools/python
@@ -143,12 +143,6 @@ async function main() {
             homedir: process.cwd(),
             // Strip out standard messages written to stdout and stderr while loading
             // After Pyodide is loaded we will replace stdstreams with setupStreams.
-            stdout(e) {
-                if (e.trim() === "Python initialization complete") {
-                    return;
-                }
-                console.log(e);
-            },
             stderr(e) {
                 if (
                     [


### PR DESCRIPTION
A small change to logging when loading Pyodide, to also indicate the time it took for the initialization,

Currently, in the console, we print,
```
Python initialization complete
```
With this change,  it would log something like,
```
Python initialization complete in 1230 ms
```

This is helpful for measuring load time (e.g. related to https://github.com/pyodide/pyodide/pull/3166/) without writing extra code, for instance just by loading the console.html 

This likely doesn't need a changelog entry.