### PR TITLE
DOCS: Get rid of those damn parentheses at the end of type names

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,6 +182,10 @@ if IN_SPHINX:
     ]
     sys.path = path_dirs + sys.path
 
+    from sphinx.domains.javascript import JavaScriptDomain, JSXRefRole
+
+    JavaScriptDomain.roles["func"] = JSXRefRole()
+
     import micropip  # noqa: F401
     import pyodide
 


### PR DESCRIPTION
This has been bothering me for a long time. Fix discovered by trial and error. The parens are getting added here:
https://github.com/sphinx-doc/sphinx/blob/master/sphinx/roles.py#L87
