### PR TITLE
Add `as_object_map` method to JsProxy

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -81,6 +81,11 @@ substitutions:
   the method is called on.
   {pr}`3130`
 
+- {{Enhancement}} A `JsProxy` now has an `as_object_map` method. This will treat
+  the object as a mapping over its `ownKeys` so for instance:
+  `run_js("({a:2, b:3})").as_object_map()["a"]` will return 2.
+  {pr}`3273`
+
 - {{ Breaking }} The messageCallback and errorCallback argument to
   {any}`loadPackage <pyodide.loadPackage>` and
   {any}`loadPackagesFromImports <pyodide.loadPackagesFromImports>`

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -272,6 +272,15 @@ EM_JS_NUM(int, hiwire_init, (), {
     }
   }
 
+  Module.iterObject = function * (object)
+  {
+    for (let k in object) {
+      if (Object.prototype.hasOwnProperty.call(object, k)) {
+        yield k;
+      }
+    }
+  };
+
   if (globalThis.BigInt) {
     Module.BigInt = BigInt;
   } else {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1610,10 +1610,10 @@ JsObjMap_ass_subscript_js,
 {
   let obj = Hiwire.get_value(idobj);
   let key = Hiwire.get_value(idkey);
-  if (!Object.prototype.hasOwnProperty.call(obj, key)) {
-    return -1;
-  }
   if(idvalue === 0) {
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+      return -1;
+    }
     delete obj[key];
   } else {
     obj[key] = Hiwire.get_value(idvalue);
@@ -1626,7 +1626,13 @@ static int
 JsObjMap_ass_subscript(PyObject* self, PyObject* pykey, PyObject* pyvalue)
 {
   if (!PyUnicode_Check(pykey)) {
-    PyErr_SetObject(PyExc_KeyError, pykey);
+    if (pyvalue) {
+      PyErr_SetString(
+        PyExc_TypeError,
+        "Can only assign keys of type string to JavaScript object map");
+    } else {
+      PyErr_SetObject(PyExc_KeyError, pykey);
+    }
     return -1;
   }
 

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -55,6 +55,7 @@
 #define IS_NODE_LIST  (1<<11)
 #define IS_TYPEDARRAY (1<<12)
 #define IS_DOUBLE_PROXY (1 << 13)
+#define IS_OBJECT_MAP (1 << 14)
 // clang-format on
 
 _Py_IDENTIFIER(get_event_loop);
@@ -101,6 +102,7 @@ typedef struct
 // clang-format on
 
 #define JsProxy_REF(x) (((JsProxy*)x)->js)
+#define JsMethod_THIS(x) (((JsProxy*)x)->this_)
 
 static void
 JsProxy_dealloc(JsProxy* self)
@@ -1501,6 +1503,178 @@ static PyMethodDef JsProxy_finally_MethodDef = {
   METH_O,
 };
 
+// Forward declaration
+static PyObject*
+create_proxy_of_type(int type_flags, JsRef object, JsRef this);
+
+static PyObject*
+JsProxy_as_object_map(PyObject* self, PyObject* Py_UNUSED(ignored))
+{
+  PyObject* type_flags_obj =
+    _PyObject_GetAttrId((PyObject*)Py_TYPE(self), &PyId__js_type_flags);
+  if (type_flags_obj == NULL) {
+    return NULL;
+  }
+  int type_flags = PyLong_AsLong(type_flags_obj);
+  Py_CLEAR(type_flags_obj);
+  if (type_flags == -1) {
+    return NULL;
+  }
+  type_flags |= IS_OBJECT_MAP;
+  return create_proxy_of_type(
+    type_flags, JsProxy_REF(self), JsMethod_THIS(self));
+}
+
+static PyMethodDef JsProxy_as_object_map_MethodDef = {
+  "as_object_map",
+  (PyCFunction)JsProxy_as_object_map,
+  METH_NOARGS,
+};
+
+EM_JS_REF(JsRef, JsObjMap_GetIter_js, (JsRef idobj), {
+  let jsobj = Hiwire.get_value(idobj);
+  return Hiwire.new_value(Module.iterObject(jsobj));
+})
+
+static PyObject*
+JsObjMap_GetIter(PyObject* self)
+{
+  JsRef iditer = JsObjMap_GetIter_js(JsProxy_REF(self));
+  if (iditer == NULL) {
+    return NULL;
+  }
+  PyObject* result = js2python(iditer);
+  hiwire_decref(iditer);
+  return result;
+}
+
+EM_JS_NUM(int, JsObjMap_length_js, (JsRef idobj), {
+  let jsobj = Hiwire.get_value(idobj);
+  let length = 0;
+  for (let _ of Module.iterObject(jsobj)) {
+    length++;
+  }
+  return length;
+})
+
+static int
+JsObjMap_length(PyObject* self)
+{
+  return JsObjMap_length_js(JsProxy_REF(self));
+}
+
+// A helper method for JsObjMap_subscript.
+EM_JS_REF(JsRef, JsObjMap_subscript_js, (JsRef idobj, JsRef idkey), {
+  let obj = Hiwire.get_value(idobj);
+  let key = Hiwire.get_value(idkey);
+  if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+    return 0;
+  }
+  return Hiwire.new_value(obj[key]);
+});
+
+static PyObject*
+JsObjMap_subscript(PyObject* self, PyObject* pyidx)
+{
+  if (!PyUnicode_Check(pyidx)) {
+    PyErr_SetObject(PyExc_KeyError, pyidx);
+    return NULL;
+  }
+
+  JsRef idkey = NULL;
+  JsRef idresult = NULL;
+  PyObject* pyresult = NULL;
+
+  idkey = python2js(pyidx);
+  FAIL_IF_NULL(idkey);
+  idresult = JsObjMap_subscript_js(JsProxy_REF(self), idkey);
+  if (idresult == NULL) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetObject(PyExc_KeyError, pyidx);
+    }
+    FAIL();
+  }
+  pyresult = js2python(idresult);
+
+finally:
+  hiwire_CLEAR(idkey);
+  hiwire_CLEAR(idresult);
+  return pyresult;
+}
+
+// A helper method for JsObjMap_ass_subscript.
+// clang-format off
+EM_JS_NUM(int,
+JsObjMap_ass_subscript_js,
+(JsRef idobj, JsRef idkey, JsRef idvalue),
+{
+  let obj = Hiwire.get_value(idobj);
+  let key = Hiwire.get_value(idkey);
+  if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+    return -1;
+  }
+  if(idvalue === 0) {
+    delete obj[key];
+  } else {
+    obj[key] = Hiwire.get_value(idvalue);
+  }
+  return 0;
+});
+// clang-format on
+
+static int
+JsObjMap_ass_subscript(PyObject* self, PyObject* pykey, PyObject* pyvalue)
+{
+  if (!PyUnicode_Check(pykey)) {
+    PyErr_SetObject(PyExc_KeyError, pykey);
+    return -1;
+  }
+
+  bool success = false;
+  JsRef idkey = NULL;
+  JsRef idvalue = NULL;
+  idkey = python2js(pykey);
+  if (pyvalue != NULL) {
+    idvalue = python2js(pyvalue);
+    FAIL_IF_NULL(idvalue);
+  }
+  int status = JsObjMap_ass_subscript_js(JsProxy_REF(self), idkey, idvalue);
+  if (status == -1) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetObject(PyExc_KeyError, pykey);
+    }
+    FAIL();
+  }
+  success = true;
+finally:
+  hiwire_CLEAR(idkey);
+  hiwire_CLEAR(idvalue);
+  return success ? 0 : -1;
+}
+
+EM_JS_NUM(int, JsObjMap_contains_js, (JsRef idobj, JsRef idkey), {
+  let obj = Hiwire.get_value(idobj);
+  let key = Hiwire.get_value(idkey);
+  return Object.prototype.hasOwnProperty.call(obj, key);
+});
+
+static int
+JsObjMap_contains(PyObject* self, PyObject* obj)
+{
+  if (!PyUnicode_Check(obj)) {
+    return 0;
+  }
+  int result = -1;
+
+  JsRef jsobj = python2js(obj);
+  FAIL_IF_NULL(jsobj);
+  result = JsObjMap_contains_js(JsProxy_REF(self), jsobj);
+
+finally:
+  hiwire_CLEAR(jsobj);
+  return result;
+}
+
 // clang-format off
 static PyNumberMethods JsProxy_NumberMethods = {
   .nb_bool = JsProxy_Bool
@@ -1694,8 +1868,6 @@ finally:
 // JsMethod
 //
 // A subclass of JsProxy for methods
-
-#define JsMethod_THIS(x) (((JsProxy*)x)->this_)
 
 /**
  * Prepare arguments from a `METH_FASTCALL | METH_KEYWORDS` Python function to a
@@ -2435,6 +2607,19 @@ JsProxy_create_subtype(int flags)
 
   PyTypeObject* base = &JsProxyType;
   int tp_flags = Py_TPFLAGS_DEFAULT;
+  if (flags & IS_OBJECT_MAP) {
+    slots[cur_slot++] =
+      (PyType_Slot){ .slot = Py_tp_iter, .pfunc = (void*)JsObjMap_GetIter };
+    slots[cur_slot++] =
+      (PyType_Slot){ .slot = Py_mp_length, .pfunc = (void*)JsObjMap_length };
+    slots[cur_slot++] = (PyType_Slot){ .slot = Py_mp_subscript,
+                                       .pfunc = (void*)JsObjMap_subscript };
+    slots[cur_slot++] = (PyType_Slot){ .slot = Py_mp_ass_subscript,
+                                       .pfunc = (void*)JsObjMap_ass_subscript };
+    slots[cur_slot++] = (PyType_Slot){ .slot = Py_sq_contains,
+                                       .pfunc = (void*)JsObjMap_contains };
+    goto skip_container_slots;
+  }
 
   if (flags & IS_ITERABLE) {
     // This uses `obj[Symbol.iterator]()`
@@ -2476,6 +2661,7 @@ JsProxy_create_subtype(int flags)
     slots[cur_slot++] =
       (PyType_Slot){ .slot = Py_sq_contains, .pfunc = (void*)JsProxy_has };
   }
+skip_container_slots:
 
   if (flags & IS_AWAITABLE) {
     slots[cur_slot++] =
@@ -2543,6 +2729,11 @@ JsProxy_create_subtype(int flags)
   if (flags & IS_DOUBLE_PROXY) {
     methods[cur_method++] = JsDoubleProxy_unwrap_MethodDef;
   }
+  if (!(flags & (IS_ARRAY | IS_TYPEDARRAY | IS_NODE_LIST | IS_BUFFER |
+                 IS_DOUBLE_PROXY | IS_ITERATOR))) {
+    methods[cur_method++] = JsProxy_as_object_map_MethodDef;
+  }
+
   methods[cur_method++] = (PyMethodDef){ 0 };
   members[cur_member++] = (PyMemberDef){ 0 };
 
@@ -2661,27 +2852,10 @@ EM_JS_NUM(int, JsProxy_array_detect, (JsRef idobj), {
 ////////////////////////////////////////////////////////////
 // Public functions
 
-/**
- * Create a JsProxy. In case it's a method, bind "this" to the argument. (In
- * most cases "this" will be NULL, `JsProxy_create` specializes to this case.)
- * We check what capabilities are present on the javascript object, set
- * appropriate flags, then we get the appropriate type with JsProxy_get_subtype.
- */
-PyObject*
-JsProxy_create_with_this(JsRef object, JsRef this)
+static int
+compute_typeflags(JsRef object)
 {
   int type_flags = 0;
-  bool success = false;
-  PyTypeObject* type = NULL;
-  PyObject* result = NULL;
-  if (hiwire_is_comlink_proxy(object)) {
-    // Comlink proxies are weird and break our feature detection pretty badly.
-    type_flags = IS_CALLABLE | IS_AWAITABLE | IS_ARRAY;
-    goto done_feature_detecting;
-  }
-  if (hiwire_is_error(object)) {
-    return JsProxy_new_error(object);
-  }
   if (hiwire_is_function(object)) {
     type_flags |= IS_CALLABLE;
   }
@@ -2719,8 +2893,15 @@ JsProxy_create_with_this(JsRef object, JsRef this)
     type_flags |= IS_DOUBLE_PROXY;
   }
   type_flags |= JsProxy_array_detect(object);
+  return type_flags;
+}
 
-done_feature_detecting:
+static PyObject*
+create_proxy_of_type(int type_flags, JsRef object, JsRef this)
+{
+  bool success = false;
+  PyTypeObject* type = NULL;
+  PyObject* result = NULL;
 
   type = JsProxy_get_subtype(type_flags);
   FAIL_IF_NULL(type);
@@ -2741,6 +2922,27 @@ finally:
     Py_CLEAR(result);
   }
   return result;
+}
+
+/**
+ * Create a JsProxy. In case it's a method, bind "this" to the argument. (In
+ * most cases "this" will be NULL, `JsProxy_create` specializes to this case.)
+ * We check what capabilities are present on the javascript object, set
+ * appropriate flags, then we get the appropriate type with JsProxy_get_subtype.
+ */
+PyObject*
+JsProxy_create_with_this(JsRef object, JsRef this)
+{
+  int type_flags = 0;
+  if (hiwire_is_comlink_proxy(object)) {
+    // Comlink proxies are weird and break our feature detection pretty badly.
+    type_flags = IS_CALLABLE | IS_AWAITABLE | IS_ARRAY;
+  } else if (hiwire_is_error(object)) {
+    return JsProxy_new_error(object);
+  } else {
+    type_flags = compute_typeflags(object);
+  }
+  return create_proxy_of_type(type_flags, object, this);
 }
 
 PyObject*
@@ -2815,6 +3017,7 @@ JsProxy_init(PyObject* core_module)
   SET_DOCSTRING(JsProxy_then_MethodDef);
   SET_DOCSTRING(JsProxy_catch_MethodDef);
   SET_DOCSTRING(JsProxy_finally_MethodDef);
+  SET_DOCSTRING(JsProxy_as_object_map_MethodDef);
   SET_DOCSTRING(JsArray_extend_MethodDef);
   SET_DOCSTRING(JsArray_reverse_MethodDef);
   SET_DOCSTRING(JsArray_reversed_MethodDef);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -63,6 +63,7 @@ _Py_IDENTIFIER(set_exception);
 _Py_IDENTIFIER(set_result);
 _Py_IDENTIFIER(__await__);
 _Py_IDENTIFIER(__dir__);
+_Py_IDENTIFIER(_js_type_flags);
 Js_IDENTIFIER(then);
 Js_IDENTIFIER(finally);
 Js_IDENTIFIER(has);
@@ -2548,6 +2549,7 @@ JsProxy_create_subtype(int flags)
   bool success = false;
   PyMethodDef* methods_heap = NULL;
   PyObject* bases = NULL;
+  PyObject* flags_obj = NULL;
   PyObject* result = NULL;
 
   // PyType_FromSpecWithBases copies "members" automatically into the end of the
@@ -2592,10 +2594,15 @@ JsProxy_create_subtype(int flags)
     ((PyTypeObject*)result)->tp_vectorcall_offset =
       offsetof(JsProxy, vectorcall);
   }
+  flags_obj = PyLong_FromLong(flags);
+  FAIL_IF_NULL(flags_obj);
+  FAIL_IF_MINUS_ONE(
+    _PyObject_SetAttrId(result, &PyId__js_type_flags, flags_obj));
 
   success = true;
 finally:
   Py_CLEAR(bases);
+  Py_CLEAR(flags_obj);
   if (!success && methods_heap != NULL) {
     PyMem_Free(methods_heap);
   }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1510,17 +1510,7 @@ create_proxy_of_type(int type_flags, JsRef object, JsRef this);
 static PyObject*
 JsProxy_as_object_map(PyObject* self, PyObject* Py_UNUSED(ignored))
 {
-  PyObject* type_flags_obj =
-    _PyObject_GetAttrId((PyObject*)Py_TYPE(self), &PyId__js_type_flags);
-  if (type_flags_obj == NULL) {
-    return NULL;
-  }
-  int type_flags = PyLong_AsLong(type_flags_obj);
-  Py_CLEAR(type_flags_obj);
-  if (type_flags == -1) {
-    return NULL;
-  }
-  type_flags |= IS_OBJECT_MAP;
+  int type_flags = IS_OBJECT_MAP;
   return create_proxy_of_type(
     type_flags, JsProxy_REF(self), JsMethod_THIS(self));
 }

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -67,6 +67,13 @@ class JsProxy:
     def object_values(self) -> "JsProxy":
         "The JavaScript API ``Object.values(object)``"
 
+    def as_object_map(self) -> "JsProxy":
+        """Makes returns a new JsProxy that treats the object as a map.
+
+        The methods ``__getitem__``, ``__setitem__``, ``__contains__``,
+        ``__len__``, etc will perform lookups via ``object[key]`` or similar.
+        """
+
     def new(self, *args: Any, **kwargs: Any) -> "JsProxy":
         """Construct a new instance of the JavaScript object"""
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -68,10 +68,14 @@ class JsProxy:
         "The JavaScript API ``Object.values(object)``"
 
     def as_object_map(self) -> "JsProxy":
-        """Makes returns a new JsProxy that treats the object as a map.
+        """Returns a new JsProxy that treats the object as a map.
 
         The methods ``__getitem__``, ``__setitem__``, ``__contains__``,
         ``__len__``, etc will perform lookups via ``object[key]`` or similar.
+
+        Note that ``len(x.as_object_map())`` evaluates in O(n) time (it iterates
+        over the object and counts how many ownKeys it has). If you need to
+        compute the length in O(1) time, use a real ``Map`` instead.
         """
 
     def new(self, *args: Any, **kwargs: Any) -> "JsProxy":

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1293,3 +1293,28 @@ def test_jsproxy_descr_get(selenium):
     assert t.f("a") == 7
     assert t.f("b") == 66
     assert t.f("c") is None
+
+
+@run_in_pyodide
+def test_jsproxy_as_object_method(selenium):
+    from pyodide.code import run_js
+
+    o = run_js("({a : 2, b: 3, c: 77, 1 : 9})").as_object_method()
+    assert len(o) == 4
+    assert set(o) == {"a", "b", "c", "1"}
+    assert "a" in o
+    assert "b" in o
+    assert "1" in o
+    assert 1 not in o
+    assert o["a"] == 2
+    assert o["1"] == 9
+    del o["a"]
+    assert "a" not in o
+    assert not hasattr(o, "a")
+    assert hasattr(o, "b")
+    assert len(o) == 3
+    assert set(o) == {"b", "c", "1"}
+    o["d"] = 36
+    assert len(o) == 4
+    assert o["d"] == 36
+    assert "constructor" not in o

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1296,10 +1296,12 @@ def test_jsproxy_descr_get(selenium):
 
 
 @run_in_pyodide
-def test_jsproxy_as_object_method(selenium):
+def test_jsproxy_as_object_map(selenium):
+    import pytest
+
     from pyodide.code import run_js
 
-    o = run_js("({a : 2, b: 3, c: 77, 1 : 9})").as_object_method()
+    o = run_js("({a : 2, b: 3, c: 77, 1 : 9})").as_object_map()
     assert len(o) == 4
     assert set(o) == {"a", "b", "c", "1"}
     assert "a" in o
@@ -1316,5 +1318,14 @@ def test_jsproxy_as_object_method(selenium):
     assert set(o) == {"b", "c", "1"}
     o["d"] = 36
     assert len(o) == 4
+    with pytest.raises(
+        TypeError, match="Can only assign keys of type string to JavaScript object map"
+    ):
+        o[1] = 2
+    assert len(o) == 4
+    assert set(o) == {"b", "c", "d", "1"}
     assert o["d"] == 36
     assert "constructor" not in o
+
+    with pytest.raises(KeyError):
+        del o[1]

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1301,7 +1301,11 @@ def test_jsproxy_as_object_map(selenium):
 
     from pyodide.code import run_js
 
-    o = run_js("({a : 2, b: 3, c: 77, 1 : 9})").as_object_map()
+    o1 = run_js("({a : 2, b: 3, c: 77, 1 : 9})")
+    with pytest.raises(TypeError, match="object is not subscriptable"):
+        o1["a"]
+    o = o1.as_object_map()
+    del o1
     assert len(o) == 4
     assert set(o) == {"a", "b", "c", "1"}
     assert "a" in o

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1330,6 +1330,7 @@ def test_jsproxy_as_object_map(selenium):
     assert set(o) == {"b", "c", "d", "1"}
     assert o["d"] == 36
     assert "constructor" not in o
+    assert o.to_py() == {"b": 3, "c": 77, "d": 36, "1": 9}
 
     with pytest.raises(KeyError):
         del o[1]


### PR DESCRIPTION
This adds a method which returns a new JsProxy that acts like a container of the JavaScript object's `ownProperties`.

See #3267

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
