### PR TITLE
Pin setuptools version temporarily

### DIFF
--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -76,6 +76,7 @@ def install_reqs(env: IsolatedEnv, reqs: set[str]) -> None:
         [
             "cython",
             "pythran",
+            "setuptools<65.6.0",  # https://github.com/pypa/setuptools/issues/3693
         ]
     )
 


### PR DESCRIPTION
A new setuptools release `65.6.0` breaks numpy build.

This is a temporary fix to make CI pass.

See: https://github.com/pypa/setuptools/issues/3693