### PR TITLE
Fix docstring error when loadPyodide is called with -OO option

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -121,6 +121,8 @@ substitutions:
 - {{ Fix }} Fixed bug in `split` argument of {any}`repr_shorten`. Added {any}`shorten` function.
   {pr}`3178`
 
+- {{ Fix }} Pyodide now loads correctly with `-OO` option.
+
 - Add Gitpod configuration to the repository.
   {pr} `3201`
 

--- a/src/py/_pyodide/docstring.py
+++ b/src/py/_pyodide/docstring.py
@@ -45,4 +45,6 @@ def get_cmeth_docstring(func):
         param._annotation = _empty  # type: ignore[attr-defined]
     sig._return_annotation = _empty  # type: ignore[attr-defined]
 
-    return func.__name__ + str(sig) + "\n--\n\n" + dedent_docstring(func.__doc__)
+    docstring = dedent_docstring(func.__doc__) if func.__doc__ is not None else ""
+
+    return func.__name__ + str(sig) + "\n--\n\n" + docstring

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1405,6 +1405,20 @@ def test_args(selenium_standalone_noload):
     )
 
 
+def test_args_OO(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+    doc = selenium.run_js(
+        """
+        let pyodide = await loadPyodide({
+            args: ['-OO']
+        });
+        pyodide.runPython(`import sys; sys.__doc__`)
+        """
+    )
+
+    assert not doc
+
+
 @pytest.mark.xfail_browsers(chrome="Node only", firefox="Node only", safari="Node only")
 def test_relative_index_url(selenium, tmp_path):
     tmp_dir = Path(tmp_path)


### PR DESCRIPTION
### Description

Related: #3211

When `loadPyodide` is called with `-OO` ({args: ["-OO"]}), which strips out all docstrings, it fails with error:

![image](https://user-images.githubusercontent.com/24893111/203450976-61b7c756-4fb0-40e9-8b3a-95a3cd2f0e12.png)

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
