### PR TITLE
NFC Improve and simplify compute_typeflags function in jsproxy.c

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -625,10 +625,6 @@ EM_JS_BOOL(bool, hiwire_get_bool, (JsRef idobj), {
   // clang-format on
 });
 
-EM_JS_BOOL(bool, hiwire_is_pyproxy, (JsRef idobj), {
-  return API.isPyProxy(Hiwire.get_value(idobj));
-});
-
 EM_JS_BOOL(bool, hiwire_is_function, (JsRef idobj), {
   // clang-format off
   return typeof Hiwire.get_value(idobj) === 'function';
@@ -690,13 +686,6 @@ MAKE_OPERATOR(not_equal, !==);
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
-EM_JS_BOOL(bool, hiwire_is_iterator, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  // clang-format off
-  return typeof jsobj.next === 'function';
-  // clang-format on
-});
-
 EM_JS_NUM(int, hiwire_next, (JsRef idobj, JsRef* result_ptr), {
   let jsobj = Hiwire.get_value(idobj);
   // clang-format off
@@ -705,13 +694,6 @@ EM_JS_NUM(int, hiwire_next, (JsRef idobj, JsRef* result_ptr), {
   let result_id = Hiwire.new_value(value);
   DEREF_U32(result_ptr, 0) = result_id;
   return done;
-});
-
-EM_JS_BOOL(bool, hiwire_is_iterable, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  // clang-format off
-  return typeof jsobj[Symbol.iterator] === 'function';
-  // clang-format on
 });
 
 EM_JS_REF(JsRef, hiwire_get_iterator, (JsRef idobj), {
@@ -748,13 +730,6 @@ EM_JS_REF(JsRef, hiwire_reversed_iterator, (JsRef idarray), {
 
   return Hiwire.new_value(new Module._reversedIterator(array));
 })
-
-EM_JS_BOOL(bool, hiwire_is_typedarray, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  // clang-format off
-  return ArrayBuffer.isView(jsobj) || (jsobj.constructor && jsobj.constructor.name === "ArrayBuffer");
-  // clang-format on
-});
 
 EM_JS_NUM(errcode, hiwire_assign_to_ptr, (JsRef idobj, void* ptr), {
   let jsobj = Hiwire.get_value(idobj);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -309,12 +309,6 @@ bool
 hiwire_get_bool(JsRef idobj);
 
 /**
- * Check whether the object is a PyProxy.
- */
-bool
-hiwire_is_pyproxy(JsRef idobj);
-
-/**
  * Check if the object is a function.
  */
 bool
@@ -407,12 +401,6 @@ bool
 hiwire_greater_than_equal(JsRef ida, JsRef idb);
 
 /**
- * Check if `typeof obj.next === "function"`
- */
-bool
-hiwire_is_iterator(JsRef idobj);
-
-/**
  * Calls the `next` function on an iterator.
  *
  * Returns -1 if an error occurs. Otherwise, `next` should return an object with
@@ -421,12 +409,6 @@ hiwire_is_iterator(JsRef idobj);
  */
 int
 hiwire_next(JsRef idobj, JsRef* result);
-
-/**
- * Check if `typeof obj[Symbol.iterator] === "function"`
- */
-bool
-hiwire_is_iterable(JsRef idobj);
 
 /**
  * Returns the iterator associated with the given object, if any.
@@ -439,12 +421,6 @@ hiwire_get_iterator(JsRef idobj);
  */
 JsRef
 hiwire_reversed_iterator(JsRef idobj);
-
-/**
- * Returns 1 if the value is a typedarray.
- */
-bool
-hiwire_is_typedarray(JsRef idobj);
 
 /**
  * Copies the buffer contents of a given ArrayBuffer view or ArrayBuffer into

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -115,6 +115,10 @@ JS_FILE(js2python_init, () => {
     } else if (value === false) {
       return __js2python_false();
     } else if (API.isPyProxy(value)) {
+      if (value.$$.ptr == 0) {
+        // Make sure to throw an error!
+        Module.PyProxy_getPtr(value);
+      }
       if (value.$$props.roundtrip) {
         if (id === undefined) {
           id = Hiwire.new_value(value);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2826,14 +2826,14 @@ finally:
 EM_JS_NUM(int, compute_typeflags, (JsRef idobj), {
   let obj = Hiwire.get_value(idobj);
   let type_flags = 0;
-  if (API.isPyProxy(obj)&& obj.$$.ptr == = 0) {
+  // clang-format off
+  if (API.isPyProxy(obj) && obj.$$.ptr === 0) {
     return 0;
   }
 
   const constructorName = obj.constructor ? obj.constructor.name : "";
   let typeTag = Object.prototype.toString.call(obj);
 
-  // clang-format off
   SET_FLAG_IF(IS_CALLABLE, typeof obj === "function")
   SET_FLAG_IF(IS_AWAITABLE, typeof obj.then === 'function')
   SET_FLAG_IF(IS_ITERABLE, typeof obj[Symbol.iterator] === 'function')

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3044,20 +3044,24 @@ JsProxy_init(PyObject* core_module)
   FAIL_IF_MINUS_ONE(JsProxy_init_docstrings());
   FAIL_IF_MINUS_ONE(PyModule_AddFunctions(core_module, methods));
 
-  PyModule_AddIntMacro(core_module, IS_ITERABLE);
-  PyModule_AddIntMacro(core_module, IS_ITERATOR);
-  PyModule_AddIntMacro(core_module, HAS_LENGTH);
-  PyModule_AddIntMacro(core_module, HAS_GET);
-  PyModule_AddIntMacro(core_module, HAS_SET);
-  PyModule_AddIntMacro(core_module, HAS_HAS);
-  PyModule_AddIntMacro(core_module, HAS_INCLUDES);
-  PyModule_AddIntMacro(core_module, IS_AWAITABLE);
-  PyModule_AddIntMacro(core_module, IS_BUFFER);
-  PyModule_AddIntMacro(core_module, IS_CALLABLE);
-  PyModule_AddIntMacro(core_module, IS_ARRAY);
-  PyModule_AddIntMacro(core_module, IS_NODE_LIST);
-  PyModule_AddIntMacro(core_module, IS_TYPEDARRAY);
-  PyModule_AddIntMacro(core_module, IS_DOUBLE_PROXY);
+#define AddFlag(flag) FAIL_IF_MINUS_ONE(PyModule_AddIntMacro(core_module, flag))
+
+  AddFlag(IS_ITERABLE);
+  AddFlag(IS_ITERATOR);
+  AddFlag(HAS_LENGTH);
+  AddFlag(HAS_GET);
+  AddFlag(HAS_SET);
+  AddFlag(HAS_HAS);
+  AddFlag(HAS_INCLUDES);
+  AddFlag(IS_AWAITABLE);
+  AddFlag(IS_BUFFER);
+  AddFlag(IS_CALLABLE);
+  AddFlag(IS_ARRAY);
+  AddFlag(IS_NODE_LIST);
+  AddFlag(IS_TYPEDARRAY);
+  AddFlag(IS_DOUBLE_PROXY);
+
+#undef AddFlag
 
   asyncio_module = PyImport_ImportModule("asyncio");
   FAIL_IF_NULL(asyncio_module);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2819,11 +2819,8 @@ finally:
 }
 
 #define SET_FLAG_IF(flag, cond)                                                \
-  try {                                                                        \
-    if (cond) {                                                                \
-      type_flags |= flag                                                       \
-    }                                                                          \
-  } catch (e) {                                                                \
+  if (cond) {                                                                  \
+    type_flags |= flag                                                         \
   }
 
 EM_JS_NUM(int, compute_typeflags, (JsRef idobj), {
@@ -2907,6 +2904,11 @@ JsProxy_create_with_this(JsRef object, JsRef this)
     return JsProxy_new_error(object);
   } else {
     type_flags = compute_typeflags(object);
+    if (type_flags == -1) {
+      PyErr_SetString(internal_error,
+                      "Internal error occurred in compute_typeflags");
+      return NULL;
+    }
   }
   return create_proxy_of_type(type_flags, object, this);
 }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2826,6 +2826,9 @@ finally:
 EM_JS_NUM(int, compute_typeflags, (JsRef idobj), {
   let obj = Hiwire.get_value(idobj);
   let type_flags = 0;
+  if (API.isPyProxy(obj)&& obj.$$.ptr == = 0) {
+    return 0;
+  }
 
   const constructorName = obj.constructor ? obj.constructor.name : "";
   let typeTag = Object.prototype.toString.call(obj);
@@ -3044,7 +3047,8 @@ JsProxy_init(PyObject* core_module)
   FAIL_IF_MINUS_ONE(JsProxy_init_docstrings());
   FAIL_IF_MINUS_ONE(PyModule_AddFunctions(core_module, methods));
 
-#define AddFlag(flag) FAIL_IF_MINUS_ONE(PyModule_AddIntMacro(core_module, flag))
+#define AddFlag(flag)                                                          \
+  FAIL_IF_MINUS_ONE(PyModule_AddIntConstant(core_module, #flag, flag))
 
   AddFlag(IS_ITERABLE);
   AddFlag(IS_ITERATOR);

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -786,7 +786,7 @@ to_js(PyObject* self,
   js_result = python2js_custom(
     obj, depth, proxies, js_dict_converter, js_default_converter);
   FAIL_IF_NULL(js_result);
-  if (hiwire_is_pyproxy(js_result)) {
+  if (pyproxy_Check(js_result)) {
     // Oops, just created a PyProxy. Wrap it I guess?
     py_result = JsProxy_create(js_result);
   } else {

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -688,7 +688,7 @@ def test_pass_destroyed_value(selenium):
     from pyodide.code import run_js
     from pyodide.ffi import JsException, create_proxy
 
-    f = run_js("(function(x){ })")
+    f = run_js("(function(x){ return x; })")
     p = create_proxy([])
     p.destroy()
     with pytest.raises(JsException, match='The object was of type "list" and had repr'):

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -682,7 +682,7 @@ def test_create_proxy_roundtrip(selenium):
 
 
 @run_in_pyodide
-def test_pass_destroyed_value(selenium):
+def test_return_destroyed_value(selenium):
     import pytest
 
     from pyodide.code import run_js

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -681,25 +681,20 @@ def test_create_proxy_roundtrip(selenium):
     run_js("(o) => { o.f.destroy(); }")(o)
 
 
+@run_in_pyodide
 def test_return_destroyed_value(selenium):
-    selenium.run_js(
-        r"""
-        self.f = function(x){ return x };
-        pyodide.runPython(`
-            from pyodide.ffi import create_proxy, JsException
-            from js import f
-            p = create_proxy([])
-            p.destroy()
-            try:
-                f(p)
-            except JsException as e:
-                assert str(e) == (
-                    "Error: Object has already been destroyed\\n"
-                    'The object was of type "list" and had repr "[]"'
-                )
-        `);
-        """
-    )
+    import pytest
+
+    from pyodide.code import run_js
+    from pyodide.ffi import JsException, create_proxy
+
+    f = run_js("(function(x){ return x })")
+    p = create_proxy([])
+    p.destroy()
+    with pytest.raises(
+        JsException, match='The object was of type "list" and had repr "[]"'
+    ):
+        f(p)
 
 
 def test_docstrings_a():

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -682,18 +682,16 @@ def test_create_proxy_roundtrip(selenium):
 
 
 @run_in_pyodide
-def test_return_destroyed_value(selenium):
+def test_pass_destroyed_value(selenium):
     import pytest
 
     from pyodide.code import run_js
     from pyodide.ffi import JsException, create_proxy
 
-    f = run_js("(function(x){ return x })")
+    f = run_js("(function(x){ })")
     p = create_proxy([])
     p.destroy()
-    with pytest.raises(
-        JsException, match='The object was of type "list" and had repr "[]"'
-    ):
+    with pytest.raises(JsException, match='The object was of type "list" and had repr'):
         f(p)
 
 


### PR DESCRIPTION
This improves `compute_typeflags` by moving the implementation
into JavaScript. This makes it more readable (because the conditions
are all in one place right next to each other rather than spread through
`hiwire.c`) and faster (because we don't have to call 15 different JavaScript
functions).