### PR TITLE
Add type field to PythonError

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -142,7 +142,10 @@ substitutions:
 - {{ Fix }} Pyodide now loads correctly with `-OO` option.
 
 - Add Gitpod configuration to the repository.
-  {pr} `3201`
+  {pr}`3201`
+
+- {{ Enhancement }} Added a type field to `PythonError`
+  {pr}`3289`
 
 ### Build System / Package Loading
 

--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -24,6 +24,19 @@ from sphinx_js.typedoc import Analyzer as TsAnalyzer
 _orig_convert_node = TsAnalyzer._convert_node
 _orig_type_name = TsAnalyzer._type_name
 
+_orig_constructor_and_members = TsAnalyzer._constructor_and_members
+
+
+def _constructor_and_members(self, cls):
+    result = _orig_constructor_and_members(self, cls)
+    for tag in cls.get("comment", {}).get("tags", []):
+        if tag["tag"] == "hideconstructor":
+            return (None, result[1])
+    return result
+
+
+TsAnalyzer._constructor_and_members = _constructor_and_members
+
 
 def destructure_param(param: dict[str, Any]) -> list[dict[str, Any]]:
     """We want to document a destructured argument as if it were several

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -277,12 +277,14 @@ export class PythonError extends Error {
    * @private
    */
   __error_address: number;
+  type: string;
 
-  constructor(message: string, error_address: number) {
+  constructor(type: string, message: string, error_address: number) {
     const oldLimit = Error.stackTraceLimit;
     Error.stackTraceLimit = Infinity;
     super(message);
     Error.stackTraceLimit = oldLimit;
+    this.type = type;
     this.__error_address = error_address;
   }
 }

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -260,7 +260,7 @@ Module.handle_js_error = function (e: any) {
  *
  * See :ref:`type-translations-errors` for more information.
  *
- * .. admonition:: Avoid Stack Frames
+ * .. admonition:: Avoid leaking stack Frames
  *    :class: warning
  *
  *    If you make a :any:`PyProxy` of ``sys.last_value``, you should be
@@ -268,6 +268,8 @@ Module.handle_js_error = function (e: any) {
  *    done. You may leak a large amount of memory including the local
  *    variables of all the stack frames in the traceback if you don't. The
  *    easiest way is to only handle the exception in Python.
+ *
+ * @hideconstructor
  */
 export class PythonError extends Error {
   /**  The address of the error we are wrapping. We may later compare this
@@ -277,8 +279,10 @@ export class PythonError extends Error {
    * @private
    */
   __error_address: number;
+  /**
+   * The Python type, e.g, ``RuntimeError`` or ``KeyError``.
+   */
   type: string;
-
   constructor(type: string, message: string, error_address: number) {
     const oldLimit = Error.stackTraceLimit;
     Error.stackTraceLimit = Infinity;

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1554,3 +1554,17 @@ def test_static_import(
             `);
             """
         )
+
+
+def test_python_error(selenium):
+    [msg, ty] = selenium.run_js(
+        """
+        try {
+            pyodide.runPython("raise TypeError('oops')");
+        } catch(e) {
+            return [e.message, e.type];
+        }
+        """
+    )
+    assert msg.endswith("TypeError: oops\n")
+    assert ty == "TypeError"


### PR DESCRIPTION
This adds a new `error.type` field to `PythonError` exceptions which contains `type(e).__qualname__`.

### Checklists


- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
