### PR TITLE
NFC Add getTypeTag helper function

### DIFF
--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -15,9 +15,8 @@ function ensureCaughtObjectIsError(e: any): Error {
     typeof e.message !== "string"
   ) {
     // We caught something really weird. Be brave!
-    let msg = `A value of type ${typeof e} with tag ${Object.prototype.toString.call(
-      e,
-    )} was thrown as an error!`;
+    const typeTag = getTypeTag(e);
+    let msg = `A value of type ${typeof e} with tag ${typeTag} was thrown as an error!`;
     try {
       msg += `\nString interpolation of the thrown value gives """${e}""".`;
     } catch (e) {

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -624,7 +624,7 @@ EM_JS_BOOL(bool, hiwire_get_bool, (JsRef idobj), {
   }
   // We want to return false on container types with size 0.
   if (val.size === 0) {
-    if(/HTML[A-Za-z]*Element/.test(Object.prototype.toString.call(val))){
+    if(/HTML[A-Za-z]*Element/.test(getTypeTag(val))){
       // HTMLSelectElement and HTMLInputElement can have size 0 but we still
       // want to return true.
       return true;
@@ -650,7 +650,7 @@ EM_JS_BOOL(bool, hiwire_is_function, (JsRef idobj), {
 
 EM_JS_BOOL(bool, hiwire_is_generator, (JsRef idobj), {
   // clang-format off
-  return Object.prototype.toString.call(Hiwire.get_value(idobj)) === "[object Generator]";
+  return getTypeTag(Hiwire.get_value(idobj)) === "[object Generator]";
   // clang-format on
 });
 
@@ -806,7 +806,7 @@ EM_JS_BOOL(bool, JsArray_Check, (JsRef idobj), {
   if (Array.isArray(obj)) {
     return true;
   }
-  let typeTag = Object.prototype.toString.call(obj);
+  let typeTag = getTypeTag(obj);
   // We want to treat some standard array-like objects as Array.
   // clang-format off
   if(typeTag === "[object HTMLCollection]" || typeTag === "[object NodeList]"){

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -259,7 +259,7 @@ JS_FILE(js2python_init, () => {
    * returned `undefined`.
    */
   function js2python_convertOther(id, value, context) {
-    let toStringTag = Object.prototype.toString.call(value);
+    let typeTag = getTypeTag(value);
     if (
       Array.isArray(value) ||
       value === "[object HTMLCollection]" ||
@@ -267,21 +267,21 @@ JS_FILE(js2python_init, () => {
     ) {
       return js2python_convertList(value, context);
     }
-    if (toStringTag === "[object Map]" || value instanceof Map) {
+    if (typeTag === "[object Map]" || value instanceof Map) {
       checkBoolIntCollision(value, "Map");
       return js2python_convertMap(value, value.entries(), context);
     }
-    if (toStringTag === "[object Set]" || value instanceof Set) {
+    if (typeTag === "[object Set]" || value instanceof Set) {
       checkBoolIntCollision(value, "Set");
       return js2python_convertSet(value, context);
     }
     if (
-      toStringTag === "[object Object]" &&
+      typeTag === "[object Object]" &&
       (value.constructor === undefined || value.constructor.name === "Object")
     ) {
       return js2python_convertMap(value, Object.entries(value), context);
     }
-    if (toStringTag === "[object ArrayBuffer]" || ArrayBuffer.isView(value)) {
+    if (typeTag === "[object ArrayBuffer]" || ArrayBuffer.isView(value)) {
       let [format_utf8, itemsize] = Module.get_buffer_datatype(value);
       return _JsBuffer_CopyIntoMemoryView(
         id,

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3567,7 +3567,7 @@ EM_JS_NUM(int, compute_typeflags, (JsRef idobj), {
   }
 
   const constructorName = obj.constructor ? obj.constructor.name : "";
-  let typeTag = Object.prototype.toString.call(obj);
+  let typeTag = getTypeTag(obj);
 
   SET_FLAG_IF(IS_CALLABLE, typeof obj === "function")
   SET_FLAG_IF(IS_AWAITABLE, typeof obj.then === 'function')

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -4,3 +4,5 @@ const Tests = {};
 API.tests = Tests;
 API.version = "0.22.0.dev0";
 Module.hiwire = Hiwire;
+const getTypeTag = (x) => Object.prototype.toString.call(x);
+API.getTypeTag = getTypeTag;

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -368,7 +368,7 @@ export function unpackArchive(
 ) {
   if (
     !ArrayBuffer.isView(buffer) &&
-    Object.prototype.toString.call(buffer) !== "[object ArrayBuffer]"
+    API.getTypeTag(buffer) !== "[object ArrayBuffer]"
   ) {
     throw new TypeError(
       `Expected argument 'buffer' to be an ArrayBuffer or an ArrayBuffer view`,


### PR DESCRIPTION
We use `Object.prototype.toString.call` a lot so I thought it would be good to add a helper function for this.
