### PR TITLE
Unpin host Python patch versions in GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: pre-commit/action@v2.0.3
 
   test-docs:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install requirements
         shell: bash -l {0}
         run: |
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install requirements
         shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10.2
+          python-version: 3.10
       - uses: pre-commit/action@v2.0.3
 
   test-docs:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10.2
+          python-version: 3.10
       - name: Install requirements
         shell: bash -l {0}
         run: |
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10.2
+          python-version: 3.10
 
       - name: Install requirements
         shell: bash -l {0}

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -8,9 +8,7 @@ emsdk/.complete: ../Makefile.envs $(wildcard patches/*.patch)
 	git clone --depth 1 https://github.com/emscripten-core/emsdk.git
 	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	cd emsdk/upstream/emscripten/ && cat ../../../patches/*.patch | patch -p1 --verbose
-	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION) \
-		--override-repository ccache-git-emscripten-64bit@https://github.com/ryanking13/ccache/tree/emscripten \
-		ccache-git-emscripten-64bit
+	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION) ccache-git-emscripten-64bit
 	cd emsdk && ./emsdk activate --embedded --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	touch emsdk/.complete
 

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -8,7 +8,9 @@ emsdk/.complete: ../Makefile.envs $(wildcard patches/*.patch)
 	git clone --depth 1 https://github.com/emscripten-core/emsdk.git
 	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	cd emsdk/upstream/emscripten/ && cat ../../../patches/*.patch | patch -p1 --verbose
-	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION) ccache-git-emscripten-64bit
+	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION) \
+		--override-repository ccache-git-emscripten-64bit@https://github.com/ryanking13/ccache/tree/emscripten \
+		ccache-git-emscripten-64bit
 	cd emsdk && ./emsdk activate --embedded --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	touch emsdk/.complete
 

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -12,7 +12,7 @@ from pyodide.console import Console, _CommandCompiler, _Compile  # noqa: E402
 
 def test_command_compiler():
     c = _Compile()
-    with pytest.raises(SyntaxError, match="invalid syntax"):
+    with pytest.raises(SyntaxError, match="(invalid syntax|incomplete input)"):
         c("def test():\n   1", "<input>", "single")
     assert isinstance(c("def test():\n   1\n", "<input>", "single"), CodeRunner)
     with pytest.raises(SyntaxError, match="invalid syntax"):
@@ -127,11 +127,13 @@ def test_interactive_console():
         import re
 
         err = fut.formatted_error or ""
-        err = re.sub(r"SyntaxError: .+", "SyntaxError: <errormsg>", err)
-        assert (
-            err
-            == '  File "<console>", line 1\n    1+\n      ^\nSyntaxError: <errormsg>\n'
-        )
+        err = re.sub(r"SyntaxError: .+", "SyntaxError: <errormsg>", err).strip()
+        assert [e.strip() for e in err.split("\n")] == [
+            'File "<console>", line 1',
+            "1+",
+            "^",
+            "SyntaxError: <errormsg>",
+        ]
 
         fut = shell.push("raise Exception('hi')")
         try:

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -123,9 +123,14 @@ def test_interactive_console():
         fut = shell.push("1+")
         assert fut.syntax_check == "syntax-error"
         assert fut.exception() is not None
+
+        import re
+
+        err = fut.formatted_error or ""
+        err = re.sub(r"SyntaxError: .+", "SyntaxError: <errormsg>", err)
         assert (
-            fut.formatted_error
-            == '  File "<console>", line 1\n    1+\n      ^\nSyntaxError: invalid syntax\n'
+            err
+            == '  File "<console>", line 1\n    1+\n      ^\nSyntaxError: <errormsg>\n'
         )
 
         fut = shell.push("raise Exception('hi')")

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -25,7 +25,7 @@ def test_command_compiler():
     c2 = _CommandCompiler()
     assert c2("def test():\n   1", "<input>", "single") is None
     assert isinstance(c2("def test():\n   1\n", "<input>", "single"), CodeRunner)
-    with pytest.raises(SyntaxError, match="invalid syntax"):
+    with pytest.raises(SyntaxError, match="(invalid syntax|incomplete input)"):
         c2("1<>2", "<input>", "single")
     assert isinstance(
         c2("from __future__ import barry_as_FLUFL", "<input>", "single"), CodeRunner


### PR DESCRIPTION
Resolve: #2006

`ubuntu 21.10` or `ubuntu 22.04` which comes with `glibc >= 2.34` had an API change:

```
* Add _SC_MINSIGSTKSZ and _SC_SIGSTKSZ.  When _DYNAMIC_STACK_SIZE_SOURCE
  or _GNU_SOURCE are defined, MINSIGSTKSZ and SIGSTKSZ are no longer
  constant on Linux.  MINSIGSTKSZ is redefined to sysconf(_SC_MINSIGSTKSZ)
  and SIGSTKSZ is redefined to sysconf (_SC_SIGSTKSZ).  This supports
  dynamic sized register sets for modern architectural features like
  Arm SVE.
``` 

This causes trouble when installing ccache port (juj/ccache) for emscripten.
This issue is fixed in upstream ccache but it is not applied to the port.

@wlach made a PR (https://github.com/juj/ccache/pull/2), but it didn't get a response.

This PR overrides ccache URL to my fork (interestingly emsdk supports overriding urls). I applied @wlach's patch to it. We can remove this when upstream ccache port gets updated.