### PR TITLE
Make fs timestamps have millisecond resolution rather than second resolution

### DIFF
--- a/emsdk/patches/0001-Actually-fill-in-tv_nsec-fields-of-stat-struct.patch
+++ b/emsdk/patches/0001-Actually-fill-in-tv_nsec-fields-of-stat-struct.patch
@@ -1,0 +1,31 @@
+From 50aeeda991f464e22ede556eb1647efea258adc4 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Thu, 1 Dec 2022 17:30:05 -0800
+Subject: [PATCH] Actually fill in tv_nsec fields of stat struct
+
+---
+ src/library_syscall.js | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/library_syscall.js b/src/library_syscall.js
+index 8f261ec92..400985062 100644
+--- a/src/library_syscall.js
++++ b/src/library_syscall.js
+@@ -62,11 +62,11 @@ var SyscallsLibrary = {
+       {{{ makeSetValue('buf', C_STRUCTS.stat.st_blksize, '4096', 'i32') }}};
+       {{{ makeSetValue('buf', C_STRUCTS.stat.st_blocks, 'stat.blocks', 'i32') }}};
+       {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_sec, 'Math.floor(stat.atime.getTime() / 1000)', 'i64') }}};
+-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_nsec, '0', SIZE_TYPE) }}};
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_nsec, '(stat.atime.getTime() % 1000) * 1000', SIZE_TYPE) }}};
+       {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_sec, 'Math.floor(stat.mtime.getTime() / 1000)', 'i64') }}};
+-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_nsec, '0', SIZE_TYPE) }}};
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_nsec, '(stat.atime.getTime() % 1000) * 1000', SIZE_TYPE) }}};
+       {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_sec, 'Math.floor(stat.ctime.getTime() / 1000)', 'i64') }}};
+-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_nsec, '0', SIZE_TYPE) }}};
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_nsec, '(stat.atime.getTime() % 1000) * 1000', SIZE_TYPE) }}};
+       {{{ makeSetValue('buf', C_STRUCTS.stat.st_ino, 'stat.ino', 'i64') }}};
+       return 0;
+     },
+-- 
+2.25.1
+

--- a/emsdk/patches/0001-Actually-fill-in-tv_nsec-fields-of-stat-struct.patch
+++ b/emsdk/patches/0001-Actually-fill-in-tv_nsec-fields-of-stat-struct.patch
@@ -1,28 +1,35 @@
-From 50aeeda991f464e22ede556eb1647efea258adc4 Mon Sep 17 00:00:00 2001
+From 04bd5e0a60e9f6497c238c43b09a50dd9f59b499 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 1 Dec 2022 17:30:05 -0800
 Subject: [PATCH] Actually fill in tv_nsec fields of stat struct
 
 ---
- src/library_syscall.js | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ src/library_syscall.js | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
 
 diff --git a/src/library_syscall.js b/src/library_syscall.js
-index 8f261ec92..400985062 100644
+index 8f261ec92..54130952a 100644
 --- a/src/library_syscall.js
 +++ b/src/library_syscall.js
-@@ -62,11 +62,11 @@ var SyscallsLibrary = {
+@@ -61,12 +61,15 @@ var SyscallsLibrary = {
+       {{{ makeSetValue('buf', C_STRUCTS.stat.st_size, 'stat.size', 'i64') }}};
        {{{ makeSetValue('buf', C_STRUCTS.stat.st_blksize, '4096', 'i32') }}};
        {{{ makeSetValue('buf', C_STRUCTS.stat.st_blocks, 'stat.blocks', 'i32') }}};
-       {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_sec, 'Math.floor(stat.atime.getTime() / 1000)', 'i64') }}};
+-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_sec, 'Math.floor(stat.atime.getTime() / 1000)', 'i64') }}};
 -      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_nsec, '0', SIZE_TYPE) }}};
-+      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_nsec, '(stat.atime.getTime() % 1000) * 1000', SIZE_TYPE) }}};
-       {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_sec, 'Math.floor(stat.mtime.getTime() / 1000)', 'i64') }}};
+-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_sec, 'Math.floor(stat.mtime.getTime() / 1000)', 'i64') }}};
 -      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_nsec, '0', SIZE_TYPE) }}};
-+      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_nsec, '(stat.atime.getTime() % 1000) * 1000', SIZE_TYPE) }}};
-       {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_sec, 'Math.floor(stat.ctime.getTime() / 1000)', 'i64') }}};
+-      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_sec, 'Math.floor(stat.ctime.getTime() / 1000)', 'i64') }}};
 -      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_nsec, '0', SIZE_TYPE) }}};
-+      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_nsec, '(stat.atime.getTime() % 1000) * 1000', SIZE_TYPE) }}};
++      var atime = stat.atime.getTime();
++      var mtime = stat.mtime.getTime();
++      var ctime = stat.ctime.getTime();
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_sec, 'Math.floor(atime / 1000)', 'i64') }}};
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_atim.tv_nsec, '(atime % 1000) * 1000', SIZE_TYPE) }}};
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_sec, 'Math.floor(mtime / 1000)', 'i64') }}};
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_mtim.tv_nsec, '(mtime % 1000) * 1000', SIZE_TYPE) }}};
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_sec, 'Math.floor(ctime / 1000)', 'i64') }}};
++      {{{ makeSetValue('buf', C_STRUCTS.stat.st_ctim.tv_nsec, '(ctime % 1000) * 1000', SIZE_TYPE) }}};
        {{{ makeSetValue('buf', C_STRUCTS.stat.st_ino, 'stat.ino', 'i64') }}};
        return 0;
      },


### PR DESCRIPTION
Resolves #3311. We can probably remove all the calls to `invalidate_caches` too...

Upstream PR: https://github.com/emscripten-core/emscripten/pull/18301

### Checklists


- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
