### PR TITLE
Fix markdown in doc

### DIFF
--- a/docs/development/building-and-testing-packages.md
+++ b/docs/development/building-and-testing-packages.md
@@ -78,7 +78,7 @@ work with binary packages.
 pyodide build
 # Install it
 pip install dist/the_wheel-cp310-cp310-emscripten_3_1_20_wasm32.whl[tests]
-````
+```
 
 To test, you can generally run the same script as you would usually do. For many
 packages this will be:

--- a/docs/development/building-and-testing-packages.md
+++ b/docs/development/building-and-testing-packages.md
@@ -65,8 +65,9 @@ Python and is sensitive to the current virtual environment will probably break.
 You can install whatever dependencies you need with pip. For a pure Python
 package, the following will work:
 
-````sh
+```sh
 pip install -e .
+```
 
 For a binary package, you will need to build a wheel with `pyodide build` and
 then point `pip` directly to the built wheel. For now, editable installs won't


### PR DESCRIPTION
### Description

The markdown is slightly wrong in 
https://pyodide.org/en/latest/development/building-and-testing-packages.html

Screenshot:
![image](https://user-images.githubusercontent.com/1680079/205590531-4b95d131-5688-43df-8aa4-4986e4b8454e.png)
