### PR TITLE
Update scikit-learn to 1.1.3

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -268,6 +268,8 @@ substitutions:
 
 - {{ Update }} Upgraded packages: numpy (1.23.5), {pr}`3284`
 
+- {{ Update }} Upgraded packages: scikit-learn (1.1.3), {pr}`3324`
+
 ## Version 0.21.3
 
 _September 15, 2022_

--- a/packages/scikit-learn/meta.yaml
+++ b/packages/scikit-learn/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: scikit-learn
-  version: 1.1.1
+  version: 1.1.3
   top-level:
     - sklearn
 source:
-  url: https://files.pythonhosted.org/packages/41/11/e931951f048908ceaf2423db48ca6ad10e0b818c2960a3bc2dacb4fa4c1d/scikit-learn-1.1.1.tar.gz
-  sha256: 3e77b71e8e644f86c8b5be7f1c285ef597de4c384961389ee3e9ca36c445b256
+  url: https://files.pythonhosted.org/packages/38/bc/319f789ce0988d9bf1379d6e40498dc119b30bec133bf76cd82ca549b69a/scikit-learn-1.1.3.tar.gz
+  sha256: bef51978a51ec19977700fe7b86aecea49c825884f3811756b74a3b152bb4e35
 
 build:
   cflags: -Wno-implicit-function-declaration


### PR DESCRIPTION
### Description

This upgrades scikit-learn to the latest released version.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
