### PR TITLE
Add support for `throw` and `return` to PyProxy of a generator

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -151,6 +151,11 @@ substitutions:
   JavaScript.
   {pr}`3290`
 
+- {{ Enhancement }} PyProxies of synchronous and asynchronous Python generators
+  now support `return` and `throw` APIs that behave like the ones on JavaScript
+  generators.
+  {pr}`3346`
+
 - {{ Enhancement }} Added `JsGenerator` and `JsIterator` types to `pyodide.ffi`.
   Added `send` method to `JsIterator`s and `throw`, and `close` methods to `JsGenerator`s.
   {pr}`3294`

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3715,7 +3715,7 @@ finally:
 
 #define SET_FLAG_IF(flag, cond)                                                \
   if (cond) {                                                                  \
-    type_flags |= flag                                                         \
+    type_flags |= flag;                                                        \
   }
 
 EM_JS_NUM(int, compute_typeflags, (JsRef idobj), {

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -14,10 +14,14 @@
 #define Py_ENTER()
 #define Py_EXIT()
 
+PyObject* Generator;
+PyObject* AsyncGenerator;
+
 _Py_IDENTIFIER(result);
 _Py_IDENTIFIER(ensure_future);
 _Py_IDENTIFIER(add_done_callback);
 _Py_IDENTIFIER(asend);
+_Py_IDENTIFIER(throw);
 
 // Use raw EM_JS for the next five commands. We intend to signal a fatal error
 // if a JavaScript error is thrown.
@@ -76,6 +80,8 @@ static PyObject* asyncio;
 #define IS_CALLABLE  (1 << 8)
 #define IS_ASYNC_ITERABLE (1 << 9)
 #define IS_ASYNC_ITERATOR (1 << 10)
+#define IS_GENERATOR (1 << 11)
+#define IS_ASYNC_GENERATOR (1 << 12)
 // clang-format on
 
 // Taken from genobject.c
@@ -121,11 +127,14 @@ pyproxy_getflags(PyObject* pyobj)
   PyBufferProcs* buffer_proto =
     obj_type->tp_as_buffer ? obj_type->tp_as_buffer : &null_buffer_proto;
 
+  bool success = false;
   int result = 0;
-  // PyObject_Size
-  if (seq_proto->sq_length || map_proto->mp_length) {
-    result |= HAS_LENGTH;
+#define SET_FLAG_IF(flag, cond)                                                \
+  if (cond) {                                                                  \
+    result |= flag;                                                            \
   }
+  // PyObject_Size
+  SET_FLAG_IF(HAS_LENGTH, seq_proto->sq_length || map_proto->mp_length);
   // PyObject_GetItem
   if (map_proto->mp_subscript || seq_proto->sq_item) {
     result |= HAS_GET;
@@ -137,45 +146,45 @@ pyproxy_getflags(PyObject* pyobj)
     }
   }
   // PyObject_SetItem
-  if (map_proto->mp_ass_subscript || seq_proto->sq_ass_item) {
-    result |= HAS_SET;
-  }
+  SET_FLAG_IF(HAS_SET, map_proto->mp_ass_subscript || seq_proto->sq_ass_item);
   // PySequence_Contains
-  if (seq_proto->sq_contains) {
-    result |= HAS_CONTAINS;
-  }
+  SET_FLAG_IF(HAS_CONTAINS, seq_proto->sq_contains);
   // PyObject_GetIter
-  if (obj_type->tp_iter || PySequence_Check(pyobj)) {
-    result |= IS_ITERABLE;
-  }
+  SET_FLAG_IF(IS_ITERABLE, obj_type->tp_iter || PySequence_Check(pyobj));
+  SET_FLAG_IF(IS_ASYNC_ITERABLE, async_proto->am_aiter);
   if (PyIter_Check(pyobj)) {
     result &= ~IS_ITERABLE;
     result |= IS_ITERATOR;
-  }
-  if (async_proto->am_aiter) {
-    result |= IS_ASYNC_ITERABLE;
   }
   if (async_proto->am_anext) {
     result &= ~IS_ASYNC_ITERABLE;
     result |= IS_ASYNC_ITERATOR;
   }
+
+  int isgen = PyObject_IsInstance(pyobj, Generator);
+  FAIL_IF_MINUS_ONE(isgen);
+  int isasyncgen = PyObject_IsInstance(pyobj, AsyncGenerator);
+  FAIL_IF_MINUS_ONE(isasyncgen);
+  SET_FLAG_IF(IS_GENERATOR, isgen);
+  SET_FLAG_IF(IS_ASYNC_GENERATOR, isasyncgen);
+
   // There's no CPython API that corresponds directly to the "await" keyword.
   // Looking at disassembly, "await" translates into opcodes GET_AWAITABLE and
   // YIELD_FROM. GET_AWAITABLE uses _PyCoro_GetAwaitableIter defined in
   // genobject.c. This tests whether _PyCoro_GetAwaitableIter is likely to
   // succeed.
-  if (async_proto->am_await || gen_is_coroutine(pyobj)) {
-    result |= IS_AWAITABLE;
-  }
-  if (buffer_proto->bf_getbuffer) {
-    result |= IS_BUFFER;
-  }
+  SET_FLAG_IF(IS_AWAITABLE, async_proto->am_await || gen_is_coroutine(pyobj));
+  SET_FLAG_IF(IS_BUFFER, buffer_proto->bf_getbuffer);
   // PyObject_Call (from call.c)
-  if (_PyVectorcall_Function(pyobj) || PyCFunction_Check(pyobj) ||
-      obj_type->tp_call) {
-    result |= IS_CALLABLE;
-  }
-  return result;
+  SET_FLAG_IF(IS_CALLABLE,
+              _PyVectorcall_Function(pyobj) || PyCFunction_Check(pyobj) ||
+                obj_type->tp_call);
+
+#undef SET_FLAG_IF
+
+  success = true;
+finally:
+  return success ? result : -1;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -625,6 +634,80 @@ finally:
   if (!success) {
     status = PYGEN_ERROR;
   }
+  return status;
+}
+
+PySendResult
+_pyproxyGen_return(PyObject* receiver, JsRef jsval, JsRef* result)
+{
+  bool success = false;
+  PySendResult status = PYGEN_ERROR;
+  PyObject* pyresult;
+
+  // Throw GeneratorExit into generator
+  pyresult =
+    _PyObject_CallMethodIdOneArg(receiver, &PyId_throw, PyExc_GeneratorExit);
+  if (pyresult == NULL) {
+    if (PyErr_ExceptionMatches(PyExc_GeneratorExit)) {
+      // If GeneratorExit comes back out, return original value.
+      PyErr_Clear();
+      status = PYGEN_RETURN;
+      hiwire_incref(jsval);
+      *result = jsval;
+      success = true;
+      goto finally;
+    }
+    //
+    FAIL_IF_MINUS_ONE(_PyGen_FetchStopIterationValue(&pyresult));
+    status = PYGEN_RETURN;
+  } else {
+    status = PYGEN_NEXT;
+  }
+  *result = python2js(pyresult);
+  FAIL_IF_NULL(*result);
+  success = true;
+finally:
+  if (!success) {
+    status = PYGEN_ERROR;
+  }
+  Py_CLEAR(pyresult);
+  return status;
+}
+
+PySendResult
+_pyproxyGen_throw(PyObject* receiver, JsRef jsval, JsRef* result)
+{
+  bool success = false;
+  PyObject* pyvalue = NULL;
+  PyObject* pyresult = NULL;
+  PySendResult status = PYGEN_ERROR;
+
+  pyvalue = js2python(jsval);
+  FAIL_IF_NULL(pyvalue);
+  if (!PyExceptionInstance_Check(pyvalue)) {
+    /* Not something you can raise.  throw() fails. */
+    PyErr_Format(PyExc_TypeError,
+                 "exceptions must be classes or instances "
+                 "deriving from BaseException, not %s",
+                 Py_TYPE(pyvalue)->tp_name);
+    FAIL();
+  }
+  pyresult = _PyObject_CallMethodIdOneArg(receiver, &PyId_throw, pyvalue);
+  if (pyresult == NULL) {
+    FAIL_IF_MINUS_ONE(_PyGen_FetchStopIterationValue(&pyresult));
+    status = PYGEN_RETURN;
+  } else {
+    status = PYGEN_NEXT;
+  }
+  *result = python2js(pyresult);
+  FAIL_IF_NULL(*result);
+  success = true;
+finally:
+  if (!success) {
+    status = PYGEN_ERROR;
+  }
+  Py_CLEAR(pyresult);
+  Py_CLEAR(pyvalue);
   return status;
 }
 
@@ -1163,7 +1246,17 @@ pyproxy_init(PyObject* core)
 {
   bool success = false;
 
-  PyObject* docstring_source = PyImport_ImportModule("_pyodide._core_docs");
+  PyObject* collections_abc = NULL;
+  PyObject* docstring_source = NULL;
+
+  collections_abc = PyImport_ImportModule("collections.abc");
+  FAIL_IF_NULL(collections_abc);
+  Generator = PyObject_GetAttrString(collections_abc, "Generator");
+  FAIL_IF_NULL(Generator);
+  AsyncGenerator = PyObject_GetAttrString(collections_abc, "AsyncGenerator");
+  FAIL_IF_NULL(AsyncGenerator);
+
+  docstring_source = PyImport_ImportModule("_pyodide._core_docs");
   FAIL_IF_NULL(docstring_source);
   FAIL_IF_MINUS_ONE(
     add_methods_and_set_docstrings(core, methods, docstring_source));
@@ -1174,5 +1267,6 @@ pyproxy_init(PyObject* core)
   success = true;
 finally:
   Py_CLEAR(docstring_source);
+  Py_CLEAR(collections_abc);
   return success ? 0 : -1;
 }

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1037,8 +1037,8 @@ export class PyProxyGeneratorMethods {
   /**
    * Throws an exception into the Generator.
    *
-   * See the documentation for `Generator.prototype.return
-   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return>_`.
+   * See the documentation for `Generator.prototype.throw
+   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/throw>_`.
    *
    * @param exception Error The error to throw into the generator. Must be an
    * instanceof ``Error``.
@@ -1157,6 +1157,20 @@ export class PyProxyAsyncIteratorMethods {
 }
 
 export class PyProxyAsyncGeneratorMethods {
+  /**
+   * Throws an exception into the Generator.
+   *
+   * See the documentation for `Generator.prototype.throw
+   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/throw>_`.
+   *
+   * @param exception Error The error to throw into the generator. Must be an
+   * instanceof ``Error``.
+   * @returns An Object with two properties: ``done`` and ``value``. When the
+   * generator yields ``some_value``, ``return`` returns ``{done : false, value
+   * : some_value}``. When the generator raises a
+   * ``StopIteration(result_value)`` exception, ``return`` returns ``{done :
+   * true, value : result_value}``.
+   */
   async throw(exc: any): Promise<IteratorResult<any, any>> {
     let idarg = Hiwire.new_value(exc);
     let idresult;

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1034,6 +1034,20 @@ export class PyProxyIteratorMethods {
 }
 
 export class PyProxyGeneratorMethods {
+  /**
+   * Throws an exception into the Generator.
+   *
+   * See the documentation for `Generator.prototype.return
+   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return>_`.
+   *
+   * @param exception Error The error to throw into the generator. Must be an
+   * instanceof ``Error``.
+   * @returns An Object with two properties: ``done`` and ``value``. When the
+   * generator yields ``some_value``, ``return`` returns ``{done : false, value
+   * : some_value}``. When the generator raises a
+   * ``StopIteration(result_value)`` exception, ``return`` returns ``{done :
+   * true, value : result_value}``.
+   */
   throw(exc: any): IteratorResult<any, any> {
     let idarg = Hiwire.new_value(exc);
     let status;
@@ -1060,18 +1074,22 @@ export class PyProxyGeneratorMethods {
   }
 
   /**
-   * This translates to the Python code ``gen.throw(StopIteration, value)``. Returns the next value of
-   * the generator. See the documentation for `Generator.prototype.return
-   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/next>`_.
-   * The return value will be sent to the Python generator.
+   * Throws a ``GeneratorExit`` into the generator and if the ``GeneratorExit``
+   * is not caught returns the argument value ``{done: true, value: v}``. If the
+   * generator catches the ``GeneratorExit`` and returns or yields another value
+   * the next value of the generator this is returned in the normal way. If it
+   * throws some error other than ``GeneratorExit`` or ``StopIteration``, that
+   * error is propagated. See the documentation for `Generator.prototype.return
+   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return>`_.
    *
    * Present only if the proxied Python object is a generator.
    *
    * @param any The value to return from the generator.
    * @returns An Object with two properties: ``done`` and ``value``. When the
-   * generator yields ``some_value``, ``return`` returns ``{done : false, value :
-   * some_value}``. When the generator raises a ``StopIteration(result_value)``
-   * exception, ``return`` returns ``{done : true, value : result_value}``.
+   * generator yields ``some_value``, ``return`` returns ``{done : false, value
+   * : some_value}``. When the generator raises a
+   * ``StopIteration(result_value)`` exception, ``return`` returns ``{done :
+   * true, value : result_value}``.
    */
   return(v: any): IteratorResult<any, any> {
     // Note: arg is optional, if arg is not supplied, it will be undefined
@@ -1174,17 +1192,20 @@ export class PyProxyAsyncGeneratorMethods {
   }
 
   /**
-   * This translates to the Python code ``gen.throw(StopIteration, value)``. Returns the next value of
-   * the generator. See the documentation for `Generator.prototype.return
-   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/next>`_.
-   * The return value will be sent to the Python generator.
+   * Throws a ``GeneratorExit`` into the generator and if the ``GeneratorExit``
+   * is not caught returns the argument value ``{done: true, value: v}``. If the
+   * generator catches the ``GeneratorExit`` and returns or yields another value
+   * the next value of the generator this is returned in the normal way. If it
+   * throws some error other than ``GeneratorExit`` or ``StopIteration``, that
+   * error is propagated. See the documentation for `Generator.prototype.return
+   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/return>`_.
    *
-   * Present only if the proxied Python object is a generator.
+   * Present only if the proxied Python object is an async generator.
    *
    * @param any The value to return from the generator.
    * @returns An Object with two properties: ``done`` and ``value``. When the
    * generator yields ``some_value``, ``return`` returns ``{done : false, value :
-   * some_value}``. When the generator raises a ``StopIteration(result_value)``
+   * some_value}``. When the generator raises a ``StopAsyncIteration(result_value)``
    * exception, ``return`` returns ``{done : true, value : result_value}``.
    */
   async return(v: any): Promise<IteratorResult<any, any>> {

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -1248,3 +1248,135 @@ async def test_async_gen(selenium):
         {"done": False, "value": 6},
         {"done": True, "value": None},
     ]
+
+
+@run_in_pyodide
+async def test_async_gen_return(selenium):
+    from pyodide.code import run_js
+
+    async def g1():
+        yield 1
+        yield 2
+
+    p = await run_js(
+        """
+        async (g) => {
+            let r = [];
+            r.push(await g.next());
+            r.push(await g.return(5));
+            return r;
+        }
+    """
+    )(g1())
+    assert p.to_py() == [{"done": False, "value": 1}, {"done": True, "value": 5}]
+
+    async def g2():
+        try:
+            yield 1
+            yield 2
+        finally:
+            yield 3  # noqa: B901
+            return  # noqa: B012, B901
+
+    p = await run_js(
+        """
+        async (g) => {
+            let r = [];
+            r.push(await g.next());
+            r.push(await g.return(5));
+            r.push(await g.next());
+            return r;
+        }
+    """
+    )(g2())
+    assert p.to_py() == [
+        {"done": False, "value": 1},
+        {"done": False, "value": 3},
+        {"done": True, "value": None},
+    ]
+
+    async def g3():
+        try:
+            yield 1
+            yield 2
+        finally:
+            return  # noqa: B901, B012
+
+    p = await run_js(
+        """
+        async (g) => {
+            let r = [];
+            r.push(await g.next());
+            r.push(await g.return(5));
+            return r;
+        }
+    """
+    )(g3())
+    assert p.to_py() == [{"done": False, "value": 1}, {"done": True, "value": None}]
+
+
+@run_in_pyodide
+async def test_async_gen_throw(selenium):
+    import pytest
+
+    from pyodide.code import run_js
+    from pyodide.ffi import JsException
+
+    async def g1():
+        yield 1
+        yield 2
+
+    p = run_js(
+        """
+        async (g) => {
+            await g.next();
+            await g.throw(new TypeError('hi'));
+        }
+    """
+    )
+    with pytest.raises(JsException, match="hi"):
+        await p(g1())
+
+    async def g2():
+        try:
+            yield 1
+            yield 2
+        finally:
+            yield 3
+            return  # noqa: B901, B012
+
+    p = await run_js(
+        """
+        async (g) => {
+            let r = [];
+            r.push(await g.next());
+            r.push(await g.throw(new TypeError('hi')));
+            r.push(await g.next());
+            return r;
+        }
+    """
+    )(g2())
+    assert p.to_py() == [
+        {"done": False, "value": 1},
+        {"done": False, "value": 3},
+        {"done": True, "value": None},
+    ]
+
+    async def g3():
+        try:
+            yield 1
+            yield 2
+        finally:
+            return  # noqa: B901, B012
+
+    p = await run_js(
+        """
+        async (g) => {
+            let r = [];
+            r.push(await g.next());
+            r.push(await g.throw(new TypeError('hi')));
+            return r;
+        }
+    """
+    )(g3())
+    assert p.to_py() == [{"done": False, "value": 1}, {"done": True, "value": None}]


### PR DESCRIPTION
Continuing the work on generator support, this adds throw and return to PyProxy of generators and async generators.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
