### PR TITLE
Update to micropip v0.2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 
+import micropip
+
 panels_add_bootstrap_css = False
 
 # -- Project information -----------------------------------------------------
@@ -33,6 +35,7 @@ else:
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
     "sphinxcontrib.napoleon",
     "myst_parser",
     "sphinx_js",
@@ -43,6 +46,7 @@ extensions = [
     "versionwarning.extension",
     "sphinx_issues",
 ]
+
 
 myst_enable_extensions = ["substitution"]
 
@@ -63,6 +67,10 @@ versionwarning_body_selector = "#main-content > div"
 
 autosummary_generate = True
 autodoc_default_flags = ["members", "inherited-members"]
+
+intersphinx_mapping = {
+    "micropip": (f"https://micropip.pyodide.org/en/v{micropip.__version__}/", None)
+}
 
 # Add modules to be mocked.
 mock_modules = ["ruamel.yaml", "tomli"]

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -13,4 +13,4 @@ sphinx-panels
 markupsafe<2.1.0
 pydantic
 # Version should be consistent with packages/micropip/meta.yaml
-micropip==0.1.0
+micropip==0.2.0

--- a/docs/usage/api-reference.md
+++ b/docs/usage/api-reference.md
@@ -6,6 +6,6 @@
 
    api/js-api.md
    api/python-api.md
-   api/micropip-api.md
+   Micropip API <https://micropip.pyodide.org/en/stable/project/api.html>
    api/pyodide-build-cli.md
 ```

--- a/docs/usage/api/micropip-api.md
+++ b/docs/usage/api/micropip-api.md
@@ -1,6 +1,3 @@
 # Micropip API
 
-```{eval-rst}
-.. automodule:: micropip
-   :members:
-```
+The Micropip documentation is now moved to [pyodide.micropip.org](https://micropip.pyodide.org/en/stable/).

--- a/docs/usage/api/micropip-api.md
+++ b/docs/usage/api/micropip-api.md
@@ -1,3 +1,3 @@
 # Micropip API
 
-The Micropip documentation is now moved to [pyodide.micropip.org](https://micropip.pyodide.org/en/stable/).
+The Micropip API documentation was moved to [pyodide.micropip.org](https://micropip.pyodide.org/en/stable/project/api.html).

--- a/packages/micropip/meta.yaml
+++ b/packages/micropip/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: micropip
   # This version needs to be consistent with docs/requirements-doc.txt
-  version: "0.1.0"
+  version: "0.2.0"
   _tag: pyodide.stdlib
   top-level:
     - micropip
 
 source:
-  sha256: 693a7fd7ce92fd95eaf9d88fe243f45951ad5c694cccf89493cbcc3666bbdeab
-  url: https://files.pythonhosted.org/packages/14/19/e5d36b2cc156c66858493dc118956f6fed2b1408e62be12e4ffed392b7cb/micropip-0.1.0-py3-none-any.whl
+  sha256: be2914a08e553e6d05cacde692db00412e6fc508d63ff70e2ae94050149c82d6
+  url: https://files.pythonhosted.org/packages/a1/7c/2f5a9b925a66261b39a9c4181c9cc4500ff5547d7b1efc76f5cba40a1d0e/micropip-0.2.0-py3-none-any.whl
 
 requirements:
   run:

--- a/packages/micropip/meta.yaml
+++ b/packages/micropip/meta.yaml
@@ -2,7 +2,6 @@ package:
   name: micropip
   # This version needs to be consistent with docs/requirements-doc.txt
   version: "0.2.0"
-  _tag: pyodide.stdlib
   top-level:
     - micropip
 


### PR DESCRIPTION
Also links to the new micropip docs.

Links to the micropip API reference should now be resolved to https://micropip.pyodide.org thanks to intersphinx. Though if we provide direct links, I'm not sure how to preserve a compatible version.

xref https://github.com/pyodide/pyodide/issues/3340