### PR TITLE
PKG Add pyodide-http

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -274,7 +274,7 @@ substitutions:
   pyheif, pillow_heif, libheif, libde265 {pr}`3161`, wordcloud {pr}`3173`,
   gdal, fiona, geopandas {pr}`3213`,
   the standard library \_hashlib module {pr}`3206` , pyinstrument {pr}`3258`,
-  gensim {pr}`3326`, smart_open {pr}`3326`,
+  gensim {pr}`3326`, smart_open {pr}`3326`, pyodide-http {pr}`3355`.
 
 - {{ Update }} Upgraded pandas to version 1.5.0.
   {pr}`3134`

--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -23,6 +23,12 @@
   debuggers, and automatic installation of
   any imported packages supported by Pyodide's `micropip`.
 
+## Workarounds for common WASM and browser limitations
+
+- [pyodide-http](https://github.com/koenvo/pyodide-http) Provides patches for
+  widely used http libraries to make them work in Pyodide environments like
+  JupyterLite.
+
 ## Dashboards and visualization
 
 - [WebDash](https://github.com/ibdafna/webdash) is a Plotly Dash distribution

--- a/packages/pyodide-http/meta.yaml
+++ b/packages/pyodide-http/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: pyodide-http
+  version: 0.2.0
+  top-level:
+    - pyodide_http
+source:
+  url: https://files.pythonhosted.org/packages/71/54/fcdafe22904c679ba7b9d562f86f43cc71bfb65197f2b51ef6e6698d6296/pyodide_http-0.2.0-py3-none-any.whl
+  sha256: 0ab778a95fc09ce59f15e4890202d17ca48dfdbe8ee2e6139e9a8589fc54d61f
+about:
+  home: https://github.com/koenvo/pyodide-http
+  PyPI: https://pypi.org/project/pyodide-http
+  summary: Patch requests, urllib and urllib3 to make them work in Pyodide
+  license: MIT

--- a/pyodide-build/pyodide_build/cli/skeleton.py
+++ b/pyodide-build/pyodide_build/cli/skeleton.py
@@ -49,7 +49,7 @@ def new_recipe_pypi(
     ),
 ) -> None:
     """
-    Create a new package.
+    Create a new package from PyPI.
     """
     pyodide_root = common.search_pyodide_root(Path.cwd()) if not root else Path(root)
     recipe_dir_ = pyodide_root / "packages" if not recipe_dir else Path(recipe_dir)


### PR DESCRIPTION
[pyodide-http](https://github.com/koenvo/pyodide-http) is a pure Python package by @koenvo. I feel it's useful for it to be part of the default distribution, so it could be loaded from imports without having to load micropip first.

Also added it to related projects.