### PR TITLE
Pyb2d v0.7.4

### DIFF
--- a/packages/pyb2d/meta.yaml
+++ b/packages/pyb2d/meta.yaml
@@ -5,8 +5,8 @@ package:
     - b2d
 
 source:
-  url: https://github.com/pyb2d/pyb2d/archive/refs/tags/0.7.2.tar.gz
-  sha256: d7cd30da300ea21073f2e9cc715a61f8c26495ff8c57ebbb7109b4dcfe62fc7c
+  url: https://github.com/pyb2d/pyb2d/archive/refs/tags/0.7.4.tar.gz
+  sha256: 1ddd4bb8c65c94d1c6e6d317ee90ae2b3bd08af7a15771aa1f37dfc82688b104
 
 requirements:
   run:


### PR DESCRIPTION
This adds Python 3.11 support.