### PR TITLE
NFC Minor python2js string conversion cleanup

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -358,10 +358,6 @@ EM_JS_REF(JsRef, hiwire_string_utf8, (const char* ptr), {
   return Hiwire.new_value(UTF8ToString(ptr));
 });
 
-EM_JS_REF(JsRef, hiwire_string_ascii, (const char* ptr), {
-  return Hiwire.new_value(AsciiToString(ptr));
-});
-
 EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
   throw Hiwire.pop_value(iderr);
 });

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -330,30 +330,6 @@ EM_JS_REF(JsRef, hiwire_double, (double val), {
   return Hiwire.new_value(val);
 });
 
-EM_JS_REF(JsRef, hiwire_string_ucs4, (const char* ptr, int len), {
-  let jsstr = "";
-  for (let i = 0; i < len; ++i) {
-    jsstr += String.fromCodePoint(DEREF_U32(ptr, i));
-  }
-  return Hiwire.new_value(jsstr);
-});
-
-EM_JS_REF(JsRef, hiwire_string_ucs2, (const char* ptr, int len), {
-  let jsstr = "";
-  for (let i = 0; i < len; ++i) {
-    jsstr += String.fromCharCode(DEREF_U16(ptr, i));
-  }
-  return Hiwire.new_value(jsstr);
-});
-
-EM_JS_REF(JsRef, hiwire_string_ucs1, (const char* ptr, int len), {
-  let jsstr = "";
-  for (let i = 0; i < len; ++i) {
-    jsstr += String.fromCharCode(DEREF_U8(ptr, i));
-  }
-  return Hiwire.new_value(jsstr);
-});
-
 EM_JS_REF(JsRef, hiwire_string_utf8, (const char* ptr), {
   return Hiwire.new_value(UTF8ToString(ptr));
 });

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -125,33 +125,6 @@ JsRef
 hiwire_double(double val);
 
 /**
- * Create a new JavaScript string, given a pointer to a buffer
- * containing UCS4 and a length. The string data itself is copied.
- *
- * Returns: New reference
- */
-JsRef
-hiwire_string_ucs4(const char* ptr, int len);
-
-/**
- * Create a new JavaScript string, given a pointer to a buffer
- * containing UCS2 and a length. The string data itself is copied.
- *
- * Returns: New reference
- */
-JsRef
-hiwire_string_ucs2(const char* ptr, int len);
-
-/**
- * Create a new JavaScript string, given a pointer to a buffer
- * containing UCS1 and a length. The string data itself is copied.
- *
- * Returns: New reference
- */
-JsRef
-hiwire_string_ucs1(const char* ptr, int len);
-
-/**
  * Create a new JavaScript string, given a pointer to a null-terminated buffer
  * containing UTF8. The string data itself is copied.
  *

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -161,16 +161,6 @@ JsRef
 hiwire_string_utf8(const char* ptr);
 
 /**
- * Create a new JavaScript string, given a pointer to a null-terminated buffer
- * containing ascii (well, technically latin-1). The string data itself is
- * copied.
- *
- * Returns: New reference
- */
-JsRef
-hiwire_string_ascii(const char* ptr);
-
-/**
  * Create a new JavaScript boolean value.
  * Return value is true if boolean != 0, false if boolean == 0.
  *

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -233,7 +233,7 @@ finally:
 JsRef
 _pyproxy_type(PyObject* ptrobj)
 {
-  return hiwire_string_ascii(ptrobj->ob_type->tp_name);
+  return hiwire_string_utf8(ptrobj->ob_type->tp_name);
 }
 
 int

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -206,14 +206,11 @@ JsRef
 _pyproxy_repr(PyObject* pyobj)
 {
   PyObject* repr_py = NULL;
-  const char* repr_utf8 = NULL;
   JsRef repr_js = NULL;
 
   repr_py = PyObject_Repr(pyobj);
   FAIL_IF_NULL(repr_py);
-  repr_utf8 = PyUnicode_AsUTF8(repr_py);
-  FAIL_IF_NULL(repr_utf8);
-  repr_js = hiwire_string_utf8(repr_utf8);
+  repr_js = js2python(repr_py);
 
 finally:
   Py_CLEAR(repr_py);

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -210,7 +210,7 @@ _pyproxy_repr(PyObject* pyobj)
 
   repr_py = PyObject_Repr(pyobj);
   FAIL_IF_NULL(repr_py);
-  repr_js = js2python(repr_py);
+  repr_js = python2js(repr_py);
 
 finally:
   Py_CLEAR(repr_py);

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -4,6 +4,7 @@
 #include "docstring.h"
 #include "hiwire.h"
 #include "js2python.h"
+#include "jsmemops.h"
 #include "jsproxy.h"
 #include "pyproxy.h"
 #include "python2js.h"

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -113,6 +113,28 @@ finally:
   return NULL;
 }
 
+// python2js string conversion
+//
+// FAQs:
+//
+// Q: Why do we use this approach rather than TextDecoder?
+//
+// A: TextDecoder does have an 'ascii' encoding and a 'ucs2' encoding which
+// sound promising. They work in many cases but not in all cases, particularly
+// when strings contain weird unprintable bytes. I suspect these conversion
+// functions are also considerably faster than TextDecoder because it takes
+// complicated extra code to cause the problematic edge case behavior of
+// TextDecoder.
+//
+//
+// Q: Is it okay to use str += more_str in a loop? Does this perform a lot of
+// copies?
+//
+// A: We haven't profiled this but I suspect that the JS VM understands this
+// code quite well and can git it into very performant code.
+// TODO: someone should compare += in a loop to building a list and using
+// list.join("") and see if one is faster than the other.
+
 EM_JS_REF(JsRef, _python2js_ucs1, (const char* ptr, int len), {
   let jsstr = "";
   for (let i = 0; i < len; ++i) {
@@ -151,8 +173,7 @@ _python2js_unicode(PyObject* x)
     case PyUnicode_4BYTE_KIND:
       return _python2js_ucs4(data, length);
     default:
-      PyErr_SetString(PyExc_ValueError, "Unknown Unicode KIND");
-      return NULL;
+      assert(false /* invalid Unicode kind */);
   }
 }
 

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -113,6 +113,30 @@ finally:
   return NULL;
 }
 
+EM_JS_REF(JsRef, _python2js_ucs1, (const char* ptr, int len), {
+  let jsstr = "";
+  for (let i = 0; i < len; ++i) {
+    jsstr += String.fromCharCode(DEREF_U8(ptr, i));
+  }
+  return Hiwire.new_value(jsstr);
+});
+
+EM_JS_REF(JsRef, _python2js_ucs2, (const char* ptr, int len), {
+  let jsstr = "";
+  for (let i = 0; i < len; ++i) {
+    jsstr += String.fromCharCode(DEREF_U16(ptr, i));
+  }
+  return Hiwire.new_value(jsstr);
+});
+
+EM_JS_REF(JsRef, _python2js_ucs4, (const char* ptr, int len), {
+  let jsstr = "";
+  for (let i = 0; i < len; ++i) {
+    jsstr += String.fromCodePoint(DEREF_U32(ptr, i));
+  }
+  return Hiwire.new_value(jsstr);
+});
+
 static JsRef
 _python2js_unicode(PyObject* x)
 {
@@ -121,11 +145,11 @@ _python2js_unicode(PyObject* x)
   int length = (int)PyUnicode_GET_LENGTH(x);
   switch (kind) {
     case PyUnicode_1BYTE_KIND:
-      return hiwire_string_ucs1(data, length);
+      return _python2js_ucs1(data, length);
     case PyUnicode_2BYTE_KIND:
-      return hiwire_string_ucs2(data, length);
+      return _python2js_ucs2(data, length);
     case PyUnicode_4BYTE_KIND:
-      return hiwire_string_ucs4(data, length);
+      return _python2js_ucs4(data, length);
     default:
       PyErr_SetString(PyExc_ValueError, "Unknown Unicode KIND");
       return NULL;


### PR DESCRIPTION
We remove `hiwire_string_ascii` in favor of `hiwire_string_utf8` (which I think is faster).
The `hiwire_string_ucs#` functions are only used in python2js for string conversion and
should only be used there I think so I moved them out of hiwire into that file.

I keep getting confused about the implementation of python2js string conversion
functions so I added a little FAQ for my future self. I also replaced the error in the
invalid string kind case with an `assert false` since CPython itself uses assertions to
check that a string has a valid kind.