### PR TITLE
Fix top level multiprocessing.connection import and update yt

### DIFF
--- a/cpython/patches/0015-Allow-multiprocessing.connection-top-level-import.patch
+++ b/cpython/patches/0015-Allow-multiprocessing.connection-top-level-import.patch
@@ -1,0 +1,28 @@
+From becbcc43e3e09a9c065ea7856a2d3069061fd570 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Mon, 19 Dec 2022 09:09:14 -0800
+Subject: [PATCH 15/15] Allow multiprocessing.connection top level import
+
+---
+ Lib/multiprocessing/connection.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Lib/multiprocessing/connection.py b/Lib/multiprocessing/connection.py
+index 510e4b5aba..372f9ced37 100644
+--- a/Lib/multiprocessing/connection.py
++++ b/Lib/multiprocessing/connection.py
+@@ -18,7 +18,10 @@
+ import tempfile
+ import itertools
+ 
+-import _multiprocessing
++try:
++    import _multiprocessing
++except ModuleNotFoundError:
++    pass
+ 
+ from . import util
+ 
+-- 
+2.25.1
+

--- a/packages/yt/meta.yaml
+++ b/packages/yt/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: yt
-  version: 4.0.4
+  version: 4.1.2
   top-level:
     - yt
 source:
-  url: https://files.pythonhosted.org/packages/4b/88/280b68ca63861d34ef7f79e5e45a0476e320d25db2663981f9a1a3a85561/yt-4.0.4.tar.gz
-  sha256: 2cd58c3579efb88c3aefadc343ee6e399d893a2be5c60e61606a0fba6148b692
+  url: https://files.pythonhosted.org/packages/e2/57/5c519b90ce1c0d254f21b76f04c02522277a4aeabea0a9c92ff2620e8bac/yt-4.1.2.tar.gz
+  sha256: 0ae03288b067721baad14c016f253dc791cd444a1f2dd5d804cf91da622a0c76
 
   patches:
     - patches/skip-openmp.patch

--- a/src/py/lib/_multiprocessing.py
+++ b/src/py/lib/_multiprocessing.py
@@ -1,0 +1,4 @@
+"""This is just here to fix top level _multiprocessing import.
+
+For instance, this makes `from multiprocessing import connection` not fail.
+"""

--- a/src/py/lib/_multiprocessing.py
+++ b/src/py/lib/_multiprocessing.py
@@ -1,4 +1,0 @@
-"""This is just here to fix top level _multiprocessing import.
-
-For instance, this makes `from multiprocessing import connection` not fail.
-"""

--- a/src/tests/test_stdlib_fixes.py
+++ b/src/tests/test_stdlib_fixes.py
@@ -50,30 +50,25 @@ def test_threading_import(selenium):
         )
 
 
+@run_in_pyodide
 def test_multiprocessing(selenium):
-    selenium.run("import multiprocessing")
+    import multiprocessing  # noqa: F401
+    from multiprocessing import connection, cpu_count  # noqa: F401
 
-    res = selenium.run(
-        """
-        from multiprocessing import cpu_count
-        cpu_count()
-        """
-    )
+    import pytest
+
+    res = cpu_count()
     assert isinstance(res, int)
     assert res > 0
 
-    msg = "Function not implemented"
-    with pytest.raises(selenium.JavascriptException, match=msg):
-        selenium.run(
-            """
-            from multiprocessing import Process
+    from multiprocessing import Process
 
-            def func():
-                return
-            process = Process(target=func)
-            process.start()
-            """
-        )
+    def func():
+        return
+
+    process = Process(target=func)
+    with pytest.raises(OSError, match="Function not implemented"):
+        process.start()
 
 
 @run_in_pyodide


### PR DESCRIPTION
This updates yt. The new yt has a top level `multiprocessing.connection` import so we patch that so that it can be imported without raising an error.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
