### PR TITLE
Fix some function signature mismatches in scipy PROPACK

### DIFF
--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -32,6 +32,7 @@ source:
     - patches/0011-Change-qh_eachvoronoi_all-FILE-type.patch
     - patches/0012-Remove-meson-requirements.patch
     - patches/0013-Fix-fitpack.patch
+    - patches/fix-daprod.patch
 
 build:
   cflags: |
@@ -39,6 +40,7 @@ build:
     -I$(HOSTSITEPACKAGES)/pythran/
     -Wno-return-type
     -DUNDERSCORE_G77
+    -DDEBUGCFUNCS
   ldflags: |
     -L$(NUMPY_LIB)/core/lib/
     -L$(NUMPY_LIB)/random/lib/

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -40,7 +40,7 @@ build:
     -I$(HOSTSITEPACKAGES)/pythran/
     -Wno-return-type
     -DUNDERSCORE_G77
-    -DDEBUGCFUNCS
+  # -DDEBUGCFUNCS
   ldflags: |
     -L$(NUMPY_LIB)/core/lib/
     -L$(NUMPY_LIB)/random/lib/

--- a/packages/scipy/patches/fix-daprod.patch
+++ b/packages/scipy/patches/fix-daprod.patch
@@ -1,0 +1,38 @@
+index cd11ef694..8f204e6f1 100644
+--- a/scipy/sparse/linalg/_propack/dpropack.pyf
++++ b/scipy/sparse/linalg/_propack/dpropack.pyf
+@@ -3,11 +3,11 @@
+ python module __user__routines
+     interface
+         function daprod(transa,m,n,x,y,dparm,iparm)
+-           character*1 :: transa
++           integer :: transa
+            integer intent(in) :: m
+            integer intent(in) :: n
+-           double precision depend(m,n),check(len(x)>=(transa[0] == 'n' ? n : m)),dimension((transa[0] == 'n' ? n : m)) :: x
+-           double precision depend(m,n),check(len(y)>=(transa[0] == 'n' ? m : n)),dimension((transa[0] == 'n' ? m : n)) :: y
++           double precision depend(m,n),check(len(x)>=(transa == 'n' ? n : m)),dimension((transa == 'n' ? n : m)) :: x
++           double precision depend(m,n),check(len(y)>=(transa == 'n' ? m : n)),dimension((transa == 'n' ? m : n)) :: y
+            integer dimension(*) :: iparm
+            double precision dimension(*) :: dparm
+         end function daprod
+--- a/scipy/sparse/linalg/_propack/PROPACK/double/dlanbpro.F
++++ b/scipy/sparse/linalg/_propack/PROPACK/double/dlanbpro.F
+@@ -108,7 +108,6 @@ c     %-----------%
+       integer ioption(*), iwork(*), iparm(*)
+       double precision rnorm,B(ldb,*), doption(*), work(*), dparm(*)
+       double precision U(ldu,*),V(ldv,*)
+-      external APROD
+ 
+ c     %------------%
+ c     | Parameters |
+@@ -136,7 +135,8 @@ c     %--------------------%
+ c     | External Functions |
+ c     %--------------------%
+       double precision dlamch,pdnrm2,pddot,dlapy2
+-      external pdnrm2,pddot
++      real aprod
++      external pdnrm2,pddot,aprod
+       external dlamch,dlapy2
+ 
+ c-------------------- Here begins executable code ---------------------

--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -63,3 +63,15 @@ def test_scipy_pytest(selenium):
     runtest("odr", "explicit")
     runtest("signal.tests.test_ltisys", "TestImpulse2")
     runtest("stats.tests.test_multivariate", "haar")
+
+
+@pytest.mark.driver_timeout(40)
+@run_in_pyodide(packages=["pytest", "scipy"])
+def test_scipy_svdp(selenium):
+    import numpy as np
+    from scipy.sparse.linalg._svdp import _svdp
+
+    np.random.seed(0)
+    n, k = 70, 10
+    A = np.random.random((n, n))
+    _svdp(A, k, kmax=5 * k)

--- a/pyodide-build/pyodide_build/_f2c_fixes.py
+++ b/pyodide-build/pyodide_build/_f2c_fixes.py
@@ -251,6 +251,10 @@ def fix_f2c_output(f2c_output_path: str) -> str | None:
         def fix_line(line: str) -> str:
             if f2c_output.name != "cgemm_ovwr.c":
                 line = line.replace("struct", "extern struct")
+            if f2c_output.name == "dgetu0.c":
+                line = line.replace("S_fp aprod", "R_fp aprod")
+            if f2c_output.name == "dlanbpro.c":
+                line = line.replace("E_fp", "R_fp")
             if "12300" in line:
                 return line.replace("static", "").replace("123001", "(*n)")
             return line


### PR DESCRIPTION
This is an attempt to resolve #3380. There seems to be three problems:
1. The usual business with fortran enums, string arguments and ftnlen for the `transa` parameter.
2. The `aprod` argument is declared to be a subroutine, which should have return type i32 but it in fact has return type f32, so we'd better say it's a function with return type real
3. For reasons I cannot comprehend, when I say the return type is real, f2c generates a declaration that says it has return type double. It feels like a bug in f2c but it is so major and obvious that it's hard to believe anyone could have missed it. Anyways I hack around it by adding a little bit more nonsense to f2cfixes.

This probably isn't quite right yet since running `_svdp` doesn't crash but it prints a very large number of the following warning:
```
Warning: call-back function cb_daprod_in___user__routines did not provide return value (index=0, type=float)
```


### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
