### PR TITLE
Improve mypy typing for pyodide package

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -114,6 +114,9 @@ substitutions:
   `js` module.
   {pr}`3298`
 
+- {{ Enhancement }} mypy understands the types of more things now.
+  {pr}`3385`
+
 - {{ Fix }} Fixed bug in `split` argument of {any}`repr_shorten`. Added {any}`shorten` function.
   {pr}`3178`
 

--- a/src/py/js.pyi
+++ b/src/py/js.pyi
@@ -2,7 +2,14 @@ from asyncio import Future
 from typing import Any, Callable, Iterable
 
 from _pyodide._core_docs import _JsProxyMetaClass
-from pyodide.ffi import JsArray, JsBuffer, JsFetchResponse, JsProxy, JsTypedArray
+from pyodide.ffi import (
+    JsArray,
+    JsBuffer,
+    JsDomElement,
+    JsFetchResponse,
+    JsProxy,
+    JsTypedArray,
+)
 from pyodide.webloop import PyodideFuture
 
 def eval(code: str) -> Any: ...
@@ -44,7 +51,7 @@ class XMLHttpRequest(_JsObject):
 
 class Object(_JsObject):
     @staticmethod
-    def fromEntries(it: Iterable[tuple[str, Any]]) -> JsProxy: ...
+    def fromEntries(it: Iterable[JsArray]) -> JsProxy: ...
 
 class Array(_JsObject):
     @staticmethod
@@ -77,15 +84,10 @@ class JSON(_JsObject):
     @staticmethod
     def parse(a: str) -> JsProxy: ...
 
-class JsElement(JsProxy):
-    tagName: str
-    children: list[JsElement]
-    def appendChild(self, child: JsElement) -> None: ...
-
 class document(_JsObject):
-    body: JsElement
-    children: list[JsElement]
+    body: JsDomElement
+    children: list[JsDomElement]
     @staticmethod
-    def createElement(tagName: str) -> JsElement: ...
+    def createElement(tagName: str) -> JsDomElement: ...
     @staticmethod
-    def appendChild(child: JsElement) -> None: ...
+    def appendChild(child: JsDomElement) -> None: ...

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -33,10 +33,13 @@ if IN_BROWSER:
 
     import _pyodide._core_docs
 
-    # This is intentionally opaque to static analysis tools (e.g., mypy) Note:
-    # Normally one would handle this by adding type stubs for _pyodide_core, but
-    # since we already are getting the correct types from _core_docs, adding a type
-    # stub would introduce a redundancy that would be difficult to maintain.
+    # This is intentionally opaque to static analysis tools (e.g., mypy)
+    #
+    # Note:
+    #   Normally one would handle this by adding type stubs for
+    #   _pyodide_core, but since we already are getting the correct types
+    #   from _core_docs, adding a type stub would introduce a redundancy
+    #   that would be difficult to maintain.
     for t in [
         "ConversionError",
         "JsException",

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -2,38 +2,17 @@ import sys
 
 IN_BROWSER = "_pyodide_core" in sys.modules
 
-
-if IN_BROWSER:
-    import _pyodide_core
-    from _pyodide_core import (
-        ConversionError,
-        JsException,
-        create_once_callable,
-        create_proxy,
-        destroy_proxies,
-        to_js,
-    )
-
-    import _pyodide._core_docs
-
-    _pyodide._core_docs._js_flags = _pyodide_core.js_flags
-else:
-    from _pyodide._core_docs import (
-        ConversionError,
-        JsException,
-        create_once_callable,
-        create_proxy,
-        destroy_proxies,
-        to_js,
-    )
-
 from _pyodide._core_docs import (
+    ConversionError,
     JsArray,
     JsAsyncGenerator,
     JsAsyncIterable,
     JsAsyncIterator,
     JsBuffer,
+    JsCallable,
+    JsDomElement,
     JsDoubleProxy,
+    JsException,
     JsFetchResponse,
     JsGenerator,
     JsIterable,
@@ -43,29 +22,52 @@ from _pyodide._core_docs import (
     JsPromise,
     JsProxy,
     JsTypedArray,
+    create_once_callable,
+    create_proxy,
+    destroy_proxies,
+    to_js,
 )
 
+if IN_BROWSER:
+    import _pyodide_core
+
+    import _pyodide._core_docs
+
+    for t in [
+        "ConversionError",
+        "JsException",
+        "create_once_callable",
+        "create_proxy",
+        "destroy_proxies",
+        "to_js",
+    ]:
+        globals()[t] = _pyodide_core[t]
+
+    _pyodide._core_docs._js_flags = _pyodide_core.js_flags
+
+
 __all__ = [
-    "JsProxy",
-    "JsDoubleProxy",
-    "JsArray",
-    "JsGenerator",
-    "JsAsyncGenerator",
-    "JsIterable",
-    "JsAsyncIterable",
-    "JsIterator",
-    "JsException",
-    "create_proxy",
-    "create_once_callable",
-    "to_js",
     "ConversionError",
-    "destroy_proxies",
-    "JsPromise",
-    "JsBuffer",
-    "JsTypedArray",
     "JsArray",
+    "JsAsyncGenerator",
+    "JsAsyncIterable",
+    "JsAsyncIterator",
+    "JsBuffer",
+    "JsDoubleProxy",
+    "JsException",
     "JsFetchResponse",
+    "JsGenerator",
+    "JsIterable",
+    "JsIterator",
     "JsMap",
     "JsMutableMap",
-    "JsAsyncIterator",
+    "JsPromise",
+    "JsProxy",
+    "JsDomElement",
+    "JsCallable",
+    "JsTypedArray",
+    "create_once_callable",
+    "create_proxy",
+    "destroy_proxies",
+    "to_js",
 ]

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -33,6 +33,7 @@ if IN_BROWSER:
 
     import _pyodide._core_docs
 
+    # This is intentionally opaque to static analysis tools (e.g., mypy)
     for t in [
         "ConversionError",
         "JsException",

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -48,7 +48,7 @@ if IN_BROWSER:
         "destroy_proxies",
         "to_js",
     ]:
-        globals()[t] = _pyodide_core[t]
+        globals()[t] = getattr(_pyodide_core, t)
 
     _pyodide._core_docs._js_flags = _pyodide_core.js_flags
 

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -36,8 +36,7 @@ if IN_BROWSER:
     # This is intentionally opaque to static analysis tools (e.g., mypy) Note:
     # Normally one would handle this by adding type stubs for _pyodide_core, but
     # since we already are getting the correct types from _core_docs, adding a type
-    # stub would introduce a redundancy that would be difficult to
-    # maintain.
+    # stub would introduce a redundancy that would be difficult to maintain.
     for t in [
         "ConversionError",
         "JsException",

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -33,7 +33,11 @@ if IN_BROWSER:
 
     import _pyodide._core_docs
 
-    # This is intentionally opaque to static analysis tools (e.g., mypy)
+    # This is intentionally opaque to static analysis tools (e.g., mypy) Note:
+    # Normally one would handle this by adding type stubs for _pyodide_core, but
+    # since we already are getting the correct types from _core_docs, adding a type
+    # stub would introduce a redundancy that would be difficult to
+    # maintain.
     for t in [
         "ConversionError",
         "JsException",

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -2,15 +2,13 @@ import json
 from io import StringIO
 from typing import IO, Any
 
-from ._core import JsFetchResponse, to_js
-
-try:
-    from js import XMLHttpRequest
-except ImportError:
-    pass
-
-from ._core import IN_BROWSER, JsBuffer, JsException
+from ._core import IN_BROWSER, JsBuffer, JsException, JsFetchResponse, to_js
 from ._package_loader import unpack_buffer
+
+if IN_BROWSER:
+    from js import Object, XMLHttpRequest
+    from js import fetch as _jsfetch
+
 
 __all__ = [
     "open_url",
@@ -225,10 +223,6 @@ async def pyfetch(url: str, **kwargs: Any) -> FetchResponse:
         keyword arguments are passed along as `optional parameters to the fetch API
         <https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters>`_.
     """
-    if IN_BROWSER:
-        from js import Object
-        from js import fetch as _jsfetch
-
     try:
         return FetchResponse(
             url, await _jsfetch(url, to_js(kwargs, dict_converter=Object.fromEntries))

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -7,8 +7,11 @@ from ._package_loader import unpack_buffer
 
 if IN_BROWSER:
     from js import Object
-    from js import fetch as _jsfetch
 
+    try:
+        from js import fetch as _jsfetch
+    except ImportError:
+        pass
     try:
         from js import XMLHttpRequest
     except ImportError:

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -6,9 +6,13 @@ from ._core import IN_BROWSER, JsBuffer, JsException, JsFetchResponse, to_js
 from ._package_loader import unpack_buffer
 
 if IN_BROWSER:
-    from js import Object, XMLHttpRequest
+    from js import Object
     from js import fetch as _jsfetch
 
+    try:
+        from js import XMLHttpRequest
+    except ImportError:
+        pass
 
 __all__ = [
     "open_url",

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -635,7 +635,7 @@ def test_create_proxy(selenium):
     assert sys.getrefcount(f) == 2
     proxy = create_proxy(f)
     assert sys.getrefcount(f) == 3
-    assert proxy() == 7
+    assert proxy() == 7  # type:ignore[operator]
     testAddListener(proxy)
     assert sys.getrefcount(f) == 3
     assert testCallListener() == 7
@@ -677,7 +677,7 @@ def test_create_proxy_roundtrip(selenium):
     assert o.f.unwrap() is f
     o.f.destroy()
     o.f = create_proxy(f, roundtrip=False)
-    assert o.f is f
+    assert o.f is f  # type: ignore[comparison-overlap]
     run_js("(o) => { o.f.destroy(); }")(o)
 
 

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -585,7 +585,7 @@ def test_wrong_way_track_proxies(selenium):
     destroy_proxies(proxylist)
     checkDestroyed(r)
     with raises(TypeError):
-        to_js(x, pyproxies=[])
+        to_js(x, pyproxies=[])  # type:ignore[call-overload]
     with raises(TypeError):
         to_js(x, pyproxies=Object.new())
     with raises(ConversionError):


### PR DESCRIPTION
The way we were handling the "routing" in `_core.py` (where in browser things are imported from `_pyodide_core` and otherwise things from `_pyodide._core_docs`) made mypy type a bunch of things as `Any`. This changes it to prevent mypy from understanding the imports from `_pyodide_core` so it will correctly type all of the methods with their types from `_pyodide._core_docs`.

This created a bunch of new type errors, so I also made various fixes to make things typecheck again.

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
