### PR TITLE
Add type parameters to JsProxy subtypes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,6 +205,9 @@ if IN_SPHINX:
     import pyodide.ffi.wrappers
     import pyodide.http
     import pyodide.webloop
+    from pyodide.ffi import JsProxy
+
+    del JsProxy.__new__
 
     # The full version, including alpha/beta/rc tags.
     release = version = pyodide.__version__

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -94,6 +94,9 @@ substitutions:
   at least closer to that than it was before).
   {pr}`3277`
 
+- {{ Enhancement }} Added type parameters to many of the `JsProxy` subtypes.
+  {pr}`3387`
+
 - {{ Enhancement }} Added `JsGenerator` and `JsIterator` types to `pyodide.ffi`.
   Added `send` method to `JsIterator`s and `throw`, and `close` methods to `JsGenerator`s.
   {pr}`3294`

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -580,7 +580,7 @@ class JsMutableMap(JsMap[_KT, _VT], Generic[_KT, _VT]):
         """
         raise NotImplementedError
 
-    def setdefault(self, key: _KT, default: _VT) -> _VT:
+    def setdefault(self, key: _KT, default: _VT | None = None) -> _VT:
         """If key in self, return self[key]. Otherwise
         sets self[key] = default and returns default.
 

--- a/src/py/js.pyi
+++ b/src/py/js.pyi
@@ -51,11 +51,11 @@ class XMLHttpRequest(_JsObject):
 
 class Object(_JsObject):
     @staticmethod
-    def fromEntries(it: Iterable[JsArray]) -> JsProxy: ...
+    def fromEntries(it: Iterable[JsArray[Any]]) -> JsProxy: ...
 
 class Array(_JsObject):
     @staticmethod
-    def new() -> JsArray: ...
+    def new() -> JsArray[Any]: ...
 
 class ImageData(_JsObject):
     @staticmethod

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -147,7 +147,7 @@ def unpack_buffer(
     calculate_dynlibs: bool = False,
     installer: str | None = None,
     source: str | None = None,
-) -> JsArray | None:
+) -> JsArray[str] | None:
     """Used to install a package either into sitepackages or into the standard
     library.
 

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1800,7 +1800,7 @@ def test_gen_send_type_errors(selenium):
     with pytest.raises(
         TypeError, match='Result should have type "object" not "number"'
     ):
-        g.send(None)
+        g.send(None)  # type:ignore[attr-defined]
 
     g = run_js(
         """
@@ -2001,7 +2001,7 @@ async def test_agen_asend(selenium):
     import pytest
 
     from pyodide.code import run_js
-    from pyodide.ffi import JsAsyncIterator, JsIterator
+    from pyodide.ffi import JsAsyncGenerator, JsIterator
 
     it = run_js(
         """
@@ -2014,7 +2014,7 @@ async def test_agen_asend(selenium):
         """
     )
 
-    assert isinstance(it, JsAsyncIterator)
+    assert isinstance(it, JsAsyncGenerator)
     assert not isinstance(it, JsIterator)
 
     assert await it.asend(None) == 2


### PR DESCRIPTION
Added type parameters to `JsArray`, `JsMap`, `JsMutableMap`, etc. Based on [the typesheds for typing](https://github.com/python/typeshed/blob/main/stdlib/typing.pyi). I skipped `JsCallable` and a few other more complicated types, those can be handled later.

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
