### PR TITLE
Pin range of auditwheel-emscripten version

### DIFF
--- a/pyodide-build/setup.cfg
+++ b/pyodide-build/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     requests
     types-requests
     typer
-    auditwheel-emscripten==0.0.9
+    auditwheel-emscripten~=0.0.9
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
As discussed in https://github.com/pyodide/pyodide/pull/3383#discussion_r1056140641, so we can fix bugs in auditwheel-emscripten without releasing new pyodide-build.
