### PR TITLE
Fix broken pyodide cli tests

### DIFF
--- a/pyodide-build/pyodide_build/cli/build.py
+++ b/pyodide-build/pyodide_build/cli/build.py
@@ -14,8 +14,6 @@ from .. import common
 from ..out_of_tree import build
 from ..out_of_tree.utils import initialize_pyodide_root
 
-app = typer.Typer()
-
 
 def _fetch_pypi_package(package_spec, destdir):
     PYMAJOR = common.get_make_flag("PYMAJOR")
@@ -144,7 +142,6 @@ def source(
 
 
 # simple 'pyodide build' command
-@app.command()  # type: ignore[misc]
 def main(
     source_location: "Optional[str]" = typer.Argument(
         "",
@@ -170,7 +167,7 @@ def main(
         pypi(source_location, exports, ctx)
 
 
-main.typer_kwargs = {
+main.typer_kwargs = {  # type: ignore[attr-defined]
     "context_settings": {
         "ignore_unknown_options": True,
         "allow_extra_args": True,

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -3,11 +3,11 @@ import shutil
 from pathlib import Path
 
 import pytest
+import typer  # type: ignore[import]
 from typer.testing import CliRunner  # type: ignore[import]
 
-from pyodide_build import __version__ as pyodide_build_version
 from pyodide_build import common
-from pyodide_build.cli import build, config, skeleton
+from pyodide_build.cli import build, build_recipes, config, skeleton
 
 only_node = pytest.mark.xfail_browsers(
     chrome="node only", firefox="node only", safari="node only"
@@ -58,18 +58,9 @@ def test_skeleton_pypi(tmp_path):
     assert "already exists" in str(result.exception)
 
 
-def test_build_recipe_with_pyodide(tmp_path, monkeypatch, request, runtime):
-    if runtime != "node":
-        pytest.xfail("node only")
-    test_build_recipe(tmp_path, monkeypatch, request)
+def test_build_recipe(selenium, tmp_path, monkeypatch, request):
+    # TODO: Run this test without building Pyodide
 
-
-def test_build_recipe(tmp_path, monkeypatch, request):
-    if "dev" in pyodide_build_version:
-        if "EMSDK" not in os.environ or "PYODIDE_ROOT" not in os.environ:
-            pytest.skip(
-                reason="Can't build recipe in dev mode without building pyodide first"
-            )
     output_dir = tmp_path / "dist"
     recipe_dir = Path(__file__).parent / "_test_recipes"
 
@@ -85,10 +76,12 @@ def test_build_recipe(tmp_path, monkeypatch, request):
     for build_dir in recipe_dir.rglob("build"):
         shutil.rmtree(build_dir)
 
+    app = typer.Typer()
+    app.command(build_recipes.recipe)
+
     result = runner.invoke(
-        build.app,
+        app,
         [
-            "recipe",
             *pkgs.keys(),
             "--recipe-dir",
             recipe_dir,
@@ -137,27 +130,22 @@ def test_config_get(cfg_name, env_var):
     assert result.stdout.strip() == common.get_make_flag(env_var)
 
 
-def test_fetch_or_build_pypi_with_pyodide(tmp_path, runtime):
-    if runtime != "node":
-        pytest.xfail("node only")
-    test_fetch_or_build_pypi(tmp_path)
+def test_fetch_or_build_pypi(selenium, tmp_path):
+    # TODO: Run this test without building Pyodide
 
-
-def test_fetch_or_build_pypi(tmp_path):
-    if "dev" in pyodide_build_version:
-        if "EMSDK" not in os.environ or "PYODIDE_ROOT" not in os.environ:
-            pytest.skip(
-                reason="Can't build recipe in dev mode without building pyodide first. Skipping test"
-            )
     output_dir = tmp_path / "dist"
     # one pure-python package (doesn't need building) and one sdist package (needs building)
     pkgs = ["pytest-pyodide", "pycryptodome==3.15.0"]
 
     os.chdir(tmp_path)
+
+    app = typer.Typer()
+    app.command(build.main)
+
     for p in pkgs:
         result = runner.invoke(
-            build.app,
-            ["main", p],
+            app,
+            [p],
         )
         assert result.exit_code == 0, result.stdout
 

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -77,7 +77,7 @@ def test_build_recipe(selenium, tmp_path, monkeypatch, request):
         shutil.rmtree(build_dir)
 
     app = typer.Typer()
-    app.command(build_recipes.recipe)
+    app.command()(build_recipes.recipe)
 
     result = runner.invoke(
         app,
@@ -140,7 +140,7 @@ def test_fetch_or_build_pypi(selenium, tmp_path):
     os.chdir(tmp_path)
 
     app = typer.Typer()
-    app.command(build.main)
+    app.command()(build.main)
 
     for p in pkgs:
         result = runner.invoke(


### PR DESCRIPTION
Some CLI tests were misconfigured and were skipped in our CI.

Note that these tests are for now not runnable before building Pyodide.