### PR TITLE
Fix 'version' in api docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,14 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md", "sphinx_pyodide"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "README.md",
+    "sphinx_pyodide",
+    ".venv",
+]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -7,7 +7,7 @@ import { loadPackage, loadedPackages } from "./load-package";
 import { isPyProxy, PyBuffer, PyProxy, TypedArray } from "./pyproxy.gen";
 import { PythonError } from "./error_handling.gen";
 import { loadBinaryFile } from "./compat";
-import version from "./version";
+import { version } from "./version";
 export { loadPackage, loadedPackages, isPyProxy };
 import "./error_handling.gen.js";
 import { setStdin, setStdout, setStderr } from "./streams";

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -12,7 +12,7 @@ import {
 
 import { createModule, setHomeDirectory } from "./module";
 import { initializeNativeFS } from "./nativefs";
-import version from "./version";
+import { version } from "./version";
 
 import type { PyodideInterface } from "./api.js";
 import type { PyProxy, PyProxyDict } from "./pyproxy.gen";

--- a/src/js/version.ts
+++ b/src/js/version.ts
@@ -5,6 +5,4 @@
  * The version here follows PEP440 which is different from the one in package.json,
  * as we want to compare this with the version of Pyodide Python package without conversion.
  */
-const version: string = "0.22.0.dev0";
-
-export default version;
+export const version: string = "0.22.0.dev0";


### PR DESCRIPTION
The documentation generation seems to get confused by the default export and
displays the `version` field as `default` instead.  This switches to a normal export.