### PR TITLE
DOCS Fix the async prefix, improvement to summary table format

### DIFF
--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -494,14 +494,14 @@ def get_jsdoc_summary_directive(app):
             """
             sig = self.get_sig(obj)
             display_name = obj.name
-            prefix = "*async* " if obj.async_ else ""
+            prefix = "**async** " if obj.async_ else ""
             summary = self.extract_summary(obj.description)
             link_name = pkgname + "." + display_name
             return (prefix, display_name, sig, summary, link_name)
 
         def get_summary_table(self, pkgname, group):
-            """Get the data for a summary table. Return value is set up to be an
-            argument of format_table.
+            """Get the data for a summary tget_summary_tableable. Return value
+            is set up to be an argument of format_table.
             """
             return [self.get_summary_row(pkgname, obj) for obj in group]
 
@@ -547,15 +547,13 @@ def get_jsdoc_summary_directive(app):
                 body.append(row)
 
             for prefix, name, sig, summary, real_name in items:
-                qualifier = "any"  # <== Only thing changed from autosummary version
+                # The body of this loop is changed from copied code.
+                qualifier = "any"
+                sig = rst.escape(sig)
+                if sig:
+                    sig = f"**{sig}**"
                 if "nosignatures" not in self.options:
-                    col1 = "{}:{}:`{} <{}>`\\ {}".format(
-                        prefix,
-                        qualifier,
-                        name,
-                        real_name,
-                        rst.escape(sig),
-                    )
+                    col1 = f"{prefix}:{qualifier}:`{name} <{real_name}>`\\ {sig}"
                 else:
                     col1 = f"{prefix}:{qualifier}:`{name} <{real_name}>`"
                 col2 = summary

--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -229,10 +229,15 @@ class JSFuncMaybeAsync(JSCallable):
         "async": directives.flag,
     }
 
-    def handle_signature(self, sig, signode):
+    def get_display_prefix(
+        self,
+    ):
         if "async" in self.options:
-            self.display_prefix = "async"
-        return super().handle_signature(sig, signode)
+            return [
+                addnodes.desc_sig_keyword("async", "async"),
+                addnodes.desc_sig_space(),
+            ]
+        return []
 
 
 JavaScriptDomain.directives["function"] = JSFuncMaybeAsync

--- a/docs/sphinx_pyodide/tests/test_directives.py
+++ b/docs/sphinx_pyodide/tests/test_directives.py
@@ -167,7 +167,7 @@ def test_summary():
     attributes = {t[1]: t for t in attributes}
     functions = {t[1]: t for t in functions}
     assert globals["loadPyodide"] == (
-        "*async* ",
+        "**async** ",
         "loadPyodide",
         "(config)",
         "Load the main Pyodide wasm module and initialize it.",
@@ -197,7 +197,7 @@ def test_summary():
     )
 
     assert functions["loadPackagesFromImports"][:-2] == (
-        "*async* ",
+        "**async** ",
         "loadPackagesFromImports",
         "(code, messageCallback, errorCallback)",
     )

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -453,6 +453,9 @@ export class PyProxyClass {
     throw new TypeError("PyProxy is not a constructor");
   }
 
+  /**
+   * @private
+   */
   get [Symbol.toStringTag]() {
     return "PyProxy";
   }


### PR DESCRIPTION
The `async` prefix was supposed to appear before an async function both in the summary
table and in the documentation entry on the function, but it was only appearing in the
summary table. Looking at the sphinx source code, I'm not sure why what I was doing
worked at all actually. This fixes the problem.

This also makes summary table entries bold, which makes them slightly more consistent
with the documentation entries.