### PR TITLE
Fix scipy build with gfortran >= 10

### DIFF
--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -358,6 +358,7 @@ def replay_genargs_handle_argument(arg: str) -> str | None:
         "-pthread",
         # this only applies to compiling fortran code, but we already f2c'd
         "-ffixed-form",
+        "-fallow-argument-mismatch",
         # On Mac, we need to omit some darwin-specific arguments
         "-bundle", "-undefined", "dynamic_lookup",
         # This flag is needed to build numpy with SIMD optimization which we currently disable


### PR DESCRIPTION
### Description

Trying to build scipy locally on Ubuntu 22.04 fails. After investigation it seems like scipy adds `-fallow-argument-mismatch` in https://github.com/scipy/scipy/blob/2f076d5a038748b811dace5cffc5b84fdbb218ac/scipy/_build_utils/_fortran.py#L145-L147. This flag then reaches a `clang` command which gives an error similar to this:

```
emcc: error: '/home/lesteve/dev/pyodide/emsdk/emsdk/upstream/bin/clang -target wasm32-unknown-emscripten -fignore-exceptions -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -DEMSCRIPTEN -Werror=implicit-function-declaration -I/home/lesteve/dev/pyodide/emsdk/emsdk/upstream/emscripten/cache/sysroot/include/SDL --sysroot=/home/lesteve/dev/pyodide/emsdk/emsdk/upstream/emscripten/cache/sysroot -Xclang -iwithsysroot/include/compat -Werror=implicit-function-declaration -Werror=mismatched-parameter-types -Werror=return-type -I/home/lesteve/dev/pyodide/packages/.libs/include -I/home/lesteve/dev/pyodide/packages/.artifacts/lib/python3.10/site-packages/pythran/ -Wno-return-type -DUNDERSCORE_G77 -O2 -g0 -fPIC -g0 -I/home/lesteve/dev/pyodide/cpython/installs/python-3.10.2/include/python3.10 -I/home/lesteve/dev/pyodide/cpython/installs/python-3.10.2/include/python3.10 -Wall -fPIC -funroll-loops -Iscipy/sparse/linalg/_eigen/arpack/ARPACK/SRC -I/tmp/build-env-56v2_lg6/lib/python3.10/site-packages/numpy/core/include -Ibuild/src.emscripten_3_1_24_wasm32-3.10/numpy/distutils/include -c -c -fallow-argument-mismatch scipy/sparse/linalg/_eigen/arpack/ARPACK/UTIL/zvout.c -o build/temp.emscripten_3_1_24_wasm32-3.10/scipy/sparse/linalg/_eigen/arpack/ARPACK/UTIL/zvout.o' failed (returned 1)
clang-16: error: unknown argument: '-fallow-argument-mismatch'
```

I am able to reproduce the issue on my fork by building scipy on top of numpy in the Github action workflow. See https://github.com/lesteve/pyodide/commit/30411618dd1a462c8e88c6867078836ed7d92318 and associated [build log](https://github.com/lesteve/pyodide/actions/runs/3824749335/jobs/6507155159).

Not 100% sure this is the best fix, but it seems quite similar to how "-ffixed-form" was skipped in  https://github.com/pyodide/pyodide/pull/1225.

### Checklists

I guess a changelog entry is not needed for this, not sure about tests.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
