### PR TITLE
DOCS Use autodoc typehints and make various improvements to autodoc rendering

### DIFF
--- a/docs/_static/css/pyodide.css
+++ b/docs/_static/css/pyodide.css
@@ -3,6 +3,7 @@
   opacity: 0.7;
 }
 
+/* Don't make code smaller than other text it looks ugly */
 code {
   font-size: 100% !important;
 }
@@ -20,4 +21,26 @@ code {
 /* Remove "captions" in text table of contents, keep subsections in sidebar */
 .toctree-wrapper > .caption {
   display: none;
+}
+
+/* Display "async", "class" prefixes and parameters in upright style not italic */
+.sig-param,
+.property {
+  font-style: normal;
+}
+
+/* For some reason autodoc messes up the rendering of return value annotations:
+   it displays it as a bulleted list with the last bullet italicized.
+
+   We monkeypatch autodoc in conf.py to add some extra css classes so we can
+   locate the return value bullets.
+*/
+.returnvalue ul {
+  list-style-type: none;
+  margin-left: -15px; /* bullet takes up 15px */
+}
+
+/* Don't italicize last bullet. */
+.returnvalue li > p > em {
+  font-style: normal;
 }

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -11,6 +11,7 @@ sphinx-js==3.1
 sphinx-version-warning~=1.1.2
 sphinx-panels
 sphinx-click
+sphinx-autodoc-typehints
 markupsafe<2.1.0
 pydantic
 # Packages that we want to document as part of the Pyodide CLI

--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -321,6 +321,12 @@ class PyodideAnalyzer:
             if key[-1].startswith("$"):
                 doclet.value.is_private = True
                 continue
+            if key[-1] == "constructor":
+                # For whatever reason, sphinx-js does not properly record
+                # whether constructors are private or not. For now, all
+                # constructors are private so leave them all off. TODO: handle
+                # this via a @private decorator in the documentation comment.
+                continue
             doclet.value.name = doclet.value.name.rpartition(".")[2]
             if filename == "module." or filename == "compat.":
                 continue
@@ -510,7 +516,7 @@ def get_jsdoc_summary_directive(app):
         #
         # We have to change the value of one string: qualifier = 'obj   ==>
         # qualifier = 'any'
-        # https://github.com/sphinx-doc/sphinx/blob/3.x/sphinx/ext/autosummary/__init__.py#L392
+        # https://github.com/sphinx-doc/sphinx/blob/6.0.x/sphinx/ext/autosummary/__init__.py#L375
         def format_table(self, items):
             """Generate a proper list of table nodes for autosummary:: directive.
 
@@ -560,5 +566,28 @@ def get_jsdoc_summary_directive(app):
                 append_row(col1, col2)
 
             return [table_spec, table]
+
+    from inspect import iscoroutinefunction
+
+    from sphinx.ext.autosummary import Autosummary, get_import_prefixes_from_env
+
+    # Monkey patch Autosummary to:
+    # 1. include "async" prefix in the summary table for async functions.
+    # 2. Render signature in bold (for better consistency with rest of docs)
+    Autosummary.get_table = JsDocSummary.format_table
+    orig_get_items = Autosummary.get_items
+
+    def get_items(self, names):
+        prefixes = get_import_prefixes_from_env(self.env)
+        items = orig_get_items(self, names)
+        new_items = []
+        for (name, item) in zip(names, items):
+            name = name.removeprefix("~")
+            _, obj, *_ = self.import_by_name(name, prefixes=prefixes)
+            prefix = "**async** " if iscoroutinefunction(obj) else ""
+            new_items.append((prefix, *item))
+        return new_items
+
+    Autosummary.get_items = get_items
 
     return JsDocSummary

--- a/docs/usage/api/python-api.md
+++ b/docs/usage/api/python-api.md
@@ -1,3 +1,5 @@
+(python-api)=
+
 # Python API
 
 Backward compatibility of the API is not guaranteed at this point.

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -252,17 +252,16 @@ Module.handle_js_error = function (e: any) {
 /**
  * A JavaScript error caused by a Python exception.
  *
- * In order to reduce the risk of large memory leaks, the ``PythonError``
+ * In order to reduce the risk of large memory leaks, the :any:`PythonError`
  * contains no reference to the Python exception that caused it. You can find
- * the actual Python exception that caused this error as `sys.last_value
- * <https://docs.python.org/3/library/sys.html#sys.last_value>`_.
+ * the actual Python exception that caused this error as :any:`sys.last_value`.
  *
  * See :ref:`type-translations-errors` for more information.
  *
  * .. admonition:: Avoid leaking stack Frames
  *    :class: warning
  *
- *    If you make a :any:`PyProxy` of ``sys.last_value``, you should be
+ *    If you make a :any:`PyProxy` of :any:`sys.last_value`, you should be
  *    especially careful to :any:`destroy() <PyProxy.destroy>` it when you are
  *    done. You may leak a large amount of memory including the local
  *    variables of all the stack frames in the traceback if you don't. The
@@ -271,7 +270,8 @@ Module.handle_js_error = function (e: any) {
  * @hideconstructor
  */
 export class PythonError extends Error {
-  /**  The address of the error we are wrapping. We may later compare this
+  /**
+   * The address of the error we are wrapping. We may later compare this
    * against sys.last_value.
    * WARNING: we don't own a reference to this pointer, dereferencing it
    * may be a use-after-free error!
@@ -279,7 +279,7 @@ export class PythonError extends Error {
    */
   __error_address: number;
   /**
-   * The Python type, e.g, ``RuntimeError`` or ``KeyError``.
+   * The Python type, e.g, :any:`RuntimeError` or :any:`KeyError`.
    */
   type: string;
   constructor(type: string, message: string, error_address: number) {

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -448,7 +448,10 @@ export class PyProxyClass {
   $$props: PyProxyProps;
   $$flags: number;
 
-  /** @private */
+  /**
+   * @private
+   * @hideconstructor
+   */
   constructor() {
     throw new TypeError("PyProxy is not a constructor");
   }
@@ -501,7 +504,7 @@ export class PyProxyClass {
    * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry>`_
    * Pyodide will automatically destroy the ``PyProxy`` when it is garbage
    * collected, however there is no guarantee that the finalizer will be run in
-   * a timely manner so it is better to ``destroy`` the proxy explicitly.
+   * a timely manner so it is better to destroy the proxy explicitly.
    *
    * @param options
    * @param options.message The error message to print if use is attempted after
@@ -572,7 +575,7 @@ export class PyProxyClass {
     dict_converter?: (array: Iterable<[key: string, value: any]>) => any;
     /**
      * Optional argument to convert objects with no default conversion. See the
-     * documentation of :any:`pyodide.ffi.to_js`.
+     * documentation of :meth:`~pyodide.ffi.to_js`.
      */
     default_converter?: (
       obj: PyProxy,
@@ -694,7 +697,7 @@ export class PyProxyLengthMethods {
   /**
    * The length of the object.
    *
-   * Present only if the proxied Python object has a ``__len__`` method.
+   * Present only if the proxied Python object has a :meth:`~object.__len__` method.
    */
   get length(): number {
     let ptrobj = _getPtr(this);
@@ -721,7 +724,7 @@ export class PyProxyGetItemMethods {
   /**
    * This translates to the Python code ``obj[key]``.
    *
-   * Present only if the proxied Python object has a ``__getitem__`` method.
+   * Present only if the proxied Python object has a :meth:`~object.__getitem__` method.
    *
    * @param key The key to look up.
    * @returns The corresponding value.
@@ -757,7 +760,7 @@ export class PyProxySetItemMethods {
   /**
    * This translates to the Python code ``obj[key] = value``.
    *
-   * Present only if the proxied Python object has a ``__setitem__`` method.
+   * Present only if the proxied Python object has a :meth:`~object.__setitem__` method.
    *
    * @param key The key to set.
    * @param value The value to set it to.
@@ -784,7 +787,7 @@ export class PyProxySetItemMethods {
   /**
    * This translates to the Python code ``del obj[key]``.
    *
-   * Present only if the proxied Python object has a ``__delitem__`` method.
+   * Present only if the proxied Python object has a :meth:`~object.__delitem__` method.
    *
    * @param key The key to delete.
    */
@@ -815,7 +818,7 @@ export class PyProxyContainsMethods {
   /**
    * This translates to the Python code ``key in obj``.
    *
-   * Present only if the proxied Python object has a ``__contains__`` method.
+   * Present only if the proxied Python object has a :meth:`~object.__contains__` method.
    *
    * @param key The key to check for.
    * @returns Is ``key`` present?
@@ -890,8 +893,9 @@ export class PyProxyIterableMethods {
    * associated to the proxy. See the documentation for `Symbol.iterator
    * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator>`_.
    *
-   * Present only if the proxied Python object is iterable (i.e., has an
-   * ``__iter__`` method).
+   * Present only if the proxied Python object is
+   * `iterable <https://docs.python.org/3/glossary.html#term-iterable>_
+   * (i.e., has an :meth:`~object.__iter__` method).
    *
    * This will be used implicitly by ``for(let x of proxy){}``.
    */
@@ -973,12 +977,12 @@ async function* aiter_helper(iterptr: number, token: {}): AsyncGenerator<any> {
 
 export class PyProxyAsyncIterableMethods {
   /**
-   * This translates to the Python code ``aiter(obj)``. Return an iterator
-   * associated to the proxy. See the documentation for `Symbol.iterator
-   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator>`_.
+   * This translates to the Python code ``aiter(obj)``. Return an async iterator
+   * associated to the proxy. See the documentation for `Symbol.asyncIterator
+   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator>`_.
    *
-   * Present only if the proxied Python object is iterable (i.e., has an
-   * ``__iter__`` method).
+   * Present only if the proxied Python object is async iterable (i.e., has an
+   * :meth:`~object.__aiter__` method).
    *
    * This will be used implicitly by ``for(let x of proxy){}``.
    */
@@ -1014,14 +1018,14 @@ export class PyProxyIteratorMethods {
   }
   /**
    * This translates to the Python code ``next(obj)``. Returns the next value of
-   * the generator. See the documentation for `Generator.prototype.next
-   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/next>`_.
+   * the generator. See the documentation for
+   * `Generator.prototype.next <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/next>`_.
    * The argument will be sent to the Python generator.
    *
    * This will be used implicitly by ``for(let x of proxy){}``.
    *
    * Present only if the proxied Python object is a generator or iterator (i.e.,
-   * has a ``send`` or ``__next__`` method).
+   * has a :meth:`~generator.send` or :meth:`~iterator.__next__` method).
    *
    * @param any The value to send to the generator. The value will be assigned
    * as a result of a yield expression.
@@ -1062,8 +1066,8 @@ export class PyProxyGeneratorMethods {
   /**
    * Throws an exception into the Generator.
    *
-   * See the documentation for `Generator.prototype.throw
-   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/throw>_`.
+   * See the documentation for
+   * `Generator.prototype.throw <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/throw>`_.
    *
    * @param exception Error The error to throw into the generator. Must be an
    * instanceof ``Error``.
@@ -1099,13 +1103,14 @@ export class PyProxyGeneratorMethods {
   }
 
   /**
-   * Throws a ``GeneratorExit`` into the generator and if the ``GeneratorExit``
-   * is not caught returns the argument value ``{done: true, value: v}``. If the
-   * generator catches the ``GeneratorExit`` and returns or yields another value
-   * the next value of the generator this is returned in the normal way. If it
-   * throws some error other than ``GeneratorExit`` or ``StopIteration``, that
-   * error is propagated. See the documentation for `Generator.prototype.return
-   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return>`_.
+   * Throws a :any:`GeneratorExit` into the generator and if the
+   * :any:`GeneratorExit` is not caught returns the argument value ``{done:
+   * true, value: v}``. If the generator catches the :any:`GeneratorExit` and
+   * returns or yields another value the next value of the generator this is
+   * returned in the normal way. If it throws some error other than
+   * :any:`GeneratorExit` or :any:`StopIteration`, that error is propagated. See
+   * the documentation for
+   * `Generator.prototype.return <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/return>`_.
    *
    * Present only if the proxied Python object is a generator.
    *
@@ -1185,8 +1190,8 @@ export class PyProxyAsyncGeneratorMethods {
   /**
    * Throws an exception into the Generator.
    *
-   * See the documentation for `Generator.prototype.throw
-   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/throw>_`.
+   * See the documentation for
+   * `Generator.prototype.throw <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/throw>`_.
    *
    * @param exception Error The error to throw into the generator. Must be an
    * instanceof ``Error``.
@@ -1231,11 +1236,11 @@ export class PyProxyAsyncGeneratorMethods {
   }
 
   /**
-   * Throws a ``GeneratorExit`` into the generator and if the ``GeneratorExit``
+   * Throws a :any:`GeneratorExit` into the generator and if the :any:`GeneratorExit`
    * is not caught returns the argument value ``{done: true, value: v}``. If the
-   * generator catches the ``GeneratorExit`` and returns or yields another value
+   * generator catches the :any:`GeneratorExit` and returns or yields another value
    * the next value of the generator this is returned in the normal way. If it
-   * throws some error other than ``GeneratorExit`` or ``StopIteration``, that
+   * throws some error other than :any:`GeneratorExit` or :any:`StopAsyncIteration`, that
    * error is propagated. See the documentation for `Generator.prototype.return
    * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/return>`_.
    *
@@ -1512,22 +1517,22 @@ export class PyProxyAwaitableMethods {
     return promise;
   }
   /**
-   * Runs ``asyncio.ensure_future(awaitable)``, executes
-   * ``onFulfilled(result)`` when the ``Future`` resolves successfully,
-   * executes ``onRejected(error)`` when the ``Future`` fails. Will be used
-   * implicitly by ``await obj``.
+   * Calls :func:`asyncio.ensure_future` on the awaitable, executes
+   * ``onFulfilled(result)`` when the ``Future`` resolves successfully, executes
+   * ``onRejected(error)`` when the ``Future`` fails. Will be used implicitly by
+   * ``await obj``.
    *
-   * See the documentation for
-   * `Promise.then
+   * See the documentation for `Promise.then
    * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then>`_
    *
    * Present only if the proxied Python object is `awaitable
-   * <https://docs.python.org/3/library/asyncio-task.html?highlight=awaitable#awaitables>`_.
+   * <https://docs.python.org/3/library/asyncio-task.html?highlight=awaitable#awaitables>`_
+   * (i.e., has an :meth:`~object.__await__` method).
    *
-   * @param onFulfilled A handler called with the result as an
-   * argument if the awaitable succeeds.
-   * @param onRejected A handler called with the error as an
-   * argument if the awaitable fails.
+   * @param onFulfilled A handler called with the result as an argument if the
+   * awaitable succeeds.
+   * @param onRejected A handler called with the error as an argument if the
+   * awaitable fails.
    * @returns The resulting Promise.
    */
   then(
@@ -1538,18 +1543,18 @@ export class PyProxyAwaitableMethods {
     return promise.then(onFulfilled, onRejected);
   }
   /**
-   * Runs ``asyncio.ensure_future(awaitable)`` and executes
+   * Calls :func:`asyncio.ensure_future` on the awaitable and executes
    * ``onRejected(error)`` if the future fails.
    *
-   * See the documentation for
-   * `Promise.catch
+   * See the documentation for `Promise.catch
    * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch>`_.
    *
    * Present only if the proxied Python object is `awaitable
    * <https://docs.python.org/3/library/asyncio-task.html?highlight=awaitable#awaitables>`_.
+   * (i.e., has an :meth:`~object.__await__` method)
    *
-   * @param onRejected A handler called with the error as an
-   * argument if the awaitable fails.
+   * @param onRejected A handler called with the error as an argument if the
+   * awaitable fails.
    * @returns The resulting Promise.
    */
   catch(onRejected: (reason: any) => any) {
@@ -1557,22 +1562,21 @@ export class PyProxyAwaitableMethods {
     return promise.catch(onRejected);
   }
   /**
-   * Runs ``asyncio.ensure_future(awaitable)`` and executes
+   * Calls :func:`asyncio.ensure_future` on the awaitable and executes
    * ``onFinally(error)`` when the future resolves.
    *
-   * See the documentation for
-   * `Promise.finally
+   * See the documentation for `Promise.finally
    * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally>`_.
    *
    * Present only if the proxied Python object is `awaitable
-   * <https://docs.python.org/3/library/asyncio-task.html?highlight=awaitable#awaitables>`_.
+   * <https://docs.python.org/3/library/asyncio-task.html?highlight=awaitable#awaitables>`_
+   * (i.e., has an :meth:`~object.__await__` method).
    *
    *
-   * @param onFinally A handler that is called with zero arguments
-   * when the awaitable resolves.
-   * @returns A Promise that resolves or rejects with the same
-   * result as the original Promise, but only after executing the
-   * ``onFinally`` handler.
+   * @param onFinally A handler that is called with zero arguments when the
+   * awaitable resolves.
+   * @returns A Promise that resolves or rejects with the same result as the
+   * original Promise, but only after executing the ``onFinally`` handler.
    */
   finally(onFinally: () => void) {
     let promise = this._ensure_future();
@@ -1586,16 +1590,16 @@ export type PyProxyCallable = PyProxy &
 
 export class PyProxyCallableMethods {
   /**
-   * The apply() method calls the specified function with a given this value,
-   * and arguments provided as an array (or an array-like object). Like the
-   * `JavaScript apply function
+   * The ``apply()`` method calls the specified function with a given this
+   * value, and arguments provided as an array (or an array-like object). Like
+   * the `JavaScript apply function
    * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply>`_.
    *
-   * Present only if the proxied Python object is callable.
+   * Present only if the proxied Python object is callable (i.e., has a :meth:`~object.__call__` method).
    *
-   * @param thisArg The `this` argument. Has no effect unless the `PyProxy` has
-   * :any:`captureThis` set. If :any:`captureThis` is set, it will be passed as
-   * the first argument to the Python function.
+   * @param thisArg The ``this`` argument. Has no effect unless the
+   * :any:`PyProxy` has :any:`captureThis` set. If :any:`captureThis` is set, it
+   * will be passed as the first argument to the Python function.
    * @param jsargs The array of arguments
    * @returns The result from the function call.
    */
@@ -1610,14 +1614,15 @@ export class PyProxyCallableMethods {
   }
   /**
    * Calls the function with a given this value and arguments provided
-   * individually. Like the `JavaScript call
-   * function <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call>`_.
+   * individually. Like the `JavaScript call function
+   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call>`_.
    *
-   * Present only if the proxied Python object is callable.
+   * Present only if the proxied Python object is callable (i.e., has a
+   * :meth:`~object.__call__` method).
    *
-   * @param thisArg The ``this`` argument. Has no effect unless the `PyProxy` has
-   * :any:`captureThis` set. If :any:`captureThis` is set, it will be passed as the first
-   * argument to the Python function.
+   * @param thisArg The ``this`` argument. Has no effect unless the
+   * :any:`PyProxy` has :any:`captureThis` set. If :any:`captureThis` is set, it
+   * will be passed as the first argument to the Python function.
    * @param jsargs The arguments
    * @returns The result from the function call.
    */
@@ -1628,7 +1633,7 @@ export class PyProxyCallableMethods {
   /**
    * Call the function with key word arguments. The last argument must be an
    * object with the keyword arguments. Present only if the proxied Python
-   * object is callable.
+   * object is callable (i.e., has a :meth:`~object.__call__` method).
    */
   callKwargs(...jsargs: any) {
     if (jsargs.length === 0) {
@@ -1650,14 +1655,17 @@ export class PyProxyCallableMethods {
    * The bind() method creates a new function that, when called, has its
    * ``this`` keyword set to the provided value, with a given sequence of
    * arguments preceding any provided when the new function is called. See the
-   * documentation for the `JavaScript bind
-   * function <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind>`_.
+   * documentation for the `JavaScript bind function
+   * <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind>`_.
    *
    * If the `PyProxy` does not have :any:`captureThis` set, the ``this``
    * parameter will be discarded. If it does have :any:`captureThis` set,
    * ``thisArg`` will be set to the first argument of the Python function. The
    * returned proxy and the original proxy have the same lifetime so destroying
    * either destroys both.
+   *
+   * Present only if the proxied Python object is callable (i.e., has a
+   * :meth:`~object.__call__` method)
    *
    * @param thisArg The value to be passed as the ``this`` parameter to the
    * target function ``func`` when the bound function is called.
@@ -1696,9 +1704,6 @@ export class PyProxyCallableMethods {
    * and the original proxy have the same lifetime so destroying either destroys
    * both.
    *
-   * @returns The resulting ``PyProxy``. It has the same lifetime as the
-   * original ``PyProxy`` but passes ``this`` to the wrapped function.
-   *
    * For example:
    *
    * .. code-block:: js
@@ -1714,6 +1719,9 @@ export class PyProxyCallableMethods {
    *    // With captureThis, it works fine:
    *    obj.f = pyodide.globals.get("f").captureThis();
    *    obj.f(); // returns 7
+   *
+   * @returns The resulting ``PyProxy``. It has the same lifetime as the
+   * original ``PyProxy`` but passes ``this`` to the wrapped function.
    *
    */
   captureThis(): PyProxy {
@@ -1948,19 +1956,6 @@ export type PyProxyDict = PyProxyWithGet & PyProxyWithSet & PyProxyWithHas;
  *    }
  *    console.log("entry is", pybuff.data[multiIndexToIndex(pybuff, [2, 0, -1])]);
  *
- * .. admonition:: Contiguity
- *    :class: warning
- *
- *    If the buffer is not contiguous, the ``data`` TypedArray will contain
- *    data that is not part of the buffer. Modifying this data may lead to
- *    undefined behavior.
- *
- * .. admonition:: Readonly buffers
- *    :class: warning
- *
- *    If ``buffer.readonly`` is ``true``, you should not modify the buffer.
- *    Modifying a readonly buffer may lead to undefined behavior.
- *
  * .. admonition:: Converting between TypedArray types
  *    :class: warning
  *
@@ -1993,68 +1988,80 @@ export class PyBuffer {
   offset: number;
 
   /**
-   * If the data is readonly, you should not modify it. There is no way
-   * for us to enforce this, but it may cause very weird behavior.
+   * If the data is readonly, you should not modify it. There is no way for us
+   * to enforce this, but it may cause very weird behavior. See
+   * :any:`memoryview.readonly`.
    */
   readonly: boolean;
 
   /**
-   * The format string for the buffer. See `the Python documentation on
-   * format strings
-   * <https://docs.python.org/3/library/struct.html#format-strings>`_.
+   * The format string for the buffer. See `the Python documentation on format
+   * strings <https://docs.python.org/3/library/struct.html#format-strings>`_.
+   * See :any:`memoryview.format`.
    */
   format: string;
 
   /**
-   * How large is each entry (in bytes)?
+   * How large is each entry (in bytes)? See :any:`memoryview.itemsize`.
    */
   itemsize: number;
 
   /**
    * The number of dimensions of the buffer. If ``ndim`` is 0, the buffer
    * represents a single scalar or struct. Otherwise, it represents an
-   * array.
+   * array. See :any:`memoryview.ndim`.
    */
   ndim: number;
 
   /**
    * The total number of bytes the buffer takes up. This is equal to
-   * ``buff.data.byteLength``.
+   * ``buff.data.byteLength``. See :any:`memoryview.nbytes`.
    */
   nbytes: number;
 
   /**
    * The shape of the buffer, that is how long it is in each dimension.
    * The length will be equal to ``ndim``. For instance, a 2x3x4 array
-   * would have shape ``[2, 3, 4]``.
+   * would have shape ``[2, 3, 4]``. See :any:`memoryview.shape`.
    */
   shape: number[];
 
   /**
    * An array of of length ``ndim`` giving the number of elements to skip
    * to get to a new element in each dimension. See the example definition
-   * of a ``multiIndexToIndex`` function above.
+   * of a ``multiIndexToIndex`` function above. See :any:`memoryview.strides`.
    */
   strides: number[];
 
   /**
-   * The actual data. A typed array of an appropriate size backed by a
-   * segment of the WASM memory.
+   * The actual data. A typed array of an appropriate size backed by a segment
+   * of the WASM memory.
    *
-   * The ``type`` argument of :any:`PyProxy.getBuffer`
-   * determines which sort of ``TypedArray`` this is. By default
-   * :any:`PyProxy.getBuffer` will look at the format string to determine the most
-   * appropriate option.
+   * The ``type`` argument of :any:`PyProxy.getBuffer` determines which sort of
+   * ``TypedArray`` this is. By default :any:`PyProxy.getBuffer` will look at
+   * the format string to determine the most appropriate option.
+   *
+   * .. admonition:: Contiguity :class: warning
+   *
+   *    If the buffer is not contiguous, the ``data`` TypedArray will contain
+   *    data that is not part of the buffer. Modifying this data leads to
+   *    undefined behavior.
+   *
+   * .. admonition:: Readonly buffers :class: warning
+   *
+   *    If ``buffer.readonly`` is ``true``, you should not modify the buffer.
+   *    Modifying a readonly buffer leads to undefined behavior.
+   *
    */
   data: TypedArray;
 
   /**
-   * Is it C contiguous?
+   * Is it C contiguous? See :any:`memoryview.c_contiguous`.
    */
   c_contiguous: boolean;
 
   /**
-   * Is it Fortran contiguous?
+   * Is it Fortran contiguous? See :any:`memoryview.f_contiguous`.
    */
   f_contiguous: boolean;
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -15,7 +15,7 @@ import { setStdin, setStdout, setStderr } from "./streams";
 API.loadBinaryFile = loadBinaryFile;
 
 /**
- * An alias to the Python :py:mod:`pyodide` package.
+ * An alias to the Python `pyodide </usage/api/python-api.html>`_ package.
  *
  * You can use this to call functions defined in the Pyodide Python package
  * from JavaScript.
@@ -173,7 +173,7 @@ export async function loadPackagesFromImports(
  *    :class: warning
  *
  *    Since pyodide 0.18.0, you must call :js:func:`loadPackagesFromImports` to
- *    import any python packages referenced via `import` statements in your
+ *    import any python packages referenced via ``import`` statements in your
  *    code. This function will no longer do it for you.
  *
  * @param code Python code to evaluate
@@ -199,8 +199,8 @@ API.runPythonAsync = runPythonAsync;
  * ``name``. This module can then be imported from Python using the standard
  * Python import system. If another module by the same name has already been
  * imported, this won't have much effect unless you also delete the imported
- * module from ``sys.modules``. This calls the {any}`pyodide_py` API
- * :func:`pyodide.register_js_module`.
+ * module from :any:`sys.modules`. This calls the :any:`pyodide_py` API
+ * :func:`~pyodide.ffi.register_js_module`.
  *
  * @param name Name of the JavaScript module to add
  * @param module JavaScript object backing the module
@@ -220,11 +220,11 @@ export function registerComlink(Comlink: any) {
 /**
  * Unregisters a JavaScript module with given name that has been previously
  * registered with :js:func:`pyodide.registerJsModule` or
- * :func:`pyodide.register_js_module`. If a JavaScript module with that name
- * does not already exist, will throw an error. Note that if the module has
- * already been imported, this won't have much effect unless you also delete
- * the imported module from ``sys.modules``. This calls the :any:`pyodide_py` API
- * :func:`pyodide.unregister_js_module`.
+ * :func:`~pyodide.ffi.register_js_module`. If a JavaScript module with that
+ * name does not already exist, will throw an error. Note that if the module has
+ * already been imported, this won't have much effect unless you also delete the
+ * imported module from ``sys.modules``. This calls the :any:`pyodide_py` API
+ * :func:`~pyodide.ffi.unregister_js_module`.
  *
  * @param name Name of the JavaScript module to remove
  */
@@ -233,7 +233,7 @@ export function unregisterJsModule(name: string) {
 }
 
 /**
- * Convert the JavaScript object to a Python object as best as possible.
+ * Convert a JavaScript object to a Python object as best as possible.
  *
  * This is similar to :any:`JsProxy.to_py` but for use from JavaScript. If the
  * object is immutable or a :any:`PyProxy`, it will be returned unchanged. If
@@ -241,7 +241,7 @@ export function unregisterJsModule(name: string) {
  *
  * See :ref:`type-translations-jsproxy-to-py` for more information.
  *
- * @param obj
+ * @param obj The object to convert.
  * @param options
  * @returns The object converted to Python.
  */
@@ -343,10 +343,12 @@ export function pyimport(mod_name: string): PyProxy {
  *
  * @param buffer The archive as an ArrayBuffer or TypedArray.
  * @param format The format of the archive. Should be one of the formats
- * recognized by `shutil.unpack_archive`. By default the options are 'bztar',
- * 'gztar', 'tar', 'zip', and 'wheel'. Several synonyms are accepted for each
- * format, e.g., for 'gztar' any of '.gztar', '.tar.gz', '.tgz', 'tar.gz' or
- * 'tgz' are considered to be synonyms.
+ * recognized by :any:`shutil.unpack_archive`. By default the options are
+ * ``'bztar'``, ``'gztar'``, ``'tar'``, ``'zip'``, and ``'wheel'``. Several
+ * synonyms are accepted for each format, e.g., for ``'gztar'`` any of
+ * ``'.gztar'``, ``'.tar.gz'``, ``'.tgz'``, ``'tar.gz'`` or ``'tgz'`` are
+ * considered to be
+ * synonyms.
  *
  * @param options
  * @param options.extractDir The directory to unpack the archive into. Defaults
@@ -438,16 +440,15 @@ API.restoreState = (state: any) => API.pyodide_py._state.restore_state(state);
  * when Pyodide is used in a webworker. The buffer should be a
  * ``SharedArrayBuffer`` shared with the main browser thread (or another
  * worker). In that case, signal ``signum`` may be sent by writing ``signum``
- * into the interrupt buffer. If ``signum`` does not satisfy 0 < ``signum`` <
- * ``NSIG`` it will be silently ignored. NSIG is 65 (internally signals are
- * indicated by a bitflag).
+ * into the interrupt buffer. If ``signum`` does not satisfy 0 < ``signum`` < 65
+ * it will be silently ignored.
  *
- * You can disable interrupts by calling `setInterruptBuffer(undefined)`.
+ * You can disable interrupts by calling ``setInterruptBuffer(undefined)``.
  *
- * If you wish to trigger a ``KeyboardInterrupt``, write ``SIGINT`` (a 2), into
+ * If you wish to trigger a :any:`KeyboardInterrupt`, write ``SIGINT`` (a 2), into
  * the interrupt buffer.
  *
- * By default ``SIGINT`` raises a ``KeyboardInterrupt`` and all other signals
+ * By default ``SIGINT`` raises a :any:`KeyboardInterrupt` and all other signals
  * are ignored. You can install custom signal handlers with the signal module.
  * Even signals that normally have special meaning and can't be overridden like
  * ``SIGKILL`` and ``SIGSEGV`` are ignored by default and can be used for any
@@ -459,11 +460,11 @@ export function setInterruptBuffer(interrupt_buffer: TypedArray) {
 }
 
 /**
- * Throws a KeyboardInterrupt error if a KeyboardInterrupt has been requested
- * via the interrupt buffer.
+ * Throws a :any:`KeyboardInterrupt` error if a :any:`KeyboardInterrupt` has
+ * been requested via the interrupt buffer.
  *
  * This can be used to enable keyboard interrupts during execution of JavaScript
- * code, just as ``PyErr_CheckSignals`` is used to enable keyboard interrupts
+ * code, just as :any:`PyErr_CheckSignals` is used to enable keyboard interrupts
  * during execution of C code.
  */
 export function checkInterrupt() {
@@ -528,9 +529,9 @@ export let FS: any;
 export let PATH: any;
 
 /**
- * An alias to the Emscripten ERRNO_CODES map of standard error codes.
+ * A map from posix error names to error codes.
  */
-export let ERRNO_CODES: any;
+export let ERRNO_CODES: { [code: string]: number };
 
 /**
  * @private

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -15,7 +15,7 @@ import { setStdin, setStdout, setStderr } from "./streams";
 API.loadBinaryFile = loadBinaryFile;
 
 /**
- * An alias to the Python `pyodide </usage/api/python-api.html>`_ package.
+ * An alias to the Python :ref:`pyodide <python-api>` package.
  *
  * You can use this to call functions defined in the Pyodide Python package
  * from JavaScript.

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -238,9 +238,9 @@ export async function loadPyodide(
     indexURL?: string;
 
     /**
-     * The URL from which Pyodide will load the Pyodide "repodata.json" lock
+     * The URL from which Pyodide will load the Pyodide ``repodata.json`` lock
      * file. You can produce custom lock files with :any:`micropip.freeze`.
-     * Default: ``${indexURL}/repodata.json``
+     * Default: ```${indexURL}/repodata.json```
      */
     lockFileURL?: string;
 
@@ -274,8 +274,10 @@ export async function loadPyodide(
      */
     jsglobals?: object;
     /**
-     * Command line arguments to pass to Python on startup.
-     * Default: ``[]``
+     * Command line arguments to pass to Python on startup. See `Python command
+     * line interface options
+     * <https://docs.python.org/3.10/using/cmdline.html#interface-options>`_ for
+     * more details. Default: ``[]``
      */
     args?: string[];
     /**

--- a/src/py/_pyodide/_base.py
+++ b/src/py/_pyodide/_base.py
@@ -19,7 +19,10 @@ def should_quiet(source: str) -> bool:
     """
     Should we suppress output?
 
-    Returns ``True`` if the last nonwhitespace character of ``code`` is a semicolon.
+    Returns
+    -------
+
+    ``True`` if the last nonwhitespace character of ``code`` is a semicolon.
 
     Examples
     --------
@@ -173,51 +176,61 @@ class CodeRunner:
 
     Parameters
     ----------
-    source : ``str``
+    source :
 
         The Python source code to run.
 
-    return_mode : ``str``
+    return_mode :
 
         Specifies what should be returned, must be one of ``'last_expr'``,
         ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
         raised. ``'last_expr'`` by default.
 
         * ``'last_expr'`` -- return the last expression
-        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
+        * ``'last_expr_or_assign'`` -- return the last expression or the last
+          assignment.
         * ``'none'`` -- always return ``None``.
 
-    quiet_trailing_semicolon : ``bool``
+    quiet_trailing_semicolon :
 
-        Specifies whether a trailing semicolon should suppress the result or not.
-        When this is ``True`` executing ``"1+1 ;"`` returns ``None``, when
-        it is ``False``, executing ``"1+1 ;"`` return ``2``. ``True`` by default.
+        Specifies whether a trailing semicolon should suppress the result or
+        not. When this is ``True`` executing ``"1+1;"`` returns ``None``, when
+        it is ``False``, executing ``"1+1;"`` return ``2``. ``True`` by default.
 
-    filename : ``str``
+    filename :
 
-        The file name to use in error messages and stack traces. ``'<exec>'`` by default.
+        The file name to use in error messages and stack traces. ``'<exec>'`` by
+        default.
 
-    mode : ``str``
+    mode :
 
-        The "mode" to compile in. One of ``"exec"``, ``"single"``, or ``"eval"``. Defaults
-        to ``"exec"``. For most purposes it's unnecessary to use this argument.
-        See the documentation for the built-in
-        `compile <https://docs.python.org/3/library/functions.html#compile>` function.
+        The "mode" to compile in. One of ``"exec"``, ``"single"``, or
+        ``"eval"``. Defaults to ``"exec"``. For most purposes it's unnecessary
+        to use this argument. See the documentation for the built-in
+        :external:py:func:`compile` function.
 
-    flags : ``int``
+    flags :
 
         The flags to compile with. See the documentation for the built-in
-        `compile <https://docs.python.org/3/library/functions.html#compile>` function.
+        :external:py:func:`compile` function.
+
 
     Attributes:
 
-        ast : The ast from parsing ``source``. If you wish to do an ast transform,
-              modify this variable before calling :any:`CodeRunner.compile`.
+        ast (ast.Module):
 
-        code : Once you call :any:`CodeRunner.compile` the compiled code will
-               be available in the code field. You can modify this variable
-               before calling :any:`CodeRunner.run` to do a code transform.
+            The ast from parsing ``source``. If you wish to do an ast transform,
+            modify this variable before calling :any:`CodeRunner.compile`.
+
+        code (CodeType):
+
+            Once you call :any:`CodeRunner.compile` the compiled code will
+            be available in the code field. You can modify this variable
+            before calling :any:`CodeRunner.run` to do a code transform.
     """
+
+    ast: ast.Module
+    code: CodeType | None
 
     def __init__(
         self,
@@ -262,7 +275,7 @@ class CodeRunner:
         self,
         globals: dict[str, Any] | None = None,
         locals: dict[str, Any] | None = None,
-    ) -> Any | None:
+    ) -> Any:
         """Executes ``self.code``.
 
         Can only be used after calling compile. The code may not use top level
@@ -271,24 +284,19 @@ class CodeRunner:
 
         Parameters
         ----------
-        globals : ``dict``
+        globals :
 
             The global scope in which to execute code. This is used as the ``globals``
-            parameter for ``exec``. If ``globals`` is absent, a new empty dictionary is used.
-            See `the exec documentation
-            <https://docs.python.org/3/library/functions.html#exec>`_ for more info.
+            parameter for :any:`exec`. If ``globals`` is absent, a new empty dictionary is used.
 
-        locals : ``dict``
+        locals :
 
             The local scope in which to execute code. This is used as the ``locals``
-            parameter for ``exec``. If ``locals`` is absent, the value of ``globals`` is
+            parameter for :any:`exec`. If ``locals`` is absent, the value of ``globals`` is
             used.
-            See `the exec documentation
-            <https://docs.python.org/3/library/functions.html#exec>`_ for more info.
 
         Returns
         -------
-        Any
 
             If the last nonwhitespace character of ``source`` is a semicolon,
             return ``None``. If the last statement is an expression, return the
@@ -316,7 +324,7 @@ class CodeRunner:
         self,
         globals: dict[str, Any] | None = None,
         locals: dict[str, Any] | None = None,
-    ) -> None:
+    ) -> Any:
         """Runs ``self.code`` which may use top level await.
 
         Can only be used after calling :any:`CodeRunner.compile`. If
@@ -325,24 +333,20 @@ class CodeRunner:
 
         Parameters
         ----------
-        globals : ``dict``
+        globals :
 
             The global scope in which to execute code. This is used as the ``globals``
-            parameter for ``exec``. If ``globals`` is absent, a new empty dictionary is used.
-            See `the exec documentation
-            <https://docs.python.org/3/library/functions.html#exec>`_ for more info.
+            parameter for :any:`exec`. If ``globals`` is absent, a new empty dictionary is used.
 
-        locals : ``dict``
+        locals :
 
-            The local scope in which to execute code. This is used as the ``locals``
-            parameter for ``exec``. If ``locals`` is absent, the value of ``globals`` is
-            used.
-            See `the exec documentation
-            <https://docs.python.org/3/library/functions.html#exec>`_ for more info.
+            The local scope in which to execute code. This is used as the
+            ``locals`` parameter for :any:`exec`. If ``locals`` is absent, the
+            value of ``globals`` is used.
 
         Returns
         -------
-        Any
+
             If the last nonwhitespace character of ``source`` is a semicolon,
             return ``None``. If the last statement is an expression, return the
             result of the expression. Use the ``return_mode`` and
@@ -375,53 +379,57 @@ def eval_code(
 
     Parameters
     ----------
-    source : ``str``
+    source :
 
         The Python source code to run.
 
-    globals : ``dict``
+    globals :
 
-        The global scope in which to execute code. This is used as the ``globals``
-        parameter for ``exec``. If ``globals`` is absent, a new empty dictionary is used.
-        See `the exec documentation
-        <https://docs.python.org/3/library/functions.html#exec>`_ for more info.
+        The global scope in which to execute code. This is used as the
+        ``globals`` parameter for :any:`exec`. If ``globals`` is absent, a new
+        empty dictionary is used.
 
-    locals : ``dict``
+    locals :
 
         The local scope in which to execute code. This is used as the ``locals``
-        parameter for ``exec``. If ``locals`` is absent, the value of ``globals`` is
-        used.
-        See `the exec documentation
-        <https://docs.python.org/3/library/functions.html#exec>`_ for more info.
+        parameter for :any:`exec`. If ``locals`` is absent, the value of
+        ``globals`` is used.
 
-    return_mode : ``str``
+    return_mode :
 
         Specifies what should be returned, must be one of ``'last_expr'``,
         ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
         raised. ``'last_expr'`` by default.
 
         * ``'last_expr'`` -- return the last expression
-        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
+        * ``'last_expr_or_assign'`` -- return the last expression or the last
+          assignment.
         * ``'none'`` -- always return ``None``.
 
-    quiet_trailing_semicolon : ``bool``
+    quiet_trailing_semicolon :
 
-        Specifies whether a trailing semicolon should suppress the result or not.
-        When this is ``True`` executing ``"1+1 ;"`` returns ``None``, when
-        it is ``False``, executing ``"1+1 ;"`` return ``2``. ``True`` by default.
+        Specifies whether a trailing semicolon should suppress the result or
+        not. When this is ``True`` executing ``"1+1 ;"`` returns ``None``, when
+        it is ``False``, executing ``"1+1 ;"`` return ``2``. ``True`` by
+        default.
 
-    filename : ``str``
+    filename :
 
-        The file name to use in error messages and stack traces. ``'<exec>'`` by default.
+        The file name to use in error messages and stack traces. ``'<exec>'`` by
+        default.
+
+    flags :
+
+        The flags to compile with. See the documentation for the built-in
+        :external:py:func:`compile` function.
 
     Returns
     -------
-    Any
 
-        If the last nonwhitespace character of ``source`` is a semicolon, return
-        ``None``. If the last statement is an expression, return the result of the
-        expression. Use the ``return_mode`` and ``quiet_trailing_semicolon``
-        parameters to modify this default behavior.
+    If the last nonwhitespace character of ``source`` is a semicolon, return
+    ``None``. If the last statement is an expression, return the result of the
+    expression. Use the ``return_mode`` and ``quiet_trailing_semicolon``
+    parameters to modify this default behavior.
 
     Examples
     --------
@@ -473,57 +481,59 @@ async def eval_code_async(
 ) -> Any:
     """Runs a code string asynchronously.
 
-    Uses `PyCF_ALLOW_TOP_LEVEL_AWAIT
-    <https://docs.python.org/3/library/ast.html#ast.PyCF_ALLOW_TOP_LEVEL_AWAIT>`_
-    to compile the code.
+    Uses :any:`ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` to compile the code.
 
     Parameters
     ----------
-    source : ``str``
+    source :
 
         The Python source code to run.
 
-    globals : ``dict``
+    globals :
 
-        The global scope in which to execute code. This is used as the ``globals``
-        parameter for ``exec``. If ``globals`` is absent, a new empty dictionary is used.
-        See `the exec documentation
-        <https://docs.python.org/3/library/functions.html#exec>`_ for more info.
+        The global scope in which to execute code. This is used as the
+        ``globals`` parameter for :any:`exec`. If ``globals`` is absent, a new
+        empty dictionary is used.
 
-    locals : ``dict``
+    locals :
 
         The local scope in which to execute code. This is used as the ``locals``
-        parameter for ``exec``. If ``locals`` is absent, the value of ``globals`` is
-        used.
-        See `the exec documentation
-        <https://docs.python.org/3/library/functions.html#exec>`_ for more info.
+        parameter for :any:`exec`. If ``locals`` is absent, the value of
+        ``globals`` is used.
 
-    return_mode : ``str``
+    return_mode :
 
         Specifies what should be returned, must be one of ``'last_expr'``,
         ``'last_expr_or_assign'`` or ``'none'``. On other values an exception is
         raised. ``'last_expr'`` by default.
 
         * ``'last_expr'`` -- return the last expression
-        * ``'last_expr_or_assign'`` -- return the last expression or the last assignment.
+        * ``'last_expr_or_assign'`` -- return the last expression or the last
+          assignment.
         * ``'none'`` -- always return ``None``.
 
-    quiet_trailing_semicolon : ``bool``
+    quiet_trailing_semicolon :
 
-        Specifies whether a trailing semicolon should suppress the result or not.
-        When this is ``True`` executing ``"1+1 ;"`` returns ``None``, when
-        it is ``False``, executing ``"1+1 ;"`` return ``2``. ``True`` by default.
+        Specifies whether a trailing semicolon should suppress the result or
+        not. When this is ``True`` executing ``"1+1 ;"`` returns ``None``, when
+        it is ``False``, executing ``"1+1 ;"`` return ``2``. ``True`` by
+        default.
 
-    filename : ``str``
+    filename :
 
-        The file name to use in error messages and stack traces. ``'<exec>'`` by default.
+        The file name to use in error messages and stack traces. ``'<exec>'`` by
+        default.
+
+    flags :
+
+        The flags to compile with. See the documentation for the built-in
+        :external:py:func:`compile` function.
 
     Returns
     -------
-    Any
         If the last nonwhitespace character of ``source`` is a semicolon, return
-        ``None``. If the last statement is an expression, return the result of the
-        expression. Use the ``return_mode`` and ``quiet_trailing_semicolon``
+        ``None``. If the last statement is an expression, return the result of
+        the expression. Use the ``return_mode`` and ``quiet_trailing_semicolon``
         parameters to modify this default behavior.
     """
     flags = flags or ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
@@ -546,12 +556,11 @@ def find_imports(source: str) -> list[str]:
 
     Parameters
     ----------
-    source : str
+    source :
        The Python source code to inspect for imports.
 
     Returns
     -------
-    ``List[str]``
         A list of module names that are imported in ``source``. If ``source`` is not
         syntactically correct Python code (after dedenting), returns an empty list.
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1116,9 +1116,9 @@ def to_js(
         desired result of the dict conversion. Some suggested values for
         this argument:
 
-            js.Map.new -- similar to the default behavior
-            js.Array.from -- convert to an array of entries
-            js.Object.fromEntries -- convert to a JavaScript object
+          * ``js.Map.new`` -- similar to the default behavior
+          * ``js.Array.from`` -- convert to an array of entries
+          * ``js.Object.fromEntries`` -- convert to a JavaScript object
 
     default_converter:
         If present will be invoked whenever Pyodide does not have some built in

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1088,7 +1088,7 @@ def to_js(
     object can be implicitly translated to JavaScript, it will be returned
     unchanged. If the object cannot be converted into JavaScript, this
     method will return a :any:`JsProxy` of a :any:`PyProxy`, as if you had
-    used :any:`pyodide.ffi.create_proxy`.
+    used :func:`~pyodide.ffi.create_proxy`.
 
     See :ref:`type-translations-pyproxy-to-js` for more information.
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -398,10 +398,10 @@ class JsBuffer(JsProxy):
 
         Copies the data twice.
 
-        The encoding argument will be passed to the Javascript
-        [``TextDecoder``](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder)
-        constructor. It should be one of the encodings listed in the table here:
-        `https://encoding.spec.whatwg.org/#names-and-labels`. The default
+        The encoding argument will be passed to the Javascript `TextDecoder
+        <(https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder)>`_
+        constructor. It should be one of the encodings listed in `the table here
+        <https://encoding.spec.whatwg.org/#names-and-labels>`_. The default
         encoding is utf8.
         """
         raise NotImplementedError
@@ -1094,23 +1094,23 @@ def to_js(
 
     Parameters
     ----------
-    obj : Any
+    obj :
         The Python object to convert
 
-    depth : int, default=-1
+    depth :
         The maximum depth to do the conversion. Negative numbers are treated
         as infinite. Set this to 1 to do a shallow conversion.
 
-    pyproxies: JsProxy, default = None
+    pyproxies:
         Should be a JavaScript ``Array``. If provided, any ``PyProxies`` generated
         will be stored here. You can later use :any:`destroy_proxies` if you want
         to destroy the proxies from Python (or from JavaScript you can just iterate
         over the ``Array`` and destroy the proxies).
 
-    create_pyproxies: bool, default=True
+    create_pyproxies:
         If you set this to False, :any:`to_js` will raise an error
 
-    dict_converter: Callable[[Iterable[JsProxy]], JsProxy], default = None
+    dict_converter:
         This converter if provided receives a (JavaScript) iterable of
         (JavaScript) pairs [key, value]. It is expected to return the
         desired result of the dict conversion. Some suggested values for
@@ -1119,7 +1119,8 @@ def to_js(
             js.Map.new -- similar to the default behavior
             js.Array.from -- convert to an array of entries
             js.Object.fromEntries -- convert to a JavaScript object
-    default_converter: Callable[[Any, Callable[[Any], JsProxy], Callable[[Any, JsProxy], None]], JsProxy], default=None
+
+    default_converter:
         If present will be invoked whenever Pyodide does not have some built in
         conversion for the object. If ``default_converter`` raises an error, the
         error will be allowed to propagate. Otherwise, the object returned will

--- a/src/py/pyodide/code.py
+++ b/src/py/pyodide/code.py
@@ -13,8 +13,8 @@ def run_js(code: str, /) -> Any:
     """
     A wrapper for the JavaScript 'eval' function.
 
-    Runs 'code' as a Javascript code string and returns the result. Unlike
-    JavaScript's 'eval', if 'code' is not a string we raise a TypeError.
+    Runs ``code`` as a Javascript code string and returns the result. Unlike
+    JavaScript's ``eval``, if ``code`` is not a string we raise a :any:`TypeError`.
     """
     from js import eval as eval_
 

--- a/src/py/pyodide/console.py
+++ b/src/py/pyodide/console.py
@@ -108,6 +108,7 @@ class _Compile(Compile):
             return_mode=return_mode,
             flags=self.flags,
         ).compile()
+        assert code_runner.code
         for feature in _features:
             if code_runner.code.co_flags & feature.compiler_flag:
                 self.flags |= feature.compiler_flag
@@ -192,43 +193,43 @@ class Console:
 
     Parameters
     ----------
-    globals : ``dict``
+    globals :
         The global namespace in which to evaluate the code. Defaults to a new empty dictionary.
 
-    stdin_callback : ``Callable[[int], str]``
+    stdin_callback :
         Function to call at each read from ``sys.stdin``. Defaults to ``None``.
 
-    stdout_callback : ``Callable[[str], None]``
+    stdout_callback :
         Function to call at each write to ``sys.stdout``. Defaults to ``None``.
 
-    stderr_callback : ``Callable[[str], None]``
+    stderr_callback :
         Function to call at each write to ``sys.stderr``. Defaults to ``None``.
 
-    persistent_stream_redirection : ``bool``
+    persistent_stream_redirection :
         Should redirection of standard streams be kept between calls to :any:`runcode <Console.runcode>`?
         Defaults to ``False``.
 
-    filename : ``str``
+    filename :
         The file name to report in error messages. Defaults to ``<console>``.
 
     Attributes
     ----------
-        globals : ``Dict[str, Any]``
+        globals :
             The namespace used as the global
 
-        stdin_callback : ``Callback[[], str]``
+        stdin_callback :
             Function to call at each read from ``sys.stdin``.
 
-        stdout_callback : ``Callback[[str], None]``
+        stdout_callback :
             Function to call at each write to ``sys.stdout``.
 
-        stderr_callback : ``Callback[[str], None]``
+        stderr_callback :
             Function to call at each write to ``sys.stderr``.
 
-        buffer : ``List[str]``
+        buffer :
             The list of strings that have been :any:`pushed <Console.push>` to the console.
 
-        completer_word_break_characters : ``str``
+        completer_word_break_characters :
             The set of characters considered by :any:`complete <Console.complete>` to be word breaks.
     """
 
@@ -494,16 +495,16 @@ def shorten(
 
     Parameters
     ----------
-    text : ``str``
+    text :
         The string to shorten if it is longer than ``limit``.
 
-    limit : ``int``
+    limit :
         The integer to compare against the length of ``text``. Defaults to ``1000``.
 
-    split : ``int``, default = None
+    split :
         The integer of the split string to return. Defaults to ``limit // 2``.
 
-    separator : str, default = "..."
+    separator :
         The string of the separator string. Defaults to ``"..."``.
 
     Returns

--- a/src/py/pyodide/ffi/wrappers.py
+++ b/src/py/pyodide/ffi/wrappers.py
@@ -14,6 +14,8 @@ if IN_BROWSER:
 
 
 class Destroyable(Protocol):
+    """:meta private:"""
+
     def destroy(self):
         pass
 

--- a/src/py/pyodide/ffi/wrappers.py
+++ b/src/py/pyodide/ffi/wrappers.py
@@ -109,3 +109,13 @@ def clear_interval(interval_retval: int | JsProxy) -> None:
     clearInterval(interval_retval)
     id = interval_retval if isinstance(interval_retval, int) else interval_retval.js_id
     INTERVAL_CALLBACKS.pop(id, DUMMY_DESTROYABLE).destroy()
+
+
+__all__ = [
+    "add_event_listener",
+    "remove_event_listener",
+    "set_timeout",
+    "clear_timeout",
+    "set_interval",
+    "clear_interval",
+]

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -88,6 +88,7 @@ def test_code_runner():
     assert cr.compile().run({"x": 3}) == 13
 
     # Code transform
+    assert cr.code
     cr.code = cr.code.replace(co_consts=(0, 3, 5, None))
     assert cr.run({"x": 4}) == 17
 


### PR DESCRIPTION
Use `autodoc-typehints` to generate the types for the Python API docs. This is a major
improvement to the rendering of a lot of things, since the signature isn't so cluttered 
with types.

I also fixed the rendering of return value annotations which used to be messed up in
a few places. I added `async` prefixes to the entries in the auto summary table and
made the font upright and bold for the signatures in the autosummary table, just like
they are in the actual documentation. I also added cpython core to intersphinx.

Finally, I went through a bunch of the API docs and fixed them to add xrefs to the
cpython docs and to make them work correctly with autodoc type hints.



<details>
<summary>Before 1</summary>

![Screenshot from 2023-01-02 21-14-24](https://user-images.githubusercontent.com/8739626/210292184-0f2bbbdd-162b-4aa9-87d1-112779b470b1.png)

</details>

<details>
<summary>After 1</summary>


![Screenshot from 2023-01-02 21-13-53](https://user-images.githubusercontent.com/8739626/210292194-10ea9648-e8bd-4cf7-a80c-6759d7893f33.png)


</details>


<details>
<summary>Before 2</summary>

![Screenshot from 2023-01-02 21-20-49](https://user-images.githubusercontent.com/8739626/210292651-c064ae3c-5b9b-4539-b1a2-b86b5dd54e02.png)


</details>

<details>
<summary>After 2</summary>


![Screenshot from 2023-01-02 21-20-36](https://user-images.githubusercontent.com/8739626/210292663-bbf76862-1eea-441c-9bb8-278704a272eb.png)



</details>