### PR TITLE
DOC Fix duplicate version section name in the changelog

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -21,8 +21,6 @@ _January 3, 2023_
 
 [See the release notes for a summary.](https://blog.pyodide.org/posts/0.22-release/)
 
-## 0.22.0
-
 ### Deployment and testing
 
 - {{ Breaking }} `pyodide-cdn2.iodide.io` is not available anymore. Please use


### PR DESCRIPTION
The version section name is repeated twice currently. This fixes it. Will cherry-pick to 0.22.X once merged.


![image](https://user-images.githubusercontent.com/630936/210395827-ca7b5e15-91ab-410b-8402-c2bf3346fc8a.png)
