### PR TITLE
DOCS Fix link to out-of-tree-builds documentation

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -287,7 +287,7 @@ _January 3, 2023_
 
 - {{ Enhancement }} Added a system for making Pyodide virtual environments. This
   is for testing out of tree builds. For more information, see [the
-  documentation](https://pyodide.org/en/stable/development/building-and-testing-packages.html).
+  documentation](building-and-testing-packages-out-of-tree).
   {pr}`2976`, {pr}`3039`, {pr}`3040`, {pr}`3044`, {pr}`3096`, {pr}`3098`,
   {pr}`3108`, {pr}`3109`, {pr}`3241`
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -287,7 +287,7 @@ _January 3, 2023_
 
 - {{ Enhancement }} Added a system for making Pyodide virtual environments. This
   is for testing out of tree builds. For more information, see [the
-  documentation](https://pyodide.org/en/stable/development/out-of-tree.html).
+  documentation](https://pyodide.org/en/stable/development/building-and-testing-packages.html).
   {pr}`2976`, {pr}`3039`, {pr}`3040`, {pr}`3044`, {pr}`3096`, {pr}`3098`,
   {pr}`3108`, {pr}`3109`, {pr}`3241`
 


### PR DESCRIPTION
### Description

A very small PR - the 0.22.0 changelog has an incorrect link to the out-of-tree builds documentation page, which this PR fixes.

Congrats on the release!
