### PR TITLE
Fix pyodide-py package name

### DIFF
--- a/src/py/setup.cfg
+++ b/src/py/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = pyodide
+name = pyodide-py
 version = 0.22.0
 author = Pyodide developers
 description = "A Python package providing core interpreter functionality for Pyodide."


### PR DESCRIPTION
I think this will fix the release CI failure (https://github.com/pyodide/pyodide/actions/runs/3829966769/jobs/6517241654).

Someone would need to make a manual release after merge.