### PR TITLE
Ignore --exclude-libs link flag

### DIFF
--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -320,6 +320,7 @@ def replay_genargs_handle_linker_opts(arg: str) -> str | None:
                 "--version-script=",
                 "-R/",  # wasm-ld does not accept -R (runtime libraries)
                 "-R.",  # wasm-ld does not accept -R (runtime libraries)
+                "--exclude-libs=",
             )
         ):
             continue


### PR DESCRIPTION
### Description

Following @ryanking13's instructions here: https://github.com/pyodide/pyodide/issues/3427#issuecomment-1374422693

I'm assuming that `--exclude-libs` will always have arguments following it, so we should be testing `startswith("--exclude-libs=")` rather than the existence of `--exclude-libs`.
