### PR TITLE
Handle response files in `calculate_exports`

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,8 @@ myst:
 - Added `pyodide py-compile` CLI command that py compiles a wheel, converting .py files
   to .pyc files
   {pr}`3253`
+- Added `.rsp` file handling in pywasmcross `calculate_exports`
+  {pr}`3438`
 
 ## Version 0.22.0
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -505,7 +505,7 @@ def calculate_exports(line: list[str], export_all: bool) -> Iterable[str]:
             all_args.extend(Path(arg).read_text().splitlines())
         else:
             all_args.append(arg)
-    
+
     objects = [arg for arg in all_args if arg.endswith((".a", ".o"))]
 
     exports = None

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -498,15 +498,14 @@ def calculate_exports(line: list[str], export_all: bool) -> Iterable[str]:
     then return all public symbols. If not, return only the public symbols that
     begin with `PyInit`.
     """
-    # Extract list of arguments, including those from response files
+    # Get all arguments, including those from response files
     all_args = []
     for arg in line:
         if arg.endswith(".rsp"):
             all_args.extend(Path(arg).read_text().splitlines())
         else:
             all_args.append(arg)
-
-    # Filter objects to only include .a and .o files
+    
     objects = [arg for arg in all_args if arg.endswith((".a", ".o"))]
 
     exports = None

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -498,7 +498,18 @@ def calculate_exports(line: list[str], export_all: bool) -> Iterable[str]:
     then return all public symbols. If not, return only the public symbols that
     begin with `PyInit`.
     """
-    objects = [arg for arg in line if arg.endswith((".a", ".o"))]
+    # Parse response files and extract list of arguments
+    objects = []
+    for arg in line:
+        if arg.endswith(".rsp"):
+            with open(arg, "r") as f:
+                objects.extend(f.read().splitlines())
+        else:
+            objects.append(arg)
+    
+    # Filter objects to only include .a and .o files
+    objects = [obj for obj in objects if obj.endswith((".a", ".o"))]
+    
     exports = None
     # Using emnm is simpler but it cannot handle bitcode. If we're only
     # exporting the PyInit symbols, save effort by using nm.

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -498,16 +498,16 @@ def calculate_exports(line: list[str], export_all: bool) -> Iterable[str]:
     then return all public symbols. If not, return only the public symbols that
     begin with `PyInit`.
     """
-    # Parse response files and extract list of arguments
-    objects = []
+    # Extract list of arguments, including those from response files
+    all_args = []
     for arg in line:
         if arg.endswith(".rsp"):
-            objects.extend(Path(arg).read_text().splitlines())
+            all_args.extend(Path(arg).read_text().splitlines())
         else:
-            objects.append(arg)
+            all_args.append(arg)
 
     # Filter objects to only include .a and .o files
-    objects = [obj for obj in objects if obj.endswith((".a", ".o"))]
+    objects = [arg for arg in all_args if arg.endswith((".a", ".o"))]
 
     exports = None
     # Using emnm is simpler but it cannot handle bitcode. If we're only

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -502,8 +502,7 @@ def calculate_exports(line: list[str], export_all: bool) -> Iterable[str]:
     objects = []
     for arg in line:
         if arg.endswith(".rsp"):
-            with open(arg) as f:
-                objects.extend(f.read().splitlines())
+            objects.extend(Path(arg).read_text().splitlines())
         else:
             objects.append(arg)
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -502,14 +502,14 @@ def calculate_exports(line: list[str], export_all: bool) -> Iterable[str]:
     objects = []
     for arg in line:
         if arg.endswith(".rsp"):
-            with open(arg, "r") as f:
+            with open(arg) as f:
                 objects.extend(f.read().splitlines())
         else:
             objects.append(arg)
-    
+
     # Filter objects to only include .a and .o files
     objects = [obj for obj in objects if obj.endswith((".a", ".o"))]
-    
+
     exports = None
     # Using emnm is simpler but it cannot handle bitcode. If we're only
     # exporting the PyInit symbols, save effort by using nm.


### PR DESCRIPTION
Closes #3436

### Description

This allows pywasmcross to handle response files in its `calculate_exports` parsing.

See here for info: https://github.com/pyodide/pyodide/issues/3427#issuecomment-1374418990

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests

## Additional notes

I haven't written any tests for this. I've only tested it in a notebook:

![image](https://user-images.githubusercontent.com/1167575/211181581-8b88dfa5-99dc-467f-ab7d-82c2560f01b1.png)

