### PR TITLE
MAINT When importing _pyodide_core fails, throw a readable error message

### DIFF
--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -367,7 +367,13 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
 
   const pyodide_py_tar = await pyodide_py_tar_promise;
   unpackPyodidePy(Module, pyodide_py_tar);
-  API.rawRun("import _pyodide_core");
+  let [err, captured_stderr] = API.rawRun("import _pyodide_core");
+  if (err) {
+    Module.API.fatal_loading_error(
+      "Failed to import _pyodide_core\n",
+      captured_stderr,
+    );
+  }
 
   const pyodide = finalizeBootstrap(API, config);
 


### PR DESCRIPTION
Helpful when developing the C code.
