### PR TITLE
MAINT Define `InternalError` and `ConversionError` in _pyodide_core

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -295,18 +295,16 @@ int
 error_handling_init(PyObject* core_module)
 {
   bool success = false;
-  internal_error = PyErr_NewException("pyodide.InternalError", NULL, NULL);
-  FAIL_IF_NULL(internal_error);
+  PyObject* _pyodide_core_docs = NULL;
+  _pyodide_core_docs = PyImport_ImportModule("_pyodide._core_docs");
+  FAIL_IF_NULL(_pyodide_core_docs);
 
-  conversion_error = PyErr_NewExceptionWithDoc(
-    "pyodide.ConversionError",
-    PyDoc_STR("Raised when conversion between Javascript and Python fails."),
-    NULL,
-    NULL);
+  internal_error = PyObject_GetAttrString(_pyodide_core_docs, "InternalError");
+  FAIL_IF_NULL(internal_error);
+  conversion_error =
+    PyObject_GetAttrString(_pyodide_core_docs, "ConversionError");
   FAIL_IF_NULL(conversion_error);
-  // ConversionError is public
-  FAIL_IF_MINUS_ONE(
-    PyObject_SetAttrString(core_module, "ConversionError", conversion_error));
+
   FAIL_IF_MINUS_ONE(PyModule_AddFunctions(core_module, methods));
 
   tbmod = PyImport_ImportModule("traceback");

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3952,6 +3952,7 @@ JsProxy_create_with_this(JsRef object, JsRef this)
   } else {
     type_flags = compute_typeflags(object);
     if (type_flags == -1) {
+      fail_test();
       PyErr_SetString(internal_error,
                       "Internal error occurred in compute_typeflags");
       return NULL;

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2660,6 +2660,9 @@ static PyTypeObject _Exc_JsException = {
   .tp_basicsize = sizeof(JsExceptionObject),
   .tp_dealloc = (destructor)JsException_dealloc,
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+  .tp_doc =
+    PyDoc_STR("An exception which wraps a Javascript error. The js_error field "
+              "contains a JsProxy for the wrapped error."),
   .tp_traverse = (traverseproc)JsException_traverse,
   .tp_clear = (inquiry)JsException_clear,
   .tp_members = JsException_members,

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2660,9 +2660,6 @@ static PyTypeObject _Exc_JsException = {
   .tp_basicsize = sizeof(JsExceptionObject),
   .tp_dealloc = (destructor)JsException_dealloc,
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
-  .tp_doc =
-    PyDoc_STR("An exception which wraps a Javascript error. The js_error field "
-              "contains a JsProxy for the wrapped error."),
   .tp_traverse = (traverseproc)JsException_traverse,
   .tp_clear = (inquiry)JsException_clear,
   .tp_members = JsException_members,

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -936,6 +936,8 @@ class ConversionError(Exception):
 
 
 class InternalError(Exception):
+    """Thrown when a recoverable assertion error occurs in internal Pyodide code"""
+
     pass
 
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -920,6 +920,8 @@ class JsRawException(JsProxy):
 class JsException(Exception):
     """
     A wrapper around a JavaScript Error to allow it to be thrown in Python.
+
+    The js_error field contains a JsProxy for the wrapped error.
     See :ref:`type-translations-errors`.
     """
 
@@ -931,6 +933,10 @@ class JsException(Exception):
 
 class ConversionError(Exception):
     """An error thrown when conversion between JavaScript and Python fails."""
+
+
+class InternalError(Exception):
+    pass
 
 
 class JsDomElement(JsProxy):

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -33,8 +33,6 @@ if IN_BROWSER:
 
     import _pyodide._core_docs
 
-    _pyodide_core.JsException.__doc__ = JsException.__doc__
-
     # This is intentionally opaque to static analysis tools (e.g., mypy)
     #
     # Note:

--- a/src/py/pyodide/_core.py
+++ b/src/py/pyodide/_core.py
@@ -33,6 +33,8 @@ if IN_BROWSER:
 
     import _pyodide._core_docs
 
+    _pyodide_core.JsException.__doc__ = JsException.__doc__
+
     # This is intentionally opaque to static analysis tools (e.g., mypy)
     #
     # Note:
@@ -41,7 +43,6 @@ if IN_BROWSER:
     #   from _core_docs, adding a type stub would introduce a redundancy
     #   that would be difficult to maintain.
     for t in [
-        "ConversionError",
         "JsException",
         "create_once_callable",
         "create_proxy",

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -543,7 +543,7 @@ def test_python2js_track_proxies(selenium):
             }
         }
         check(result);
-        assertThrows(() => x.toJs({create_pyproxies : false}), "PythonError", "pyodide.ConversionError");
+        assertThrows(() => x.toJs({create_pyproxies : false}), "PythonError", "pyodide.ffi.ConversionError");
         x.destroy();
         """
     )


### PR DESCRIPTION
Some minor cleanup: define `InternalError` and `ConversionError` in `_pyodide_core` and just import them into C.