### PR TITLE
DOCS: Help Spinx find ffi types

### DIFF
--- a/docs/sphinx_pyodide/sphinx_pyodide/__init__.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/__init__.py
@@ -41,8 +41,28 @@ def patch_templates():
     JsRenderer.rst = patched_rst_method
 
 
+def patch_documenter():
+    from sphinx.ext.autodoc import ModuleAnalyzer
+
+    orig_for_module = ModuleAnalyzer.for_module.__func__
+
+    @classmethod  # type: ignore[misc]
+    def for_module(cls: type, modname: str) -> ModuleAnalyzer:
+        if modname == "pyodide.ffi":
+            modname = "_pyodide._core_docs"
+        return orig_for_module(cls, modname)
+
+    ModuleAnalyzer.for_module = for_module
+
+    from sphinx.ext.autodoc import FunctionDocumenter, MethodDocumenter
+
+    del FunctionDocumenter.format_signature
+    del MethodDocumenter.format_signature
+
+
 def setup(app):
     patch_templates()
+    patch_documenter()
     app.add_lexer("pyodide", PyodideLexer)
     app.add_lexer("html-pyodide", HtmlPyodideLexer)
     app.setup_extension("sphinx_js")

--- a/docs/sphinx_pyodide/sphinx_pyodide/__init__.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/__init__.py
@@ -65,18 +65,9 @@ def fix_pyodide_ffi_path():
     ModuleAnalyzer.for_module = for_module
 
 
-def fix_autodoc_typehints_for_overloaded_methods():
-    """See https://github.com/tox-dev/sphinx-autodoc-typehints/issues/296"""
-    from sphinx.ext.autodoc import FunctionDocumenter, MethodDocumenter
-
-    del FunctionDocumenter.format_signature
-    del MethodDocumenter.format_signature
-
-
 def setup(app):
     patch_templates()
     fix_pyodide_ffi_path()
-    fix_autodoc_typehints_for_overloaded_methods()
     app.add_lexer("pyodide", PyodideLexer)
     app.add_lexer("html-pyodide", HtmlPyodideLexer)
     app.setup_extension("sphinx_js")


### PR DESCRIPTION
Two fixes:

The `pyodide.ffi` stuff is defined in `_pyodide._core_docs`. We don't want `_pyodide._core_docs` to appear in the documentation because this isn't where you should import things from so we override the `__name__` of `_pyodide._core_docs` to be `pyodide.ffi`. But then Sphinx fails to locate the source for the stuff defined in `_pyodide._core_docs`. This patches `ModuleAnalyzer` to tell it to look for the source of things from `pyodide.ffi` in `_pyodide._core_docs`.

If a function has a typing.overload then the code path that sphinx-autodoc takes is not one that sphinx-autodoc-typehints can handle.
See https://github.com/tox-dev/sphinx-autodoc-typehints/issues/296
