### PR TITLE
Minor docs fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,12 +249,11 @@ def globalReplace(app, docname, source):
 
 global_replacements = {"{{PYODIDE_CDN_URL}}": CDN_URL}
 
-from sphinx_autodoc_typehints import format_annotation
-
 
 def typehints_formatter(annotation, config):
     """Adjust the rendering of various types that sphinx_autodoc_typehints mishandles"""
     from sphinx_autodoc_typehints import (
+        format_annotation,
         get_annotation_args,
         get_annotation_class_name,
         get_annotation_module,
@@ -267,6 +266,9 @@ def typehints_formatter(annotation, config):
     except ValueError:
         return None
     full_name = f"{module}.{class_name}"
+    if full_name == "ast.Module":
+        return "`Module <https://docs.python.org/3/library/ast.html#module-ast>`_"
+
     if full_name == "collections.abc.Callable" and args:
         # Not sure what causes this, it isn't a bug in sphinx-autodoc-typehints
         fmt = [format_annotation(arg, config) for arg in args]

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -9,7 +9,7 @@ sphinx-issues
 sphinx-js>=3.2.1
 sphinx-version-warning>=1.1.2
 sphinx-click
-sphinx-autodoc-typehints>=1.21.1
+sphinx-autodoc-typehints>=1.21.3
 pydantic
 # Packages that we want to document as part of the Pyodide CLI
 ./pyodide-build/

--- a/docs/sphinx_pyodide/sphinx_pyodide/__init__.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/__init__.py
@@ -1,5 +1,3 @@
-from sphinx.addnodes import desc_signature
-
 from .jsdoc import (
     PyodideAnalyzer,
     get_jsdoc_content_directive,
@@ -43,57 +41,6 @@ def patch_templates():
     JsRenderer.rst = patched_rst_method
 
 
-def patch_py_attribute_handle_signature():
-    """
-    Patch PyAttribute.handle_signature so that it renders rst instead of
-    escaping it.
-    """
-    from docutils import nodes
-    from docutils.parsers.rst import Parser as RstParser
-    from docutils.utils import new_document
-    from sphinx import addnodes
-    from sphinx.domains.python import PyAttribute
-
-    def handle_signature(
-        self: PyAttribute, sig: str, signode: desc_signature
-    ) -> tuple[str, str]:
-        """This changes the handling for types compared to upstream version.
-        Parse rst in the type name instead of escaping it.
-
-        The `if typ:` block is changed compared to upstream, rest is same.
-        """
-        fullname, prefix = super(PyAttribute, self).handle_signature(sig, signode)
-
-        typ = self.options.get("type")
-        if typ:
-            settings = self.state.document.settings
-            doc = new_document("", settings)
-            RstParser().parse(typ, doc)
-            # Remove top level paragraph node so that there is no line break.
-            annotations = doc.children[0].children
-            signode += addnodes.desc_annotation(
-                typ,
-                "",
-                addnodes.desc_sig_punctuation("", ":"),
-                addnodes.desc_sig_space(),
-                *annotations
-            )
-        value = self.options.get("value")
-        if value:
-            signode += addnodes.desc_annotation(
-                value,
-                "",
-                addnodes.desc_sig_space(),
-                addnodes.desc_sig_punctuation("", "="),
-                addnodes.desc_sig_space(),
-                nodes.Text(value),
-            )
-
-        return fullname, prefix
-
-    PyAttribute.handle_signature = handle_signature
-
-
 def remove_property_prefix():
     """
     I don't think it is important to distinguish in the docs between properties
@@ -107,33 +54,8 @@ def remove_property_prefix():
     PyProperty.get_signature_prefix = get_signature_prefix
 
 
-def patch_attribute_documenter(app):
-    """Instead of using stringify-typehint in
-    `AttributeDocumenter.add_directive_header`, use `format_annotation`.
-    """
-    import sphinx.ext.autodoc
-    from sphinx.ext.autodoc import AttributeDocumenter
-    from sphinx_autodoc_typehints import format_annotation
-
-    def stringify_typehint(annotation, *args, **kwargs):
-        return format_annotation(annotation, app.config)
-
-    orig_add_directive_header = AttributeDocumenter.add_directive_header
-
-    def add_directive_header(*args, **kwargs):
-        orig_stringify_typehint = sphinx.ext.autodoc.stringify_typehint
-        sphinx.ext.autodoc.stringify_typehint = stringify_typehint
-        result = orig_add_directive_header(*args, **kwargs)
-        sphinx.ext.autodoc.stringify_typehint = orig_stringify_typehint
-        return result
-
-    AttributeDocumenter.add_directive_header = add_directive_header
-
-
 def setup(app):
     patch_templates()
-    patch_py_attribute_handle_signature()
-    patch_attribute_documenter(app)
     remove_property_prefix()
     app.add_lexer("pyodide", PyodideLexer)
     app.add_lexer("html-pyodide", HtmlPyodideLexer)


### PR DESCRIPTION
Remove the `property` prefix from properties, add a link for `ast.Module`.

Previously this included more significant changes but they have been upstreamed into sphinx-autodoc-typehints.