### PR TITLE
Add sphinx-design, fix tabs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "versionwarning.extension",
     "sphinx_issues",
     "sphinx_autodoc_typehints",
+    "sphinx_design",  # Used for tabs in building-from-sources.md
 ]
 
 

--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -66,7 +66,9 @@ You need Python 3.10.2 to run the build scripts. To make sure that the correct
 Python is used during the build it is recommended to use a [virtual
 environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment),
 
-```{tabbed} Linux
+````{tab-set}
+
+```{tab-item} Linux
 
 To build on Linux, you need:
 
@@ -76,7 +78,7 @@ To build on Linux, you need:
 
 ```
 
-```{tabbed} MacOS
+```{tab-item} MacOS
 
 To build on MacOS, you need:
 
@@ -93,6 +95,7 @@ To build on MacOS, you need:
   GNU sed (`brew install gnu-sed`) and [re-defining them temporarily as `patch` and
   `sed`](https://formulae.brew.sh/formula/gnu-sed).
 ```
+````
 
 ```{note}
 If you encounter issues with the requirements, it is useful to check the exact

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -10,6 +10,7 @@ sphinx-js>=3.2.1
 sphinx-version-warning>=1.1.2
 sphinx-click
 sphinx-autodoc-typehints>=1.21.1
+sphinx-design>=0.3.0
 pydantic
 # Packages that we want to document as part of the Pyodide CLI
 ./pyodide-build/


### PR DESCRIPTION
In #3461 I dropped `sphinx-panels` but of course we *were* using it. It has a successor called
`sphinx-design` which works with sphinx 5.x (still not 6.x but we have several packages that cap 
sphinx <6). I also updated the use of the tabbed directive to the new sphinx-design api.