### PR TITLE
DOCS Remove ensure_argument_types and use autodoc-typehints feature for this

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -250,6 +250,8 @@ def globalReplace(app, docname, source):
 
 global_replacements = {"{{PYODIDE_CDN_URL}}": CDN_URL}
 
+always_document_param_types = True
+
 
 def typehints_formatter(annotation, config):
     """Adjust the rendering of various types that sphinx_autodoc_typehints mishandles"""

--- a/docs/sphinx_pyodide/sphinx_pyodide/napoleon_fixes.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/napoleon_fixes.py
@@ -40,40 +40,6 @@ def fix_screwed_up_return_info(
     lines.insert(at, f":rtype: {formatted_annotation}")
 
 
-def ensure_argument_types(
-    app: Sphinx, what: str, name: str, obj: Any, lines: list[str]
-) -> None:
-    """If there is no Parameters section at all, this adds type
-    annotations for all the arguments.
-    """
-    for at, line in enumerate(lines):
-        if line.startswith(":param"):
-            return
-        if line.startswith(("..", ":return", ":rtype")):
-            at = at
-            if line.startswith(".."):
-                lines.insert(at, "")
-            break
-    else:
-        # Confusing. See test_ensure_argument_types_only_summary.
-        while lines[-3:] != ["", "", ""]:
-            lines.append("")
-            at += 1
-        at -= 1
-
-    type_hints = get_all_type_hints(app.config.autodoc_mock_imports, obj, name)
-    to_add = []
-    if lines[at].strip() != "":
-        to_add.append("")
-    type_hints.pop("return", None)
-    for (key, value) in type_hints.items():
-        formatted_annotation = format_annotation(value, app.config)
-        to_add.append(f":type {key}: {formatted_annotation}")
-        to_add.append(f":param {key}:")
-
-    lines[at:at] = to_add
-
-
 LEADING_STAR_PAT = re.compile(r"(^\s*) \*")
 
 
@@ -152,7 +118,7 @@ def process_docstring(
     if what in ["method", "function"]:
         fix_bulleted_return_annotation(lines)
         fix_screwed_up_return_info(app, what, name, obj, lines)
-        ensure_argument_types(app, what, name, obj, lines)
+        # ensure_argument_types(app, what, name, obj, lines)
 
     if what == "class":
         fix_constructor_arg_and_attr_same_name(app, what, name, obj, lines)

--- a/docs/sphinx_pyodide/tests/test_napoleon_fixes.py
+++ b/docs/sphinx_pyodide/tests/test_napoleon_fixes.py
@@ -1,12 +1,11 @@
 from textwrap import dedent
-from typing import Any, Callable, TypeVar
+from typing import Callable, TypeVar
 from unittest.mock import create_autospec
 
 import pytest
 from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx_pyodide.napoleon_fixes import (
-    ensure_argument_types,
     fix_bulleted_return_annotation,
     fix_constructor_arg_and_attr_same_name,
     fix_screwed_up_return_info,
@@ -145,97 +144,6 @@ def test_fix_screwed_up_return_info(func):
     lines = doc.splitlines()
     fix_screwed_up_return_info(app, "function", func.__name__, func, lines)
     assert "\n".join(lines).strip() == dedent(func.FIXED_DOC).strip()
-
-
-@fixed_doc(
-    """\
-    Summary info
-
-
-    :type a: :py:class:`int`
-    :param a:
-    :type b: :py:class:`str`
-    :param b:
-    :return: Some info about the return value
-    """
-)
-def no_param_docs(a: int, b: str) -> int:
-    """
-    Summary info
-
-    :return: Some info about the return value
-    """
-    return 6
-
-
-@unchanged_doc
-def some_param_docs(a: int, b: str) -> int:
-    """
-    Summary info
-
-    :type a: :py:class:`int`
-    :param a: Info about a
-    :return: Some info about the return value
-    """
-    return 6
-
-
-@fixed_doc(
-    """\
-    Summary info
-
-    :type a: :py:class:`int`
-    :param a:
-    :type b: :py:class:`str`
-    :param b:
-
-    .. rubric:: Example
-
-    Here are some examples of this function.
-    """
-)
-def no_params_example(a: int, b: str) -> int:
-    """
-    Summary info
-
-    .. rubric:: Example
-
-    Here are some examples of this function.
-    """
-    return 6
-
-
-@fixed_doc(
-    """\
-    Summary only
-
-    :type a: :py:class:`str`
-    :param a:
-    """
-)
-def only_summary(a: str) -> None:
-    """Summary only"""
-
-
-@pytest.mark.parametrize(
-    "func", [no_param_docs, no_params_example, some_param_docs, only_summary]
-)
-def test_ensure_argument_types(func):
-    doc = dedent(func.__doc__)
-    lines = doc.splitlines()
-    ensure_argument_types(app, "function", func.__name__, func, lines)
-    expected = dedent(func.FIXED_DOC).strip()
-    assert "\n".join(lines).strip() == expected
-
-
-@pytest.mark.parametrize("newlines", [0, 1, 2, 3, 4])
-def test_ensure_argument_types_only_summary(newlines):
-    func: Any = only_summary
-    doc = dedent(func.__doc__) + "\n" * newlines
-    lines = doc.splitlines()
-    ensure_argument_types(app, "function", func.__name__, func, lines)
-    expected = dedent(func.FIXED_DOC).strip()
-    assert "\n".join(lines).strip() == expected
 
 
 @fixed_doc(


### PR DESCRIPTION
Turns out there was a setting for this. Should have read the docs!