### PR TITLE
Fix setStdin to insert a null after each buffer if autoEOF parameter is true.

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -28,6 +28,10 @@ myst:
 - {{ Fix }} `pyodide config` won't print extra messages anymore.
   {pr}`3483`
 
+- {{ Breaking }} `setStdin` now accepts an extra `autoEOF` parameter. If `true`,
+  it will insert an EOF automatically after each string or buffer. Defaults to `true`.
+  {pr}`3488`
+
 ### Build System
 
 - {{ Enhancement }} Improved logging in `pyodide-build` with rich.

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -19,7 +19,8 @@ type InFuncType = () =>
   | undefined
   | string
   | ArrayBuffer
-  | ArrayBufferView;
+  | ArrayBufferView
+  | number;
 
 // To define the output behavior of a tty we need to define put_char and fsync.
 // fsync flushes the stream.
@@ -191,12 +192,17 @@ function setStdinError() {
  * the current input buffer is exhausted. It should return one of:
  *
  * - ``null`` or ``undefined``: these are interpreted as end of file.
+ * - a number
  * - a string
  * - an :js:class:`ArrayBuffer` or :js:class:`TypedArray` with
  *   :js:data:`~TypedArray.BYTES_PER_ELEMENT` equal to 1.
  *
+ * If a number is returned, it is interpreted as a single character code. The
+ * number should be between 0 and 255.
+ *
  * If a string is returned, a new line is appended if one is not present and the
- * resulting string is turned into a :js:class:`Uint8Array` using :js:class:`TextEncoder`.
+ * resulting string is turned into a :js:class:`Uint8Array` using
+ * :js:class:`TextEncoder`.
  *
  * Returning a buffer is more efficient and allows returning partial lines of
  * text.
@@ -204,12 +210,18 @@ function setStdinError() {
  * @param options.stdin The stdin handler.
  * @param options.error If this is set to ``true``, attempts to read from stdin
  * will always set an IO error.
- *
  * @param options.isatty Should ``isatty(stdin)`` be ``true`` or ``false``
  * (default ``false``).
+ * @param options.autoEOF Insert an EOF automatically after each string
+ * or buffer? (default ``true``).
  */
 export function setStdin(
-  options: { stdin?: InFuncType; error?: boolean; isatty?: boolean } = {},
+  options: {
+    stdin?: InFuncType;
+    error?: boolean;
+    isatty?: boolean;
+    autoEOF?: boolean;
+  } = {},
 ) {
   if (options.stdin && options.error) {
     throw new TypeError(
@@ -221,8 +233,10 @@ export function setStdin(
     return;
   }
   if (options.stdin) {
+    let autoEOF = options.autoEOF;
+    autoEOF = autoEOF === undefined ? true : autoEOF;
     isattys.stdin = !!options.isatty;
-    const get_char = make_get_char(options.stdin);
+    const get_char = make_get_char(options.stdin, autoEOF);
     ttyout_ops.get_char = get_char;
     ttyerr_ops.get_char = get_char;
     refreshStreams();
@@ -355,7 +369,7 @@ export function setStderr(
 const textencoder = new TextEncoder();
 const textdecoder = new TextDecoder();
 
-function make_get_char(infunc: InFuncType): GetCharType {
+function make_get_char(infunc: InFuncType, autoEOF: boolean): GetCharType {
   let index = 0;
   let buf: Uint8Array = new Uint8Array(0);
   let insertEOF = false;
@@ -374,12 +388,13 @@ function make_get_char(infunc: InFuncType): GetCharType {
         if (input === undefined || input === null) {
           return null;
         }
-        if (typeof input === "string") {
+        if (typeof input === "number") {
+          return input;
+        } else if (typeof input === "string") {
           if (!input.endsWith("\n")) {
             input += "\n";
           }
           buf = textencoder.encode(input);
-          insertEOF = true;
         } else if (ArrayBuffer.isView(input)) {
           if ((input as any).BYTES_PER_ELEMENT !== 1) {
             throw new Error("Expected BYTES_PER_ELEMENT to be 1");
@@ -396,6 +411,9 @@ function make_get_char(infunc: InFuncType): GetCharType {
         }
         if (buf.length === 0) {
           return null;
+        }
+        if (autoEOF) {
+          insertEOF = true;
         }
         index = 0;
       }

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -358,6 +358,7 @@ const textdecoder = new TextDecoder();
 function make_get_char(infunc: InFuncType): GetCharType {
   let index = 0;
   let buf: Uint8Array = new Uint8Array(0);
+  let insertEOF = false;
   // get_char has 3 particular return values:
   // a.) the next character represented as an integer
   // b.) undefined to signal that no data is currently available
@@ -365,6 +366,10 @@ function make_get_char(infunc: InFuncType): GetCharType {
   return function get_char() {
     try {
       if (index >= buf.length) {
+        if (insertEOF) {
+          insertEOF = false;
+          return null;
+        }
         let input = infunc();
         if (input === undefined || input === null) {
           return null;
@@ -374,6 +379,7 @@ function make_get_char(infunc: InFuncType): GetCharType {
             input += "\n";
           }
           buf = textencoder.encode(input);
+          insertEOF = true;
         } else if (ArrayBuffer.isView(input)) {
           if ((input as any).BYTES_PER_ELEMENT !== 1) {
             throw new Error("Expected BYTES_PER_ELEMENT to be 1");


### PR DESCRIPTION
Resolves #3413.

I added a new argument to `setStdin` called `autoEOF` which if `true` causes `setStdin` to automatically
insert an EOF after each buffer or string. It defaults to `true`, which is a breaking change. Set it to `false`
to get the behavior from before this PR.

I also added an option that allows the stdin function to directly return a character code.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests