### PR TITLE
fix: pass only build args

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,10 @@ myst:
 
 ## Unreleased
 
+- {{ Fix }} pyodide build: Don't pass the directory to the build backend args,
+  only pass the arguments.
+  {pr}`3490`
+
 ## Version 0.22.0
 
 _January 3, 2023_

--- a/pyodide-build/pyodide_build/cli/build.py
+++ b/pyodide-build/pyodide_build/cli/build.py
@@ -52,7 +52,6 @@ def pypi(
     """Fetch a wheel from pypi, or build from source if none available."""
     initialize_pyodide_root()
     common.check_emscripten_version()
-    backend_flags = ctx.args
     curdir = Path.cwd()
     (curdir / "dist").mkdir(exist_ok=True)
 
@@ -69,7 +68,7 @@ def pypi(
 
         # sdist - needs building
         os.chdir(tmpdir)
-        build.run(exports, backend_flags)
+        build.run(exports, ctx.args)
         for src in (temppath / "dist").iterdir():
             print(f"Built {str(src.name)}")
             shutil.copy(str(src), str(curdir / "dist"))
@@ -86,7 +85,6 @@ def url(
     """Fetch a wheel or build sdist from url."""
     initialize_pyodide_root()
     common.check_emscripten_version()
-    backend_flags = ctx.args
     curdir = Path.cwd()
     (curdir / "dist").mkdir(exist_ok=True)
 
@@ -119,7 +117,7 @@ def url(
                     # unzipped here
                     os.chdir(tmpdir)
                 print(os.listdir(tmpdir))
-                build.run(exports, backend_flags)
+                build.run(exports, ctx.args)
                 for src in (temppath / "dist").iterdir():
                     print(f"Built {str(src.name)}")
                     shutil.copy(str(src), str(curdir / "dist"))
@@ -137,8 +135,8 @@ def source(
     """Use pypa/build to build a Python package from source"""
     initialize_pyodide_root()
     common.check_emscripten_version()
-    backend_flags = [source_location] + ctx.args
-    build.run(exports, backend_flags)
+    os.chdir(source_location)
+    build.run(exports, ctx.args)
 
 
 # simple 'pyodide build' command

--- a/pyodide-build/pyodide_build/cli/build.py
+++ b/pyodide-build/pyodide_build/cli/build.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse
 
 import requests
@@ -124,7 +125,7 @@ def url(
 
 
 def source(
-    source_location: str | None = typer.Argument(None),
+    source_location: "Optional[str]" = typer.Argument(None),
     exports: str = typer.Option(
         "requested",
         help="Which symbols should be exported when linking .so files?",
@@ -141,8 +142,7 @@ def source(
 
 # simple 'pyodide build' command
 def main(
-    source_location: str
-    | None = typer.Argument(
+    source_location: "Optional[str]" = typer.Argument(
         "",
         help="Build source, can be source folder, pypi version specification, or url to a source dist archive or wheel file. If this is blank, it will build the current directory.",
     ),

--- a/pyodide-build/pyodide_build/cli/build.py
+++ b/pyodide-build/pyodide_build/cli/build.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Optional
 from urllib.parse import urlparse
 
 import requests
@@ -125,7 +124,7 @@ def url(
 
 
 def source(
-    source_location: "Optional[str]" = typer.Argument(None),
+    source_location: str | None = typer.Argument(None),
     exports: str = typer.Option(
         "requested",
         help="Which symbols should be exported when linking .so files?",
@@ -135,13 +134,15 @@ def source(
     """Use pypa/build to build a Python package from source"""
     initialize_pyodide_root()
     common.check_emscripten_version()
-    os.chdir(source_location)
+    if source_location:
+        os.chdir(source_location)
     build.run(exports, ctx.args)
 
 
 # simple 'pyodide build' command
 def main(
-    source_location: "Optional[str]" = typer.Argument(
+    source_location: str
+    | None = typer.Argument(
         "",
         help="Build source, can be source folder, pypi version specification, or url to a source dist archive or wheel file. If this is blank, it will build the current directory.",
     ),


### PR DESCRIPTION
This is #3417 backported to stable for 0.22.1. Thanks @agoose77!

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
