### PR TITLE
Fix standard out in console.html

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -73,9 +73,15 @@
 
       async function main() {
         let term;
+        let returnEOF = false;
         globalThis.pyodide = await loadPyodide({
           stdin: () => {
+            if (returnEOF) {
+              returnEOF = false;
+              return null;
+            }
             let result = prompt();
+            returnEOF = true;
             echo(result);
             return result;
           },


### PR DESCRIPTION
Resolves #3413.

Since #3488 is an API break, I think it's ineligible for backport. This is a workaround.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
