### PR TITLE
fix(docs): Update micropip docs link on Website

### DIFF
--- a/docs/usage/api/micropip-api.md
+++ b/docs/usage/api/micropip-api.md
@@ -4,4 +4,4 @@
 
 # Micropip API
 
-The Micropip API documentation was moved to [pyodide.micropip.org](https://micropip.pyodide.org/en/stable/project/api.html).
+The Micropip API documentation was moved to [micropip.pyodide.org](https://micropip.pyodide.org/en/stable/project/api.html).


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1t87pMU5tKwODBiKDUnl41k6D8meFU0%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=J65NEm1)
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

[This](https://pyodide.org/en/stable/usage/api/micropip-api.html) page on the docs references to `pyodide.micropip.org` as the docs website, but it points to `micropip.pyodide.org`, this PR changes the text content to suit the link it points towards.

![image](https://user-images.githubusercontent.com/76237496/214099648-e5b58ac3-18b5-4154-82b1-e04364521510.png)
![image](https://user-images.githubusercontent.com/76237496/214099690-5e5eee1f-576b-4df4-8165-a27bc6c1ce21.png)

:)

