### PR TITLE
Improve messages in case of system exit

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -36,6 +36,10 @@ myst:
   it will insert an EOF automatically after each string or buffer. Defaults to `true`.
   {pr}`3488`
 
+- {{ Enhancement }} Pyodide displays a better message when someone calls posix
+  `exit` or `os._exit`.
+  {pr}`3496`
+
 ### Build System
 
 - {{ Enhancement }} Improved logging in `pyodide-build` with rich.

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -8,7 +8,7 @@ function ensureCaughtObjectIsError(e: any): Error {
   if (typeof e === "string") {
     // Sometimes emscripten throws a raw string...
     e = new Error(e);
-  } else if (typeof e === "object" && e.name === "ExitStatus") {
+  } else if (e && typeof e === "object" && e.name === "ExitStatus") {
     let status = e.status;
     e = new Exit(e.message);
     e.status = status;

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -8,6 +8,10 @@ function ensureCaughtObjectIsError(e: any): Error {
   if (typeof e === "string") {
     // Sometimes emscripten throws a raw string...
     e = new Error(e);
+  } else if (typeof e === "object" && e.name === "ExitStatus") {
+    let status = e.status;
+    e = new Exit(e.message);
+    e.status = status;
   } else if (
     typeof e !== "object" ||
     e === null ||
@@ -88,20 +92,28 @@ API.fatal_error = function (e: any) {
   // Mark e so we know not to handle it later in EM_JS wrappers
   e.pyodide_fatal_error = true;
   fatal_error_occurred = true;
-  console.error(
-    "Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.",
-  );
-  console.error("The cause of the fatal error was:");
-  if (API.inTestHoist) {
-    // Test hoist won't print the error object in a useful way so convert it to
-    // string.
-    console.error(e.toString());
-    console.error(e.stack);
-  } else {
-    console.error(e);
+  const isexit = e instanceof Exit;
+  console.log({ e, isexit });
+  if (!isexit) {
+    console.error(
+      "Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.",
+    );
+    console.error("The cause of the fatal error was:");
+    if (API.inTestHoist) {
+      // Test hoist won't print the error object in a useful way so convert it to
+      // string.
+      console.error(e.toString());
+      console.error(e.stack);
+    } else {
+      console.error(e);
+    }
   }
   try {
-    Module._dump_traceback();
+    if (!isexit) {
+      Module._dump_traceback();
+    }
+    let reason = isexit ? "exited" : "fatally failed";
+    let msg = `Pyodide already ${reason} and can no longer be used.`;
     for (let key of Object.keys(API.public_api)) {
       if (key.startsWith("_") || key === "version") {
         continue;
@@ -110,9 +122,7 @@ API.fatal_error = function (e: any) {
         enumerable: true,
         configurable: true,
         get: () => {
-          throw new Error(
-            "Pyodide already fatally failed and can no longer be used.",
-          );
+          throw new Error(msg);
         },
       });
     }
@@ -125,11 +135,6 @@ API.fatal_error = function (e: any) {
   }
   throw e;
 };
-
-class FatalPyodideError extends Error {}
-Object.defineProperty(FatalPyodideError.prototype, "name", {
-  value: FatalPyodideError.name,
-});
 
 let stderr_chars: number[] = [];
 API.capture_stderr = function () {
@@ -292,9 +297,6 @@ export class PythonError extends Error {
     this.__error_address = error_address;
   }
 }
-Object.defineProperty(PythonError.prototype, "name", {
-  value: PythonError.name,
-});
 API.PythonError = PythonError;
 // A special marker. If we call a CPython API from an EM_JS function and the
 // CPython API sets an error, we might want to return an error status back to
@@ -310,7 +312,14 @@ class _PropagatePythonError extends Error {
     );
   }
 }
-Object.defineProperty(_PropagatePythonError.prototype, "name", {
-  value: _PropagatePythonError.name,
-});
+function setName(errClass: any) {
+  Object.defineProperty(errClass.prototype, "name", {
+    value: errClass.name,
+  });
+}
+
+class FatalPyodideError extends Error {}
+class Exit extends Error {}
+[_PropagatePythonError, FatalPyodideError, Exit, PythonError].forEach(setName);
+
 Module._PropagatePythonError = _PropagatePythonError;

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -93,7 +93,6 @@ API.fatal_error = function (e: any) {
   e.pyodide_fatal_error = true;
   fatal_error_occurred = true;
   const isexit = e instanceof Exit;
-  console.log({ e, isexit });
   if (!isexit) {
     console.error(
       "Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.",

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -211,12 +211,17 @@
         };
         term.ready = Promise.resolve();
         pyodide._api.on_fatal = async (e) => {
-          term.error(
-            "Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.",
-          );
-          term.error("The cause of the fatal error was:");
-          term.error(e);
-          term.error("Look in the browser console for more details.");
+          if (e.name === "Exit") {
+            term.error(e);
+            term.error("Pyodide exited and can no longer be used.");
+          } else {
+            term.error(
+              "Pyodide has suffered a fatal error. Please report this to the Pyodide maintainers.",
+            );
+            term.error("The cause of the fatal error was:");
+            term.error(e);
+            term.error("Look in the browser console for more details.");
+          }
           await term.ready;
           term.pause();
           await sleep(15);

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -843,6 +843,29 @@ def test_fatal_error(selenium_standalone):
     )
 
 
+@pytest.mark.skip_refcount_check
+def test_exit_error(selenium_standalone):
+    x = selenium_standalone.run_js(
+        """
+        try {
+            pyodide.runPython(`
+                import os
+                def f():
+                    g()
+                def g():
+                    h()
+                def h():
+                    os._exit(0)
+                f()
+            `);
+        } catch(e){
+            return e.toString();
+        }
+        """
+    )
+    assert x == "Exit: Program terminated with exit(0)"
+
+
 def test_reentrant_error(selenium):
     caught = selenium.run_js(
         """


### PR DESCRIPTION
This prints a better set of error messages in case someone calls `os._exit()` or in C code `exit()` is used.

Resolves #3486.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
