### PR TITLE
Xfail the urllib test in safari

### DIFF
--- a/src/tests/python_tests.yaml
+++ b/src/tests/python_tests.yaml
@@ -803,7 +803,8 @@
 - test_unpack
 - test_unpack_ex
 - test_unparse
-- test_urllib
+- test_urllib:
+    xfail-safari: Doesn't work
 - test_urllib2:
     skip:
       - test_http_body_pipe # fork


### PR DESCRIPTION
Safari core tests fail starting with this one. Try xfailing it.