### PR TITLE
xfail richcmp test

### DIFF
--- a/src/tests/python_tests.yaml
+++ b/src/tests/python_tests.yaml
@@ -606,7 +606,8 @@
     xfail: All tests fork
 - test_reprlib
 - test_resource
-- test_richcmp
+- test_richcmp:
+    xfail: Maximum call stack size exceeded
 - test_rlcompleter
 - test_robotparser:
     xfail: socket


### PR DESCRIPTION
This test started to occasionally fail with the error: `RangeError: Maximum call stack size exceeded`, after we updated to Python 3.11.