### PR TITLE
ENH Add --no-deps parameter to build-recipes CLI

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -67,6 +67,10 @@ myst:
   This command is hidden by default since it is not intended for use by end users.
   {pr}`3411` {pr}`3463`
 
+- `pyodide build-recipes` now accepts `--no-deps` parameter,
+  which skips building dependencies of the package. This replaces `pyodide-build buildpkg`.
+  {pr}`3520`
+
 ## Version 0.22.1
 
 _January 25, 2023_

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 import typer
 
-from .. import buildall, pywasmcross
+from .. import buildall, buildpkg, pywasmcross
+from ..common import init_environment
+from ..logger import logger
 
 
 def recipe(
@@ -13,6 +15,9 @@ def recipe(
         None,
         help="The directory containing the recipe of packages. "
         "If not specified, the default is `./packages`",
+    ),
+    no_deps: bool = typer.Option(
+        False, help="If true, do not build dependencies of the specified packages. "
     ),
     install: bool = typer.Option(
         False,
@@ -46,8 +51,12 @@ def recipe(
         False,
         help="Force rebuild of all packages regardless of whether they appear to have been updated",
     ),
+    continue_: bool = typer.Option(
+        False,
+        "--continue",
+        help="Continue a build from the middle. For debugging. Implies '--force-rebuild'",
+    ),
     n_jobs: int = typer.Option(4, help="Number of packages to build in parallel"),
-    ctx: typer.Context = typer.Context,
 ) -> None:
     """Build packages using yaml recipes and create repodata.json"""
     root = Path.cwd()
@@ -55,29 +64,45 @@ def recipe(
     install_dir_ = root / "dist" if not install_dir else Path(install_dir).resolve()
     log_dir_ = None if not log_dir else Path(log_dir).resolve()
 
+    if not recipe_dir_.is_dir():
+        raise FileNotFoundError(f"Recipe directory {recipe_dir_} not found")
+
+    init_environment()
+
     build_args = pywasmcross.BuildArgs(
-        pkgname="",
         cflags=cflags,
         cxxflags=cxxflags,
         ldflags=ldflags,
         target_install_dir=target_install_dir,
         host_install_dir=host_install_dir,
     )
-
-    if len(packages) == 1 and "," in packages[0]:
-        # Handle packages passed with old comma separated syntax.
-        # This is to support `PYODIDE_PACKAGES="pkg1,pkg2,..." make` syntax.
-        targets = packages[0].replace(" ", "")
-    else:
-        targets = ",".join(packages)
-
     build_args = buildall.set_default_build_args(build_args)
-    pkg_map = buildall.build_packages(
-        recipe_dir_, targets, build_args, n_jobs, force_rebuild
-    )
 
-    if log_dir_:
-        buildall.copy_logs(pkg_map, log_dir_)
+    if no_deps:
+        if install or log_dir_:
+            logger.warning(
+                "WARNING: when --no-deps is set, --install and --log-dir parameters are ignored",
+            )
 
-    if install:
-        buildall.install_packages(pkg_map, install_dir_)
+        # TODO: use multiprocessing?
+        for package in packages:
+            package_path = recipe_dir_ / package
+            buildpkg.build_package(package_path, build_args, force_rebuild, continue_)
+
+    else:
+        if len(packages) == 1 and "," in packages[0]:
+            # Handle packages passed with old comma separated syntax.
+            # This is to support `PYODIDE_PACKAGES="pkg1,pkg2,..." make` syntax.
+            targets = packages[0].replace(" ", "")
+        else:
+            targets = ",".join(packages)
+
+        pkg_map = buildall.build_packages(
+            recipe_dir_, targets, build_args, n_jobs, force_rebuild
+        )
+
+        if log_dir_:
+            buildall.copy_logs(pkg_map, log_dir_)
+
+        if install:
+            buildall.install_packages(pkg_map, install_dir_)

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -128,7 +128,7 @@ def test_build_recipe_no_deps(selenium, tmp_path):
     assert result.exit_code == 0, result.stdout
 
     for pkg in pkgs_to_build:
-        assert f"built {pkg} in" in result.stdout
+        assert f"Succeeded building package {pkg}" in result.stdout
 
     for pkg in pkgs_to_build:
         dist_dir = recipe_dir / pkg / "dist"
@@ -170,7 +170,7 @@ def test_build_recipe_no_deps_force_rebuild(selenium, tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "Successfully built" not in result.stdout
+    assert f"Succeeded building package {pkg}" not in result.stdout
 
     result = runner.invoke(
         app,
@@ -184,7 +184,7 @@ def test_build_recipe_no_deps_force_rebuild(selenium, tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "Successfully built" in result.stdout
+    assert f"Succeeded building package {pkg}" in result.stdout
 
 
 def test_build_recipe_no_deps_continue(selenium, tmp_path):
@@ -210,22 +210,24 @@ def test_build_recipe_no_deps_continue(selenium, tmp_path):
     )
 
     assert result.exit_code == 0, result.stdout
-    assert "Successfully built" in result.stdout
+    assert f"Succeeded building package {pkg}" in result.stdout
 
-    for whl in (recipe_dir / pkg / "dist").glob("*.whl"):
-        whl.unlink()
+    for wheels in (recipe_dir / pkg / "build").rglob("*.whl"):
+        wheels.unlink()
 
     pyproject_toml = next((recipe_dir / pkg / "build").rglob("pyproject.toml"))
 
     # Modify some metadata and check it is applied when rebuilt with --continue flag
     version = "99.99.99"
     with open(pyproject_toml, encoding="utf-8") as f:
-        pyproject = f.read()
+        pyproject_data = f.read()
 
-    pyproject.replace('version = "1.0.0"', f'version = "{version}"')
+    pyproject_data = pyproject_data.replace(
+        'version = "1.0.0"', f'version = "{version}"'
+    )
 
     with open(pyproject_toml, "w", encoding="utf-8") as f:
-        f.write(pyproject)
+        f.write(pyproject_data)
 
     result = runner.invoke(
         app,
@@ -239,7 +241,7 @@ def test_build_recipe_no_deps_continue(selenium, tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "Successfully built" in result.stdout
+    assert f"Succeeded building package {pkg}" in result.stdout
     assert f"{pkg}-{version}-py3-none-any.whl" in result.stdout
 
 

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -170,7 +170,8 @@ def test_build_recipe_no_deps_force_rebuild(selenium, tmp_path):
     )
 
     assert result.exit_code == 0
-    assert f"Succeeded building package {pkg}" not in result.stdout
+    assert f"running bdist_wheel" not in result.stdout
+    assert f"Succeeded building package {pkg}" in result.stdout
 
     result = runner.invoke(
         app,
@@ -184,6 +185,7 @@ def test_build_recipe_no_deps_force_rebuild(selenium, tmp_path):
     )
 
     assert result.exit_code == 0
+    assert f"running bdist_wheel" in result.stdout
     assert f"Succeeded building package {pkg}" in result.stdout
 
 

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -62,7 +62,7 @@ def test_skeleton_pypi(tmp_path):
     assert "already exists" in str(result.exception)
 
 
-def test_build_recipe(selenium, tmp_path, monkeypatch, request):
+def test_build_recipe(selenium, tmp_path):
     # TODO: Run this test without building Pyodide
 
     output_dir = tmp_path / "dist"
@@ -101,6 +101,132 @@ def test_build_recipe(selenium, tmp_path, monkeypatch, request):
 
     built_wheels = set(output_dir.glob("*.whl"))
     assert len(built_wheels) == len(pkgs_to_build)
+
+
+def test_build_recipe_no_deps(selenium, tmp_path):
+    # TODO: Run this test without building Pyodide
+
+    recipe_dir = Path(__file__).parent / "_test_recipes"
+
+    for build_dir in recipe_dir.rglob("build"):
+        shutil.rmtree(build_dir)
+
+    app = typer.Typer()
+    app.command()(build_recipes.recipe)
+
+    pkgs_to_build = ["pkg_test_graph1", "pkg_test_graph3"]
+    result = runner.invoke(
+        app,
+        [
+            *pkgs_to_build,
+            "--recipe-dir",
+            recipe_dir,
+            "--no-deps",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+
+    for pkg in pkgs_to_build:
+        assert f"built {pkg} in" in result.stdout
+
+    for pkg in pkgs_to_build:
+        dist_dir = recipe_dir / pkg / "dist"
+        assert len(list(dist_dir.glob("*.whl"))) == 1
+
+
+def test_build_recipe_no_deps_force_rebuild(selenium, tmp_path):
+    # TODO: Run this test without building Pyodide
+
+    recipe_dir = Path(__file__).parent / "_test_recipes"
+
+    for build_dir in recipe_dir.rglob("build"):
+        shutil.rmtree(build_dir)
+
+    app = typer.Typer()
+    app.command()(build_recipes.recipe)
+
+    pkg = "pkg_test_graph1"
+    result = runner.invoke(
+        app,
+        [
+            pkg,
+            "--recipe-dir",
+            recipe_dir,
+            "--no-deps",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            pkg,
+            "--recipe-dir",
+            recipe_dir,
+            "--no-deps",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Successfully built" not in result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            pkg,
+            "--recipe-dir",
+            recipe_dir,
+            "--no-deps",
+            "--force-rebuild",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Successfully built" in result.stdout
+
+
+def test_build_recipe_no_deps_continue(selenium, tmp_path):
+    # TODO: Run this test without building Pyodide
+
+    recipe_dir = Path(__file__).parent / "_test_recipes"
+
+    for build_dir in recipe_dir.rglob("build"):
+        shutil.rmtree(build_dir)
+
+    app = typer.Typer()
+    app.command()(build_recipes.recipe)
+
+    pkg = "pkg_test_graph1"
+    result = runner.invoke(
+        app,
+        [
+            pkg,
+            "--recipe-dir",
+            recipe_dir,
+            "--no-deps",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Successfully built" in result.stdout
+
+    for build_dir in recipe_dir.rglob("build"):
+        shutil.rmtree(build_dir)
+
+    result = runner.invoke(
+        app,
+        [
+            pkg,
+            "--recipe-dir",
+            recipe_dir,
+            "--no-deps",
+            "--continue",
+        ],
+    )
+
+    assert result.exit_code != 0
 
 
 def test_config_list():

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -170,7 +170,7 @@ def test_build_recipe_no_deps_force_rebuild(selenium, tmp_path):
     )
 
     assert result.exit_code == 0
-    assert f"running bdist_wheel" not in result.stdout
+    assert "Creating virtualenv isolated environment" not in result.stdout
     assert f"Succeeded building package {pkg}" in result.stdout
 
     result = runner.invoke(
@@ -185,7 +185,7 @@ def test_build_recipe_no_deps_force_rebuild(selenium, tmp_path):
     )
 
     assert result.exit_code == 0
-    assert f"running bdist_wheel" in result.stdout
+    assert "Creating virtualenv isolated environment" in result.stdout
     assert f"Succeeded building package {pkg}" in result.stdout
 
 


### PR DESCRIPTION
### Description

This adds `--no-deps` parameter to `pyodide build-recipes` CLI, which is a replacement for `pyodide_build buildpkg` entrypoint.

Ref: #2879

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
