### PR TITLE
CI Fix isort in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/PyCQA/isort
-    rev: "5.11.4"
+    rev: "5.11.5"
     hooks:
       - id: isort
 


### PR DESCRIPTION
Bumping isort version in pre-commit to avoid the CI issues we are seeing in all MRs due to
https://stackoverflow.com/a/75281814/1791279