### PR TITLE
CI Show compressed size of main modules after build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,11 @@ jobs:
 
       - run:
           name: check-size
-          command: du dist/ -abh --max-depth 1  | sort -k 2
+          command: |
+            du dist/ -abh --max-depth 1  | sort -k 2
+
+            pip install brotli
+            ./tools/check_compressed_size.py dist/pyodide.asm.*
 
       - save_cache:
           paths:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,11 @@ jobs:
           ccache -s
 
       - name: check-size
-        run: ls -lh dist/
+        run: |
+          ls -lh dist/
+
+          pip install brotli
+          ./tools/check_compressed_size.py dist/pyodide.asm.*
 
       - name: Store artifacts build
         uses: actions/upload-artifact@v2

--- a/tools/check_compressed_size.py
+++ b/tools/check_compressed_size.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import gzip
+import sys
+from pathlib import Path
+
+try:
+    import brotli
+except ImportError:
+    print("WARNING: Brotli not installed")
+    brotli = None
+
+
+def kb(size: int) -> int:
+    return size // 1024
+
+
+def check_size(file: str | Path) -> None:
+    file = Path(file)
+
+    if not file.is_file():
+        print(f"ERROR: {file} is not a file")
+        return
+
+    print(f"- {file.name}:")
+
+    print(f"    Original size: {kb(file.stat().st_size)} KB")
+
+    data = file.read_bytes()
+    compressed_data_1 = gzip.compress(data, compresslevel=1)
+    compressed_data_6 = gzip.compress(data, compresslevel=9)
+    compressed_data_9 = gzip.compress(data, compresslevel=9)
+
+    print(f"    Gzip compressed size (level 1): {kb(len(compressed_data_1))} KB")
+    print(f"    Gzip compressed size (level 6): {kb(len(compressed_data_6))} KB")
+    print(f"    Gzip compressed size (level 9): {kb(len(compressed_data_9))} KB")
+
+    if brotli:
+        compress_data_brotli = brotli.compress(data)
+        print(f"    Brotli compressed size: {len(compress_data_brotli)} KB")
+
+
+def main():
+
+    files = sys.argv[1:]
+    if not files:
+        print(f"Usage: {sys.argv[0]} <file> ...")
+
+    for file in files:
+        check_size(file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_compressed_size.py
+++ b/tools/check_compressed_size.py
@@ -37,7 +37,7 @@ def check_size(file: str | Path) -> None:
 
     if brotli:
         compress_data_brotli = brotli.compress(data)
-        print(f"    Brotli compressed size: {len(compress_data_brotli)} KB")
+        print(f"    Brotli compressed size: {kb(len(compress_data_brotli))} KB")
 
 
 def main():

--- a/tools/check_compressed_size.py
+++ b/tools/check_compressed_size.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# A short script to check the size of files when compressed.
+# Usage:
+#   check_compressed_size.py pyodide.asm.js pyodide.asm.wasm
+
 import gzip
 import sys
 from pathlib import Path


### PR DESCRIPTION
### Description

This adds a short helper script which shows a gzip and brotli compressed size of a file, and use it in CI to check compressed size of `pyodide.asm.*` after build in addition to the original file size.

```
- pyodide.asm.data:
    Original size: 5023 KB
    Gzip compressed size (level 1): 3386 KB
    Gzip compressed size (level 6): 3217 KB
    Gzip compressed size (level 9): 3217 KB
    Brotli compressed size: 2788 KB
- pyodide.asm.js:
    Original size: 1189 KB
    Gzip compressed size (level 1): 248 KB
    Gzip compressed size (level 6): 211 KB
    Gzip compressed size (level 9): 211 KB
    Brotli compressed size: 173 KB
- pyodide.asm.wasm:
    Original size: 8710 KB
    Gzip compressed size (level 1): 3142 KB
    Gzip compressed size (level 6): 2791 KB
    Gzip compressed size (level 9): 2791 KB
    Brotli compressed size: 2099 KB
```