### PR TITLE
Add package_type field to repodata.json

### DIFF
--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -602,6 +602,11 @@ def _generate_package_hash(full_path: Path) -> str:
     return sha256_hash.hexdigest()
 
 
+def _get_unvendored_stdlibs(pkg_map: dict[str, BasePackage]) -> list[str]:
+    unvendored_stdlibs = filter(lambda pkg: pkg.package_type == "cpython_module", pkg_map.values())
+    return [pkg.name for pkg in unvendored_stdlibs]
+
+
 def generate_packagedata(
     output_dir: Path, pkg_map: dict[str, BasePackage]
 ) -> dict[str, Any]:
@@ -678,7 +683,8 @@ def generate_repodata(
         "python": sys.version.partition(" ")[0],
     }
     packages = generate_packagedata(output_dir, pkg_map)
-    return dict(info=info, packages=packages)
+    unvendored_stdlibs = _get_unvendored_stdlibs(pkg_map)
+    return dict(info=info, packages=packages, unvendored_stdlibs=unvendored_stdlibs)
 
 
 def copy_packages_to_dist_dir(

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -602,11 +602,6 @@ def _generate_package_hash(full_path: Path) -> str:
     return sha256_hash.hexdigest()
 
 
-def _get_unvendored_stdlibs(pkg_map: dict[str, BasePackage]) -> list[str]:
-    unvendored_stdlibs = filter(lambda pkg: pkg.package_type == "cpython_module", pkg_map.values())
-    return [pkg.name for pkg in unvendored_stdlibs]
-
-
 def generate_packagedata(
     output_dir: Path, pkg_map: dict[str, BasePackage]
 ) -> dict[str, Any]:
@@ -622,6 +617,7 @@ def generate_packagedata(
             "file_name": pkg.file_name,
             "install_dir": pkg.install_dir,
             "sha256": _generate_package_hash(Path(output_dir, pkg.file_name)),
+            "package_type": pkg.package_type,
             "imports": [],
         }
 
@@ -683,8 +679,7 @@ def generate_repodata(
         "python": sys.version.partition(" ")[0],
     }
     packages = generate_packagedata(output_dir, pkg_map)
-    unvendored_stdlibs = _get_unvendored_stdlibs(pkg_map)
-    return dict(info=info, packages=packages, unvendored_stdlibs=unvendored_stdlibs)
+    return dict(info=info, packages=packages)
 
 
 def copy_packages_to_dist_dir(

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -195,12 +195,12 @@ def install_stdlib(venv_bin: Path) -> None:
             "-c",
             dedent(
                 f"""
-                from _pyodide._importhook import UNVENDORED_STDLIBS_AND_TEST;
-                from pyodide_js import loadPackage;
+                from pyodide_js import loadPackage
                 from pyodide_js._api import repodata_packages
+                from pyodide_js._api import repodata_unvendored_stdlibs_and_test
                 shared_libs = [pkgname for (pkgname,pkg) in repodata_packages.object_entries() if getattr(pkg, "shared_library", False)]
 
-                to_load = [*UNVENDORED_STDLIBS_AND_TEST, *shared_libs, *{to_load!r}]
+                to_load = [*repodata_unvendored_stdlibs_and_test, *shared_libs, *{to_load!r}]
                 loadPackage(to_load);
                 """
             ),

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -80,9 +80,14 @@ def test_generate_repodata(tmp_path):
         "file_name": "pkg_1.whl",
         "depends": ["pkg_1_1", "pkg_3", "libtest_shared"],
         "imports": ["pkg_1"],
+        "package_type": "package",
         "install_dir": "site",
         "sha256": hashes["pkg_1"],
     }
+
+    assert (
+        package_data["packages"]["libtest_shared"]["package_type"] == "shared_library"
+    )
 
     sharedlib_imports = package_data["packages"]["libtest_shared"]["imports"]
     assert not sharedlib_imports, (

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -39,6 +39,16 @@ async function initializePackageIndex(lockFileURL: string) {
   API.repodata_info = repodata.info;
   API.repodata_packages = repodata.packages;
 
+  if (repodata.unvendored_stdlibs !== undefined) {
+    API.repodata_unvendored_stdlibs_and_test = repodata.unvendored_stdlibs;
+  } else {
+    API.repodata_unvendored_stdlibs_and_test = [];
+  }
+
+  API.repodata_unvendored_stdlibs = API.repodata_unvendored_stdlibs_and_test.filter(
+    (lib: string) => lib !== "test"
+  );
+
   // compute the inverted index for imports to package names
   API._import_name_to_package_name = new Map();
   for (let name of Object.keys(API.repodata_packages)) {

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -38,24 +38,26 @@ async function initializePackageIndex(lockFileURL: string) {
   }
   API.repodata_info = repodata.info;
   API.repodata_packages = repodata.packages;
-
-  if (repodata.unvendored_stdlibs !== undefined) {
-    API.repodata_unvendored_stdlibs_and_test = repodata.unvendored_stdlibs;
-  } else {
-    API.repodata_unvendored_stdlibs_and_test = [];
-  }
-
-  API.repodata_unvendored_stdlibs = API.repodata_unvendored_stdlibs_and_test.filter(
-    (lib: string) => lib !== "test"
-  );
+  API.repodata_unvendored_stdlibs_and_test = [];
 
   // compute the inverted index for imports to package names
   API._import_name_to_package_name = new Map();
   for (let name of Object.keys(API.repodata_packages)) {
-    for (let import_name of API.repodata_packages[name].imports) {
+    const pkg = API.repodata_packages[name];
+
+    for (let import_name of pkg.imports) {
       API._import_name_to_package_name.set(import_name, name);
     }
+
+    if (pkg.package_type === "cpython_module") {
+      API.repodata_unvendored_stdlibs_and_test.push(name);
+    }
   }
+
+  API.repodata_unvendored_stdlibs =
+    API.repodata_unvendored_stdlibs_and_test.filter(
+      (lib: string) => lib !== "test",
+    );
 }
 
 API.packageIndexReady = initializePackageIndex(API.config.lockFileURL);

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -393,7 +393,7 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
   }
   API.package_loader.init_loaded_packages();
   if (config.fullStdLib) {
-    await pyodide.loadPackage(API._pyodide._importhook.UNVENDORED_STDLIBS);
+    await pyodide.loadPackage(API.repodata_unvendored_stdlibs);
   }
   API.initializeStreams(config.stdin, config.stdout, config.stderr);
   return pyodide;

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -386,7 +386,10 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
   await API.packageIndexReady;
 
   let importhook = API._pyodide._importhook;
-  importhook.register_module_not_found_hook(API._import_name_to_package_name);
+  importhook.register_module_not_found_hook(
+    API._import_name_to_package_name,
+    API.repodata_unvendored_stdlibs_and_test,
+  );
 
   if (API.repodata_info.version !== version) {
     throw new Error("Lock file version doesn't match Pyodide version");

--- a/src/py/_pyodide/_importhook.py
+++ b/src/py/_pyodide/_importhook.py
@@ -180,7 +180,7 @@ def get_module_not_found_error(import_name):
     )
 
 
-def register_module_not_found_hook(packages: Any) -> None:
+def register_module_not_found_hook(packages: Any, unvendored: Any) -> None:
     """
     A function that adds UnvendoredStdlibFinder to the end of sys.meta_path.
 
@@ -189,6 +189,8 @@ def register_module_not_found_hook(packages: Any) -> None:
     """
     global orig_get_module_not_found_error
     global REPODATA_PACKAGES_IMPORT_TO_PACKAGE_NAME
+    global UNVENDORED_STDLIBS_AND_TEST
     REPODATA_PACKAGES_IMPORT_TO_PACKAGE_NAME = packages.to_py()
+    UNVENDORED_STDLIBS_AND_TEST = unvendored.to_py()
     orig_get_module_not_found_error = _bootstrap._get_module_not_found_error
     _bootstrap._get_module_not_found_error = get_module_not_found_error

--- a/src/py/_pyodide/_importhook.py
+++ b/src/py/_pyodide/_importhook.py
@@ -134,17 +134,7 @@ def register_js_finder() -> None:
 
 
 STDLIBS = sys.stdlib_module_names | {"test"}
-# TODO: Move this list to js side
-UNVENDORED_STDLIBS = [
-    "distutils",
-    "ssl",
-    "lzma",
-    "sqlite3",
-    "hashlib",
-    "pydoc_data",
-    "pydecimal",
-]
-UNVENDORED_STDLIBS_AND_TEST = UNVENDORED_STDLIBS + ["test"]
+UNVENDORED_STDLIBS_AND_TEST: set[str] = set()
 
 
 from importlib import _bootstrap  # type: ignore[attr-defined]
@@ -199,6 +189,6 @@ def register_module_not_found_hook(packages: Any, unvendored: Any) -> None:
     global REPODATA_PACKAGES_IMPORT_TO_PACKAGE_NAME
     global UNVENDORED_STDLIBS_AND_TEST
     REPODATA_PACKAGES_IMPORT_TO_PACKAGE_NAME = packages.to_py()
-    UNVENDORED_STDLIBS_AND_TEST = unvendored.to_py()
+    UNVENDORED_STDLIBS_AND_TEST = set(unvendored.to_py())
     orig_get_module_not_found_error = _bootstrap._get_module_not_found_error
     _bootstrap._get_module_not_found_error = get_module_not_found_error

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1319,11 +1319,10 @@ def test_fullstdlib(selenium_standalone_noload):
         await pyodide.loadPackage("micropip");
 
         pyodide.runPython(`
-            import _pyodide
+            import pyodide_js
             import micropip
             loaded_packages = micropip.list()
-            print(loaded_packages)
-            assert all((lib in micropip.list()) for lib in _pyodide._importhook.UNVENDORED_STDLIBS)
+            assert all((lib in micropip.list()) for lib in pyodide_js._api.repodata_unvendored_stdlibs)
         `);
         """
     )


### PR DESCRIPTION
### Description

This PR adds `package_type` field to repodata.json and use it to create a list of unvendored standard libraries. After this we don't need to manage a hard-coded list of unvendored stdlib lists in pyodide-py.

### Checklists

- [x] Add / update tests
