### PR TITLE
DOCS, MAINT: Replace :any: xrefs with more specific types

### DIFF
--- a/docs/project/release-notes/v0.17.0.md
+++ b/docs/project/release-notes/v0.17.0.md
@@ -21,7 +21,7 @@ issues and that future releases will have fewer breaking changes.
 We added full support for asyncio, including a new Python event loop that
 schedules tasks on the browser event loop, support for top level await in
 {any}`pyodide.runPythonAsync`, and implementations of `await` for {any}`JsProxy <pyodide.ffi.JsProxy>`
-and {any}`PyProxy`, so that it is possible to await a Python awaitable from
+and {js:class}`PyProxy`, so that it is possible to await a Python awaitable from
 JavaScript and a JavaScript thenable from Python. This allows seamless
 interoperability:
 
@@ -99,7 +99,7 @@ We added several new conversion APIs to give more explicit control over the
 foreign function interface. In particular, the goal was to make it easier for
 users to avoid leaking memory.
 
-For the basic use cases, we have {any}`PyProxy.toJs` and `JsProxy.to_py`
+For the basic use cases, we have {js:meth}`PyProxy.toJs` and `JsProxy.to_py`
 which respectively convert Python objects to JavaScript objects and JavaScript
 objects to Python objects. We also added also "wrong-way" conversion functions
 {any}`pyodide.to_js <pyodide.ffi.to_js>` and {any}`pyodide.toPy` which are particularly helpful for
@@ -110,7 +110,7 @@ The promise handler methods `JsProxy.then`, `JsProxy.catch`, and
 `JsProxy.finally_` were particularly hard to use without leaking memory so
 they have been updated with internal magic to automatically manage the memory.
 
-For more advanced use cases where control over the life cycle of a {any}`PyProxy` is
+For more advanced use cases where control over the life cycle of a {js:class}`PyProxy` is
 needed, there are {any}`create_proxy` and {any}`create_once_callable`.
 
 (Added in PRs {pr}`1186`, {pr}`1244`, {pr}`1344`, {pr}`1436`)
@@ -150,8 +150,8 @@ The buffer translation code in previous versions was less flexible, leaked memor
 and had serious bugs including use after free ({issue}`749`) and buffer overflow errors.
 
 We completely reworked these: buffers are now proxied like most other objects.
-In simple use cases they can be converted with a copy using {any}`PyProxy.toJs`
-and `JsProxy.to_py`. We added new APIs {any}`PyProxy.getBuffer`,
+In simple use cases they can be converted with a copy using {js:meth}`PyProxy.toJs`
+and `JsProxy.to_py`. We added new APIs `PyProxy.getBuffer`,
 `JsProxy.assign`, and `JsProxy.assign_to` which give more fine-grained
 control, though they are not yet as ergonomic as they could be.
 

--- a/docs/sphinx_pyodide/sphinx_pyodide/mdn_xrefs.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/mdn_xrefs.py
@@ -77,6 +77,7 @@ DATA = {
         "TypedArray.BYTES_PER_ELEMENT": "$global/",
     },
     "js:attribute": {
+        "TypedArray.byteLength": "$global/",
         "Response.type": "API/",
         "Response.url": "API/",
         "Response.statusText": "API/",

--- a/docs/usage/api/python-api.md
+++ b/docs/usage/api/python-api.md
@@ -7,7 +7,7 @@ Backward compatibility of the API is not guaranteed at this point.
 **JavaScript Modules**
 
 By default there are two JavaScript modules. More can be added with
-{any}`pyodide.registerJsModule`. You can import these modules using the Python
+{js:func}`pyodide.registerJsModule`. You can import these modules using the Python
 `import` statement in the normal way.
 
 ```{eval-rst}
@@ -30,9 +30,9 @@ By default there are two JavaScript modules. More can be added with
       - Similar to the Python builtin `code` module but handles top level await. Used
         for implementing the Pyodide console.
    *  - :py:mod:`pyodide.ffi`
-      - The :any:`JsProxy <pyodide.ffi.JsProxy>` class and utilities to help interact with JavaScript code.
+      - The :py:class:`~pyodide.ffi.JsProxy` class and utilities to help interact with JavaScript code.
    *  - :py:mod:`pyodide.http`
-      - Defines :any:`pyfetch` and other functions for making network requests.
+      - Defines :py:func:`~pyodide.http.pyfetch` and other functions for making network requests.
    *  - :py:mod:`pyodide.webloop`
       - The Pyodide event loop implementation. This is automatically configured
         correctly for most use cases it is unlikely you will need it outside of niche

--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -11,7 +11,7 @@ converting a Python string to the equivalent a JavaScript string. By "proxying"
 an object we mean producing a special object in the target language that
 forwards requests to the source language. When we proxy a JavaScript object into
 Python, the result is a {py:class}`~pyodide.ffi.JsProxy` object. When we proxy a
-Python object into JavaScript, the result is a {any}`PyProxy` object. A proxied
+Python object into JavaScript, the result is a {js:class}`PyProxy` object. A proxied
 object can be explicitly converted using the explicit conversion methods
 {py:meth}`JsProxy.to_py <pyodide.ffi.JsProxy.to_py>` and
 {js:func}`PyProxy.toJs`.
@@ -22,7 +22,7 @@ Python to JavaScript translations occur:
 - when [importing Python objects into JavaScript](type-translations_using-py-obj-from-js)
 - when passing arguments to a JavaScript function called from Python,
 - when returning the results of a Python function called from JavaScript,
-- when accessing an attribute of a {any}`PyProxy`
+- when accessing an attribute of a {js:class}`PyProxy`
 
 JavaScript to Python translations occur:
 
@@ -35,7 +35,7 @@ JavaScript to Python translations occur:
 :class: warning
 
 Any time a Python to JavaScript translation occurs, it may create a
-{any}`PyProxy`. To avoid memory leaks, you must store the {any}`PyProxy` and
+{js:class}`PyProxy`. To avoid memory leaks, you must store the {js:class}`PyProxy` and
 {js:func}`~PyProxy.destroy` it when you are done with it. See
 {ref}`call-py-from-js` for more info.
 ```
@@ -120,8 +120,8 @@ language.
 
 ### Proxying from JavaScript into Python
 
-When most JavaScript objects are translated into Python a {any}`JsProxy <pyodide.ffi.JsProxy>` is
-returned. The following operations are currently supported on a {any}`JsProxy <pyodide.ffi.JsProxy>`:
+When most JavaScript objects are translated into Python a {py:class}`~pyodide.ffi.JsProxy` is
+returned. The following operations are currently supported on a {py:class}`~pyodide.ffi.JsProxy`:
 
 | Python                             | JavaScript                        |
 | ---------------------------------- | --------------------------------- |
@@ -189,11 +189,11 @@ JavaScript uses `array[7]`. For these cases, we translate:
 
 ### Proxying from Python into JavaScript
 
-When most Python objects are translated to JavaScript a {any}`PyProxy` is
+When most Python objects are translated to JavaScript a {js:class}`PyProxy` is
 produced.
 
 Fewer operations can be overloaded in JavaScript than in Python, so some
-operations are more cumbersome on a {any}`PyProxy` than on a {any}`JsProxy <pyodide.ffi.JsProxy>`. The
+operations are more cumbersome on a {js:class}`PyProxy` than on a {py:class}`~pyodide.ffi.JsProxy`. The
 following operations are supported:
 
 | JavaScript                          | Python              |
@@ -234,9 +234,9 @@ foo(); // throws Error: Object has already been destroyed
 
 ### Python to JavaScript
 
-Explicit conversion of a {any}`PyProxy` into a native JavaScript object is done
+Explicit conversion of a {js:class}`PyProxy` into a native JavaScript object is done
 with the {js:func}`PyProxy.toJs` method. You can also perform such a conversion in
-Python using {any}`to_js <pyodide.ffi.to_js>` which behaves in much the same way. By
+Python using {py:func}`~pyodide.ffi.to_js` which behaves in much the same way. By
 default, the {js:func}`~PyProxy.toJs` method does a recursive "deep" conversion, to do a shallow
 conversion use `proxy.toJs({depth : 1})`. In addition to [the normal type
 conversion](type-translations_py2js-table), {js:func}`~PyProxy.toJs` method performs the following
@@ -428,8 +428,8 @@ converted to Python and the converted value is used to resolve the
 Any PyProxies created in converting the arguments are also destroyed at this
 point.
 
-As a result of this, if a `PyProxy` is persisted to be used later, then it must
-either be copied using {any}`PyProxy.copy` in JavaScript, or it must be created
+As a result of this, if a {js:class}`PyProxy` is persisted to be used later, then it must
+either be copied using {js:meth}`PyProxy.copy` in JavaScript, or it must be created
 with {py:func}`~pyodide.ffi.create_proxy` or
 {py:func}`~pyodide.ffi.create_once_callable`. If it's only going to be called
 once use {py:func}`~pyodide.ffi.create_once_callable`:
@@ -576,7 +576,7 @@ to produce a traceback with certain functions filtered out), use that.
 
 ```{admonition} Be careful Proxying Stack Frames
 :class: warning
-If you make a {any}`PyProxy` of {py:data}`sys.last_value`, you should be especially
+If you make a {js:class}`PyProxy` of {py:data}`sys.last_value`, you should be especially
 careful to {js:meth}`~PyProxy.destroy` it when you are done with it, or
 you may leak a large amount of memory if you don't.
 ```
@@ -614,7 +614,7 @@ objects on the custom namespaces.
 ### Importing Python objects into JavaScript
 
 A Python global variable in the `__main__` global scope can be imported into
-JavaScript using the {any}`pyodide.globals.get <PyProxy.get>` method. Given the
+JavaScript using the {js:meth}`pyodide.globals.get <PyProxy.get>` method. Given the
 name of the Python global variable, it returns the value of the variable
 translated to JavaScript.
 
@@ -624,8 +624,8 @@ let x = pyodide.globals.get("x");
 
 As always, if the result is a `PyProxy` and you care about not leaking the
 Python object, you must destroy it when you are done. It's also possible to set
-values in the Python global scope with {any}`pyodide.globals.set <PyProxy.set>`
-or remove them with {any}`pyodide.globals.delete <PyProxy.delete>`:
+values in the Python global scope with {js:meth}`pyodide.globals.set <PyProxy.set>`
+or remove them with {js:meth}`pyodide.globals.delete <PyProxy.delete>`:
 
 ```pyodide
 pyodide.globals.set("x", 2);
@@ -641,7 +641,7 @@ pyodide.runPython("x=2", my_py_namespace);
 let x = my_py_namespace.get("x");
 ```
 
-To access a Python module from JavaScript, use {any}`pyodide.pyimport`:
+To access a Python module from JavaScript, use {js:func}`~pyodide.pyimport`:
 
 ```js
 let sys = pyodide.pyimport("sys");
@@ -673,7 +673,7 @@ console.log(window.x); // 2
 ```
 
 You can create your own custom JavaScript modules using
-{any}`pyodide.registerJsModule` and they will behave like the `js` module except
+{js:func}`pyodide.registerJsModule` and they will behave like the `js` module except
 with a custom scope:
 
 ```pyodide

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -256,17 +256,17 @@ Module.handle_js_error = function (e: any) {
 /**
  * A JavaScript error caused by a Python exception.
  *
- * In order to reduce the risk of large memory leaks, the :any:`PythonError`
+ * In order to reduce the risk of large memory leaks, the :py:exc:`PythonError`
  * contains no reference to the Python exception that caused it. You can find
- * the actual Python exception that caused this error as :any:`sys.last_value`.
+ * the actual Python exception that caused this error as :py:data:`sys.last_value`.
  *
  * See :ref:`type translations of errors <type-translations-errors>` for more information.
  *
  * .. admonition:: Avoid leaking stack Frames
  *    :class: warning
  *
- *    If you make a :any:`PyProxy` of :any:`sys.last_value`, you should be
- *    especially careful to :any:`destroy() <PyProxy.destroy>` it when you are
+ *    If you make a :js:class:`~pyodide.PyProxy` of :py:data:`sys.last_value`, you should be
+ *    especially careful to :js:meth:`~pyodide.PyProxy.destroy` it when you are
  *    done. You may leak a large amount of memory including the local
  *    variables of all the stack frames in the traceback if you don't. The
  *    easiest way is to only handle the exception in Python.
@@ -283,8 +283,8 @@ export class PythonError extends Error {
    */
   __error_address: number;
   /**
-   * The name of the Python error class, e.g, :any:`RuntimeError` or
-   * :any:`KeyError`.
+   * The name of the Python error class, e.g, :py:exc:`RuntimeError` or
+   * :py:exc:`KeyError`.
    */
   type: string;
   constructor(type: string, message: string, error_address: number) {

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -127,7 +127,7 @@ type PyProxyProps = {
   /**
    * captureThis tracks whether this should be passed as the first argument to
    * the Python function or not. We keep it false by default. To make a PyProxy
-   * where the `this` argument is included, call the `captureThis` method.
+   * where the ``this`` argument is included, call the :js:meth:`captureThis` method.
    */
   captureThis: boolean;
   /**
@@ -135,7 +135,7 @@ type PyProxyProps = {
    */
   isBound: boolean;
   /**
-   * the `this` value that has been bound to the PyProxy
+   * the ``this`` value that has been bound to the PyProxy
    */
   boundThis?: any;
   /**
@@ -153,7 +153,7 @@ type PyProxyProps = {
  * allows the copy of the PyProxy to share its attribute cache with the original
  * version. In all other cases, pyproxy_new should be called with one argument.
  *
- * In the case that the Python object is callable, PyProxyClass inherits from
+ * In the case that the Python object is callable, PyProxy inherits from
  * Function so that PyProxy objects can be callable. In that case we MUST expose
  * certain properties inherited from Function, but we do our best to remove as
  * many as possible.
@@ -552,16 +552,18 @@ export class PyProxyClass {
     /** How many layers deep to perform the conversion. Defaults to infinite */
     depth?: number;
     /**
-     * If provided, ``toJs`` will store all PyProxies created in this list. This
-     * allows you to easily destroy all the PyProxies by iterating the list
-     * without having to recurse over the generated structure. The most common
-     * use case is to create a new empty list, pass the list as `pyproxies`, and
-     * then later iterate over `pyproxies` to destroy all of created proxies.
+     * If provided, :js:meth:`toJs` will store all PyProxies created in this
+     * list. This allows you to easily destroy all the PyProxies by iterating
+     * the list without having to recurse over the generated structure. The most
+     * common use case is to create a new empty list, pass the list as
+     * ``pyproxies``, and then later iterate over ``pyproxies`` to destroy all of
+     * created proxies.
      */
     pyproxies?: PyProxy[];
     /**
-     * If false, ``toJs`` will throw a :py:exc:`~pyodide.ffi.ConversionError` rather than
-     * producing a ``PyProxy``.
+     * If false, :js:meth:`toJs` will throw a
+     * :py:exc:`~pyodide.ffi.ConversionError` rather than producing a
+     * :js:class:`PyProxy`.
      */
     create_pyproxies?: boolean;
     /**

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -54,7 +54,7 @@ API.runPythonInternal = function (code: string): any {
 };
 
 /**
- * Runs a string of Python code from JavaScript, using :any:`pyodide.code.eval_code`
+ * Runs a string of Python code from JavaScript, using :py:func:`~pyodide.code.eval_code`
  * to evaluate the code. If the last statement in the Python code is an
  * expression (and the code doesn't end with a semicolon), the value of the
  * expression is returned.
@@ -62,9 +62,9 @@ API.runPythonInternal = function (code: string): any {
  * @param code Python code to evaluate
  * @param options
  * @param options.globals An optional Python dictionary to use as the globals.
- *        Defaults to :any:`pyodide.globals`.
+ *        Defaults to :js:attr:`pyodide.globals`.
  * @returns The result of the Python code translated to JavaScript. See the
- *          documentation for :any:`pyodide.code.eval_code` for more info.
+ *          documentation for :py:func:`~pyodide.code.eval_code` for more info.
  */
 export function runPython(
   code: string,
@@ -94,7 +94,7 @@ let loadPackagesFromImportsPositionalCallbackDeprecationWarned = false;
  * ``pyodide.loadPackage(['numpy'])``.
  *
  * @param code The code to inspect.
- * @param options Options passed to :any:`pyodide.loadPackage`.
+ * @param options Options passed to :js:func:`pyodide.loadPackage`.
  * @param options.messageCallback A callback, called with progress messages
  *    (optional)
  * @param options.errorCallback A callback, called with error/warning messages
@@ -155,7 +155,7 @@ export async function loadPackagesFromImports(
 
 /**
  * Run a Python code string with top level await using
- * :any:`pyodide.code.eval_code_async` to evaluate the code. Returns a promise which
+ * :py:func:`~pyodide.code.eval_code_async` to evaluate the code. Returns a promise which
  * resolves when execution completes. If the last statement in the Python code
  * is an expression (and the code doesn't end with a semicolon), the returned
  * promise will resolve to the value of this expression.
@@ -183,7 +183,7 @@ export async function loadPackagesFromImports(
  * @param code Python code to evaluate
  * @param options
  * @param options.globals An optional Python dictionary to use as the globals.
- * Defaults to :any:`pyodide.globals`.
+ * Defaults to :js:attr:`pyodide.globals`.
  * @returns The result of the Python code translated to JavaScript.
  * @async
  */
@@ -203,7 +203,7 @@ API.runPythonAsync = runPythonAsync;
  * ``name``. This module can then be imported from Python using the standard
  * Python import system. If another module by the same name has already been
  * imported, this won't have much effect unless you also delete the imported
- * module from :py:data:`sys.modules`. This calls the :any:`pyodide_py` API
+ * module from :py:data:`sys.modules`. This calls
  * :func:`~pyodide.ffi.register_js_module`.
  *
  * @param name Name of the JavaScript module to add
@@ -227,8 +227,8 @@ export function registerComlink(Comlink: any) {
  * :func:`~pyodide.ffi.register_js_module`. If a JavaScript module with that
  * name does not already exist, will throw an error. Note that if the module has
  * already been imported, this won't have much effect unless you also delete the
- * imported module from :py:data:`sys.modules`. This calls the :any:`pyodide_py`
- * API :func:`~pyodide.ffi.unregister_js_module`.
+ * imported module from :py:data:`sys.modules`. This calls
+ * :func:`~pyodide.ffi.unregister_js_module`.
  *
  * @param name Name of the JavaScript module to remove
  */
@@ -239,8 +239,8 @@ export function unregisterJsModule(name: string) {
 /**
  * Convert a JavaScript object to a Python object as best as possible.
  *
- * This is similar to :any:`JsProxy.to_py` but for use from JavaScript. If the
- * object is immutable or a :any:`PyProxy`, it will be returned unchanged. If
+ * This is similar to :py:meth:`~pyodide.ffi.JsProxy.to_py` but for use from JavaScript. If the
+ * object is immutable or a :py:class:`~pyodide.PyProxy`, it will be returned unchanged. If
  * the object cannot be converted into Python, it will be returned unchanged.
  *
  * See :ref:`type-translations-jsproxy-to-py` for more information.
@@ -261,7 +261,7 @@ export function toPy(
     depth: number;
     /**
      * Optional argument to convert objects with no default conversion. See the
-     * documentation of :any:`JsProxy.to_py`.
+     * documentation of :py:meth:`~pyodide.ffi.JsProxy.to_py`.
      */
     defaultConverter?: (
       value: any,
@@ -347,7 +347,7 @@ export function pyimport(mod_name: string): PyProxy {
  *
  * @param buffer The archive as an :js:class:`ArrayBuffer` or :js:class:`TypedArray`.
  * @param format The format of the archive. Should be one of the formats
- * recognized by :any:`shutil.unpack_archive`. By default the options are
+ * recognized by :py:func:`shutil.unpack_archive`. By default the options are
  * ``'bztar'``, ``'gztar'``, ``'tar'``, ``'zip'``, and ``'wheel'``. Several
  * synonyms are accepted for each format, e.g., for ``'gztar'`` any of
  * ``'.gztar'``, ``'.tar.gz'``, ``'.tgz'``, ``'tar.gz'`` or ``'tgz'`` are
@@ -384,18 +384,19 @@ export function unpackArchive(
   });
 }
 
-type NativeFS = {
-  syncfs: Function;
+/** @private */
+export type NativeFS = {
+  syncfs: () => Promise<void>;
 };
 
 /**
- * Mounts FileSystemDirectoryHandle in to the target directory.
+ * Mounts a ``FileSystemDirectoryHandle`` into the target directory.
  *
  * @param path The absolute path in the Emscripten file system to mount the
  * native directory. If the directory does not exist, it will be created. If it
  * does exist, it must be empty.
- * @param fileSystemHandle A handle returned by navigator.storage.getDirectory()
- * or window.showDirectoryPicker().
+ * @param fileSystemHandle A handle returned by ``navigator.storage.getDirectory()``
+ * or ``window.showDirectoryPicker()``.
  */
 export async function mountNativeFS(
   path: string,
@@ -449,10 +450,10 @@ API.restoreState = (state: any) => API.pyodide_py._state.restore_state(state);
  *
  * You can disable interrupts by calling ``setInterruptBuffer(undefined)``.
  *
- * If you wish to trigger a :any:`KeyboardInterrupt`, write ``SIGINT`` (a 2),
+ * If you wish to trigger a :py:exc:`KeyboardInterrupt`, write ``SIGINT`` (a 2)
  * into the interrupt buffer.
  *
- * By default ``SIGINT`` raises a :any:`KeyboardInterrupt` and all other signals
+ * By default ``SIGINT`` raises a :py:exc:`KeyboardInterrupt` and all other signals
  * are ignored. You can install custom signal handlers with the signal module.
  * Even signals that normally have special meaning and can't be overridden like
  * ``SIGKILL`` and ``SIGSEGV`` are ignored by default and can be used for any
@@ -464,11 +465,11 @@ export function setInterruptBuffer(interrupt_buffer: TypedArray) {
 }
 
 /**
- * Throws a :any:`KeyboardInterrupt` error if a :any:`KeyboardInterrupt` has
+ * Throws a :py:exc:`KeyboardInterrupt` error if a :py:exc:`KeyboardInterrupt` has
  * been requested via the interrupt buffer.
  *
  * This can be used to enable keyboard interrupts during execution of JavaScript
- * code, just as :any:`PyErr_CheckSignals` is used to enable keyboard interrupts
+ * code, just as :c:func:`PyErr_CheckSignals` is used to enable keyboard interrupts
  * during execution of C code.
  */
 export function checkInterrupt() {

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -346,12 +346,12 @@ let loadPackagePositionalCallbackDeprecationWarned = false;
  * package in the virtual filesystem. The package needs to be imported from
  * Python before it can be used.
  *
- * @param names Either a single package name or
- * URL or a list of them. URLs can be absolute or relative. The URLs must have
- * file name ``<package-name>.js`` and there must be a file called
- * ``<package-name>.data`` in the same directory. The argument can be a
- * ``PyProxy`` of a list, in which case the list will be converted to JavaScript
- * and the ``PyProxy`` will be destroyed.
+ * @param names Either a single package name or URL or a list of them. URLs can
+ * be absolute or relative. The URLs must have file name ``<package-name>.js``
+ * and there must be a file called ``<package-name>.data`` in the same
+ * directory. The argument can be a :js:class:`~pyodide.PyProxy` of a list, in
+ * which case the list will be converted to JavaScript and the
+ * :js:class:`~pyodide.PyProxy` will be destroyed.
  * @param options
  * @param options.messageCallback A callback, called with progress messages
  *    (optional)

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -239,7 +239,7 @@ export async function loadPyodide(
 
     /**
      * The URL from which Pyodide will load the Pyodide ``repodata.json`` lock
-     * file. You can produce custom lock files with :any:`micropip.freeze`.
+     * file. You can produce custom lock files with :py:func:`micropip.freeze`.
      * Default: ```${indexURL}/repodata.json```
      */
     lockFileURL?: string;

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -191,7 +191,7 @@ function setStdinError() {
  * The stdin handler is called with zero arguments whenever stdin is read and
  * the current input buffer is exhausted. It should return one of:
  *
- * - ``null`` or ``undefined``: these are interpreted as end of file.
+ * - :js:data:`null` or :js:data:`undefined`: these are interpreted as end of file.
  * - a number
  * - a string
  * - an :js:class:`ArrayBuffer` or :js:class:`TypedArray` with
@@ -210,10 +210,10 @@ function setStdinError() {
  * @param options.stdin The stdin handler.
  * @param options.error If this is set to ``true``, attempts to read from stdin
  * will always set an IO error.
- * @param options.isatty Should ``isatty(stdin)`` be ``true`` or ``false``
- * (default ``false``).
- * @param options.autoEOF Insert an EOF automatically after each string
- * or buffer? (default ``true``).
+ * @param options.isatty Should :py:func:`isatty(stdin) <os.isatty>` be ``true``
+ * or ``false`` (default ``false``).
+ * @param options.autoEOF Insert an EOF automatically after each string or
+ * buffer? (default ``true``).
  */
 export function setStdin(
   options: {
@@ -272,8 +272,9 @@ function setDefaultStdout() {
  * not.
  * @param options.raw A raw handler is called with the handler is called with a
  * `number` for each byte of the output to stdout.
- * @param options.isatty Should ``isatty(stdout)`` return ``true`` or ``false``.
- * Can only be set to ``true`` if a raw handler is provided (default ``false``).
+ * @param options.isatty Should :py:func:`isatty(stdout) <os.isatty>` return
+ * ``true`` or ``false``. Can only be set to ``true`` if a raw handler is
+ * provided (default ``false``).
  */
 export function setStdout(
   options: {
@@ -333,8 +334,9 @@ function setDefaultStderr() {
  * buffered so it is impossible to make a tty with it).
  * @param options.raw A raw handler is called with the handler is called with a
  * `number` for each byte of the output to stderr.
- * @param options.isatty Should ``isatty(stderr)`` return ``true`` or ``false``.
- * Can only be set to ``true`` if a raw handler is provided (default ``false``).
+ * @param options.isatty Should :py:func:`isatty(stderr) <os.isatty>` return
+ * ``true`` or ``false``. Can only be set to ``true`` if a raw handler is
+ * provided (default ``false``).
  */
 export function setStderr(
   options: {

--- a/src/py/_pyodide/_base.py
+++ b/src/py/_pyodide/_base.py
@@ -169,8 +169,8 @@ class CodeRunner:
 
     It is primarily intended for REPLs and other sophisticated consumers that
     may wish to add their own AST transformations, separately signal to the user
-    when parsing is complete, etc. The simpler :any:`eval_code` and
-    :any:`eval_code_async` apis should be preferred when their flexibility
+    when parsing is complete, etc. The simpler :py:func:`eval_code` and
+    :py:func:`eval_code_async` apis should be preferred when their flexibility
     suffices.
 
     Parameters
@@ -216,14 +216,14 @@ class CodeRunner:
     ast: ast.Module
     """
     The ast from parsing ``source``. If you wish to do an ast transform,
-    modify this variable before calling :any:`CodeRunner.compile`.
+    modify this variable before calling :py:meth:`CodeRunner.compile`.
     """
 
     code: CodeType | None
     """
-    Once you call :any:`CodeRunner.compile` the compiled code will
+    Once you call :py:meth:`CodeRunner.compile` the compiled code will
     be available in the code field. You can modify this variable
-    before calling :any:`CodeRunner.run` to do a code transform.
+    before calling :py:meth:`CodeRunner.run` to do a code transform.
     """
 
     def __init__(
@@ -273,7 +273,7 @@ class CodeRunner:
         """Executes ``self.code``.
 
         Can only be used after calling compile. The code may not use top level
-        await, use :any:`CodeRunner.run_async` for code that uses top level
+        await, use :py:meth:`CodeRunner.run_async` for code that uses top level
         await.
 
         Parameters
@@ -281,12 +281,12 @@ class CodeRunner:
         globals :
 
             The global scope in which to execute code. This is used as the ``globals``
-            parameter for :any:`exec`. If ``globals`` is absent, a new empty dictionary is used.
+            parameter for :py:func:`exec`. If ``globals`` is absent, a new empty dictionary is used.
 
         locals :
 
             The local scope in which to execute code. This is used as the ``locals``
-            parameter for :any:`exec`. If ``locals`` is absent, the value of ``globals`` is
+            parameter for :py:func:`exec`. If ``locals`` is absent, the value of ``globals`` is
             used.
 
         Returns
@@ -321,7 +321,7 @@ class CodeRunner:
     ) -> Any:
         """Runs ``self.code`` which may use top level await.
 
-        Can only be used after calling :any:`CodeRunner.compile`. If
+        Can only be used after calling :py:meth:`CodeRunner.compile`. If
         ``self.code`` uses top level await, automatically awaits the resulting
         coroutine.
 
@@ -330,12 +330,12 @@ class CodeRunner:
         globals :
 
             The global scope in which to execute code. This is used as the ``globals``
-            parameter for :any:`exec`. If ``globals`` is absent, a new empty dictionary is used.
+            parameter for :py:func:`exec`. If ``globals`` is absent, a new empty dictionary is used.
 
         locals :
 
             The local scope in which to execute code. This is used as the
-            ``locals`` parameter for :any:`exec`. If ``locals`` is absent, the
+            ``locals`` parameter for :py:func:`exec`. If ``locals`` is absent, the
             value of ``globals`` is used.
 
         Returns
@@ -380,13 +380,13 @@ def eval_code(
     globals :
 
         The global scope in which to execute code. This is used as the
-        ``globals`` parameter for :any:`exec`. If ``globals`` is absent, a new
+        ``globals`` parameter for :py:func:`exec`. If ``globals`` is absent, a new
         empty dictionary is used.
 
     locals :
 
         The local scope in which to execute code. This is used as the ``locals``
-        parameter for :any:`exec`. If ``locals`` is absent, the value of
+        parameter for :py:func:`exec`. If ``locals`` is absent, the value of
         ``globals`` is used.
 
     return_mode :
@@ -473,7 +473,7 @@ async def eval_code_async(
 ) -> Any:
     """Runs a code string asynchronously.
 
-    Uses :any:`ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` to compile the code.
+    Uses :py:data:`ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` to compile the code.
 
     Parameters
     ----------
@@ -484,13 +484,13 @@ async def eval_code_async(
     globals :
 
         The global scope in which to execute code. This is used as the
-        ``globals`` parameter for :any:`exec`. If ``globals`` is absent, a new
+        ``globals`` parameter for :py:func:`exec`. If ``globals`` is absent, a new
         empty dictionary is used.
 
     locals :
 
         The local scope in which to execute code. This is used as the ``locals``
-        parameter for :any:`exec`. If ``locals`` is absent, the value of
+        parameter for :py:func:`exec`. If ``locals`` is absent, the value of
         ``globals`` is used.
 
     return_mode :

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -94,7 +94,7 @@ class JsProxy(metaclass=_JsProxyMetaClass):
     For more information see the :ref:`type-translations` documentation. In
     particular, see
     :ref:`the list of __dunder__ methods <type-translations-jsproxy>`
-    that are (conditionally) implemented on :any:`JsProxy`.
+    that are (conditionally) implemented on :py:class:`JsProxy`.
     """
 
     _js_type_flags: Any = 0
@@ -145,7 +145,7 @@ class JsProxy(metaclass=_JsProxyMetaClass):
 
         Note that ``len(x.as_object_map())`` evaluates in O(n) time (it iterates
         over the object and counts how many ownKeys it has). If you need to
-        compute the length in O(1) time, use a real ``Map`` instead.
+        compute the length in O(1) time, use a real :js:class:`Map` instead.
         """
         raise NotImplementedError
 
@@ -187,7 +187,7 @@ class JsProxy(metaclass=_JsProxyMetaClass):
         --------
 
         Here are a couple examples of converter functions. In addition to the
-        normal conversions, convert ``Date`` to ``datetime``:
+        normal conversions, convert :js:class:`Date`` to :py:class:`~datetime.datetime`:
 
         .. code-block:: python
 
@@ -220,7 +220,7 @@ class JsProxy(metaclass=_JsProxyMetaClass):
                 }
             }
 
-        We can use the following ``default_converter`` to convert ``Pair`` to ``list``:
+        We can use the following ``default_converter`` to convert ``Pair`` to :py:class:`list`:
 
         .. code-block:: python
 
@@ -250,7 +250,7 @@ class JsProxy(metaclass=_JsProxyMetaClass):
 
 
 class JsDoubleProxy(JsProxy):
-    """A double proxy created with :any:`create_proxy`."""
+    """A double proxy created with :py:func:`create_proxy`."""
 
     _js_type_flags = ["IS_DOUBLE_PROXY"]
 
@@ -259,16 +259,20 @@ class JsDoubleProxy(JsProxy):
         pass
 
     def unwrap(self) -> Any:
-        """Unwrap a double proxy created with :any:`create_proxy` into the
+        """Unwrap a double proxy created with :py:func:`create_proxy` into the
         wrapped Python object.
         """
         raise NotImplementedError
 
 
 class JsPromise(JsProxy):
-    """A JsProxy of a promise (or some other awaitable JavaScript object).
+    """A :py:class:`~pyodide.ffi.JsProxy` of a :js:class:`Promise`
 
-    A JavaScript object is considered to be a Promise if it has a "then" method.
+    Or of some other `thenable
+    <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables>`_
+    JavaScript object.
+
+    A JavaScript object is considered to be a :js:class:`Promise` if it has a ``then`` method.
     """
 
     _js_type_flags = ["IS_AWAITABLE"]
@@ -276,7 +280,7 @@ class JsPromise(JsProxy):
     def then(
         self, onfulfilled: Callable[[Any], Any], onrejected: Callable[[Any], Any]
     ) -> "JsPromise":
-        """The ``Promise.then`` API, wrapped to manage the lifetimes of the
+        """The :js:meth:`Promise.then` API, wrapped to manage the lifetimes of the
         handlers.
 
         Pyodide will automatically release the references to the handlers
@@ -285,7 +289,7 @@ class JsPromise(JsProxy):
         raise NotImplementedError
 
     def catch(self, onrejected: Callable[[Any], Any], /) -> "JsPromise":
-        """The ``Promise.catch`` API, wrapped to manage the lifetimes of the
+        """The :js:meth:`Promise.catch` API, wrapped to manage the lifetimes of the
         handler.
 
         Pyodide will automatically release the references to the handler
@@ -294,7 +298,7 @@ class JsPromise(JsProxy):
         raise NotImplementedError
 
     def finally_(self, onfinally: Callable[[], Any], /) -> "JsPromise":
-        """The ``Promise.finally`` API, wrapped to manage the lifetimes of
+        """The :js:meth:`Promise.finally` API, wrapped to manage the lifetimes of
         the handler.
 
         Pyodide will automatically release the references to the handler
@@ -448,7 +452,7 @@ class JsArray(JsProxy, Generic[T]):
     def pop(self, /, index: int = -1) -> T:
         """Remove and return the ``item`` at ``index`` (default last).
 
-        Raises :any:`IndexError` if list is empty or index is out of range.
+        Raises :py:exc:`IndexError` if list is empty or index is out of range.
         """
         raise NotImplementedError
 
@@ -461,7 +465,7 @@ class JsArray(JsProxy, Generic[T]):
     def index(self, /, value: T, start: int = 0, stop: int = sys.maxsize) -> int:
         """Return first ``index`` at which ``value`` appears in the ``Array``.
 
-        Raises :any:`ValueError` if the value is not present.
+        Raises :py:exc:`ValueError` if the value is not present.
         """
         raise NotImplementedError
 
@@ -558,7 +562,7 @@ class JsMutableMap(JsMap[KT, VT], Generic[KT, VT]):
     number (idiomatically it should be called ``size``) and it must be iterable.
 
     Instances of the JavaScript builtin ``Map`` class are ``JsMutableMap`` s.
-    Also proxies returned by :any:`JsProxy.as_object_map` are instances of
+    Also proxies returned by :py:meth:`JsProxy.as_object_map` are instances of
     ``JsMap`` .
     """
 
@@ -623,7 +627,7 @@ class JsMutableMap(JsMap[KT, VT], Generic[KT, VT]):
                 Extra key-values pairs to insert into the map. Only usable for
                 inserting extra strings.
 
-        If ``other`` is present and is a :any:`Mapping` or has a ``keys``
+        If ``other`` is present and is a :py:class:`~collections.abc.Mapping` or has a ``keys``
         method, does
 
         .. code-block:: python
@@ -657,7 +661,7 @@ class JsMutableMap(JsMap[KT, VT], Generic[KT, VT]):
 class JsIterator(JsProxy, Generic[Tco]):
     """A JsProxy of a JavaScript iterator.
 
-    An object is a :any:`JsAsyncIterator` if it has a :js:meth:`~Iterator.next` method and either has a
+    An object is a :py:class:`JsAsyncIterator` if it has a :js:meth:`~Iterator.next` method and either has a
     :js:data:`Symbol.iterator` or has no :js:data:`Symbol.asyncIterator`.
     """
 
@@ -673,7 +677,7 @@ class JsIterator(JsProxy, Generic[Tco]):
 class JsAsyncIterator(JsProxy, Generic[Tco]):
     """A JsProxy of a JavaScript async iterator.
 
-    An object is a :any:`JsAsyncIterator` if it has a
+    An object is a :py:class:`JsAsyncIterator` if it has a
     :js:meth:`~AsyncIterator.next` method and either has a
     :js:data:`Symbol.asyncIterator` or has no :js:data:`Symbol.iterator`
     """
@@ -731,7 +735,7 @@ class JsGenerator(JsIterable[Tco], Generic[Tco, Tcontra, Vco]):
 
         The ``value`` argument becomes the result of the current yield
         expression. The ``send()`` method returns the next value yielded by the
-        generator, or raises :any:`StopIteration` if the generator exits without
+        generator, or raises :py:exc:`StopIteration` if the generator exits without
         yielding another value. When ``send()`` is called to start the
         generator, the argument will be ignored. Unlike in Python, we cannot
         detect that the generator hasn't started yet, and no error will be
@@ -769,7 +773,7 @@ class JsGenerator(JsIterable[Tco], Generic[Tco, Tcontra, Vco]):
         returns the next value yielded by the generator function.
 
         If the generator exits without yielding another value, a
-        :any:`StopIteration` exception is raised. If the generator function does
+        :py:exc:`StopIteration` exception is raised. If the generator function does
         not catch the passed-in exception, or raises a different exception, then
         that exception propagates to the caller.
 
@@ -787,13 +791,13 @@ class JsGenerator(JsIterable[Tco], Generic[Tco, Tcontra, Vco]):
         raise NotImplementedError
 
     def close(self) -> None:
-        """Raises a :any:`GeneratorExit` at the point where the generator
+        """Raises a :py:exc:`GeneratorExit` at the point where the generator
         function was paused.
 
         If the generator function then exits gracefully, is already closed, or
-        raises :any:`GeneratorExit` (by not catching the exception), ``close()``
+        raises :py:exc:`GeneratorExit` (by not catching the exception), ``close()``
         returns to its caller. If the generator yields a value, a
-        :any:`RuntimeError` is raised. If the generator raises any other
+        :py:exc:`RuntimeError` is raised. If the generator raises any other
         exception, it is propagated to the caller. ``close()`` does nothing if
         the generator has already exited due to an exception or normal exit.
         """
@@ -806,7 +810,7 @@ class JsGenerator(JsIterable[Tco], Generic[Tco, Tcontra, Vco]):
 
 
 class JsFetchResponse(JsProxy):
-    """A :any:`JsFetchResponse` object represents a :js:data:`Response` to a
+    """A :py:class:`JsFetchResponse` object represents a :js:data:`Response` to a
     :js:func:`fetch` request.
     """
 
@@ -858,7 +862,7 @@ class JsAsyncGenerator(JsAsyncIterable[Tco], Generic[Tco, Tcontra, Vco]):
         The ``value`` argument becomes the result of the current yield
         expression. The awaitable returned by the ``asend()`` method will return
         the next value yielded by the generator or raises
-        :any:`StopAsyncIteration` if the asynchronous generator returns. If the
+        :py:exc:`StopAsyncIteration` if the asynchronous generator returns. If the
         generator returned a value, this value is discarded (because in Python
         async generators cannot return a value).
 
@@ -895,7 +899,7 @@ class JsAsyncGenerator(JsAsyncIterable[Tco], Generic[Tco, Tcontra, Vco]):
         generator was paused.
 
         The awaitable returned by ``athrow()`` method will return the next value
-        yielded by the generator or raises :any:`StopAsyncIteration` if the
+        yielded by the generator or raises :py:exc:`StopAsyncIteration` if the
         asynchronous generator returns. If the generator returned a value, this
         value is discarded (because in Python async generators cannot return a
         value). If the generator function does not catch the passed-in
@@ -905,13 +909,13 @@ class JsAsyncGenerator(JsAsyncIterable[Tco], Generic[Tco, Tcontra, Vco]):
         raise NotImplementedError
 
     def aclose(self) -> Awaitable[None]:
-        """Raises a :any:`GeneratorExit` at the point where the generator
+        """Raises a :py:exc:`GeneratorExit` at the point where the generator
         function was paused.
 
         If the generator function then exits gracefully, is already closed, or
-        raises :any:`GeneratorExit` (by not catching the exception),
+        raises :py:exc:`GeneratorExit` (by not catching the exception),
         ``aclose()`` returns to its caller. If the generator yields a value, a
-        :any:`RuntimeError` is raised. If the generator raises any other
+        :py:exc:`RuntimeError` is raised. If the generator raises any other
         exception, it is propagated to the caller. ``aclose()`` does nothing if
         the generator has already exited due to an exception or normal exit.
         """
@@ -1011,10 +1015,11 @@ def create_once_callable(obj: Callable[..., Any], /) -> JsOnceCallable:
 def create_proxy(
     obj: Any, /, *, capture_this: bool = False, roundtrip: bool = True
 ) -> JsDoubleProxy:
-    """Create a :any:`JsProxy` of a :any:`PyProxy`.
+    """Create a :py:class:`JsProxy` of a :js:class:`~pyodide.PyProxy`.
 
-    This allows explicit control over the lifetime of the :any:`PyProxy` from
-    Python: call the :py:meth:`~JsDoubleProxy.destroy` API when done.
+    This allows explicit control over the lifetime of the
+    :js:class:`~pyodide.PyProxy` from Python: call the
+    :py:meth:`~JsDoubleProxy.destroy` API when done.
 
     Parameters
     ----------
@@ -1022,15 +1027,16 @@ def create_proxy(
         The object to wrap.
 
     capture_this :
-        If the object is callable, should ``this`` be passed as the first argument
-        when calling it from JavaScript.
+        If the object is callable, should ``this`` be passed as the first
+        argument when calling it from JavaScript.
 
     roundtrip:
         When the proxy is converted back from JavaScript to Python, if this is
         ``True`` it is converted into a double proxy. If ``False``, it is
         unwrapped into a Python object. In the case that ``roundtrip`` is
-        ``True`` it is possible to unwrap a double proxy with the :any:`unwrap`
-        method. This is useful to allow easier control of lifetimes from Python:
+        ``True`` it is possible to unwrap a double proxy with the
+        :py:meth:`JsDoubleProxy.unwrap` method. This is useful to allow easier
+        control of lifetimes from Python:
 
         .. code-block:: python
 
@@ -1113,10 +1119,10 @@ def to_js(
 ) -> Any:
     """Convert the object to JavaScript.
 
-    This is similar to :any:`PyProxy.toJs`, but for use from Python. If the
+    This is similar to :js:meth:`~pyodide.PyProxy.toJs`, but for use from Python. If the
     object can be implicitly translated to JavaScript, it will be returned
     unchanged. If the object cannot be converted into JavaScript, this method
-    will return a :any:`JsProxy` of a :any:`PyProxy`, as if you had used
+    will return a :py:class:`JsProxy` of a :js:class:`~pyodide.PyProxy`, as if you had used
     :func:`~pyodide.ffi.create_proxy`.
 
     See :ref:`type-translations-pyproxy-to-js` for more information.
@@ -1131,13 +1137,13 @@ def to_js(
         infinite. Set this to 1 to do a shallow conversion.
 
     pyproxies:
-        Should be a JavaScript ``Array``. If provided, any ``PyProxies``
-        generated will be stored here. You can later use :any:`destroy_proxies`
+        Should be a JavaScript :js:class:`Array`. If provided, any ``PyProxies``
+        generated will be stored here. You can later use :py:meth:`destroy_proxies`
         if you want to destroy the proxies from Python (or from JavaScript you
-        can just iterate over the ``Array`` and destroy the proxies).
+        can just iterate over the :js:class:`Array` and destroy the proxies).
 
     create_pyproxies:
-        If you set this to :any:`False`, :any:`to_js` will raise an error rather
+        If you set this to :py:data:`False`, :py:func:`to_js` will raise an error rather
         than creating any pyproxies.
 
     dict_converter:
@@ -1195,7 +1201,7 @@ def to_js(
                 self.first = first self.second = second
 
     We can use the following ``default_converter`` to convert ``Pair`` to
-    ``Array``:
+    :js:class:`Array`:
 
     .. code-block:: python
 
@@ -1227,8 +1233,8 @@ def destroy_proxies(pyproxies: JsArray[Any], /) -> None:
     """Destroy all PyProxies in a JavaScript array.
 
     pyproxies must be a JavaScript Array of PyProxies. Intended for use
-    with the arrays created from the "pyproxies" argument of :any:`PyProxy.toJs`
-    and :any:`to_js`. This method is necessary because indexing the Array from
+    with the arrays created from the "pyproxies" argument of :js:meth:`~pyodide.PyProxy.toJs`
+    and :py:func:`to_js`. This method is necessary because indexing the Array from
     Python automatically unwraps the PyProxy into the wrapped Python object.
     """
     pass

--- a/src/py/_pyodide/_importhook.py
+++ b/src/py/_pyodide/_importhook.py
@@ -49,8 +49,8 @@ class JsFinder(MetaPathFinder):
         can then be imported from Python using the standard Python import
         system. If another module by the same name has already been imported,
         this won't have much effect unless you also delete the imported module
-        from :any:`sys.modules`. This is called by the JavaScript API
-        :any:`pyodide.registerJsModule`.
+        from :py:data:`sys.modules`. This is called by the JavaScript API
+        :js:func:`pyodide.registerJsModule`.
 
         Parameters
         ----------
@@ -74,12 +74,12 @@ class JsFinder(MetaPathFinder):
     def unregister_js_module(self, name: str) -> None:
         """
         Unregisters a JavaScript module with given name that has been previously
-        registered with :any:`pyodide.registerJsModule` or
-        :any:`pyodide.ffi.register_js_module`. If a JavaScript module with that name
+        registered with :js:func:`pyodide.registerJsModule` or
+        :py:func:`pyodide.ffi.register_js_module`. If a JavaScript module with that name
         does not already exist, will raise an error. If the module has already
         been imported, this won't have much effect unless you also delete the
-        imported module from ``sys.modules``. This is called by the JavaScript
-        API :any:`pyodide.unregisterJsModule`.
+        imported module from :py:data:`sys.modules`. This is called by the JavaScript
+        API :js:func:`pyodide.unregisterJsModule`.
 
         Parameters
         ----------

--- a/src/py/pyodide/code.py
+++ b/src/py/pyodide/code.py
@@ -14,7 +14,7 @@ def run_js(code: str, /) -> Any:
     A wrapper for the :js:func:`eval` function.
 
     Runs ``code`` as a Javascript code string and returns the result. Unlike
-    :js:func:`eval`, if ``code`` is not a string we raise a :any:`TypeError`.
+    :js:func:`eval`, if ``code`` is not a string we raise a :py:exc:`TypeError`.
     """
     from js import eval as eval_
 

--- a/src/py/pyodide/console.py
+++ b/src/py/pyodide/console.py
@@ -154,7 +154,7 @@ COMPLETE: ConsoleFutureStatus = "complete"
 
 
 class ConsoleFuture(Future[Any]):
-    """A future with extra fields used as the return value for :any:`Console` apis."""
+    """A future with extra fields used as the return value for :py:class:`Console` apis."""
 
     syntax_check: ConsoleFutureStatus
     """
@@ -195,7 +195,7 @@ class Console:
     asynchronous execution of the code.
 
     The stream callbacks can be modified directly by assigning to
-    :any:`Console.stdin_callback` (for example) as long as
+    :py:attr:`~Console.stdin_callback` (for example) as long as
     ``persistent_stream_redirection`` is ``False``.
 
     Parameters
@@ -207,20 +207,20 @@ class Console:
 
     stdin_callback :
 
-        Function to call at each read from :any:`sys.stdin`. Defaults to :any:`None`.
+        Function to call at each read from :py:data:`sys.stdin`. Defaults to :py:data:`None`.
 
     stdout_callback :
 
-        Function to call at each write to :any:`sys.stdout`. Defaults to :any:`None`.
+        Function to call at each write to :py:data:`sys.stdout`. Defaults to :py:data:`None`.
 
     stderr_callback :
 
-        Function to call at each write to :any:`sys.stderr`. Defaults to :any:`None`.
+        Function to call at each write to :py:data:`sys.stderr`. Defaults to :py:data:`None`.
 
     persistent_stream_redirection :
 
         Should redirection of standard streams be kept between calls to
-        :py:meth:`~Console.runcode`? Defaults to :any:`False`.
+        :py:meth:`~Console.runcode`? Defaults to :py:data:`False`.
 
     filename :
 
@@ -231,19 +231,19 @@ class Console:
     """The namespace used as the globals"""
 
     stdin_callback: Callable[[int], str] | None
-    """The function to call at each read from :any:`sys.stdin`"""
+    """The function to call at each read from :py:data:`sys.stdin`"""
 
     stdout_callback: Callable[[str], None] | None
-    """Function to call at each write to :any:`sys.stdout`."""
+    """Function to call at each write to :py:data:`sys.stdout`."""
 
     stderr_callback: Callable[[str], None] | None
-    """Function to call at each write to :any:`sys.stderr`."""
+    """Function to call at each write to :py:data:`sys.stderr`."""
 
     buffer: list[str]
-    """The list of strings that have been :any:`pushed <Console.push>` to the console."""
+    """The list of strings that have been :py:meth:`pushed <Console.push>` to the console."""
 
     completer_word_break_characters: str
-    """The set of characters considered by :any:`complete <Console.complete>` to be word breaks."""
+    """The set of characters considered by :py:meth:`complete <Console.complete>` to be word breaks."""
 
     def __init__(
         self,
@@ -447,9 +447,9 @@ class Console:
 
         Returns
         -------
-        completions : :any:`list`\[:any:`str`]
+        completions : :py:class:`list`\[:py:class:`str`]
             A list of completion strings.
-        start : :any:`int`
+        start : :py:class:`int`
             The index where completion starts.
 
         Examples
@@ -470,7 +470,7 @@ class Console:
 
 
 class PyodideConsole(Console):
-    """A subclass of :any:`Console` that uses :any:`pyodide.loadPackagesFromImports` before running the code."""
+    """A subclass of :py:class:`Console` that uses :js:func:`pyodide.loadPackagesFromImports` before running the code."""
 
     async def runcode(self, source: str, code: CodeRunner) -> ConsoleFuture:
         """Execute a code object.
@@ -480,7 +480,7 @@ class PyodideConsole(Console):
             The return value is a dependent sum type with the following possibilities:
             * `("success", result : Any)` -- the code executed successfully
             * `("exception", message : str)` -- An exception occurred. `message` is the
-            result of calling :any:`Console.formattraceback`.
+            result of calling :py:meth:`Console.formattraceback`.
         """
         from pyodide_js import loadPackagesFromImports
 

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -54,7 +54,7 @@ class FetchResponse:
     url
         URL to fetch
     js_response
-        A :any:`JsProxy` of the fetch response
+        A :py:class:`~pyodide.ffi.JsProxy` of the fetch response
     """
 
     def __init__(self, url: str, js_response: JsFetchResponse):
@@ -66,7 +66,7 @@ class FetchResponse:
         """Has the response been used yet?
 
         If so, attempting to retrieve the body again will raise an
-        :any:`OSError`. Use :py:meth:`~FetchResponse.clone` first to avoid this.
+        :py:exc:`OSError`. Use :py:meth:`~FetchResponse.clone` first to avoid this.
         See :js:attr:`Response.bodyUsed`.
         """
         return self.js_response.bodyUsed
@@ -129,9 +129,9 @@ class FetchResponse:
             raise OSError("Response body is already used")
 
     def clone(self) -> "FetchResponse":
-        """Return an identical copy of the :any:`FetchResponse`.
+        """Return an identical copy of the :py:class:`FetchResponse`.
 
-        This method exists to allow multiple uses of :any:`FetchResponse`
+        This method exists to allow multiple uses of :py:class:`FetchResponse`
         objects. See :js:meth:`Response.clone`.
         """
         if self.js_response.bodyUsed:
@@ -161,7 +161,7 @@ class FetchResponse:
         return json.loads(await self.string(), **kwargs)
 
     async def memoryview(self) -> memoryview:
-        """Return the response body as a :any:`memoryview` object"""
+        """Return the response body as a :py:class:`memoryview` object"""
         self._raise_if_failed()
         return (await self.buffer()).to_memoryview()
 
@@ -206,9 +206,9 @@ class FetchResponse:
     ) -> None:
         """Treat the data as an archive and unpack it into target directory.
 
-        Assumes that the file is an archive in a format that :any:`shutil` has
+        Assumes that the file is an archive in a format that :py:mod:`shutil` has
         an unpacker for. The arguments ``extract_dir`` and ``format`` are passed
-        directly on to :any:`shutil.unpack_archive`.
+        directly on to :py:func:`shutil.unpack_archive`.
 
         Parameters
         ----------
@@ -222,7 +222,7 @@ class FetchResponse:
             :py:func:`shutil.register_unpack_format`. If not provided,
             :py:meth:`unpack_archive` will use the archive file name extension and
             see if an unpacker was registered for that extension. In case none
-            is found, a :any:`ValueError` is raised.
+            is found, a :py:exc:`ValueError` is raised.
         """
         buf = await self.buffer()
         filename = self._url.rsplit("/", -1)[-1]

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -562,7 +562,7 @@ class WebLoop(asyncio.AbstractEventLoop):
 
 class WebLoopPolicy(asyncio.DefaultEventLoopPolicy):
     """
-    A simple event loop policy for managing :any:`WebLoop`-based event loops.
+    A simple event loop policy for managing :py:class:`WebLoop`-based event loops.
     """
 
     def __init__(self):


### PR DESCRIPTION
This leads to more consistent rendering (functions and methods get parens after them) and reduces chances of warnings about getting the wrong link.