### PR TITLE
Fix console.html url in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -326,7 +326,7 @@ def setup(app):
     app.add_config_value("global_replacements", {}, True)
     app.add_config_value("CDN_URL", "", True)
     app.connect("source-read", global_replace)
-    
+
     apply_patches()
     calculate_pyodide_version(app)
     ensure_typedoc_on_path()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -327,6 +327,7 @@ def setup(app):
     app.add_config_value("CDN_URL", "", True)
     app.connect("source-read", global_replace)
 
+    calculate_pyodide_version(app)
     apply_patches()
     ensure_typedoc_on_path()
     create_generated_typescript_files(app)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -326,9 +326,9 @@ def setup(app):
     app.add_config_value("global_replacements", {}, True)
     app.add_config_value("CDN_URL", "", True)
     app.connect("source-read", global_replace)
-
-    calculate_pyodide_version(app)
+    
     apply_patches()
+    calculate_pyodide_version(app)
     ensure_typedoc_on_path()
     create_generated_typescript_files(app)
     write_console_html(app)


### PR DESCRIPTION
@hoodmane I guess calling `calculate_pyodide_version` is omitted during the refactor in #3512.