### PR TITLE
Deepfreeze encodings module

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -102,6 +102,7 @@ $(BUILD)/$(LIB): $(BUILD)/Makefile $(BUILD)/pyconfig.h $(BUILD)/Modules/Setup.lo
 	cp Setup.local $(BUILD)/Modules/
 	( \
 		cd $(BUILD); \
+		make regen-frozen; \
 		emmake make CROSS_COMPILE=yes $(LIB) -j $${PYODIDE_JOBS:-3} \
 	)
 	touch $(BUILD)/$(LIB)

--- a/cpython/patches/0001-Public-pymain_run_python.patch
+++ b/cpython/patches/0001-Public-pymain_run_python.patch
@@ -1,7 +1,7 @@
 From 8dc93243eb0cdf27a81e9baf156df621cc8e2eb9 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sun, 17 Jul 2022 14:40:39 +0100
-Subject: [PATCH 1/8] Public pymain_run_python
+Subject: [PATCH 1/9] Public pymain_run_python
 
 ---
  Modules/main.c | 2 +-

--- a/cpython/patches/0002-Patch-importlib-to-allow-modifications-to-ModuleNotF.patch
+++ b/cpython/patches/0002-Patch-importlib-to-allow-modifications-to-ModuleNotF.patch
@@ -1,7 +1,7 @@
 From 90812b6dc97860ef164a2810ebf5f3121dfc919e Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 16 Nov 2022 14:02:53 -0800
-Subject: [PATCH 2/8] Patch importlib to allow modifications to
+Subject: [PATCH 2/9] Patch importlib to allow modifications to
  ModuleNotFoundError
 
 ---

--- a/cpython/patches/0003-Add-emscripten-platform-support-to-ctypes.util.find_.patch
+++ b/cpython/patches/0003-Add-emscripten-platform-support-to-ctypes.util.find_.patch
@@ -1,7 +1,7 @@
 From bb33672157df771613c9d6c61756c5294f13333d Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 2 Dec 2022 11:36:44 +0000
-Subject: [PATCH 3/8] Add emscripten platform support to
+Subject: [PATCH 3/9] Add emscripten platform support to
  ctypes.util.find_library
 
 ---

--- a/cpython/patches/0004-Allow-multiprocessing.connection-top-level-import.patch
+++ b/cpython/patches/0004-Allow-multiprocessing.connection-top-level-import.patch
@@ -1,7 +1,7 @@
 From becbcc43e3e09a9c065ea7856a2d3069061fd570 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Mon, 19 Dec 2022 09:09:14 -0800
-Subject: [PATCH 4/8] Allow multiprocessing.connection top level import
+Subject: [PATCH 4/9] Allow multiprocessing.connection top level import
 
 ---
  Lib/multiprocessing/connection.py | 5 ++++-

--- a/cpython/patches/0005-gh-93839-Move-Lib-ctypes-test-to-Lib-test-test_ctype.patch
+++ b/cpython/patches/0005-gh-93839-Move-Lib-ctypes-test-to-Lib-test-test_ctype.patch
@@ -1,7 +1,7 @@
 From d82e0bfe8b98a122ca443b356d81998c804b686e Mon Sep 17 00:00:00 2001
 From: Victor Stinner <vstinner@python.org>
 Date: Tue, 21 Jun 2022 10:24:33 +0200
-Subject: [PATCH 5/8] gh-93839: Move Lib/ctypes/test/ to Lib/test/test_ctypes/
+Subject: [PATCH 5/9] gh-93839: Move Lib/ctypes/test/ to Lib/test/test_ctypes/
  (#94041)
 
 * Move Lib/ctypes/test/ to Lib/test/test_ctypes/

--- a/cpython/patches/0006-gh-93839-Move-Lib-unttest-test-to-Lib-test-test_unit.patch
+++ b/cpython/patches/0006-gh-93839-Move-Lib-unttest-test-to-Lib-test-test_unit.patch
@@ -1,7 +1,7 @@
 From c735d545343c3ab002c62596b2fb2cfa4488b0af Mon Sep 17 00:00:00 2001
 From: Victor Stinner <vstinner@python.org>
 Date: Tue, 21 Jun 2022 10:27:59 +0200
-Subject: [PATCH 6/8] gh-93839: Move Lib/unttest/test/ to Lib/test/test_unittest/
+Subject: [PATCH 6/9] gh-93839: Move Lib/unttest/test/ to Lib/test/test_unittest/
  (#94043)
 
 * Move Lib/unittest/test/ to Lib/test/test_unittest/

--- a/cpython/patches/0007-gh-93839-Use-load_package_tests-for-testmock-GH-9405.patch
+++ b/cpython/patches/0007-gh-93839-Use-load_package_tests-for-testmock-GH-9405.patch
@@ -1,7 +1,7 @@
 From 50ebd72fb0e69c78f95cea3d4a47589beb91ac37 Mon Sep 17 00:00:00 2001
 From: Christian Heimes <christian@python.org>
 Date: Tue, 21 Jun 2022 14:51:39 +0200
-Subject: [PATCH 7/8] gh-93839: Use load_package_tests() for testmock (GH-94055)
+Subject: [PATCH 7/9] gh-93839: Use load_package_tests() for testmock (GH-94055)
 
 Fixes failing tests on WebAssembly platforms.
 

--- a/cpython/patches/0008-Move-test-directories.patch
+++ b/cpython/patches/0008-Move-test-directories.patch
@@ -1,7 +1,7 @@
 From 4c71c808cc65ed6003b1e29d583c71586ebb36e1 Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Wed, 25 Jan 2023 15:54:16 +0900
-Subject: [PATCH 8/8] Move test directories
+Subject: [PATCH 8/9] Move test directories
 
 ---
  Makefile.pre.in | 6 +++---

--- a/cpython/patches/0009-Deep-freeze-encodings-module.patch.patch
+++ b/cpython/patches/0009-Deep-freeze-encodings-module.patch.patch
@@ -1,0 +1,25 @@
+From c32547924bf564b8f31d05a65001f60a0c2dce9d Mon Sep 17 00:00:00 2001
+From: Gyeongjae Choi <def6488@gmail.com>
+Date: Fri, 3 Feb 2023 05:06:20 +0000
+Subject: [PATCH 9/9] Deep-freeze encodings module
+
+---
+ Tools/scripts/freeze_modules.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Tools/scripts/freeze_modules.py b/Tools/scripts/freeze_modules.py
+index dd208c7847..a6e624369e 100644
+--- a/Tools/scripts/freeze_modules.py
++++ b/Tools/scripts/freeze_modules.py
+@@ -52,7 +52,7 @@
+         # For now we do not freeze the encodings, due # to the noise all
+         # those extra modules add to the text printed during the build.
+         # (See https://github.com/python/cpython/pull/28398#pullrequestreview-756856469.)
+-        #'<encodings.*>',
++        '<encodings.*>',
+         'io',
+         ]),
+     ('stdlib - startup, with site', [
+-- 
+2.37.3
+

--- a/src/tests/test_stdlib_fixes.py
+++ b/src/tests/test_stdlib_fixes.py
@@ -88,3 +88,10 @@ def test_ctypes_util_find_library(selenium):
         assert find_library("foo") == os.path.join(tmpdir, "libfoo.so")
         assert find_library("bar") == os.path.join(tmpdir, "libbar.so")
         assert find_library("baz") is None
+
+
+@run_in_pyodide
+def test_encodings_deepfrozen(selenium):
+    import encodings
+
+    assert repr(encodings) == "<module 'encodings' (frozen)>"


### PR DESCRIPTION
### Description

Deep-freeze stdlib `encodings`. After this, the size of `pyodide.asm.wasm` **increases** ~1.1MB.

Deep-freezing `encodings` is, hopefully, a final step to achive initializing Python interpreter without any python codes, which is a requirement for #3166. This was not done in upstream because of following reason:

```python
# For now we do not freeze the encodings, due # to the noise all
# those extra modules add to the text printed during the build.
# (See https://github.com/python/cpython/pull/28398#pullrequestreview-756856469.)
```

- Related: #3524 

### Checklists

- [x] Add / update tests
