### PR TITLE
Fix isPyProxy so that it works correctly with multiple Pyodide interpreters

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -66,6 +66,12 @@ myst:
   longer changes unhandled rejections in promises.
   {pr}`3542`
 
+- {{ Enhancement }} Checking whether an object is an instance of a `PyProxy` now
+  only recognizes a `PyProxy` generated from the same Python interpreter. This
+  means that creating multiple interpreters and importing a `PyProxy` from one
+  into another no longer causes a fatal error.
+  {pr}`3545`
+
 ### Build System
 
 - {{ Enhancement}} Add `--build-dependencies` to pyodide build command

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -62,7 +62,7 @@ declare function Py_EXIT(): void;
 // end-pyodide-skip
 
 function isPyProxy(jsobj: any): jsobj is PyProxy {
-  return !!jsobj && jsobj.$$ !== undefined && jsobj.$$.type === "PyProxy";
+  return jsobj instanceof PyProxy;
 }
 API.isPyProxy = isPyProxy;
 
@@ -464,11 +464,6 @@ export class PyProxy {
    */
   constructor() {
     throw new TypeError("PyProxy is not a constructor");
-  }
-
-  /** @private */
-  static [Symbol.hasInstance](obj: any): obj is PyProxy {
-    return API.isPyProxy(obj);
   }
 
   /** @private */

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -1457,3 +1457,13 @@ def test_roundtrip_no_destroy(selenium):
     """
     )(p)
     assert not isalive(p)
+
+
+@run_in_pyodide
+async def test_multiple_interpreters(selenium):
+    from js import loadPyodide  # type:ignore[attr-defined]
+
+    py2 = await loadPyodide()
+    d1 = {"a": 2}
+    d2 = py2.runPython(str(d1))
+    assert d2.toJs().to_py() == d1


### PR DESCRIPTION
This actually just removes code so that we use the default `instanceof` behavior. The added test fatally fails without this patch.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
