### PR TITLE
Add `replace_nbsp` parameter to Console.push

### DIFF
--- a/src/py/pyodide/console.py
+++ b/src/py/pyodide/console.py
@@ -333,6 +333,10 @@ class Console:
         finally:
             self._streams_redirected = False
 
+    def _replace_nbsp(self, string: str) -> str:
+        string_ = string.replace("\u00A0", " ")
+        return string_
+
     def runsource(self, source: str, filename: str = "<console>") -> ConsoleFuture:
         """Compile and run source code in the interpreter."""
         res: ConsoleFuture | None
@@ -415,7 +419,7 @@ class Console:
             traceback.format_exception(type(e), e, e.__traceback__, -nframes)
         )
 
-    def push(self, line: str) -> ConsoleFuture:
+    def push(self, line: str, replace_nbsp: bool = False) -> ConsoleFuture:
         """Push a line to the interpreter.
 
         The line should not have a trailing newline; it may have internal
@@ -425,9 +429,16 @@ class Console:
         invalid, the buffer is reset; otherwise, the command is incomplete, and
         the buffer is left as it was after the line was appended.
 
+        If replace_nbsp is True, replace all "NO-BREAK SPACE (U+00A0)" letters
+        into regular space (U+0020).
+
         The return value is the result of calling :py:meth:`~Console.runsource` on the current buffer
         contents.
         """
+
+        if replace_nbsp:
+            line = self._replace_nbsp(line)
+
         self.buffer.append(line)
         source = "\n".join(self.buffer)
         result = self.runsource(source, self.filename)

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -130,7 +130,7 @@
           term.pause();
           // multiline should be split (useful when pasting)
           for (const c of command.split("\n")) {
-            let fut = pyconsole.push(c);
+            let fut = pyconsole.push(c, (replace_nbsp = true));
             term.set_prompt(fut.syntax_check === "incomplete" ? ps2 : ps1);
             switch (fut.syntax_check) {
               case "syntax-error":

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -130,7 +130,7 @@
           term.pause();
           // multiline should be split (useful when pasting)
           for (const c of command.split("\n")) {
-            let fut = pyconsole.push(c, (replace_nbsp = true));
+            let fut = pyconsole.push(c, true);
             term.set_prompt(fut.syntax_check === "incomplete" ? ps2 : ps1);
             switch (fut.syntax_check) {
               case "syntax-error":

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -148,6 +148,33 @@ def test_interactive_console():
     asyncio.run(test())
 
 
+def test_nbsp():
+    shell = Console()
+
+    async def get_result_replace(input):
+        res = shell.push(input, replace_nbsp=True)
+        assert res.syntax_check == "complete"
+        return await res
+
+    async def test():
+        fut = shell.push("import\xa0sys", replace_nbsp=False)
+        try:
+            await fut
+        except Exception:
+            assert fut.formatted_error is not None
+            assert (
+                "SyntaxError: invalid non-printable character U+00A0"
+                in fut.formatted_error
+            )
+
+        assert await get_result_replace("x\xa0=\xa05") is None
+        assert await get_result_replace("x") == 5
+        assert await get_result_replace("x\xa0\xa0**\xa0\xa02") == 25
+        assert await get_result_replace("import\xa0\xa0sys") is None
+
+    asyncio.run(test())
+
+
 def test_top_level_await():
     from asyncio import Queue, sleep
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Resolve #3337

Add `replace_nbsp` parameter to Console.push, and use it in console.html.
If the parameter is set to True, replace all nbsp letters to regular space.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
