### PR TITLE
ENH Autodetect the number of cores when invoking `pyodide build-recipes`

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -100,8 +100,8 @@ myst:
   `PYODIDE_PACKAGES="tag:core" make`.
   {pr}`3444`
 
-- {{ Enhancement }} `pyodide build-recipes` now autodetect number of
-  CPU cores in the system and use them for parallel builds.
+- {{ Enhancement }} `pyodide build-recipes` now autodetects the number of
+  CPU cores in the system and uses them for parallel builds.
   {pr}`3559`
 
 ### Pyodide CLI

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -100,6 +100,10 @@ myst:
   `PYODIDE_PACKAGES="tag:core" make`.
   {pr}`3444`
 
+- {{ Enhancement }} `pyodide build-recipes` now autodetect number of
+  CPU cores in the system and use them for parallel builds.
+  {pr}`3559`
+
 ### Pyodide CLI
 
 - Added `pyodide py-compile` CLI command that py compiles a wheel, converting

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import typer
 
 from .. import buildall, buildpkg, pywasmcross
-from ..common import init_environment
+from ..common import get_num_cores, init_environment
 from ..logger import logger
 
 
@@ -56,13 +56,17 @@ def recipe(
         "--continue",
         help="Continue a build from the middle. For debugging. Implies '--force-rebuild'",
     ),
-    n_jobs: int = typer.Option(4, help="Number of packages to build in parallel"),
+    n_jobs: int = typer.Option(
+        None,
+        help="Number of packages to build in parallel  (default: # of cores in the system)",
+    ),
 ) -> None:
     """Build packages using yaml recipes and create repodata.json"""
     root = Path.cwd()
     recipe_dir_ = root / "packages" if not recipe_dir else Path(recipe_dir).resolve()
     install_dir_ = root / "dist" if not install_dir else Path(install_dir).resolve()
     log_dir_ = None if not log_dir else Path(log_dir).resolve()
+    n_jobs = n_jobs or get_num_cores()
 
     if not recipe_dir_.is_dir():
         raise FileNotFoundError(f"Recipe directory {recipe_dir_} not found")

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -406,3 +406,17 @@ def set_build_environment(env: dict[str, str]) -> None:
         tools_dir / "cmake/Modules/Platform/Emscripten.cmake"
     )
     env["PYO3_CONFIG_FILE"] = str(tools_dir / "pyo3_config.ini")
+
+
+def get_num_cores() -> int:
+    """
+    Get the number of cores available on the system.
+    If the number of cores cannot be determined, return 1.
+    """
+    import os
+
+    cpu_count = os.cpu_count()
+    if cpu_count is not None:
+        return cpu_count
+    else:
+        return 1

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -194,11 +194,11 @@ def test_get_num_cores(monkeypatch):
     import os
 
     with monkeypatch.context() as m:
-        m.setattr(os, "cpu_count", lambda exe: 2)
+        m.setattr(os, "cpu_count", lambda: 2)
 
         assert get_num_cores() == 2
 
     with monkeypatch.context() as m:
-        m.setattr(os, "cpu_count", lambda exe: None)
+        m.setattr(os, "cpu_count", lambda: None)
 
         assert get_num_cores() == 1

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -8,6 +8,7 @@ from pyodide_build.common import (
     find_missing_executables,
     get_make_environment_vars,
     get_make_flag,
+    get_num_cores,
     parse_top_level_import_name,
     platform,
     search_pyodide_root,
@@ -187,3 +188,17 @@ def test_environment_var_substitution(monkeypatch):
         and args["cxxflags"] == "Robert Mc Roberts"
         and args["ldflags"] == '"-lpyodide_build_dir"'
     )
+
+
+def test_get_num_cores(monkeypatch):
+    import os
+
+    with monkeypatch.context() as m:
+        m.setattr(os, "cpu_found", lambda exe: 2)
+
+        assert get_num_cores() == 2
+
+    with monkeypatch.context() as m:
+        m.setattr(os, "cpu_found", lambda exe: None)
+
+        assert get_num_cores() == 1

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -194,11 +194,11 @@ def test_get_num_cores(monkeypatch):
     import os
 
     with monkeypatch.context() as m:
-        m.setattr(os, "cpu_found", lambda exe: 2)
+        m.setattr(os, "cpu_count", lambda exe: 2)
 
         assert get_num_cores() == 2
 
     with monkeypatch.context() as m:
-        m.setattr(os, "cpu_found", lambda exe: None)
+        m.setattr(os, "cpu_count", lambda exe: None)
 
         assert get_num_cores() == 1


### PR DESCRIPTION
### Description

When calling `pyoddie build-recipes`, set the number of parallel jobs to number of cpus in the system by default.

Split off from #3544 with some modification.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
