### PR TITLE
BLD Remove _pywasmcross entrypoint

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,9 +9,8 @@ github:
     addLabel: false
 tasks:
   - name: Setup the environment
-    command: |
-      PYTHON_VERSION=3.10.2
+    init: |
+      PYTHON_VERSION=3.11.1
       pyenv install $PYTHON_VERSION
       pyenv global $PYTHON_VERSION
       python -m pip install -r requirements.txt
-      ./run_docker

--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -18,6 +18,7 @@ from build.__main__ import (
     _ProjectBuilder,
 )
 from build.env import IsolatedEnv
+
 from packaging.requirements import Requirement
 
 from . import common, pywasmcross
@@ -155,20 +156,19 @@ def make_command_wrapper_symlinks(symlink_dir: Path) -> dict[str, str]:
     -------
     The dictionary of compiler environment variables that points to the symlinks.
     """
+
+    pywasmcross_exe = symlink_dir / "pywasmcross.py"
+    shutil.copy2(pywasmcross.__file__, pywasmcross_exe)
+    pywasmcross_exe.chmod(0o755)
+
     env = {}
     for symlink in pywasmcross.SYMLINKS:
         symlink_path = symlink_dir / symlink
         if os.path.lexists(symlink_path) and not symlink_path.exists():
             # remove broken symlink so it can be re-created
             symlink_path.unlink()
-        try:
-            pywasmcross_exe = shutil.which("_pywasmcross")
-            if pywasmcross_exe:
-                symlink_path.symlink_to(pywasmcross_exe)
-            else:
-                symlink_path.symlink_to(pywasmcross.__file__)
-        except FileExistsError:
-            pass
+
+        symlink_path.symlink_to(pywasmcross_exe)
         if symlink == "c++":
             var = "CXX"
         else:

--- a/pyodide-build/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide-build/pyodide_build/tests/test_pypabuild.py
@@ -36,6 +36,11 @@ def test_make_command_wrapper_symlinks(tmp_path):
     symlink_dir = tmp_path
     env = pypabuild.make_command_wrapper_symlinks(symlink_dir)
 
+    wrapper = symlink_dir / "pywasmcross.py"
+    assert wrapper.exists()
+    assert not wrapper.is_symlink()
+    assert wrapper.stat().st_mode & 0o755 == 0o755
+
     for _, path in env.items():
         symlink_path = symlink_dir / path
 

--- a/pyodide-build/setup.cfg
+++ b/pyodide-build/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
 [options.entry_points]
 console_scripts =
     pyodide-build = pyodide_build.__main__:main
-    _pywasmcross = pyodide_build.pywasmcross:compiler_main
 pyodide.cli =
     build = pyodide_build.cli.build:main
     build-recipes = pyodide_build.cli.build_recipes:recipe


### PR DESCRIPTION
### Description

Remove `_pywasmcross` entrypoint that sometimes cause an issue when combined with Python version management tools like `pyenv`. (See [the comment here](https://github.com/pyodide/pyodide/pull/3544#discussion_r1096869651))

Instead, copy `pywasmcross.py` itself into the symlink directory and execute it.