### PR TITLE
Improve the error message when a meta.yaml file is not found

### DIFF
--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -368,7 +368,9 @@ def generate_dependency_graph(
         pkgname = packages.pop()
 
         if pkgname not in all_recipes:
-            raise ValueError(f"No metadata file found for the following package: {pkgname}")
+            raise ValueError(
+                f"No metadata file found for the following package: {pkgname}"
+            )
 
         pkg = Package(packages_dir / pkgname, all_recipes[pkgname])
         pkg_map[pkgname] = pkg

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -367,6 +367,9 @@ def generate_dependency_graph(
     while packages:
         pkgname = packages.pop()
 
+        if pkgname not in all_recipes:
+            raise ValueError(f"No metadata file found for the following package: {pkgname}")
+
         pkg = Package(packages_dir / pkgname, all_recipes[pkgname])
         pkg_map[pkgname] = pkg
         graph[pkgname] = pkg.dependencies


### PR DESCRIPTION
The error message that is shown when a meta.yaml file that doesn't exist was not very helpful:

e.g.

```yaml
requirements:
  run:
    - pkg_not_exist
```
Before:


```
...
│ /src/pyodide-build/pyodide_build/buildall.py:373 in generate_dependency_graph                    │
│                                                                                                  │
│   370 │   │   # if pkgname not in all_recipes:                                                   │
│   371 │   │   #     raise ValueError(f"No metadata file found for the following package: {pkgn   │
│   372 │   │                                                                                      │
│ ❱ 373 │   │   pkg = Package(packages_dir / pkgname, all_recipes[pkgname])                        │
│   374 │   │   pkg_map[pkgname] = pkg                                                             │
│   375 │   │   graph[pkgname] = pkg.dependencies                                                  │
│   376 │   │   for dep in pkg.dependencies:                                                       │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: 'pkg_not_exist'
```

After:

```
│ /src/pyodide-build/pyodide_build/buildall.py:371 in generate_dependency_graph                    │
│                                                                                                  │
│   368 │   │   pkgname = packages.pop()                                                           │
│   369 │   │                                                                                      │
│   370 │   │   if pkgname not in all_recipes:                                                     │
│ ❱ 371 │   │   │   raise ValueError(f"No metadata file found for the following package: {pkgnam   │
│   372 │   │                                                                                      │
│   373 │   │   pkg = Package(packages_dir / pkgname, all_recipes[pkgname])                        │
│   374 │   │   pkg_map[pkgname] = pkg                                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError: No metadata file found for the following package: pkg_not_exist
```