### PR TITLE
MAINT Initialize filesystem in a single point

### DIFF
--- a/src/js/module.ts
+++ b/src/js/module.ts
@@ -92,7 +92,7 @@ function setHomeDirectory(Module: Module, path: string) {
 
 /**
  * Mount local directories to the virtual file system. Only for Node.js.
- * @param Module The Emscripten Module.
+ * @param module The Emscripten Module.
  * @param mounts The list of paths to mount.
  */
 function mountLocalDirectories(Module: Module, mounts: string[]) {
@@ -111,5 +111,5 @@ function mountLocalDirectories(Module: Module, mounts: string[]) {
 export function initializeFileSystem(Module: Module, config: ConfigType) {
   setHomeDirectory(Module, config.homedir);
   mountLocalDirectories(Module, config._node_mounts);
-  initializeNativeFS(Module);
+  Module.preRun.push(() => initializeNativeFS(Module));
 }

--- a/src/js/module.ts
+++ b/src/js/module.ts
@@ -1,5 +1,8 @@
 /** @private */
 
+import { ConfigType } from "./pyodide";
+import { initializeNativeFS } from "./nativefs";
+
 type FSNode = any;
 type FSStream = any;
 
@@ -28,6 +31,7 @@ export interface FS {
   chmod: (path: string, mode: number) => void;
   utime: (path: string, atime: number, mtime: number) => void;
   rmdir: (path: string) => void;
+  mount: (type: any, opts: any, mountpoint: string) => any;
 }
 
 export interface Module {
@@ -66,10 +70,11 @@ export function createModule(): any {
  * Make the home directory inside the virtual file system,
  * then change the working directory to it.
  *
- * @param path
+ * @param Module The Emscripten Module.
+ * @param path The path to the home directory.
  * @private
  */
-export function setHomeDirectory(Module: Module, path: string) {
+function setHomeDirectory(Module: Module, path: string) {
   Module.preRun.push(function () {
     const fallbackPath = "/";
     try {
@@ -83,4 +88,28 @@ export function setHomeDirectory(Module: Module, path: string) {
     Module.ENV.HOME = path;
     Module.FS.chdir(path);
   });
+}
+
+/**
+ * Mount local directories to the virtual file system. Only for Node.js.
+ * @param Module The Emscripten Module.
+ * @param mounts The list of paths to mount.
+ */
+function mountLocalDirectories(Module: Module, mounts: string[]) {
+  Module.preRun.push(() => {
+    for (const mount of mounts) {
+      Module.FS.mkdirTree(mount);
+      Module.FS.mount(Module.FS.filesystems.NODEFS, { root: mount }, mount);
+    }
+  });
+}
+
+/**
+ * Initialize the virtual file system, before loading Python interpreter.
+ * @private
+ */
+export function initializeFileSystem(Module: Module, config: ConfigType) {
+  setHomeDirectory(Module, config.homedir);
+  mountLocalDirectories(Module, config._node_mounts);
+  initializeNativeFS(Module);
 }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -10,8 +10,7 @@ import {
   resolvePath,
 } from "./compat";
 
-import { createModule, setHomeDirectory } from "./module";
-import { initializeNativeFS } from "./nativefs";
+import { createModule, initializeFileSystem } from "./module";
 import { version } from "./version";
 
 import type { PyodideInterface } from "./api.js";
@@ -308,18 +307,11 @@ export async function loadPyodide(
   const Module = createModule();
   Module.print = config.stdout;
   Module.printErr = config.stderr;
-  Module.preRun.push(() => {
-    for (const mount of config._node_mounts) {
-      Module.FS.mkdirTree(mount);
-      Module.FS.mount(Module.NODEFS, { root: mount }, mount);
-    }
-  });
-
   Module.arguments = config.args;
   const API: any = { config };
   Module.API = API;
 
-  setHomeDirectory(Module, config.homedir);
+  initializeFileSystem(Module, config);
 
   const moduleLoaded = new Promise((r) => (Module.postRun = r));
 
@@ -359,8 +351,6 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
   Module.locateFile = (path: string) => {
     throw new Error("Didn't expect to load any more file_packager files!");
   };
-
-  initializeNativeFS(Module);
 
   const pyodide_py_tar = await pyodide_py_tar_promise;
   unpackPyodidePy(Module, pyodide_py_tar);


### PR DESCRIPTION
### Description

We do several filesystem operations before loading Python.

- Mount _node_mounts
- Create default directories
- Register NativeFS file system

This PR organizes all those operations into a single function.

This is an another split off from #3582.