### PR TITLE
Add url parameter to install_xbuildenv

### DIFF
--- a/pyodide-build/pyodide_build/cli/xbuildenv.py
+++ b/pyodide-build/pyodide_build/cli/xbuildenv.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import typer
+
+from ..install_xbuildenv import install
+
+app = typer.Typer(hidden=True)
+
+
+@app.callback()
+def callback():
+    """
+    Create or install cross build environment
+    """
+
+
+@app.command("install")  # type: ignore[misc]
+def _install(
+    path: Path = typer.Option(".pyodide-xbuildenv", help="path to xbuildenv directory"),
+    download: bool = typer.Option(False, help="download xbuildenv before installing"),
+    url: str = typer.Option(None, help="URL to download xbuildenv from"),
+) -> None:
+    """
+    Install xbuildenv.
+
+    The isntalled environment is the same as the one that would result from
+    `PYODIDE_PACKAGES='scipy' make` except that it is much faster.
+    The goal is to enable out-of-tree builds for binary packages that depend
+    on numpy or scipy.
+    Note: this is a private endpoint that should not be used outside of the Pyodide Makefile.
+    """
+    install(path, download=download, url=url)

--- a/pyodide-build/pyodide_build/install_xbuildenv.py
+++ b/pyodide-build/pyodide_build/install_xbuildenv.py
@@ -90,6 +90,25 @@ def install_xbuildenv(version: str, xbuildenv_path: Path) -> None:
 
 
 def install(path: Path, *, download: bool = False, url: str | None = None) -> None:
+    """
+    Install cross-build environment.
+
+    Parameters
+    ----------
+    path
+        A path to the cross-build environment.
+    download
+        Whether to download the cross-build environment before installing it.
+    url
+        URL to download the cross-build environment from. This is only used
+        if `download` is True. The URL should point to a tarball containing
+        the cross-build environment. If not specified, the corresponding
+        release on GitHub is used.
+
+        Warning: if you are downloading from a version that is not the same
+        as the current version of pyodide-build, make sure that the cross-build
+        environment is compatible with the current version of Pyodide.
+    """
     from . import __version__
 
     version = __version__

--- a/pyodide-build/pyodide_build/install_xbuildenv.py
+++ b/pyodide-build/pyodide_build/install_xbuildenv.py
@@ -78,8 +78,8 @@ def install_xbuildenv(version: str, xbuildenv_path: Path) -> None:
         xbuildenv_path / "site-packages-extras", host_site_packages, dirs_exist_ok=True
     )
     cdn_base = f"https://cdn.jsdelivr.net/pyodide/v{version}/full/"
-    if (xbuildenv_root / "repodata.json").exists():
-        repodata_bytes = (xbuildenv_root / "repodata.json").read_bytes()
+    if (repodata_json := xbuildenv_root / "dist" / "repodata.json").exists():
+        repodata_bytes = repodata_json.read_bytes()
     else:
         repodata_url = cdn_base + "repodata.json"
         with urlopen(repodata_url) as response:

--- a/pyodide-build/pyodide_build/install_xbuildenv.py
+++ b/pyodide-build/pyodide_build/install_xbuildenv.py
@@ -1,11 +1,12 @@
 import argparse
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
 from urllib.request import urlopen, urlretrieve
 
-from .common import exit_with_stdio, get_make_flag, get_pyodide_root
+from .common import exit_with_stdio, get_make_flag
 from .create_pypa_index import create_pypa_index
 from .logger import logger
 
@@ -48,12 +49,13 @@ def download_xbuildenv(
 
 def install_xbuildenv(version: str, xbuildenv_path: Path) -> None:
     logger.info("Installing xbuild environment")
+
     xbuildenv_path = xbuildenv_path / "xbuildenv"
-    pyodide_root = get_pyodide_root()
     xbuildenv_root = xbuildenv_path / "pyodide-root"
-    host_site_packages = xbuildenv_root / Path(
-        get_make_flag("HOSTSITEPACKAGES")
-    ).relative_to(pyodide_root)
+
+    os.environ["PYODIDE_ROOT"] = str(xbuildenv_root)
+
+    host_site_packages = Path(get_make_flag("HOSTSITEPACKAGES"))
     host_site_packages.mkdir(exist_ok=True, parents=True)
     result = subprocess.run(
         [

--- a/pyodide-build/pyodide_build/out_of_tree/utils.py
+++ b/pyodide-build/pyodide_build/out_of_tree/utils.py
@@ -34,6 +34,6 @@ def initialize_pyodide_root(*, quiet: bool = False) -> None:
         return
     except FileNotFoundError:
         pass
-
     env = Path(".pyodide-xbuildenv")
+    os.environ["PYODIDE_ROOT"] = str(env / "xbuildenv/pyodide-root")
     ensure_env_installed(env, quiet=quiet)

--- a/pyodide-build/pyodide_build/out_of_tree/utils.py
+++ b/pyodide-build/pyodide_build/out_of_tree/utils.py
@@ -34,6 +34,6 @@ def initialize_pyodide_root(*, quiet: bool = False) -> None:
         return
     except FileNotFoundError:
         pass
+
     env = Path(".pyodide-xbuildenv")
-    os.environ["PYODIDE_ROOT"] = str(env / "xbuildenv/pyodide-root")
     ensure_env_installed(env, quiet=quiet)

--- a/pyodide-build/pyodide_build/tests/fixture.py
+++ b/pyodide-build/pyodide_build/tests/fixture.py
@@ -1,6 +1,11 @@
+import json
+import shutil
 from pathlib import Path
+from typing import Any
 
 import pytest
+
+from ..common import chdir
 
 
 @pytest.fixture(scope="module")
@@ -20,3 +25,53 @@ def temp_python_lib(tmp_path_factory):
     (path / "hello_pyodide.py").write_text("def hello(): return 'hello'")
 
     yield libdir
+
+
+def mock_repodata_json() -> dict[str, Any]:
+    # TODO: use pydantic
+
+    return {
+        "info": {
+            "version": "0.22.1",
+        },
+        "packages": {},
+    }
+
+
+@pytest.fixture(scope="module")
+def temp_xbuildenv(tmp_path_factory):
+    """
+    Create a temporary xbuildenv archive
+    """
+    base = tmp_path_factory.mktemp("base")
+
+    path = Path(base)
+
+    xbuildenv = path / "xbuildenv"
+    xbuildenv.mkdir()
+
+    pyodide_root = xbuildenv / "pyodide-root"
+    site_packages_extra = xbuildenv / "site-packages-extras"
+    requirements_txt = xbuildenv / "requirements.txt"
+
+    pyodide_root.mkdir()
+    site_packages_extra.mkdir()
+    requirements_txt.touch()
+
+    (pyodide_root / "Makefile.envs").write_text(
+        """
+export HOSTSITEPACKAGES=$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages
+
+.output_vars:
+	set
+"""
+    )
+    (pyodide_root / "dist").mkdir()
+    (pyodide_root / "dist" / "repodata.json").write_text(
+        json.dumps(mock_repodata_json())
+    )
+
+    with chdir(base):
+        archive_name = shutil.make_archive("xbuildenv", "tar")
+
+    yield base, archive_name

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -9,7 +9,14 @@ import typer
 from typer.testing import CliRunner  # type: ignore[import]
 
 from pyodide_build import common
-from pyodide_build.cli import build, build_recipes, config, create_zipfile, skeleton
+from pyodide_build.cli import (
+    build,
+    build_recipes,
+    config,
+    create_zipfile,
+    skeleton,
+    xbuildenv,
+)
 
 from .fixture import temp_python_lib
 
@@ -328,3 +335,24 @@ def test_create_zipfile_compile(temp_python_lib, tmp_path):
     with ZipFile(output) as zf:
         assert "module1.pyc" in zf.namelist()
         assert "module2.pyc" in zf.namelist()
+
+
+def test_xbuildenv_install(tmp_path):
+    envpath = Path(tmp_path) / ".xbuildenv"
+    result = runner.invoke(
+        xbuildenv.app,
+        [
+            "install",
+            "--path",
+            str(envpath),
+            "--download",
+            "--url",
+            "https://github.com/pyodide/pyodide/releases/download/0.22.1/xbuildenv-0.22.1.tar.bz2",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "Downloading xbuild environment" in result.stdout, result.stdout
+    assert "Installing xbuild environment" in result.stdout, result.stdout
+    assert (envpath / "pyodide-root").is_dir()
+    assert (envpath / "site-packages-extras").is_dir()

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -354,5 +354,5 @@ def test_xbuildenv_install(tmp_path):
     assert result.exit_code == 0, result.stdout
     assert "Downloading xbuild environment" in result.stdout, result.stdout
     assert "Installing xbuild environment" in result.stdout, result.stdout
-    assert (envpath / "pyodide-root").is_dir()
-    assert (envpath / "site-packages-extras").is_dir()
+    assert (envpath / "xbuildenv" / "pyodide-root").is_dir()
+    assert (envpath / "xbuildenv" / "site-packages-extras").is_dir()

--- a/pyodide-build/setup.cfg
+++ b/pyodide-build/setup.cfg
@@ -54,6 +54,7 @@ pyodide.cli =
     py-compile = pyodide_build.cli.py_compile:main
     config = pyodide_build.cli.config:app
     create-zipfile = pyodide_build.cli.create_zipfile:main
+    xbuildenv = pyodide_build.cli.xbuildenv:app
 
 [options.extras_require]
 test =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ module = [
   "tomllib",
   "tomli",
   "typer",
+  "pytest_pyodide",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
### Description

Resolve #3567 

Adds url paramter to `install_xbuildenv`, which helps installing xbuildenv from arbitrary URL. This is mostly for developers / maintainers who want to test tot xbuildenv.

This PR also adds a private CLI entrypoint `pyodide xbuildenv install`.

### Checklists

- [x] Add / update tests
