### PR TITLE
Add FAQ, Docs for working around JS Objects named like Python Keywords

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -423,3 +423,48 @@ So in order to persist changes, you have to call
 [`pyodide.FS.syncfs()`](https://emscripten.org/docs/api_reference/Filesystem-API.html#FS.syncfs).
 See [Emscripten File System API](https://emscripten.org/docs/api_reference/Filesystem-API.html#persistent-data)
 for more details.
+
+## How can I access JavaScript objects/attributes in Python if their names are Python keywords?
+
+Some JavaScript objects may have names or attributes which are also [Python Keywords](https://docs.python.org/3/reference/lexical_analysis.html#keywords), making them difficult to interact with when importing them into Python. For example, all three of the following uses of `runPython` will throw a SyntaxError:
+
+```pyodide
+//The built-in method Array.from() overlaps with Python's "from"
+pyodide.runPython(`from js import Array; print(Array.from([1,2,3]))`);
+
+//"global" is a valid attribute name in JS, but a reserved keyword in Python
+people = {global: "lots and lots"};
+pyodide.runPython(`from js import people; print(people.global)`);
+
+//"lambda" is a valid object name in JS, but a reserved keyword in Python
+lambda = (x) => {return x + 1};
+pyodide.runPython(`from js import lambda; print(lambda(1))`);
+```
+
+For JS objects with attributes that are Python reserved keywords, {py:func}`getattr` and {py:func}`setattr` can be used to access the attribute by name:
+
+```pyodide
+pyodide.runPython(`
+    from js import Array
+    fromFunc = getattr(Array, 'from')
+    print(fromFunc([1,2,3]))
+    `);
+
+people = {global: "lots and lots"};
+pyodide.runPython(`
+    from js import people
+    setattr(people, 'global', 'even more')
+    print(getattr(people, 'global'))
+    `);
+```
+
+For objects whose names are keywords, one can similarly use {py:func}`getattr` on the `js` module itself:
+
+```pyodide
+lambda = (x) => {return x + 1};
+pyodide.runPython(`
+    import js
+    js_lambda = getattr(js, 'lambda')
+    print(js_lambda(1))
+    `);
+```

--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -723,3 +723,27 @@ pyodide.runPython(`
 `);
 console.log(my_js_namespace.y); // 7
 ```
+
+If the JavaScript object's name is a reserved Python keyword, the {py:func}`setattr` function can be used to access the object by name within the js module::
+
+```pyodide
+lambda = (x) => {return x + 1};
+//'from js import lambda' will cause a Syntax Error, since 'lambda' is a Python reserved keyword. Instead:
+pyodide.runPython(`
+    import js
+    js_lambda = getattr(js, 'lambda')
+    print(js_lambda(1))
+    `);
+```
+
+If a JavaScript object has a property that is a reserved Python keyword, the {py:func}`setattr` and {py:func}`getattr` function can be used to access that property by name:
+
+```pyodide
+people = {global: "lots and lots"};
+//Trying to access 'people.global' will raise a Syntax Error, since 'global' is a Python reserved keyword. Instead:
+pyodide.runPython(`
+    from js import people
+    setattr(people, 'global', 'even more')
+    print(getattr(people, 'global'))
+    `);
+```


### PR DESCRIPTION
### Description

In response to #3615, this PR adds a new section to the FAQ and the Type Conversions page, with strategies for dealing with JavaScript objects whose names or properties are the same as Python keywords.  

For instance, to pull an example from this PR's FAQ.md:

```js
people = {global: "lots and lots"};

//raises SyntaxError, since 'global' is a Python reserved keyword
pyodide.runPython(`from js import people; print(people.global)`);

//Using setattr() and getattr() to access the 'global' attribute by name works:
pyodide.runPython(`
    from js import people
    setattr(people, 'global', 'even more')
    print(getattr(people, 'global'))
    `);
```

### Checklists

_None of the checklist items apply - this is purely additions to the documentation._

Closes #3615.