### PR TITLE
Fix pytest warning that find_import() has moved to pyodide.code

### DIFF
--- a/src/py/_pyodide/_base.py
+++ b/src/py/_pyodide/_base.py
@@ -557,7 +557,7 @@ def find_imports(source: str) -> list[str]:
 
     Examples
     --------
-    >>> from pyodide import find_imports
+    >>> from pyodide.code import find_imports
     >>> source = "import numpy as np; import scipy.stats"
     >>> find_imports(source)
     ['numpy', 'scipy']


### PR DESCRIPTION
From pytest warnings summary in CircleCI `test-core-node`:
> src/py/_pyodide/_base.py::_pyodide._base.find_imports
  /root/repo/src/py/pyodide/\_\_init\_\_.py:78: FutureWarning: pyodide.find_imports has been moved to pyodide.code.find_imports Accessing it through the pyodide module is deprecated.
```diff
-     >>> from pyodide import find_imports
+     >>> from pyodide.code import find_imports
```
The pytest warning is removed when `test-core-node` is run on CircleCI.

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
