### PR TITLE
Ruff is now compatible with Python pattern matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,15 @@ select = [
   "B0",    # bugbear (all B0* checks enabled by default)
   "B904",  # bugbear (Within an except clause, raise exceptions with raise ... from err)
   "B905",  # bugbear (zip() without an explicit strict= parameter set.)
+  "C9",    # McCabe code complexity
+  "PLC",   # pylint convention
+  "PLE",   # pylint error
   "UP",    # pyupgrade
   "I",     # isort
   "PGH",   # pygrep-hooks
 ]
-# Remove E999 once pattern matching is supported
-# https://github.com/charliermarsh/ruff/issues/282
-ignore = ["E402", "E501", "E731", "E741", "E999"]
+ignore = ["E402", "E501", "E731", "E741"]
+# line-length = 264  # E501 line-too-long
 target-version = "py311"
 
 [tool.ruff.per-file-ignores]
@@ -66,7 +68,6 @@ target-version = "py311"
 "src/tests/test_typeconversions.py" = [
   "PGH001",  # No builtin `eval()` allowed
 ]
-
 
 [tool.ruff.isort]
 known-first-party = [
@@ -83,6 +84,9 @@ known-third-party = [
 
 [tool.ruff.flake8-bugbear]
 extend-immutable-calls = ["typer.Argument", "typer.Option"]
+
+[tool.ruff.mccabe]
+max-complexity = 31
 
 [tool.pytest.ini_options]
 norecursedirs = [


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - the reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

As discussed at https://github.com/pyodide/pyodide/pull/3522#issuecomment-1450003295 Ruff is now compatible with Python pattern matching so we can add a few more Ruff tests.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation
