### PR TITLE
Update galpy to v1.8.2

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -161,6 +161,8 @@ myst:
 
 - New packages: fastparquet {pr}`3590`, cramjam {pr}`3590`.
 
+- Upgraded packages: galpy {pr}`3630`.
+
 ## Version 0.22.1
 
 _January 25, 2023_

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -161,7 +161,7 @@ myst:
 
 - New packages: fastparquet {pr}`3590`, cramjam {pr}`3590`.
 
-- Upgraded packages: galpy {pr}`3630`.
+- Upgraded packages: galpy (1.8.2) {pr}`3630`.
 
 ## Version 0.22.1
 

--- a/packages/galpy/meta.yaml
+++ b/packages/galpy/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: galpy
-  version: 1.8.1
+  version: 1.8.2
   top-level:
     - galpy
 source:
-  url: https://files.pythonhosted.org/packages/97/5b/ef489c571595f753fd86634e93f941897bf3511317ec829f5b080a390bb1/galpy-1.8.1.tar.gz
-  sha256: 9e2b55e50aab4aa7f4313ab9c333ac4512a4338e8d111fce5f6c14456ea53a07
+  url: https://files.pythonhosted.org/packages/8a/4e/50e80d32b225df532f4a38dca41a9b14585c2c4b9c8a7186084a2afb5d41/galpy-1.8.2.tar.gz
+  sha256: d02e79a4f95a94466b2e7fd511db95e13aaf3e7eb9a8e76ec99e1aabd62ff065
 build:
   script:
     export LIBGSL_INCLUDE_PATH=$(pkg-config --cflags-only-I --dont-define-prefix gsl)


### PR DESCRIPTION
Update `galpy` to resolve `numpy` 1.24 incompatibility of `galpy` v1.8.1 as noted in #3593.

From the documentation, it wasn't obvious that I could to this simply with:
```
pyodide skeleton pypi galpy --update
```
maybe that should be mentioned somewhere on the `development/new-packages` page.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- ~[ ] Add / update tests~
- ~[ ] Add new / update outdated documentation~
