### PR TITLE
New package: sourmash (and deps)

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -28,8 +28,8 @@ myst:
 
 ### Packages
 
-- New packages: sourmash {pr}`3635, screed {pr}`3635, bitstring {pr}`3635,
-  deprecation {pr}`3635, cachetools {pr}`3635.
+- New packages: sourmash {pr}`3635`, screed {pr}`3635`, bitstring {pr}`3635`,
+  deprecation {pr}`3635`, cachetools {pr}`3635`.
 
 ## Version 0.23.0
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -26,6 +26,11 @@ myst:
   a single file.
   {pr}`3727`
 
+### Packages
+
+- New packages: sourmash {pr}`3635, screed {pr}`3635, bitstring {pr}`3635,
+  deprecation {pr}`3635, cachetools {pr}`3635.
+
 ## Version 0.23.0
 
 _March 30, 2023_

--- a/packages/bitstring/meta.yaml
+++ b/packages/bitstring/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: bitstring
+  version: 4.0.1
+  top-level:
+    - bitstring
+source:
+  url: https://files.pythonhosted.org/packages/1b/07/951d7bc9804fcec26e8cdbf1d352018a21c16194d42e3f38cb7f5564ca4b/bitstring-4.0.1-py3-none-any.whl
+  sha256: 4a27cdefd95eb535c4b79e0afcdb5532ba1dba0aaed98a31ad98f46b1e0d5bd9
+about:
+  home: ""
+  PyPI: https://pypi.org/project/bitstring
+  summary: Simple construction, analysis and modification of binary data.
+  license: ""

--- a/packages/cachetools/meta.yaml
+++ b/packages/cachetools/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: cachetools
+  version: 5.3.0
+  top-level:
+    - cachetools
+source:
+  url: https://files.pythonhosted.org/packages/db/14/2b48a834d349eee94677e8702ea2ef98b7c674b090153ea8d3f6a788584e/cachetools-5.3.0-py3-none-any.whl
+  sha256: 429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4
+about:
+  home: https://github.com/tkem/cachetools/
+  PyPI: https://pypi.org/project/cachetools
+  summary: Extensible memoizing collections and decorators
+  license: MIT

--- a/packages/deprecation/meta.yaml
+++ b/packages/deprecation/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: deprecation
+  version: 2.1.0
+  top-level:
+    - deprecation
+source:
+  url: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
+  sha256: a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a
+about:
+  home: http://deprecation.readthedocs.io/
+  PyPI: https://pypi.org/project/deprecation
+  summary: A library to handle automated deprecations
+  license: Apache 2

--- a/packages/deprecation/meta.yaml
+++ b/packages/deprecation/meta.yaml
@@ -3,6 +3,9 @@ package:
   version: 2.1.0
   top-level:
     - deprecation
+requirements:
+  run:
+    - packaging
 source:
   url: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
   sha256: a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a

--- a/packages/screed/meta.yaml
+++ b/packages/screed/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: screed
+  version: 1.1.2
+  top-level:
+    - bigtests
+    - screed
+source:
+  url: https://files.pythonhosted.org/packages/a6/c1/e33d75369bffaf304b891afa34aa8b9765f117931673cdf8837eba9b0efb/screed-1.1.2-py2.py3-none-any.whl
+  sha256: 413e9cfce4b4908d0fa1fe69dcd2c523641a02a856eb196f9ce2183657f342dc
+about:
+  home: https://github.com/dib-lab/screed
+  PyPI: https://pypi.org/project/screed
+  summary: a Python library for loading FASTA and FASTQ sequences
+  license: BSD 3-clause

--- a/packages/sourmash/meta.yaml
+++ b/packages/sourmash/meta.yaml
@@ -5,11 +5,15 @@ package:
     - sourmash 
 requirements:
   run:
+    - screed
     - cffi
+    - deprecation
+    - cachetools
     - numpy
     - matplotlib
     - scipy
     - sqlite3
+    - bitstring
 source:
 #  url: https://pypi.io/packages/source/s/sourmash/sourmash-4.7.0.tar.gz
 #  sha256: 4135ac82059da24a30f3b9554ecd0107dbf68eac2828f39fa275038554b76311

--- a/packages/sourmash/meta.yaml
+++ b/packages/sourmash/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: sourmash
+  version: 4.7.0
+  top-level:
+    - sourmash 
+requirements:
+  run:
+    - cffi
+    - numpy
+    - matplotlib
+    - scipy
+    - sqlite3
+source:
+#  url: https://pypi.io/packages/source/s/sourmash/sourmash-4.7.0.tar.gz
+#  sha256: 4135ac82059da24a30f3b9554ecd0107dbf68eac2828f39fa275038554b76311
+  url: https://codeload.github.com/sourmash-bio/sourmash/tar.gz/fecfc97c3ec0be1dcfe43c73a12297f1295b5199
+  sha256: d09c60b8b815f418dbc98d3b0c64d5e8527f6d17b2dbe03e476f947ee02b7d65
+build:
+  script: |
+    rustup toolchain install ${RUST_TOOLCHAIN} && rustup default ${RUST_TOOLCHAIN}
+    rustup target add wasm32-unknown-emscripten --toolchain ${RUST_TOOLCHAIN}
+about:
+  home: https://github.com/sourmash-bio/sourmash
+  PyPI: https://pypi.org/project/sourmash
+  summary: Compute and compare MinHash signatures for DNA data sets.
+  license: BSD-3-Clause

--- a/packages/sourmash/meta.yaml
+++ b/packages/sourmash/meta.yaml
@@ -2,7 +2,7 @@ package:
   name: sourmash
   version: 4.7.0
   top-level:
-    - sourmash 
+    - sourmash
 requirements:
   run:
     - screed
@@ -15,8 +15,8 @@ requirements:
     - sqlite3
     - bitstring
 source:
-#  url: https://pypi.io/packages/source/s/sourmash/sourmash-4.7.0.tar.gz
-#  sha256: 4135ac82059da24a30f3b9554ecd0107dbf68eac2828f39fa275038554b76311
+  #  url: https://pypi.io/packages/source/s/sourmash/sourmash-4.7.0.tar.gz
+  #  sha256: 4135ac82059da24a30f3b9554ecd0107dbf68eac2828f39fa275038554b76311
   url: https://codeload.github.com/sourmash-bio/sourmash/tar.gz/fecfc97c3ec0be1dcfe43c73a12297f1295b5199
   sha256: d09c60b8b815f418dbc98d3b0c64d5e8527f6d17b2dbe03e476f947ee02b7d65
 build:

--- a/packages/sourmash/meta.yaml
+++ b/packages/sourmash/meta.yaml
@@ -18,7 +18,7 @@ source:
   #  url: https://pypi.io/packages/source/s/sourmash/sourmash-4.7.0.tar.gz
   #  sha256: 4135ac82059da24a30f3b9554ecd0107dbf68eac2828f39fa275038554b76311
   url: https://codeload.github.com/sourmash-bio/sourmash/tar.gz/fecfc97c3ec0be1dcfe43c73a12297f1295b5199
-  sha256: d09c60b8b815f418dbc98d3b0c64d5e8527f6d17b2dbe03e476f947ee02b7d65
+  sha256: 0dff73ca2252877108756cc1e53ef5981312a9006be93dfd88cbd7aaaf35f6ae
 build:
   script: |
     rustup toolchain install ${RUST_TOOLCHAIN} && rustup default ${RUST_TOOLCHAIN}

--- a/packages/sourmash/meta.yaml
+++ b/packages/sourmash/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: sourmash
-  version: 4.7.0
+  version: 4.8.0
   top-level:
     - sourmash
 requirements:
@@ -15,10 +15,8 @@ requirements:
     - sqlite3
     - bitstring
 source:
-  #  url: https://pypi.io/packages/source/s/sourmash/sourmash-4.7.0.tar.gz
-  #  sha256: 4135ac82059da24a30f3b9554ecd0107dbf68eac2828f39fa275038554b76311
-  url: https://codeload.github.com/sourmash-bio/sourmash/tar.gz/fecfc97c3ec0be1dcfe43c73a12297f1295b5199
-  sha256: 0dff73ca2252877108756cc1e53ef5981312a9006be93dfd88cbd7aaaf35f6ae
+  url: https://pypi.io/packages/source/s/sourmash/sourmash-4.8.0.tar.gz
+  sha256: 778d5d182f9e625ae560a5b3a2fdf6bd4fd3b876c84593da8c8c07d11ce2c697
 build:
   script: |
     rustup toolchain install ${RUST_TOOLCHAIN} && rustup default ${RUST_TOOLCHAIN}

--- a/packages/sourmash/test_sourmash.py
+++ b/packages/sourmash/test_sourmash.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_pyodide import run_in_pyodide
 
 

--- a/packages/sourmash/test_sourmash.py
+++ b/packages/sourmash/test_sourmash.py
@@ -1,0 +1,22 @@
+import pytest
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["sourmash"])
+def test_simple_save_load(selenium):
+    from pathlib import Path
+    from tempfile import TemporaryDirectory
+
+    import sourmash
+
+    mh = sourmash.MinHash(0, 5, scaled=1)
+    mh.add_sequence("ACGTAGGTATAGGATACCTCGCTAGTACGTGCA")
+    ss = sourmash.SourmashSignature(mh, name="foo")
+
+    with TemporaryDirectory() as td:
+        name = Path(td) / "test.sig"
+        with open(name, "w") as fp:
+            sourmash.save_signatures([ss], fp=fp)
+
+        loaded = sourmash.load_one_signature(str(name))
+        assert loaded.equals(ss)

--- a/packages/sourmash/test_sourmash.py
+++ b/packages/sourmash/test_sourmash.py
@@ -1,6 +1,8 @@
+import pytest
 from pytest_pyodide import run_in_pyodide
 
 
+@pytest.mark.driver_timeout(60)
 @run_in_pyodide(packages=["sourmash"])
 def test_simple_save_load(selenium):
     from pathlib import Path

--- a/packages/sourmash/test_sourmash.py
+++ b/packages/sourmash/test_sourmash.py
@@ -18,4 +18,4 @@ def test_simple_save_load(selenium):
             sourmash.save_signatures([ss], fp=fp)
 
         loaded = sourmash.load_one_signature(str(name))
-        assert loaded.equals(ss)
+        assert loaded == ss


### PR DESCRIPTION
### Description

Add sourmash (Python + Rust extension, packaged with maturin) and missing pure-wheel deps (screed, bitstring, cachetools, deprecation).

After a couple of fixes in https://github.com/sourmash-bio/sourmash/pull/2433 I managed to build it out-of-tree, would like to have it available here to make it easier to distribute (while PyPI doesn't support emscripten wheels).

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation
