### PR TITLE
Add hereditary option to as_object_map

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,11 @@ myst:
 
 ## Unreleased
 
+- {{ Enhancement }} `as_object_map` now accepts a keyword argument `hereditary`.
+  If set to `True` and indexing the object returns a plain-old-object, then the
+  return value will be automatically mapped in `as_object_map` as well.
+  {pr}`3638`
+
 - {{ Enhancement }} Python does not allow reserved words to be used as attributes.
   For instance, `Array.from` is a `SyntaxError`. (JavaScript has a more robust
   parser which can handle this.) To handle this, if an attribute to a `JsProxy`

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -42,6 +42,17 @@ _js2python_pyproxy(PyObject* val)
   return val;
 }
 
+EM_JS_REF(PyObject*, js2python_immutable, (JsRef id), {
+  let value = Hiwire.get_value(id);
+  let result = Module.js2python_convertImmutable(value, id);
+  // clang-format off
+  if (result !== undefined) {
+    // clang-format on
+    return result;
+  }
+  return 0;
+});
+
 EM_JS_REF(PyObject*, js2python, (JsRef id), {
   let value = Hiwire.get_value(id);
   let result = Module.js2python_convertImmutable(value, id);

--- a/src/core/js2python.h
+++ b/src/core/js2python.h
@@ -18,6 +18,9 @@ PyObject*
 js2python(JsRef x);
 
 PyObject*
+js2python_immutable(JsRef x);
+
+PyObject*
 js2python_convert(JsRef x, int depth, JsRef defaultConverter);
 
 /** Initialize any global variables used by this module. */

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -1,3 +1,7 @@
+/**
+ * A Python object that wraps a JavaScript object. Used to allow JavaScript
+ * objects to be passed into Python.
+ */
 #ifndef JSPROXY_H
 #define JSPROXY_H
 // clang-format off
@@ -6,46 +10,53 @@
 // clang-format on
 #include "hiwire.h"
 
-/** A Python object that a JavaScript object inside. Used for any non-standard
- *  data types that are passed from JavaScript to Python.
+/**
+ *
  */
+int
+JsProxy_compute_typeflags(JsRef obj);
 
-/** Make a new JsProxy.
- *  \param v The JavaScript object.
- *  \return The Python object wrapping the JavaScript object.
+PyObject*
+JsProxy_create_with_type(int type_flags, JsRef object, JsRef this);
+
+PyObject*
+JsProxy_create_objmap(JsRef object, bool objmap);
+
+/**
+ * Make a new JsProxy.
+ * @param object The JavaScript object.
+ * @param this If object is a function, the value of this to be used when
+ *        calling it.
+ * @return The Python object wrapping the JavaScript object.
+ */
+PyObject*
+JsProxy_create_with_this(JsRef object, JsRef this);
+
+/**
+ * Make a new JsProxy.
+ * @param v The JavaScript object.
+ * @return The Python object wrapping the JavaScript object.
  */
 PyObject*
 JsProxy_create(JsRef v);
 
-PyObject*
-JsProxy_create_with_this(JsRef object, JsRef this);
-
-/** Check if a Python object is a JsProxy object.
- *  \param x The Python object
- *  \return true if the object is a JsProxy object.
+/**
+ * Check if a Python object is a JsProxy.
+ * @param x The Python object
+ * @return true if the object is a JsProxy.
  */
 bool
 JsProxy_Check(PyObject* x);
 
-/** Grab the underlying JavaScript object from the JsProxy object.
- *  \param x The JsProxy object.  Must confirm that it is a JsProxy object using
- *    JsProxy_Check. \return The JavaScript object.
+/**
+ * Grab the underlying JavaScript object from the JsProxy.
+ * @param x The JsProxy object. Will fatally fail if it isn't a JsProxy.
+ * @return The JavaScript object.
  */
 JsRef
 JsProxy_AsJs(PyObject* x);
 
-/**
- * obj must be a JsProxy of a buffer (we do no checking!)
- * Make a new Python Buffer object and copy the data from obj into
- *
- */
-PyObject*
-JsBuffer_CloneIntoPython(JsRef jsbuffer,
-                         Py_ssize_t byteLength,
-                         char* format,
-                         Py_ssize_t itemsize);
-
-/** Initialize global state for the JsProxy functionality. */
+/** Initialize global state for JsProxy functionality. */
 int
 JsProxy_init(PyObject* core_module);
 

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1731,6 +1731,30 @@ def test_object_map_mapping_methods(selenium):
 
 
 @run_in_pyodide
+def test_as_object_map_heritable(selenium):
+    import pytest
+    from pyodide.code import run_js
+
+    o = run_js("({1:{2: 9, 3: 77}, 3:{6: 5, 12: 3, 2: 9}})")
+    mh = o.as_object_map(hereditary=True)
+    mn = o.as_object_map(hereditary=False)
+    assert mh["1"]["3"] == 77
+
+    with pytest.raises(TypeError):
+        mn["1"]["3"]
+
+    for x in mh.values():
+        assert x["2"] == 9
+
+    for x in mn.values():
+        with pytest.raises(TypeError):
+            x["2"]
+
+    n = mh.pop("1")
+    assert n["3"] == 77
+
+
+@run_in_pyodide
 def test_jsproxy_subtypes(selenium):
     import pytest
 


### PR DESCRIPTION
This automatically apply as_object_map to the values of the map when the values are "plain old objects".

This behavior is slightly naive but I think it will satisfy most people who have requested this feature.


- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
