### PR TITLE
DOC use MyST inline attrs for external links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ extensions = [
 ]
 
 
-myst_enable_extensions = ["substitution"]
+myst_enable_extensions = ["substitution", "attrs_inline"]
 
 js_language = "typescript"
 jsdoc_config_path = "../src/js/tsconfig.json"

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -4,11 +4,8 @@
 
 ## Try it online
 
-<!-- Use rst to avoid myst_parser trying to resolve ../.console.html and not creating a link  -->
-
-```{eval-rst}
-Try Pyodide in a `REPL <../console.html>`_ directly in your browser (no installation needed).
-```
+Try Pyodide in a [REPL](../console.html){.external} directly in your browser
+(no installation needed).
 
 ## Setup
 
@@ -146,12 +143,9 @@ you can access the global variable `x` from JavaScript in your browser's
 developer console with `pyodide.globals.get("x")`. The same goes for functions
 and imports. See {ref}`type-translations` for more details.
 
-<!-- Use rst to avoid myst_parser trying to resolve ../console.html and not creating a link  -->
-
-```{eval-rst}
-You can try it yourself in the browser console. Go to the `Pyodide REPL URL
-<../console.html>`_ and type the following into the browser console::
-```
+You can try it yourself in the browser console. Go to the [Pyodide REPL
+URL](../console.html){.external} and type the following into the browser
+console:
 
 ```pyodide
 await pyodide.loadPackage("numpy");


### PR DESCRIPTION
### Description

Follow-up of https://github.com/pyodide/pyodide/pull/3244 now that MyST supports marking a link as external via inline attrs.

See https://myst-parser.readthedocs.io/en/stable/syntax/cross-referencing.html#customising-external-url-resolution for more details, got the tip from https://github.com/executablebooks/MyST-Parser/discussions/677#discussioncomment-5214070.
