### PR TITLE
Fix scikit-image optional dependencies

### DIFF
--- a/packages/scikit-image/meta.yaml
+++ b/packages/scikit-image/meta.yaml
@@ -13,12 +13,11 @@ source:
 requirements:
   host:
     - numpy
-  run:
     - distutils
+  run:
     - packaging
     - numpy
     - scipy
-    - matplotlib
     - networkx
     - Pillow
     - imageio

--- a/packages/scikit-image/meta.yaml
+++ b/packages/scikit-image/meta.yaml
@@ -13,7 +13,6 @@ source:
 requirements:
   host:
     - numpy
-    - distutils
   run:
     - packaging
     - numpy


### PR DESCRIPTION
scikit-image currently installs both matplotlib and distutils at runtime, while I think they are not necessary.
 - matplotlib is an [optional dependency](https://github.com/scikit-image/scikit-image/blob/v0.19.3/requirements/optional.txt)
 - distutils is a build dependency

So this should reduce the download size when using scikit-image significantly (6.4 MB for matplotlib)