### PR TITLE
Fix arpack *eupd issues due to numpy 1.24 f2py changes

### DIFF
--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -63,6 +63,7 @@ def test_scipy_pytest(selenium):
     runtest("odr", "explicit")
     runtest("signal.tests.test_ltisys", "TestImpulse2")
     runtest("stats.tests.test_multivariate", "haar")
+    runtest("sparse.linalg._eigen", "test_svds_parameter_k_which")
 
 
 @pytest.mark.driver_timeout(40)

--- a/pyodide-build/pyodide_build/_f2c_fixes.py
+++ b/pyodide-build/pyodide_build/_f2c_fixes.py
@@ -279,8 +279,7 @@ def fix_f2c_output(f2c_output_path: str) -> str | None:
         # straightforward
         regrouped_lines = regroup_lines(lines)
         lines = [
-            re.sub(
-                r",?\s*ftnlen\s*(howmny_len|bmat_len)", "", line)
+            re.sub(r",?\s*ftnlen\s*(howmny_len|bmat_len)", "", line)
             for line in regrouped_lines
         ]
 

--- a/pyodide-build/pyodide_build/_f2c_fixes.py
+++ b/pyodide-build/pyodide_build/_f2c_fixes.py
@@ -268,6 +268,22 @@ def fix_f2c_output(f2c_output_path: str) -> str | None:
                 """
             )
 
+    # In numpy 1.24 f2py changed its treatment of character argument. In
+    # particular it does not generate a ftnlen parameter for each
+    # character parameter but f2c still generates it. The following code
+    # removes unneeded ftnlen parameters from the f2ced signature. The
+    # problematic subroutines and parameters are the ones with a type character
+    # in scipy/sparse/linalg/_eigen/arpack/arpack.pyf.src
+    if "eupd.c" in str(f2c_output):
+        # put signature on a single line to make replacement more
+        # straightforward
+        regrouped_lines = regroup_lines(lines)
+        lines = [
+            re.sub(
+                r",?\s*ftnlen\s*(howmny_len|bmat_len)", "", line)
+            for line in regrouped_lines
+        ]
+
     with open(f2c_output, "w") as f:
         f.writelines(lines)
 


### PR DESCRIPTION
### Description

Fix #3640. The root cause seems like a f2py change in numpy 1.24. I tested this locally and this makes the `scipy.sparse.linag.tests` pass (except a few expected failures like tests that try to start a new thread).

Not sure if I need a changelog entry for this since #3640 only affects `main` and not any Pyodide release.

Not sure if it is worth adding a test in packages/scipy/test_scipy.py. For example with a snippet similar to the one in #3640, although it is not a very thorough test:
```py
import numpy as np

from scipy.sparse.linalg import svds

rng = np.random.default_rng(0)
A = rng.random((10, 10))

res = svds(A, k=3, which='LM', random_state=0)
```

### Checklists

- [x] Add / update tests
