### PR TITLE
Plugin / Hook support

### DIFF
--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -4,7 +4,7 @@
 import ErrorStackParser from "error-stack-parser";
 import { loadScript, initNodeModules, pathSep, resolvePath } from "./compat";
 
-import { createModule, initializeFileSystem } from "./module";
+import { createModule, initializeFileSystem, Module } from "./module";
 import { version } from "./version";
 
 import type { PyodideInterface } from "./api.js";
@@ -167,12 +167,17 @@ export type ConfigType = {
   lockFileURL: string;
   homedir: string;
   fullStdLib?: boolean;
+  hooks?: PyodideHook[];
   stdin?: () => string;
   stdout?: (msg: string) => void;
   stderr?: (msg: string) => void;
   jsglobals?: object;
   args: string[];
   _node_mounts: string[];
+};
+
+export type PyodideHook = {
+  beforeFileSystemInitialized?: (module: Module) => void;
 };
 
 /**
@@ -212,6 +217,10 @@ export async function loadPyodide(
      * Default: ``false``
      */
     fullStdLib?: boolean;
+    /**
+     * Hooks to run at various stages of Pyodide initialization.
+     */
+    hooks?: PyodideHook[];
     /**
      * Override the standard input callback. Should ask the user for one line of
      * input.
@@ -259,6 +268,7 @@ export async function loadPyodide(
     lockFileURL: indexURL! + "repodata.json",
     args: [],
     _node_mounts: [],
+    hooks: [],
   };
   const config = Object.assign(default_config, options) as ConfigType;
 

--- a/src/tests/test_pyodide_hook.py
+++ b/src/tests/test_pyodide_hook.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.xfail_browsers(firefox="no localstorage access", node="no idbfs")
 def test_hook_indexedDB(selenium_standalone_noload):
     selenium = selenium_standalone_noload
 
@@ -15,19 +19,15 @@ def test_hook_indexedDB(selenium_standalone_noload):
                         Module.removeRunDependency("install-idbfs");
                     })
 
-                    const hasCache = localStorage.getItem('PYODIDE_IDB_CACHE') === 'true';
+                    const hasCache = localStorage.getItem("PYODIDE_IDB_CACHE") === "true";
                     if(hasCache){
                         Module.fileSystemInitialized = true;
                     }
                 });
             }
         }
-        """
-    )
 
-    selenium.run_js(
-        """
-        let pyodide = await loadPyodide({
+        pyodide = await loadPyodide({
             hooks : [indexedDBHook],
         });
 
@@ -35,16 +35,12 @@ def test_hook_indexedDB(selenium_standalone_noload):
         pyodide.runPython('assert open("/lib/hello.txt").read() == "hello world"');
 
         await new Promise((resolve, _) => pyodide.FS.syncfs(false, resolve));
-        localStorage.setItem('PYODIDE_IDB_CACHE', 'true');
-        """
-    )
+        localStorage.setItem("PYODIDE_IDB_CACHE", "true");
 
-    selenium.run_js(
-        """
-        let pyodide2 = await loadPyodide({
+        pyodide2 = await loadPyodide({
             hooks : [indexedDBHook],
         });
 
-        pyodide2.runPython('open("/lib/hello.txt").read() == "hello world"');
+        pyodide2.runPython('assert open("/lib/hello.txt").read() == "hello world"');
         """
     )

--- a/src/tests/test_pyodide_hook.py
+++ b/src/tests/test_pyodide_hook.py
@@ -1,0 +1,50 @@
+def test_hook_indexedDB(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+
+    selenium.run_js(
+        """
+        indexedDBHook = {
+            beforeFileSystemInitialized: (Module) => {
+                Module.preRun.push(() => {
+                    const mountDir = '/lib';
+                    Module.FS.mkdirTree(mountDir);
+                    Module.FS.mount(Module.IDBFS, {root : "."}, "/lib");
+
+                    Module.addRunDependency("install-idbfs");
+                    Module.FS.syncfs(true, () => {
+                        Module.removeRunDependency("install-idbfs");
+                    })
+
+                    const hasCache = localStorage.getItem('PYODIDE_IDB_CACHE') === 'true';
+                    if(hasCache){
+                        Module.fileSystemInitialized = true;
+                    }
+                });
+            }
+        }
+        """
+    )
+
+    selenium.run_js(
+        """
+        let pyodide = await loadPyodide({
+            hooks : [indexedDBHook],
+        });
+
+        pyodide.runPython('f = open("/lib/hello.txt", "w"); f.write("hello world"); f.close()');
+        pyodide.runPython('assert open("/lib/hello.txt").read() == "hello world"');
+
+        await new Promise((resolve, _) => pyodide.FS.syncfs(false, resolve));
+        localStorage.setItem('PYODIDE_IDB_CACHE', 'true');
+        """
+    )
+
+    selenium.run_js(
+        """
+        let pyodide2 = await loadPyodide({
+            hooks : [indexedDBHook],
+        });
+
+        pyodide2.runPython('open("/lib/hello.txt").read() == "hello world"');
+        """
+    )


### PR DESCRIPTION
**This PR is not for merging.** This PR includes a simple hook that can override our file system bootstrap stage.

- Related: #3316

I am opening this to gather more opinions about supporting hooks which people can modify Pyodide's internal behavior.

Some possible use cases that I can think of are:

1. Modifying the file system before bootstrapping Pyodide.

For example, @madhur-tandon opened an issue (#3274) about having a separate file system that can prefetch files and can be shared between Pyodide instances.

On the other hand, @joemarshall mentioned about https://github.com/pyodide/pyodide/issues/3269#issuecomment-1335252076 caching the file system into indexedDB, and reuse it in the next visit (included PoC in this PR).

2. Supporting other platforms.

For example, there is a PR about adding support for greasemonkey (#3597). It is a good feature, however, AFAIK no Pyodide devs know deeply about greasemonkey, so it is hard for us to maintain it. But if we can support it as a hook/plugin, then someone else who knows about greasemonkey can maintain it.

---

If we decide to support this feature, then I think first we need to 1) standardize the Pyodide bootstrap stages and document it, 2) and also standardize some internal APIs (`loadScript`, `loadBinaryFile`) that people might want to modify.

WDYT?

cc: @madhur-tandon, @antocuni, @tubaman, @joemarshall



