### PR TITLE
Add experimental support for EM_JS code in side modules

### DIFF
--- a/emsdk/patches/0001-Allow-EM_JS-to-be-used-in-side-modules.patch
+++ b/emsdk/patches/0001-Allow-EM_JS-to-be-used-in-side-modules.patch
@@ -1,0 +1,48 @@
+From fb68a1cf6e2acb37cb91027747997279bcd034af Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Mon, 20 Mar 2023 18:34:22 +0000
+Subject: [PATCH] Allow EM_JS to be used in side modules
+
+---
+ emscripten.py | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/emscripten.py b/emscripten.py
+index 19459d9c2..77cab35fd 100644
+--- a/emscripten.py
++++ b/emscripten.py
+@@ -297,6 +297,22 @@ def create_named_globals(metadata):
+   return '\n'.join(named_globals)
+ 
+ 
++def side_module_emjs(metadata, out_wasm):
++  em_js_funcs = create_em_js(metadata)
++  lib = ", ".join(metadata.emJsFuncs.keys())
++  lib = "{%s}\n" % lib
++  outcode = "globalThis.__tmpMergeLibsFunction = function(Module) {\n"
++  outcode += '\n'.join(em_js_funcs) + '\n\n'
++  outcode += "Module.mergeLibSymbols(\n"
++  outcode += lib
++  outcode += ");\n"
++  outcode += "}\n"
++  from pathlib import Path
++  Path(out_wasm).with_suffix(".so.js").write_text(outcode)
++  logger.debug('emscript: skipping remaining js glue generation')
++  return
++
++
+ def emscript(in_wasm, out_wasm, outfile_js, memfile):
+   # Overview:
+   #   * Run wasm-emscripten-finalize to extract metadata and modify the binary
+@@ -344,7 +360,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
+ 
+   if settings.SIDE_MODULE:
+     if metadata.emJsFuncs:
+-      exit_with_error('EM_JS is not supported in side modules')
++      side_module_emjs(emJsFuncs, out_wasm)
+     logger.debug('emscript: skipping remaining js glue generation')
+     return
+ 
+-- 
+2.34.1
+

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -286,14 +286,15 @@ async function installPackage(
   }
   const filename = pkg.file_name;
   // This Python helper function unpacks the buffer and lists out any .so files in it.
-  const dynlibs: string[] = API.package_loader.unpack_buffer.callKwargs({
-    buffer,
-    filename,
-    target: pkg.install_dir,
-    calculate_dynlibs: true,
-    installer: "pyodide.loadPackage",
-    source: channel === DEFAULT_CHANNEL ? "pyodide" : channel,
-  });
+  const dynlibs: [string[], string[]] =
+    API.package_loader.unpack_buffer.callKwargs({
+      buffer,
+      filename,
+      target: pkg.install_dir,
+      calculate_dynlibs: true,
+      installer: "pyodide.loadPackage",
+      source: channel === DEFAULT_CHANNEL ? "pyodide" : channel,
+    });
 
   if (DEBUG) {
     console.debug(


### PR DESCRIPTION
Based on my discussion with @szabolcsdombi in #3671, I thought it would be fun to experiment with enabling `EM_JS` in side modules. The `EM_JS` is put into a file called `blah.so.js` which contains code like:
```js
globalThis.__tmpMergeLibsFunction = function(Module) {
	function function_implemented_in_javascript(argument) { console.log('hello', argument); }
	
	Module.mergeLibSymbols(
		{function_implemented_in_javascript}
	);
}
```
we load it with `loadScript`, call `__tmpMergeLibsFunction` and then delete it. We need a lock around this code to ensure that another library doesn't write over the `__tmpMergeLibsFunction` global before the first is used (we need to use a global because of classic workers).

I tested it manually against @szabolcsdombi's example:
https://github.com/szabolcsdombi/pyodide-custom-module-imports/commit/3d51d923cb89941024ea31cc38b8df73a2a199ad
and it seems to work.

@sbc100

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
