### PR TITLE
Remove deprecated methods

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -32,6 +32,7 @@ pytest_pyodide.runner.INITIALIZE_SCRIPT = """
     pyodide._api.package_loader.sub_resource_hash;
     pyodide.runPython("");
     pyodide.pyimport("pyodide.ffi.wrappers").destroy();
+    pyodide.pyimport("pyodide.http").destroy();
 """
 
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -129,6 +129,15 @@ myst:
   replaced by `pyodide build-recipes`, and `pyodide-build mkpkg` which is
   replaced by `pyodide skeleton pypi` {pr}`3668`
 
+- {{ Breaking }} Removed support for calling functions from the root of `pyodide` package
+  directly. This has been deprecated since v0.21.0. Now all functions are only available
+  under submodules.
+  {pr}`3677`
+
+- {{ Breaking }} Removed support for passing the "message" argument to `PyProxy.destroy`
+  in a positional argument. This has been deprecated since v0.22.0.
+  {pr}`3677`
+
 ### Build System
 
 - {{ Enhancement}} Add `--build-dependencies` to pyodide build command

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -52,7 +52,7 @@ def test_install_simple(selenium_standalone_micropip):
             return await pyodide.runPythonAsync(`
                 import os
                 import micropip
-                from pyodide import to_js
+                from pyodide.ffi import to_js
                 # Package 'pyodide-micropip-test' has dependency on 'snowballstemmer'
                 # It is used to test markers support
                 await micropip.install('pyodide-micropip-test')

--- a/packages/pandas/test_pandas.py
+++ b/packages/pandas/test_pandas.py
@@ -62,11 +62,11 @@ def test_load_largish_file(selenium_standalone, request, httpserver):
 
     selenium.run(
         f"""
-        import pyodide
+        import pyodide.http
         import matplotlib.pyplot as plt
         import pandas as pd
 
-        df = pd.read_json(pyodide.open_url('{request_url}'))
+        df = pd.read_json(pyodide.http.open_url('{request_url}'))
         assert df.shape == ({n_rows}, 8)
         """
     )

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -434,10 +434,6 @@ Module.callPyObject = function (ptrobj: number, jsargs: any) {
   return Module.callPyObjectKwargs(ptrobj, jsargs, {});
 };
 
-const DESTROY_MSG_POSITIONAL_ARG_DEPRECATED =
-  "Using a positional argument for the message argument for 'destroy' is deprecated and will be removed in v0.23";
-let DESTROY_MSG_POSITIONAL_ARG_WARNED = false;
-
 export interface PyProxy {
   [x: string]: any;
 }
@@ -519,13 +515,6 @@ export class PyProxy {
    *
    */
   destroy(options: { message?: string; destroyRoundtrip?: boolean } = {}) {
-    if (typeof options === "string") {
-      if (!DESTROY_MSG_POSITIONAL_ARG_WARNED) {
-        DESTROY_MSG_POSITIONAL_ARG_WARNED = true;
-        console.warn(DESTROY_MSG_POSITIONAL_ARG_DEPRECATED);
-      }
-      options = { message: options };
-    }
     options = Object.assign({ message: "", destroyRoundtrip: true }, options);
     const { message: m, destroyRoundtrip: d } = options;
     Module.pyproxy_destroy(this, m, d);

--- a/src/py/pyodide/__init__.py
+++ b/src/py/pyodide/__init__.py
@@ -14,73 +14,8 @@ __version__ = "0.22.0"
 
 __all__ = ["__version__", "console", "code", "ffi", "http", "webloop"]
 
-from typing import Any
-
-from . import _state  # noqa: F401
-from .code import (
-    CodeRunner,  # noqa: F401
-    eval_code,  # noqa: F401
-    eval_code_async,  # noqa: F401
-    find_imports,  # noqa: F401
-    should_quiet,  # noqa: F401
-)
-from .ffi import (
-    ConversionError,  # noqa: F401
-    JsException,  # noqa: F401
-    JsProxy,  # noqa: F401
-    create_once_callable,  # noqa: F401
-    create_proxy,  # noqa: F401
-    destroy_proxies,  # noqa: F401
-    register_js_module,  # noqa: F401
-    to_js,  # noqa: F401
-    unregister_js_module,  # noqa: F401
-)
-from .http import open_url  # noqa: F401
-
-DEPRECATED_LIST = {
-    "CodeRunner": "code",
-    "eval_code": "code",
-    "eval_code_async": "code",
-    "find_imports": "code",
-    "should_quiet": "code",
-    "open_url": "http",
-    "ConversionError": "ffi",
-    "JsException": "ffi",
-    "JsProxy": "ffi",
-    "create_once_callable": "ffi",
-    "create_proxy": "ffi",
-    "destroy_proxies": "ffi",
-    "to_js": "ffi",
-    "register_js_module": "ffi",
-    "unregister_js_module": "ffi",
-}
-
 
 from .webloop import _initialize_event_loop
 
 _initialize_event_loop()
 del _initialize_event_loop
-
-
-def __dir__() -> list[str]:
-    return __all__
-
-
-for name in DEPRECATED_LIST:
-    globals()[f"_deprecated_{name}"] = globals()[name]
-    del globals()[name]
-
-
-def __getattr__(name: str) -> Any:
-    if name in DEPRECATED_LIST:
-        from warnings import warn
-
-        warn(
-            f"pyodide.{name} has been moved to pyodide.{DEPRECATED_LIST[name]}.{name} "
-            "Accessing it through the pyodide module is deprecated.",
-            FutureWarning,
-        )
-        # Put the name back so we won't warn next time this name is accessed
-        globals()[name] = globals()[f"_deprecated_{name}"]
-        return globals()[name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/py/pyodide/__init__.py
+++ b/src/py/pyodide/__init__.py
@@ -14,7 +14,7 @@ __version__ = "0.22.0"
 
 __all__ = ["__version__", "console", "code", "ffi", "http", "webloop"]
 
-
+from . import _state  # noqa: F401
 from .webloop import _initialize_event_loop
 
 _initialize_event_loop()

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -159,7 +159,7 @@
                   }),
                 );
               }
-              if (pyodide.isPyProxy(value)) {
+              if (pyodide.ffi.isPyProxy(value)) {
                 value.destroy();
               }
             } catch (e) {

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -159,7 +159,7 @@
                   }),
                 );
               }
-              if (pyodide.ffi.isPyProxy(value)) {
+              if (value instanceof pyodide.ffi.PyProxy) {
                 value.destroy();
               }
             } catch (e) {

--- a/src/tests/test_asyncio.py
+++ b/src/tests/test_asyncio.py
@@ -13,7 +13,7 @@ def test_await_jsproxy(selenium):
             global resolve
             resolve = res
         from js import Promise
-        from pyodide import create_once_callable
+        from pyodide.ffi import create_once_callable
         p = Promise.new(create_once_callable(prom))
         async def temp():
             x = await p
@@ -43,7 +43,7 @@ def test_then_jsproxy(selenium):
             reject = rej
 
         from js import Promise
-        from pyodide import create_once_callable
+        from pyodide.ffi import create_once_callable
         result = None
         err = None
         finally_occurred = False
@@ -245,9 +245,9 @@ def test_eval_code_await_jsproxy(selenium):
             global resolve
             resolve = res
         from js import Promise
-        from pyodide import create_once_callable
+        from pyodide.ffi import create_once_callable
         p = Promise.new(create_once_callable(prom))
-        from pyodide import eval_code_async
+        from pyodide.code import eval_code_async
         c = eval_code_async(
             '''
             x = await p
@@ -273,7 +273,7 @@ def test_eval_code_await_fetch(selenium):
     selenium.run(
         """
         from js import fetch
-        from pyodide import eval_code_async
+        from pyodide.code import eval_code_async
         c = eval_code_async(
             '''
             response = await fetch("console.html")
@@ -310,7 +310,7 @@ def test_eval_code_await_error(selenium):
         self.async_js_raises = async_js_raises;
         pyodide.runPython(`
             from js import async_js_raises
-            from pyodide import eval_code_async
+            from pyodide.code import eval_code_async
             c = eval_code_async(
                 '''
                 await async_js_raises()

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1733,6 +1733,7 @@ def test_object_map_mapping_methods(selenium):
 @run_in_pyodide
 def test_as_object_map_heritable(selenium):
     import pytest
+
     from pyodide.code import run_js
 
     o = run_js("({1:{2: 9, 3: 77}, 3:{6: 5, 12: 3, 2: 9}})")

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1518,28 +1518,6 @@ def test_deprecations(selenium_standalone):
 
 
 @run_in_pyodide(packages=["pytest"])
-def test_moved_deprecation_warnings(selenium_standalone):
-    import pytest
-
-    import pyodide
-    from pyodide import DEPRECATED_LIST, code, ffi, http  # noqa: F401
-
-    for func, mod in DEPRECATED_LIST.items():
-        getattr(getattr(pyodide, mod), func)
-
-    for func, mod in DEPRECATED_LIST.items():
-        with pytest.warns(FutureWarning, match=mod):
-            getattr(pyodide, func)
-
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        for func in DEPRECATED_LIST.keys():
-            getattr(pyodide, func)
-
-
-@run_in_pyodide(packages=["pytest"])
 def test_module_not_found_hook(selenium_standalone):
     import importlib
 

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -12,8 +12,8 @@ def test_open_url(selenium, httpserver):
     assert (
         selenium.run(
             f"""
-            import pyodide
-            pyodide.open_url('{request_url}').read()
+            from pyodide.http import open_url
+            open_url('{request_url}').read()
             """
         )
         == "HELLO"

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -494,7 +494,7 @@ def test_pyproxy_mixins3(selenium):
         """
         let [Test, t] = pyodide.runPython(`
             class Test: pass
-            from pyodide import to_js
+            from pyodide.ffi import to_js
             to_js([Test, Test()])
         `);
         assert(() => Test.prototype === undefined);
@@ -536,7 +536,7 @@ def test_pyproxy_mixins4(selenium):
                 prototype="prototype"
                 name="me"
                 length=7
-            from pyodide import to_js
+            from pyodide.ffi import to_js
             to_js([Test, Test()])
         `);
         assert(() => Test.$prototype === "prototype");
@@ -561,7 +561,7 @@ def test_pyproxy_mixins5(selenium):
             class Test:
                 def __len__(self):
                     return 9
-            from pyodide import to_js
+            from pyodide.ffi import to_js
             to_js([Test, Test()])
         `);
         assert(() => !("length" in Test));
@@ -880,7 +880,7 @@ def test_pyproxy_call(selenium):
     selenium.run_js(
         """
         pyodide.runPython(`
-            from pyodide import to_js
+            from pyodide.ffi import to_js
             def f(x=2, y=3):
                 return to_js([x, y])
         `);


### PR DESCRIPTION
Remove deprecated methods before releasing 0.23 following the [deprecation timeline](https://github.com/pyodide/pyodide/blob/main/docs/project/deprecation-timeline.md)
