### PR TITLE
MAINT Improvements to mkpkg error handling

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -16,7 +16,7 @@ all:
 
 update-all:
 	for pkg in $$(find . -maxdepth 1 ! -name ".*" -type d -exec basename {} \; | tail -n +2); do \
-		PYODIDE_ROOT=$(PYODIDE_ROOT) pyodide skeleton pypi "$${pkg}" --update; \
+		PYODIDE_ROOT=$(PYODIDE_ROOT) pyodide skeleton pypi "$${pkg}" --update-patched; \
 	done
 
 clean:

--- a/pyodide-build/pyodide_build/cli/skeleton.py
+++ b/pyodide-build/pyodide_build/cli/skeleton.py
@@ -1,10 +1,10 @@
 # Create or update a package recipe skeleton,
 # inspired from `conda skeleton` command.
 
+import sys
 from pathlib import Path
 
 import typer
-import sys
 
 from .. import common, mkpkg
 from ..logger import logger
@@ -70,7 +70,7 @@ def new_recipe_pypi(
             sys.exit(1)
         except mkpkg.MkpkgSkipped as e:
             logger.warn(f"{name} update skipped: {e}")
-        except Exception as e:
+        except Exception:
             print(name)
             raise
     else:

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -46,6 +46,9 @@ class MetadataDict(TypedDict):
     vulnerabilities: list[Any]
 
 
+class MkpkgSkipped(Exception):
+    pass
+
 class MkpkgFailedException(Exception):
     pass
 
@@ -224,12 +227,13 @@ def update_package(
 
     yaml_content = yaml.load(meta_path.read_bytes())
 
-    if "url" not in yaml_content["source"]:
-        raise MkpkgFailedException(f"Skipping: {package} is a local package!")
-
     build_info = yaml_content.get("build", {})
-    if build_info.get("library", False) or build_info.get("sharedlibrary", False):
-        raise MkpkgFailedException(f"Skipping: {package} is a library!")
+    ty = build_info.get("type", None)
+    if ty in ["static_library", "shared_library", "cpython_module"]:
+        raise MkpkgSkipped(f"{package} is a {ty.replace('_', ' ')}!")
+
+    if "url" not in yaml_content["source"]:
+        raise MkpkgSkipped(f"{package} is a local package!")
 
     if yaml_content["source"]["url"].endswith("whl"):
         old_fmt = "wheel"

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -49,6 +49,7 @@ class MetadataDict(TypedDict):
 class MkpkgSkipped(Exception):
     pass
 
+
 class MkpkgFailedException(Exception):
     pass
 


### PR DESCRIPTION
Resolves #3682. Removes tracebacks from "user errors" and improves error messages.
