### PR TITLE
DOC Add a link to the GitHub repository

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,8 @@ html_logo = "_static/img/pyodide-logo.png"
 # theme-specific options
 html_theme_options: dict[str, Any] = {
     "announcement": "",
+    "repository_url": "https://github.com/pyodide/pyodide",
+    "use_repository_button": True,
 }
 
 # paths that contain custom static files (such as style sheets)


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Most documentation sites have a link to their GitHub repositories. I believe the [Pyodide Docs site](https://pyodide.readthedocs.io/) doesn't have a GitHub link in an easily detectable place. Adding a link to the GitHub repository in the site header will improve the developer experience. 😀

This PR uses sphinx-book-theme's built-in `"repository_url"` and `"use_repository_button"` options as suggested by @ryanking13 in #3686 .

**Current**: No link to GitHub
![image](https://user-images.githubusercontent.com/1064036/227450942-c86aa0f9-c6a0-455d-a175-b2fbee4a4966.png)

**After PR**: Add a GitHub link to the header
![image](https://user-images.githubusercontent.com/1064036/227450630-f557e13e-642f-4f53-9ae4-e8e1f32e094a.png)

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->
