### PR TITLE
PKG Add yarl and idna

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -199,9 +199,10 @@ myst:
 ### Packages
 
 - New packages: fastparquet {pr}`3590`, cramjam {pr}`3590`, pynacl {pr}`3500`,
-  mypy {pr}`3504`, multidict {pr}`3581`
+  mypy {pr}`3504`, multidict {pr}`3581`, yarl {pr}`3702`, idna {pr}`3702`.
 
 - Upgraded packages: galpy (1.8.2) {pr}`3630`, scikit-learn (1.2.2) {pr}`3654`
+  See all package versions in this release in {ref}`packages-in-pyodide`.
 
 ## Version 0.22.1
 

--- a/packages/idna/meta.yaml
+++ b/packages/idna/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: idna
+  version: "3.4"
+  top-level:
+    - idna
+source:
+  url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl
+  sha256: 90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+about:
+  home: https://github.com/kjd/idna
+  PyPI: https://pypi.org/project/idna
+  summary: Internationalized Domain Names in Applications (IDNA)
+  license: BSD-3-Clause license

--- a/packages/idna/test_idna.py
+++ b/packages/idna/test_idna.py
@@ -1,0 +1,8 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["idna"])
+def test_idna(selenium_standalone):
+    import idna
+
+    assert idna.encode("ドメイン.テスト") == b"xn--eckwd4c7c.xn--zckzah"

--- a/packages/yarl/meta.yaml
+++ b/packages/yarl/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: yarl
+  version: 1.8.2
+  top-level:
+    - yarl
+source:
+  url: https://files.pythonhosted.org/packages/c4/1e/1b204050c601d5cd82b45d5c8f439cb6f744a2ce0c0a6f83be0ddf0dc7b2/yarl-1.8.2.tar.gz
+  sha256: 49d43402c6e3013ad0978602bf6bf5328535c48d192304b91b97a3c6790b1562
+requirements:
+  run:
+    - multidict
+    - idna
+about:
+  home: https://github.com/aio-libs/yarl/
+  PyPI: https://pypi.org/project/yarl
+  summary: Yet another URL library
+  license: Apache 2

--- a/packages/yarl/test_yarl.py
+++ b/packages/yarl/test_yarl.py
@@ -1,0 +1,10 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["yarl"])
+def test_yarl(selenium_standalone):
+    from yarl import URL
+
+    url = URL("https://www.python.org/~guido?arg=1#frag")
+    assert url.host == "www.python.org"
+    assert url.query_string == "arg=1"


### PR DESCRIPTION
This adds the [yarl](https://github.com/aio-libs/yarl) package which is a requirement (with some Cython code) for the openai client library (https://github.com/pyodide/pyodide/issues/3588).  At least 3 people asked for it on different channels...

[idna](https://github.com/kjd/idna) is a Pure python dependency of yarl.

In any case, both of these libraries are pretty small and seem useful for web-related stuff.

I added tests and a changelog. Unless there are comments, will merge on green CI later today as this is fairly low risk.