### PR TITLE
WIP: Support saving and restoring thread state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ dist/libpyodide.a: \
 	src/core/python2js_buffer.o \
 	src/core/python2js.o \
 	src/core/pyodide_pre.o \
-	src/core/pyversion.o
+	src/core/pyversion.o \
+	src/core/threadstate.o
 	emar rcs dist/libpyodide.a $(filter %.o,$^)
 
 

--- a/packages/emscripten-loop-test/emscripten-loop-test/emscripten-loop-test.cpp
+++ b/packages/emscripten-loop-test/emscripten-loop-test/emscripten-loop-test.cpp
@@ -1,0 +1,50 @@
+#define PY_SSIZE_T_CLEAN
+
+#include "Python.h"
+#include <emscripten.h>
+
+long counter = 0;
+
+void
+inner_loop(void)
+{
+  if (counter < 100) {
+    counter += 1;
+  }
+}
+
+static PyObject*
+main_loop(void)
+{
+  emscripten_set_main_loop(inner_loop, 0, 1);
+  Py_RETURN_NONE;
+}
+
+static PyObject*
+get_counter(void)
+{
+  return PyLong_FromLong(counter);
+}
+
+static PyMethodDef Methods[] = {
+  { "main_loop", (PyCFunction)main_loop, METH_NOARGS },
+  { "get_counter", (PyCFunction)get_counter, METH_NOARGS },
+  { NULL, NULL, 0, NULL } /* Sentinel */
+};
+
+static struct PyModuleDef module = {
+  PyModuleDef_HEAD_INIT,
+  "emscripten_loop_test",                   /* name of module */
+  "Tests for the emscripten loop handling", /* module documentation, may be NULL
+                                             */
+  -1, /* size of per-interpreter state of the module,
+         or -1 if the module keeps state in global variables. */
+  Methods
+};
+
+PyMODINIT_FUNC
+PyInit_emscripten_loop_test(void)
+{
+  PyObject* module_object = PyModule_Create(&module);
+  return module_object;
+}

--- a/packages/emscripten-loop-test/emscripten-loop-test/pyproject.toml
+++ b/packages/emscripten-loop-test/emscripten-loop-test/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "emscripten-loop-test"
+version = "0.1"

--- a/packages/emscripten-loop-test/emscripten-loop-test/setup.py
+++ b/packages/emscripten-loop-test/emscripten-loop-test/setup.py
@@ -1,0 +1,10 @@
+from setuptools import Extension, setup
+
+setup(
+    ext_modules=[
+        Extension(
+            name="emscripten_loop_test",
+            sources=["emscripten-loop-test.cpp"],
+        ),
+    ]
+)

--- a/packages/emscripten-loop-test/meta.yaml
+++ b/packages/emscripten-loop-test/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: emscripten-loop-test
+  version: "0.1"
+  tag:
+    - core
+    - pyodide.test
+  top-level:
+    - emscripten_loop_test
+source:
+  path: emscripten-loop-test

--- a/packages/emscripten-loop-test/test_emscripten_loop_test.py
+++ b/packages/emscripten-loop-test/test_emscripten_loop_test.py
@@ -1,0 +1,12 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["emscripten-loop-test"])
+def test_emscripten_loop(selenium):
+    import emscripten_loop_test
+
+    assert emscripten_loop_test.get_counter() == 0
+
+    emscripten_loop_test.main_loop()
+
+    assert emscripten_loop_test.get_counter() == 100

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -138,6 +138,27 @@ API.fatal_error = function (e: any) {
   throw e;
 };
 
+/**
+ * Signal a fatal error if the exception is not an expected exception.
+ *
+ * @argument e {any} The cause of the fatal error.
+ * @private
+ */
+API.maybe_fatal_error = function (e: any) {
+  // Emscripten throws "unwind" to stop current code and return to the main event loop.
+  // This is expected behavior and should not be treated as a fatal error.
+  // However, after the "unwind" exception is caught, the call stack is not unwound
+  // properly and there are dead frames remaining on the stack.
+  // This might cause problems in the future, so we need to find a way to fix it.
+  // See: 1) https://github.com/emscripten-core/emscripten/issues/16071
+  //      2) https://github.com/kitao/pyxel/issues/418
+  if (typeof e === "string" && e == "unwind") {
+    return;
+  }
+
+  return API.fatal_error(e);
+};
+
 let stderr_chars: number[] = [];
 API.capture_stderr = function () {
   stderr_chars = [];

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -152,7 +152,14 @@ API.maybe_fatal_error = function (e: any) {
   // This might cause problems in the future, so we need to find a way to fix it.
   // See: 1) https://github.com/emscripten-core/emscripten/issues/16071
   //      2) https://github.com/kitao/pyxel/issues/418
-  if (typeof e === "string" && e == "unwind") {
+  if (e && e == "unwind") {
+    if (!Module._is_thread_state_saved()) {
+      console.warn(
+        "No thread state saved. Make sure to save the thread state before calling a function " +
+          "that uses emscripten_set_main_loop().",
+      );
+    }
+
     return;
   }
 

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -414,7 +414,8 @@ Module.callPyObjectKwargs = function (
     );
     Py_EXIT();
   } catch (e) {
-    API.fatal_error(e);
+    API.maybe_fatal_error(e);
+    return;
   } finally {
     Hiwire.decref(idargs);
     Hiwire.decref(idkwnames);

--- a/src/core/threadstate.c
+++ b/src/core/threadstate.c
@@ -1,0 +1,53 @@
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
+PyThreadState* saved_state = NULL;
+
+/**
+ * Save the current thread state and create a new one from
+ * the current interpreter state.
+ */
+void
+save_current_thread_state()
+{
+  if (saved_state != NULL) {
+#ifdef DEBUG_F
+    printf("save_current_thread_state: already saved state");
+#endif
+    return;
+  }
+  PyThreadState* tstate = PyThreadState_Get();
+  PyInterpreterState* interp = PyThreadState_GetInterpreter(tstate);
+
+  PyThreadState* new_tstate = PyThreadState_New(interp);
+
+  PyThreadState_Swap(new_tstate);
+  saved_state = tstate;
+}
+
+/**
+ * Restore the thread state that was saved by
+ * save_current_thread_state.
+ */
+void
+restore_thread_state()
+{
+  if (saved_state == NULL) {
+#ifdef DEBUG_F
+    printf("restore_thread_state: no saved state");
+#endif
+    return;
+  }
+  PyThreadState* tstate = PyThreadState_Get();
+  PyThreadState_Swap(saved_state);
+  PyThreadState_Clear(tstate);
+  PyThreadState_Delete(tstate);
+
+  saved_state = NULL;
+}
+
+int
+is_thread_state_saved()
+{
+  return saved_state != NULL;
+}

--- a/src/core/threadstate.h
+++ b/src/core/threadstate.h
@@ -1,0 +1,11 @@
+#ifndef THREADSTATE_H
+#define THREADSTATE_H
+
+void
+save_current_thread_state()
+
+  void restore_thread_state()
+
+    bool is_thread_state_saved()
+
+#endif // THREADSTATE_H

--- a/src/core/threadstate.h
+++ b/src/core/threadstate.h
@@ -2,10 +2,12 @@
 #define THREADSTATE_H
 
 void
-save_current_thread_state()
+save_current_thread_state();
 
-  void restore_thread_state()
+void
+restore_thread_state();
 
-    bool is_thread_state_saved()
+bool
+is_thread_state_saved();
 
 #endif // THREADSTATE_H

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -5,6 +5,10 @@ import "./module";
 import { ffi } from "./ffi";
 
 import { loadPackage, loadedPackages } from "./load-package";
+import {
+  is_running_infinite_loop,
+  cancel_infinite_loop,
+} from "./infinite-loop";
 import { PyBufferView, PyBuffer, TypedArray, PyProxy } from "./pyproxy.gen";
 import { PythonError } from "./error_handling.gen";
 import { loadBinaryFile } from "./compat";
@@ -132,6 +136,10 @@ export class PyodideAPI {
    * from JavaScript.
    */
   static pyodide_py = {} as PyProxy; // actually defined in loadPyodide (see pyodide.js)
+
+  static is_running_infinite_loop = is_running_infinite_loop;
+
+  static cancel_infinite_loop = cancel_infinite_loop;
 
   /**
    * Inspect a Python code chunk and use :js:func:`pyodide.loadPackage` to install

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -5,10 +5,7 @@ import "./module";
 import { ffi } from "./ffi";
 
 import { loadPackage, loadedPackages } from "./load-package";
-import {
-  is_running_infinite_loop,
-  cancel_infinite_loop,
-} from "./infinite-loop";
+import { loop } from "./infinite-loop";
 import { PyBufferView, PyBuffer, TypedArray, PyProxy } from "./pyproxy.gen";
 import { PythonError } from "./error_handling.gen";
 import { loadBinaryFile } from "./compat";
@@ -137,9 +134,7 @@ export class PyodideAPI {
    */
   static pyodide_py = {} as PyProxy; // actually defined in loadPyodide (see pyodide.js)
 
-  static is_running_infinite_loop = is_running_infinite_loop;
-
-  static cancel_infinite_loop = cancel_infinite_loop;
+  static loop = loop;
 
   /**
    * Inspect a Python code chunk and use :js:func:`pyodide.loadPackage` to install

--- a/src/js/infinite-loop.ts
+++ b/src/js/infinite-loop.ts
@@ -1,0 +1,23 @@
+declare var Module: any;
+declare var DEBUG: boolean;
+
+/**
+ * Checks if the program is running an infinite loop
+ * @returns {boolean}
+ */
+export function is_running_infinite_loop(): boolean {
+  return Module.Browser.mainLoop.func === null;
+}
+
+/**
+ * Cancel the running infinite loop
+ */
+export function cancel_infinite_loop(): void {
+  if (!is_running_infinite_loop()) {
+    if (DEBUG) {
+      console.log("[DEBUG] No running infinite loop");
+    }
+  }
+
+  Module._emscripten_cancel_main_loop();
+}

--- a/src/js/infinite-loop.ts
+++ b/src/js/infinite-loop.ts
@@ -2,22 +2,70 @@ declare var Module: any;
 declare var DEBUG: boolean;
 
 /**
- * Checks if the program is running an infinite loop
+ * Checks if the program is running an main loop
  * @returns {boolean}
  */
-export function is_running_infinite_loop(): boolean {
-  return Module.Browser.mainLoop.func === null;
+export function running(): boolean {
+  return !Module.Browser.mainLoop.func === null;
 }
 
 /**
- * Cancel the running infinite loop
+ * Cancel the running main loop
  */
-export function cancel_infinite_loop(): void {
-  if (!is_running_infinite_loop()) {
+export function cancel(): void {
+  if (!running()) {
     if (DEBUG) {
-      console.log("[DEBUG] No running infinite loop");
+      console.log("[DEBUG] No running main loop");
     }
   }
 
   Module._emscripten_cancel_main_loop();
 }
+
+/**
+ * Save the current thread state
+ */
+export function saveThreadState(): void {
+  if (Module._is_thread_state_saved()) {
+    if (DEBUG) {
+      console.debug("[DEBUG] Thread state already saved");
+    }
+    return;
+  }
+
+  Module._save_current_thread_state();
+}
+
+/**
+ * Restore the thread state
+ */
+export function restoreThreadState(): void {
+  if (!Module._is_thread_state_saved()) {
+    if (DEBUG) {
+      console.debug("[DEBUG] Thread state not saved");
+    }
+    return;
+  }
+
+  Module._restore_thread_state();
+}
+
+/**
+ * @private
+ */
+export interface PyodideLoopInterface {
+  running: () => boolean;
+  cancel: () => void;
+  saveThreadState: () => void;
+  restoreThreadState: () => void;
+}
+
+/**
+ * @private
+ */
+export const loop: PyodideLoopInterface = {
+  running,
+  cancel,
+  saveThreadState,
+  restoreThreadState,
+};

--- a/src/tests/test_emscripten_loop.py
+++ b/src/tests/test_emscripten_loop.py
@@ -1,0 +1,92 @@
+import pytest
+
+
+@pytest.mark.skip_refcount_check
+@pytest.mark.skip_pyproxy_check
+def test_unwind_state_save_restore(selenium_standalone):
+    selenium = selenium_standalone
+
+    selenium.run_js(
+        """
+        throw_unwind = () => {
+            throw "unwind";
+        }
+
+        pyodide.loop.saveThreadState()
+
+        pyodide.runPython(`
+            from _pyodide_core import raw_call
+            from js import throw_unwind
+
+            def unwind_call():
+                raw_call(throw_unwind)
+
+            unwind_call()
+        `)
+
+        pyodide.runPython(`
+            import sys
+            frame = sys._getframe()
+            func_names = []
+            while frame:
+                func_names.append(frame.f_code.co_name)
+                frame = frame.f_back
+
+            assert "unwind_call" in func_names
+            print(func_names)
+        `)
+
+        pyodide.loop.cancel()
+
+        pyodide.loop.restoreThreadState()
+
+        pyodide.runPython(`
+            import sys
+            frame = sys._getframe()
+            func_names = []
+            while frame:
+                func_names.append(frame.f_code.co_name)
+                frame = frame.f_back
+
+            assert "unwind_call" not in func_names
+            print(func_names)
+        `)
+        """
+    )
+
+
+# @pytest.mark.skip_refcount_check
+# @pytest.mark.skip_pyproxy_check
+# def test_unwind(selenium_standalone):
+#     selenium = selenium_standalone
+
+#     selenium.run_js(
+#         """
+#         throw_unwind = () => {
+#             throw "unwind";
+#         }
+
+#         pyodide.runPython(`
+#             from _pyodide_core import raw_call
+#             from js import throw_unwind
+
+#             def unwind_call():
+#                 raw_call(throw_unwind)
+
+#             unwind_call()
+#         `)
+
+#         pyodide.runPython(`
+#             import sys
+#             frame = sys._getframe()
+#             func_names = []
+#             while frame:
+#                 func_names.append(frame.f_code.co_name)
+#                 frame = frame.f_back
+
+#             assert "unwind_call" in func_names
+#         `)
+#         """
+#     )
+
+#     assert "No thread state saved" in selenium.logs


### PR DESCRIPTION
### Description

Resolve: #3697 

This is a WIP PR trying to resolve #3697 by saving and restoring thread state. This is not ready to be reviewed. I am opening this to share my approach.

The basic idea is:

1. Save old thread state, replace it with newer one.

```cpp
void
save_current_thread_state()
{
  PyThreadState* tstate = PyThreadState_Get();
  PyInterpreterState* interp = PyThreadState_GetInterpreter(tstate);

  PyThreadState* new_tstate = PyThreadState_New(interp);

  PyThreadState_Swap(new_tstate);
  saved_state = tstate;
}
```

2. Restore the old thread state.

```cpp
void
restore_thread_state()
{
  PyThreadState* tstate = PyThreadState_Get();
  PyThreadState_Swap(saved_state);
  PyThreadState_Clear(tstate);
  PyThreadState_Delete(tstate);

  saved_state = NULL;
}
```

__Sving and restoring thread state (pseudocode):__

```js
// 1. Users need to save thread state explicitly
saveThreadState();

// 2. Run code that loops forever
loopsForever();

// 3. While there is a running loop, call stack is corrupted
pyodide.runPython("...") // WARNING: there is a running loop ...

// 4. Cancel the running loop and restore thread state
if (stopEvent) {
  cancelLoop()
  restoreThreadState();
}

// 5. Call stack is cleared, so it is okay to run other Python codes.
pyodide.runPython("...") // OK
```



### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
