### PR TITLE
Make PyProxy of async iterator JavaScript async iterables

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -123,6 +123,21 @@ myst:
 
 ### Python / JavaScript Foreign Function Interface
 
+- {{ Fix }} PyProxies of Async iterators are now async iterable JavaScript
+  objects. The code:
+
+  ```javascript
+  for await (let x of async_iterator_pyproxy) {
+    // ...
+  }
+  ```
+
+  would previously fail with `TypeError: async_iterator_pyproxy is not async
+iterable`. (Python async _iterables_ that were not also iterators were already
+  async iterable, the problem was only with Python objects that are both async
+  _iterable_ and an async iterator.)
+  {pr}`3708`
+
 - {{ Breaking }} Removed support for calling functions from the root of `pyodide` package
   directly. This has been deprecated since v0.21.0. Now all functions are only available
   under submodules.

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1265,6 +1265,10 @@ export class PyAsyncIterator extends PyProxy {
 export interface PyAsyncIterator extends PyAsyncIteratorMethods {}
 
 export class PyAsyncIteratorMethods {
+  /** @private */
+  [Symbol.asyncIterator]() {
+    return this;
+  }
   /**
    * This translates to the Python code ``anext(obj)``. Returns the next value
    * of the asynchronous iterator. The argument will be sent to the Python

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -1063,13 +1063,48 @@ def test_pyproxy_this2(selenium):
 
 
 @run_in_pyodide
-async def test_async_iter(selenium):
+async def test_async_iter1(selenium):
     from pyodide.code import run_js
 
     class Gen:
         async def __aiter__(self):
             yield 1
             yield 2
+
+    g = Gen()
+
+    p = run_js(
+        """
+        async (g) => {
+            assert(() => g instanceof pyodide.ffi.PyAsyncIterable);
+            let r = [];
+            for await (let a of g) {
+                r.push(a);
+            }
+            return r;
+        }
+    """
+    )(g)
+
+    assert (await p).to_py() == [1, 2]
+
+
+@run_in_pyodide
+async def test_async_iter2(selenium):
+    from pyodide.code import run_js
+
+    class Gen:
+        def __init__(self):
+            self.i = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            self.i += 1
+            if self.i > 2:
+                raise StopAsyncIteration
+            return self.i
 
     g = Gen()
 
@@ -1256,7 +1291,7 @@ def test_gen_throw(selenium):
 
 
 @run_in_pyodide
-async def test_async_gen(selenium):
+async def test_async_gen1(selenium):
     from pyodide.code import run_js
 
     async def g():
@@ -1287,6 +1322,28 @@ async def test_async_gen(selenium):
         {"done": False, "value": 6},
         {"done": True, "value": None},
     ]
+
+
+@run_in_pyodide
+async def test_async_gen2(selenium):
+    from pyodide.code import run_js
+
+    async def g():
+        for n in range(3):
+            yield n
+
+    p = run_js(
+        """
+        async (g) => {
+            let result = [];
+            for await (let x of g){
+                result.push(x);
+            }
+            return result;
+        }
+    """
+    )(g())
+    assert (await p).to_py() == [0, 1, 2]
 
 
 @run_in_pyodide


### PR DESCRIPTION
This was a pretty simple omission. I added test coverage. Resolves #3678


- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
