### PR TITLE
export python_stdlib.zip in package.json

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -13,6 +13,13 @@ myst:
 
 # Change Log
 
+## Unreleased
+
+### Deployment
+
+- {{ Fix }} Export `python_stdlib.zip` in `package.json`.
+  {pr}`3723`
+
 ## Version 0.23.0
 
 _March 30, 2023_

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -47,6 +47,7 @@
     },
     "./pyodide.asm.wasm": "./pyodide.asm.wasm",
     "./pyodide.asm.js": "./pyodide.asm.js",
+    "./python_stdlib.zip": "./python_stdlib.zip",
     "./pyodide.mjs": "./pyodide.mjs",
     "./pyodide.js": "./pyodide.js",
     "./package.json": "./package.json",


### PR DESCRIPTION
Tools like webpack can't resolve files that are not exported, so we need to export `python_stdlib.zip` along with the other binary files.

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

It looks like v0.23.0 changed which binary files are needed (removed `pyodide_py.tar` and `pyodide.asm.data` and added `python_stdlib.zip`). The old files were removed from the exports but the new file was not added to the exports.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry

