### PR TITLE
Remove pyparsing dependency in packaging

### DIFF
--- a/packages/packaging/meta.yaml
+++ b/packages/packaging/meta.yaml
@@ -7,9 +7,6 @@ source:
   sha256: b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
   url: https://files.pythonhosted.org/packages/47/d5/aca8ff6f49aa5565df1c826e7bf5e85a6df852ee063600c1efa5b932968c/packaging-23.0.tar.gz
 
-requirements:
-  run:
-    - pyparsing
 about:
   home: https://github.com/pypa/packaging
   PyPI: https://pypi.org/project/packaging


### PR DESCRIPTION
We forgot to remove it when updating `packaging`.