### PR TITLE
Code size reduction via AST rewrite

### DIFF
--- a/pyodide-build/pyodide_build/_minify.py
+++ b/pyodide-build/pyodide_build/_minify.py
@@ -1,0 +1,83 @@
+import ast
+import shutil
+import zipfile
+from pathlib import Path
+from time import perf_counter
+
+import typer
+
+app = typer.Typer()
+
+
+class StripDocstringsTransformer(ast.NodeTransformer):
+    """Strip docstring in an AST tree."""
+
+    def visit_FunctionDef(self, node):
+        """Remove the docstring from the function definition"""
+        if ast.get_docstring(node, clean=False) is not None:
+            node.body[0].value = ast.Constant(value=None, kind=None)
+        # Continue processing the function's body
+        self.generic_visit(node)
+        return node
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+    visit_ClassDef = visit_FunctionDef
+
+
+def _strip_module_docstring(tree: ast.Module) -> ast.Module:
+    """Remove docstring from module.
+
+    If the first statement is an expression with a string value, remove it.
+    """
+    if (
+        tree.body
+        and isinstance(expr := tree.body[0], ast.Expr)
+        and isinstance(expr.value, ast.Str | ast.Constant)
+        and isinstance(expr.value.value, str)
+    ):
+        tree.body.pop(0)
+    return tree
+
+
+@app.command()  # type: ignore[misc]
+def main(
+    input_dir: Path = typer.Argument(..., help="Path to the folder to compress"),
+    strip_docstrings: bool = typer.Option(False, help="Strip docstrings"),
+) -> None:
+    """Minify a folder of Python files."""
+    output_dirname = input_dir.name + "_stripped"
+    if strip_docstrings:
+        output_dirname += "_no_docstrings"
+    output_dir = input_dir.parent / output_dirname
+    shutil.rmtree(output_dir, ignore_errors=True)
+    shutil.copytree(input_dir, output_dir)
+    t0 = perf_counter()
+    n_processed = 0
+    for file in output_dir.glob("**/*.py"):
+        if not file.is_file():
+            continue
+
+        code = file.read_text()
+
+        tree = ast.parse(code)
+        if strip_docstrings:
+            tree = _strip_module_docstring(tree)
+            tree = StripDocstringsTransformer().visit(tree)
+
+        uncommented_code = ast.unparse(tree)
+        file.write_text(uncommented_code)
+        n_processed += 1
+
+    print(f"Processed {n_processed} files in {perf_counter() - t0:.2f} seconds")
+
+    zip_path = output_dir.parent / (output_dir.name + ".zip")
+    with zipfile.ZipFile(zip_path, "w", compression=0) as fh:
+        for file in output_dir.glob("**/*"):
+            if not file.is_file():
+                continue
+            fh.write(file, file.relative_to(output_dir))
+    print(f"Created zip file at {zip_path}")
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
This aims to apply light and reliable code size reduction via AST rewrite of the package source code.

### Proposal

Several code size reductions could be done by processing AST:

1. If we read code AST and write it back unmodified, it will,
    - strip comments
    - group imports
    - normalize whitespace, normalize single/double quotes, and sometimes re-organise parenthesis

while keeping the same code behavior.   [Here](https://github.com/rth/cpython/compare/3.11.2-reference...3.11.2-rewritten) is an example of the diff when it's applied to the standard library.


This does reduce the code size by around 20% for the brotli compressed stlib (see benchmarks below), and aside from tracebacks not having the original line number I feel it has very few downsides.
Processing the stdlib takes ~2s on extracted files (in a tmpfs folder) so it's fairly fast.

I would propose doing this by default.

2. Additionally strip function and module docstring

This yields additional gains: with the previous step around 43% size reduction on the stdlib, but well some users do need docstrings. So we can't do this by default, however, it could be useful for some custom deployments.

These can also help a bit when applied before py-compiling. Related discussion iin [discuss.python.org](https://discuss.python.org/t/reduce-size-and-improve-compression-of-pyc-files/25352/2)

At some point in the past, we did try https://pypi.org/project/python-minifier/ but it was rather slow and not very usable to run for each commit + I'm not convinced that it's a good thing to rename variables in Python code. 

### Benchmarks

#### Standard Library

| Compression Type | Original   | Stripped (1) | Stripped + No Docstrings (1+2) |
|------------------|------------|----------|--------------------------|
| No Compression   | 8.5M       | 6.2M  (-27%)    | 4.8M     (-43%)                 |
| Gzip             | 2.0M       | 1.5M (-25%)     | 1.0M   (-50%)                   |
| Brotli           | 1.4M       | 1.1M (-21%)     | 766K   ( -45%)                 |

#### packaging 

An example of another pure Python package,

| Compression Type | Original   | Stripped (1) | Stripped + No Docstrings (1+2) |
|------------------|------------|----------|--------------------------|
| No Compression   | 138K       | 112K (-18%)    | 89K   (-35%)                   |
| Gzip             | 36K        | 29K (-19%)      | 23K  (-36%)                    |
| Brotli           | 30K        | 25K  (-16%)     | 20K    (-33%)                  |

#### pandas

An example of a scientific Python package with lots of compiled code,

| Compression Type | Original | Stripped | Stripped + No Docstrings |
|------------------|----------|----------|--------------------------|
| No Compression   | 21M      | 20M (-5%)     | 18M    (-14%)                  |
| Gzip             | 4.9M      | 4.6M (-6%)     | 4.2M  (-14%)                    |
| Brotli           | 2.8M      | 2.6M (-7%)     | 2.3M  (-17%)                   |


### Implementation

Currently, the implementation is not ready for review (it's just a script processing a folder with .py files currently). Overall I feel it would be easier if this was a post-processing script similar to `py-compile`, maybe `pyodide minimize`
 - then the question is we expect users to apply it. Having both `py-compile` and `minimize` to rewrite the same zip / wheels multiple times feels a bit unfortunate, so maybe they should be merged.
 - what package the code should belong in.  Right now it's pretty simple, but I guess it could evolve into more complex rules, and/or more stripping of binaries. This is kind of the direction I wanted to work on in `pyodide-pack` or in any case it would be easier to do this post-processing work in some standalone pure Python package, independently from the main build logic which is already fairly complex (and has a ~3 month release cycle). 

If you have any thoughts on this please let me know.

TODO: 
 - [ ] decide on the CLI API we want and in which package
 - [ ] agree what transformation should be done by default if any
 - [ ] make sure all package tests still pass after this change