### PR TITLE
Make SET_FLAG_IF more paranoid

### DIFF
--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -85,6 +85,12 @@ console_error_obj(JsRef obj);
 #define LOG_EM_JS_ERROR(__funcname__, err)
 #endif
 
+#ifdef DEBUG_F
+#define IF_DEBUG(arg) arg
+#else
+#define IF_DEBUG(arg)
+#endif
+
 // Need an extra layer to expand LOG_EM_JS_ERROR.
 #define EM_JS_DEFER(ret, func_name, args, body...)                             \
   EM_JS(ret, func_name, args, body)

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3987,6 +3987,7 @@ finally:
       type_flags |= flag;                                                      \
     }                                                                          \
   } catch (e) {                                                                \
+    IF_DEBUG(console.warn(`Error raised in SET_FLAG_IF(#flag, #cond)`));       \
   }
 
 EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3982,8 +3982,11 @@ finally:
 }
 
 #define SET_FLAG_IF(flag, cond)                                                \
-  if (cond) {                                                                  \
-    type_flags |= flag;                                                        \
+  try {                                                                        \
+    if (cond) {                                                                \
+      type_flags |= flag;                                                      \
+    }                                                                          \
+  } catch (e) {                                                                \
   }
 
 EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -769,6 +769,7 @@ def test_errors(selenium):
                 __contains__ = te
                 __await__ = te
                 __repr__ = te
+            to_js(Temp())
             Temp()
         `);
         assertThrows(() => t.x, "PythonError", "");

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -753,6 +753,7 @@ def test_errors(selenium):
     selenium.run_js(
         r"""
         let t = pyodide.runPython(`
+            from pyodide.ffi import to_js
             def te(self, *args, **kwargs):
                 raise Exception(repr(args))
             class Temp:

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -411,6 +411,21 @@ def test_hyp_tojs_no_crash(selenium, obj):
         del __main__.x
 
 
+@pytest.mark.skip_refcount_check
+@pytest.mark.skip_pyproxy_check
+@given(obj=any_strategy)
+@example(obj=range(0, 2147483648))  # length is too big to fit in ssize_t
+@settings(
+    std_hypothesis_settings,
+    max_examples=25,
+)
+@run_in_pyodide
+def test_hypothesis(selenium_standalone, obj):
+    from pyodide.ffi import to_js
+
+    to_js(obj)
+
+
 @pytest.mark.parametrize(
     "py,js",
     [


### PR DESCRIPTION
This fixes a regression introduced in #3283. To be properly paranoid we should assume that each property access can raise an error.

The bug also depends on this branch here:
https://github.com/pyodide/pyodide/blob/main/src/core/python2js.c#L833-L834
which is a bit suspect...
