### PR TITLE
Fix set_build_environment so that it works even if HOME is unset

### DIFF
--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -29,6 +29,7 @@ from .recipe import load_all_recipes
 BUILD_VARS: set[str] = {
     "PATH",
     "PYTHONPATH",
+    "PYODIDE_JOBS",
     "PYODIDE_ROOT",
     "PYTHONINCLUDE",
     "NUMPY_LIB",
@@ -395,14 +396,15 @@ def set_build_environment(env: dict[str, str]) -> None:
 
     Sets common environment between in tree and out of tree package builds.
     """
-    env.update({key: os.environ[key] for key in BUILD_VARS})
+    env.update({key: os.environ[key] for key in BUILD_VARS if key in os.environ})
     env["PYODIDE"] = "1"
-    if "PYODIDE_JOBS" in os.environ:
-        env["PYODIDE_JOBS"] = os.environ["PYODIDE_JOBS"]
 
-    env["PKG_CONFIG_PATH"] = env["WASM_PKG_CONFIG_PATH"]
+    pkg_config_parts = []
+    if "WASM_PKG_CONFIG_PATH" in os.environ:
+        pkg_config_parts.append(env["WASM_PKG_CONFIG_PATH"])
     if "PKG_CONFIG_PATH" in os.environ:
-        env["PKG_CONFIG_PATH"] += f":{os.environ['PKG_CONFIG_PATH']}"
+        pkg_config_parts.append(os.environ["PKG_CONFIG_PATH"])
+    env["PKG_CONFIG_PATH"] = ":".join(pkg_config_parts)
 
     tools_dir = Path(__file__).parent / "tools"
 

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -253,6 +253,7 @@ def test_set_build_environment(monkeypatch):
     import os
 
     monkeypatch.delenv("PKG_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("WASM_PKG_CONFIG_PATH", raising=False)
     monkeypatch.setenv("RANDOM_ENV", 1234)
     e: dict[str, str] = {}
     set_build_environment(e)

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -252,6 +252,7 @@ def test_repack_zip_archive(
 def test_set_build_environment(monkeypatch):
     import os
 
+    monkeypatch.delenv("PKG_CONFIG_PATH", raising=False)
     monkeypatch.setenv("RANDOM_ENV", 1234)
     e: dict[str, str] = {}
     set_build_environment(e)

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -14,6 +14,7 @@ from pyodide_build.common import (
     platform,
     repack_zip_archive,
     search_pyodide_root,
+    set_build_environment,
 )
 
 
@@ -246,3 +247,29 @@ def test_repack_zip_archive(
         assert fh.namelist() == ["a/b.txt", "a/b/c.txt"]
         assert fh.getinfo("a/b.txt").compress_type == expected_compression_type
     assert input_path.stat().st_size == expected_size
+
+
+def test_set_build_environment(monkeypatch):
+    import os
+
+    monkeypatch.setenv("RANDOM_ENV", 1234)
+    e: dict[str, str] = {}
+    set_build_environment(e)
+    assert e.get("HOME") == os.environ.get("HOME")
+    assert e.get("PATH") == os.environ.get("PATH")
+    assert e["PYODIDE"] == "1"
+    assert "RANDOM_ENV" not in e
+    assert e["PKG_CONFIG_PATH"] == ""
+
+    e = {}
+    monkeypatch.setenv("PKG_CONFIG_PATH", "/x/y/z:/c/d/e")
+    set_build_environment(e)
+    assert e["PKG_CONFIG_PATH"] == "/x/y/z:/c/d/e"
+
+    monkeypatch.delenv("HOME")
+    monkeypatch.setenv("WASM_PKG_CONFIG_PATH", "/a/b/c")
+    monkeypatch.setenv("PKG_CONFIG_PATH", "/x/y/z:/c/d/e")
+    e = {}
+    set_build_environment(e)
+    assert "HOME" not in e
+    assert e["PKG_CONFIG_PATH"] == "/a/b/c:/x/y/z:/c/d/e"


### PR DESCRIPTION
I'm running into a crash in cibuildwheel where some of its CI environments don't set HOME. This fixes `set_build_environment` to be a bit more resistant against crashes due to missing environment variables.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
