### PR TITLE
Pass the source and build directory explicitly, don't use chdir

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -417,16 +417,17 @@ def compile(
     )
     backend_flags = build_metadata.backend_flags
 
-    with chdir(srcpath), build_env_ctx as build_env:
+    with build_env_ctx as build_env:
         if build_metadata.cross_script is not None:
             with BashRunnerWithSharedEnvironment(build_env) as runner:
-                runner.run(build_metadata.cross_script)
+                runner.run(build_metadata.cross_script, cwd=srcpath)
                 build_env = runner.env
 
         from .pypabuild import build
 
+        outpath = srcpath / "dist"
         try:
-            build(build_env, backend_flags)
+            build(srcpath, outpath, build_env, backend_flags)
         except BaseException:
             build_log_path = Path("build.log")
             if build_log_path.exists():

--- a/pyodide-build/pyodide_build/out_of_tree/build.py
+++ b/pyodide-build/pyodide_build/out_of_tree/build.py
@@ -5,9 +5,8 @@ from typing import Any
 from .. import common, pypabuild
 
 
-def run(exports: Any, args: list[str], outdir: Path | None = None) -> Path:
-    if outdir is None:
-        outdir = Path("./dist")
+def run(srcdir: Path, outdir: Path, exports: Any, args: list[str]) -> Path:
+    outdir = outdir.resolve()
     cflags = common.get_make_flag("SIDE_MODULE_CFLAGS")
     cflags += f" {os.environ.get('CFLAGS', '')}"
     cxxflags = common.get_make_flag("SIDE_MODULE_CXXFLAGS")
@@ -28,5 +27,5 @@ def run(exports: Any, args: list[str], outdir: Path | None = None) -> Path:
     )
 
     with build_env_ctx as env:
-        built_wheel = pypabuild.build(env, " ".join(args), outdir=str(outdir))
+        built_wheel = pypabuild.build(srcdir, outdir, env, " ".join(args))
     return Path(built_wheel)

--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -230,18 +230,18 @@ def get_build_env(
 
 
 def build(
-    build_env: Mapping[str, str], backend_flags: str, outdir: str | None = None
+    srcdir: Path,
+    outdir: Path,
+    build_env: Mapping[str, str],
+    backend_flags: str,
 ) -> str:
-    srcdir = Path.cwd()
-    if outdir is None:
-        outdir = str(srcdir / "dist")
     builder = _ProjectBuilder(str(srcdir))
     distribution = "wheel"
     config_settings = parse_backend_flags(backend_flags)
     try:
         with _handle_build_error():
             built = _build_in_isolated_env(
-                build_env, builder, outdir, distribution, config_settings
+                build_env, builder, str(outdir), distribution, config_settings
             )
             print("{bold}{green}Successfully built {}{reset}".format(built, **_STYLES))
             return built


### PR DESCRIPTION
This switches to passing the source and build directories as arguments. It adds an output-directory argument to pyodide build allowing us to indicate where the output wheel should go independent of the build directory. I also did some cleanup of the logic added in #3310

### Checklist

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
