### PR TITLE
More improvements to JsProxy_compute_typeflags

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -628,7 +628,7 @@ EM_JS_BOOL(bool, hiwire_is_generator, (JsRef idobj), {
 
 EM_JS_BOOL(bool, hiwire_is_async_generator, (JsRef idobj), {
   // clang-format off
-  return Object.prototype.toString.call(Hiwire.get_value(idobj)) === "[object AsyncGenerator]";
+  return getTypeTag(Hiwire.get_value(idobj)) === "[object AsyncGenerator]";
   // clang-format on
 });
 

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -4006,10 +4006,10 @@ EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {
   // we'll run into trouble. I think that for this to happen, someone would have
   // to pass in some weird and maliciously constructed object. Anyways for
   // maximum safety, we double check that only one of these is set.
-  SET_FLAG_IF(IS_CALLABLE, typeof obj === "function")
-  SET_FLAG_IF_HAS_METHOD(IS_AWAITABLE, "then")
-  SET_FLAG_IF_HAS_METHOD(IS_ITERABLE, Symbol.iterator)
-  SET_FLAG_IF_HAS_METHOD(IS_ASYNC_ITERABLE, Symbol.asyncIterator)
+  SET_FLAG_IF(IS_CALLABLE, typeof obj === "function");
+  SET_FLAG_IF_HAS_METHOD(IS_AWAITABLE, "then");
+  SET_FLAG_IF_HAS_METHOD(IS_ITERABLE, Symbol.iterator);
+  SET_FLAG_IF_HAS_METHOD(IS_ASYNC_ITERABLE, Symbol.asyncIterator);
   SET_FLAG_IF(IS_ITERATOR, hasMethod(obj, "next") && (hasMethod(obj, Symbol.iterator) || !hasMethod(obj, Symbol.asyncIterator)));
   SET_FLAG_IF(IS_ASYNC_ITERATOR, hasMethod(obj, "next") && (!hasMethod(obj, Symbol.iterator) || hasMethod(obj, Symbol.asyncIterator)));
   SET_FLAG_IF(HAS_LENGTH,

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3998,7 +3998,6 @@ EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {
     return 0;
   }
 
-  const constructorName = obj.constructor ? obj.constructor.name : "";
   let typeTag = getTypeTag(obj);
 
 
@@ -4020,14 +4019,14 @@ EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {
   SET_FLAG_IF_HAS_METHOD(HAS_HAS, "has");
   SET_FLAG_IF_HAS_METHOD(HAS_INCLUDES, "includes");
   SET_FLAG_IF(IS_BUFFER,
-              (ArrayBuffer.isView(obj) || (constructorName === "ArrayBuffer")) && !(type_flags & IS_CALLABLE));
+              (ArrayBuffer.isView(obj) || (typeTag === '[object ArrayBuffer]')) && !(type_flags & IS_CALLABLE));
   SET_FLAG_IF(IS_DOUBLE_PROXY, API.isPyProxy(obj));
   SET_FLAG_IF(IS_ARRAY, Array.isArray(obj));
   SET_FLAG_IF(IS_NODE_LIST,
               typeTag === "[object HTMLCollection]" ||
               typeTag === "[object NodeList]");
   SET_FLAG_IF(IS_TYPEDARRAY,
-              ArrayBuffer.isView(obj) && constructorName !== "DataView");
+              ArrayBuffer.isView(obj) && typeTag !== '[object DataView]');
   SET_FLAG_IF(IS_GENERATOR, typeTag === "[object Generator]");
   SET_FLAG_IF(IS_ASYNC_GENERATOR, typeTag === "[object AsyncGenerator]");
   SET_FLAG_IF(IS_ERROR, (hasProperty(obj, "name") && hasProperty(obj, "message") && hasProperty(obj, "stack")) && !(type_flags & (IS_CALLABLE | IS_BUFFER)));

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3988,7 +3988,7 @@ finally:
 
 // hasMethod won't ever raise an error (it's surrounded in try+catch)
 #define SET_FLAG_IF_HAS_METHOD(flag, meth)                                     \
-  SET_FLAG_IF_HAS_METHOD(flag, hasMethod(obj, meth))
+  SET_FLAG_IF(flag, hasMethod(obj, meth))
 
 EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {
   let obj = Hiwire.get_value(idobj);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3982,13 +3982,13 @@ finally:
 }
 
 #define SET_FLAG_IF(flag, cond)                                                \
-  try {                                                                        \
-    if (cond) {                                                                \
-      type_flags |= flag;                                                      \
-    }                                                                          \
-  } catch (e) {                                                                \
-    IF_DEBUG(console.warn(`Error raised in SET_FLAG_IF(#flag, #cond)`));       \
+  if (cond) {                                                                  \
+    type_flags |= flag;                                                        \
   }
+
+// hasMethod won't ever raise an error (it's surrounded in try+catch)
+#define SET_FLAG_IF_HAS_METHOD(flag, meth)                                     \
+  SET_FLAG_IF_HAS_METHOD(flag, hasMethod(obj, meth))
 
 EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {
   let obj = Hiwire.get_value(idobj);
@@ -4001,23 +4001,24 @@ EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {
   const constructorName = obj.constructor ? obj.constructor.name : "";
   let typeTag = getTypeTag(obj);
 
+
   // If we somehow set more than one of IS_CALLABLE, IS_BUFFER, and IS_ERROR,
   // we'll run into trouble. I think that for this to happen, someone would have
   // to pass in some weird and maliciously constructed object. Anyways for
   // maximum safety, we double check that only one of these is set.
   SET_FLAG_IF(IS_CALLABLE, typeof obj === "function")
-  SET_FLAG_IF(IS_AWAITABLE, typeof obj.then === 'function')
-  SET_FLAG_IF(IS_ITERABLE, typeof obj[Symbol.iterator] === 'function')
-  SET_FLAG_IF(IS_ASYNC_ITERABLE, typeof obj[Symbol.asyncIterator] === 'function')
-  SET_FLAG_IF(IS_ITERATOR, typeof obj.next === 'function' && (typeof obj[Symbol.iterator] === 'function' || typeof obj[Symbol.asyncIterator] !== 'function') );
-  SET_FLAG_IF(IS_ASYNC_ITERATOR, typeof obj.next === 'function' && (typeof obj[Symbol.iterator] !== 'function' || typeof obj[Symbol.asyncIterator] === 'function') );
+  SET_FLAG_IF_HAS_METHOD(IS_AWAITABLE, "then")
+  SET_FLAG_IF_HAS_METHOD(IS_ITERABLE, Symbol.iterator)
+  SET_FLAG_IF_HAS_METHOD(IS_ASYNC_ITERABLE, Symbol.asyncIterator)
+  SET_FLAG_IF(IS_ITERATOR, hasMethod(obj, "next") && (hasMethod(obj, Symbol.iterator) || !hasMethod(obj, Symbol.asyncIterator)));
+  SET_FLAG_IF(IS_ASYNC_ITERATOR, hasMethod(obj, "next") && (!hasMethod(obj, Symbol.iterator) || hasMethod(obj, Symbol.asyncIterator)));
   SET_FLAG_IF(HAS_LENGTH,
-    (typeof obj.size === "number") ||
-    (typeof obj.length === "number" && typeof obj !== "function"));
-  SET_FLAG_IF(HAS_GET, typeof obj.get === "function");
-  SET_FLAG_IF(HAS_SET, typeof obj.set === "function");
-  SET_FLAG_IF(HAS_HAS, typeof obj.has === "function");
-  SET_FLAG_IF(HAS_INCLUDES, typeof obj.includes === "function");
+    (hasProperty(obj, "size")) ||
+    (hasProperty(obj, "length") && typeof obj !== "function"));
+  SET_FLAG_IF_HAS_METHOD(HAS_GET, "get");
+  SET_FLAG_IF_HAS_METHOD(HAS_SET, "set");
+  SET_FLAG_IF_HAS_METHOD(HAS_HAS, "has");
+  SET_FLAG_IF_HAS_METHOD(HAS_INCLUDES, "includes");
   SET_FLAG_IF(IS_BUFFER,
               (ArrayBuffer.isView(obj) || (constructorName === "ArrayBuffer")) && !(type_flags & IS_CALLABLE));
   SET_FLAG_IF(IS_DOUBLE_PROXY, API.isPyProxy(obj));
@@ -4026,10 +4027,10 @@ EM_JS_NUM(int, JsProxy_compute_typeflags, (JsRef idobj), {
               typeTag === "[object HTMLCollection]" ||
               typeTag === "[object NodeList]");
   SET_FLAG_IF(IS_TYPEDARRAY,
-              ArrayBuffer.isView(obj) && obj.constructor.name !== "DataView");
+              ArrayBuffer.isView(obj) && constructorName !== "DataView");
   SET_FLAG_IF(IS_GENERATOR, typeTag === "[object Generator]");
   SET_FLAG_IF(IS_ASYNC_GENERATOR, typeTag === "[object AsyncGenerator]");
-  SET_FLAG_IF(IS_ERROR, (typeof obj.stack === "string" && typeof obj.message === "string") && !(type_flags & (IS_CALLABLE | IS_BUFFER)));
+  SET_FLAG_IF(IS_ERROR, (hasProperty(obj, "name") && hasProperty(obj, "message") && hasProperty(obj, "stack")) && !(type_flags & (IS_CALLABLE | IS_BUFFER)));
   // clang-format on
   return type_flags;
 });

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -4,7 +4,13 @@ const Tests = {};
 API.tests = Tests;
 API.version = "0.24.0.dev0";
 Module.hiwire = Hiwire;
-const getTypeTag = (x) => Object.prototype.toString.call(x);
+function getTypeTag(x) {
+  try {
+    return Object.prototype.toString.call(x);
+  } catch (e) {
+    return "";
+  }
+}
 API.getTypeTag = getTypeTag;
 
 /**

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -23,12 +23,14 @@ API.getTypeTag = getTypeTag;
  * prop: a string or symbol
  */
 function hasProperty(obj, prop) {
-  while (obj) {
-    if (Object.getOwnPropertyDescriptor(obj, prop)) {
-      return true;
+  try {
+    while (obj) {
+      if (Object.getOwnPropertyDescriptor(obj, prop)) {
+        return true;
+      }
+      obj = Object.getPrototypeOf(obj);
     }
-    obj = Object.getPrototypeOf(obj);
-  }
+  } catch (e) {}
   return false;
 }
 

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -6,3 +6,39 @@ API.version = "0.24.0.dev0";
 Module.hiwire = Hiwire;
 const getTypeTag = (x) => Object.prototype.toString.call(x);
 API.getTypeTag = getTypeTag;
+
+/**
+ * Safe property check
+ *
+ * Observe whether a property exists or not without invoking getters.
+ * Should never throw as long as arguments have the correct types.
+ *
+ * obj: an object
+ * prop: a string or symbol
+ */
+function hasProperty(obj, prop) {
+  while (obj) {
+    if (Object.getOwnPropertyDescriptor(obj, prop)) {
+      return true;
+    }
+    obj = Object.getPrototypeOf(obj);
+  }
+  return false;
+}
+
+/**
+ * Observe whether a method exists or not
+ *
+ * Invokes getters but catches any error produced by a getter and throws it away.
+ * Never throws an error
+ *
+ * obj: an object
+ * prop: a string or symbol
+ */
+function hasMethod(obj, prop) {
+  try {
+    return typeof obj[prop] === "function";
+  } catch (e) {
+    return false;
+  }
+}

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -63,7 +63,11 @@ declare function Py_EXIT(): void;
 // end-pyodide-skip
 
 function isPyProxy(jsobj: any): jsobj is PyProxy {
-  return jsobj instanceof PyProxy;
+  try {
+    return jsobj instanceof PyProxy;
+  } catch (e) {
+    return false;
+  }
 }
 API.isPyProxy = isPyProxy;
 

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -2286,26 +2286,13 @@ def test_python_reserved_keywords(selenium):
 
 
 @run_in_pyodide
-def test_malicious_getters(selenium):
-    """Test that we survive being passed a wide variety of horrific objects"""
+def test_revoked_proxy(selenium):
+    """I think this is just about the worst thing that it is possible to
+    make.
+
+    A good stress test for our systems...
+    """
     from pyodide.code import run_js
 
-    getters = [
-        "[Symbol.toStringTag]",
-        "constructor",
-        "then",
-        "[Symbol.iterator]",
-        "[Symbol.asyncIterator]",
-        "next",
-        "size",
-        "length",
-        "get",
-        "set",
-        "has",
-        "includes",
-        "name",
-        "message",
-        "stack",
-    ]
-    for name in getters:
-        run_js("""({get %s() {throw new Error("oops")}})""" % name)
+    x = run_js("(p = Proxy.revocable({}, {})); p.revoke(); p.proxy")
+    run_js("((x) => x)")(x)

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -2283,3 +2283,29 @@ def test_python_reserved_keywords(selenium):
         setattr(o, "async", 2)
     with pytest.raises(AttributeError, match="reserved.*delete.*'async_'"):
         delattr(o, "async")
+
+
+@run_in_pyodide
+def test_malicious_getters(selenium):
+    """Test that we survive being passed a wide variety of horrific objects"""
+    from pyodide.code import run_js
+
+    getters = [
+        "[Symbol.toStringTag]",
+        "constructor",
+        "then",
+        "[Symbol.iterator]",
+        "[Symbol.asyncIterator]",
+        "next",
+        "size",
+        "length",
+        "get",
+        "set",
+        "has",
+        "includes",
+        "name",
+        "message",
+        "stack",
+    ]
+    for name in getters:
+        run_js("""({get %s() {throw new Error("oops")}})""" % name)


### PR DESCRIPTION
This is a followup to #3740 which rearranges the logic a bit more on further consideration.

I found out that if you create a revocable Proxy and then revoke it, a huge number of browser
internal operations raise TypeErrors. Such an object is thus an excellent stress test for our
handling of explosive objects. Overall we do quite well, `isPyProxy` and `compute_type_flags`
are actually the only spots where we run into trouble (and `PyProxy_Check` is the only spot
that is raising a fatal error).

This changes it so that an object with a `length` getter that throws an error or returns
not an integer will have a `__len__` in Python that always throws an error. It can't check
the type anymore because it avoids invoking getters so if the result is a return value from
a getter it won't know the type. The same is true for the `Error.name`, `Error.message`, and
`Error.stack` fields.

To check for methods, I still use `typeof x[method] === "function"`, invoking the getter.
Usually functions don't have getters anyways and I think it is weirder to have false positives
in this case. If there is a getter and it raises an error, we catch it and throw it away.

### Checklist

- [x] Add / update tests
