### PR TITLE
Make sure PYODIDE_ROOT points to absolute path in out-of-tree build

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -26,6 +26,11 @@ myst:
   a single file.
   {pr}`3727`
 
+### Build System
+
+- {{ Fix }} Fix `PYODIDE_ROOT` to point the correct directory when running out-of-tree build.
+  {pr}`3751`
+
 ### Packages
 
 - New packages: sourmash {pr}`3635`, screed {pr}`3635`, bitstring {pr}`3635`,

--- a/pyodide-build/pyodide_build/__init__.py
+++ b/pyodide-build/pyodide_build/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.23.0"  # For test, revert before merge
+__version__ = "0.24.0.dev0"

--- a/pyodide-build/pyodide_build/__init__.py
+++ b/pyodide-build/pyodide_build/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.24.0.dev0"
+__version__ = "0.23.0"  # For test, revert before merge

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -223,6 +223,11 @@ def get_make_environment_vars() -> dict[str, str]:
         capture_output=True,
         text=True,
     )
+
+    if result.returncode != 0:
+        logger.error("ERROR: Failed to load environment variables from Makefile.envs")
+        exit_with_stdio(result)
+
     for line in result.stdout.splitlines():
         equalPos = line.find("=")
         if equalPos != -1:

--- a/pyodide-build/pyodide_build/out_of_tree/utils.py
+++ b/pyodide-build/pyodide_build/out_of_tree/utils.py
@@ -34,6 +34,6 @@ def initialize_pyodide_root(*, quiet: bool = False) -> None:
         return
     except FileNotFoundError:
         pass
-    env = Path(".pyodide-xbuildenv")
+    env = Path(".pyodide-xbuildenv").resolve()
     os.environ["PYODIDE_ROOT"] = str(env / "xbuildenv/pyodide-root")
     ensure_env_installed(env, quiet=quiet)


### PR DESCRIPTION
### Description

Resolve: #3722

This is a minimal fix for #3722 to include in 0.23.1

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
