### PR TITLE
Update libmpfr version and use ftp.gnu.org

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -39,6 +39,7 @@ myst:
 
 - New packages: sourmash {pr}`3635`, screed {pr}`3635`, bitstring {pr}`3635`,
   deprecation {pr}`3635`, cachetools {pr}`3635`.
+- Upgraded libmpfr to 4.2.0 {pr}`3756`.
 
 ## Version 0.23.0
 

--- a/packages/libmpfr/meta.yaml
+++ b/packages/libmpfr/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: 4.1.0
 
 source:
-  url: https://mirror.ihost.md/gnu/mpfr/mpfr-4.1.0.tar.xz
-  sha256: 0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
+  url: https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.0.tar.xz
+  sha256: 06a378df13501248c1b2db5aa977a2c8126ae849a9d9b7be2546fb4a9c26d993
 
 requirements:
   host:


### PR DESCRIPTION
### Description

Upgraded libmpfr to its latest version 4.2.0 released January 2023.

The https://www.mpfr.org/ has fixed its HTTPS certificate issue, but it does list the FTP GNU server for its releases. IMO this is a bit easier to see all the releases at once in https://ftp.gnu.org/gnu/mpfr/ compared to https://www.mpfr.org and I would expect the GNU FTP to be more reliable.

Related to #3749

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
