### PR TITLE
Create tools/docker_image_tag.py

### DIFF
--- a/tools/docker_image_tag.py
+++ b/tools/docker_image_tag.py
@@ -13,12 +13,12 @@ import requests
 
 def latest_version_of_chrome() -> str:
     URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"
-    return requests.get(URL).text.split('.')[0]
+    return requests.get(URL).text.split(".")[0]
 
 
 def latest_version_of_firefox() -> str:
     URL = "https://www.mozilla.org/en-US/firefox/releasenotes"
-    return requests.get(URL, allow_redirects=True).url.split('/')[-3].split('.')[0]
+    return requests.get(URL, allow_redirects=True).url.split("/")[-3].split(".")[0]
 
 
 def docker_image_tag() -> str:
@@ -31,7 +31,7 @@ def docker_image_tag() -> str:
     return f"{date.today():%Y%m%d}-{chrome}-{firefox}-{python}"
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(latest_version_of_chrome())
     print(latest_version_of_firefox())
     print(docker_image_tag())

--- a/tools/docker_image_tag.py
+++ b/tools/docker_image_tag.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Get the current versions of Chrome and Firefox to aid in tagging Docker images.
+
+Old Docker image tag: 20230411-chromelatest-firefoxlatest
+New Docker image tag: 20230411-chrome112-firefox112-py311
+"""
+from datetime import date
+from sys import version_info
+
+import requests
+
+
+def latest_version_of_chrome() -> str:
+    URL = "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"
+    return requests.get(URL).text.split('.')[0]
+
+
+def latest_version_of_firefox() -> str:
+    URL = "https://www.mozilla.org/en-US/firefox/releasenotes"
+    return requests.get(URL, allow_redirects=True).url.split('/')[-3].split('.')[0]
+
+
+def docker_image_tag() -> str:
+    """
+    Return 20230411-chrome112-firefox112-py311
+    """
+    chrome = f"chrome{latest_version_of_chrome()}"
+    firefox = f"firefox{latest_version_of_firefox()}"
+    python = "py{}{}".format(*version_info)
+    return f"{date.today():%Y%m%d}-{chrome}-{firefox}-{python}"
+
+
+if __name__ == '__main__':
+    print(latest_version_of_chrome())
+    print(latest_version_of_firefox())
+    print(docker_image_tag())


### PR DESCRIPTION
As discussed at https://github.com/pyodide/pyodide/pull/3741#discussion_r1163164001

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Simple utility to calculate a Docker image tag for https://hub.docker.com/r/pyodide/pyodide-env/tags
Format: `20230411-chrome112-firefox112-py311`
Could be used in `Dockerfile` or in `.github/workflows/docker_image.yml`

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
