### PR TITLE
Fix out of tree pip

### DIFF
--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -110,7 +110,7 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         """
         from pip._vendor.distlib import scripts
         def get_executable():
-            return sys.executable.remove_suffix("-host")
+            return sys.executable.removesuffix("-host")
 
         scripts.get_executable = get_executable
         """

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -105,10 +105,14 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         # when pip installs an executable it uses sys.executable to create the
         # shebang for the installed executable. The shebang for pip points to
         # python-host but we want the shebang of the executable that we install
-        # to point to Pyodide python. So remove the "-host" suffix from
-        # sys.executable.
+        # to point to Pyodide python. We monkeypatch distlib.scripts.get_executable
+        # to return the value with the host suffix removed.
         """
-        sys.executable = sys.executable.removesuffix("-host")
+        from pip._vendor.distlib import scripts
+        def get_executable():
+            return sys.executable.remove_suffix("-host")
+
+        scripts.get_executable = get_executable
         """
         f"""
         os_name, sys_platform, multiarch, host_platform = {platform_data}


### PR DESCRIPTION
#3752 broke pip's ability to build a pure Python wheel because it would run subprocesses in Pyodide python. This is a slightly more targeted approach to #3752 which just monkeypatches shebang generation. 

Most of the file we monkey patch hasn't changed in ~10 years so it's pretty stable.