### PR TITLE
Numpy patch release 1.24.3

### DIFF
--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: numpy
-  version: 1.24.2
+  version: 1.24.3
   tag:
     - min-scipy-stack
   top-level:
     - numpy
 source:
-  url: https://files.pythonhosted.org/packages/e4/a9/6704bb5e1d1d778d3a6ee1278a8d8134f0db160e09d52863a24edb58eab5/numpy-1.24.2.tar.gz
-  sha256: 003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22
+  url: https://files.pythonhosted.org/packages/2c/d4/590ae7df5044465cc9fa2db152ae12468694d62d952b1528ecff328ef7fc/numpy-1.24.3.tar.gz
+  sha256: ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155
 
 build:
   backend-flags: --disable-optimization


### PR DESCRIPTION
Let’s see if the patch release passes CI.
