### PR TITLE
Avoid compressing archives twice

### DIFF
--- a/packages/xarray/meta.yaml
+++ b/packages/xarray/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: xarray
-  version: 2023.3.0
+  version: 2023.4.1
 
   top-level:
     - xarray
 source:
-  url: https://files.pythonhosted.org/packages/76/eb/61bdb6379ee643b13f184580f80eb2114892fd82fee716b79ab837da98f0/xarray-2023.4.0-py3-none-any.whl
-  sha256: 23a404106c434215f370f642aae481339dfb91efc107533c8e9ca5f1ed8ed0f1
+  url: https://files.pythonhosted.org/packages/2d/66/b3cae67f287f6d51685abe961c9bea85e8ba0a4acbb7c2c516d0b3ce0848/xarray-2023.4.1-py3-none-any.whl
+  sha256: 1c5b8d21e8a2416789e5458efeb635a2a7cf660b6d24af84aaf817224b9cabca
 requirements:
   run:
     - numpy

--- a/tools/deploy_s3.py
+++ b/tools/deploy_s3.py
@@ -111,15 +111,23 @@ def deploy_to_s3_main(
             raise typer.Exit()
 
         with open(file_path, "rb") as fh_in:
-            # Use gzip compression for storage. This only impacts storage on
-            # AWS and transfer between S3 and the CDN. It has no impact on the
-            # compression received by the end user (since the CDN re-compresses
-            # files).
-            fh_compressed = io.BytesIO()
-            with gzip.GzipFile(fileobj=fh_compressed, mode="wb") as gzip_file:
-                shutil.copyfileobj(fh_in, gzip_file)
+            compressed = file_path.suffix in (".gz", ".bz2")
+            
+            if compressed:
+                # If the file is already compressed, we don't need to
+                # re-compress it.
+                typer.echo(f"{file_path} is already compressed, skipping compression")
+                fh_compressed = fh_in
+            else:
+                # Use gzip compression for storage. This only impacts storage on
+                # AWS and transfer between S3 and the CDN. It has no impact on the
+                # compression received by the end user (since the CDN re-compresses
+                # files).
+                fh_compressed = io.BytesIO()
+                with gzip.GzipFile(fileobj=fh_compressed, mode="wb") as gzip_file:
+                    shutil.copyfileobj(fh_in, gzip_file)
 
-            fh_compressed.seek(0)
+                fh_compressed.seek(0)
 
             content_type = None
             if file_path.suffix in (".zip", ".whl", ".tar", ".a"):
@@ -136,8 +144,8 @@ def deploy_to_s3_main(
 
             extra_args = {
                 "CacheControl": cache_control,
-                "ContentEncoding": "gzip",
                 "ContentType": content_type,
+                "ContentEncoding": "identity" if compressed else "gzip"
             }
 
             if not pretend:

--- a/tools/deploy_s3.py
+++ b/tools/deploy_s3.py
@@ -145,8 +145,10 @@ def deploy_to_s3_main(
             extra_args = {
                 "CacheControl": cache_control,
                 "ContentType": content_type,
-                "ContentEncoding": "identity" if compressed else "gzip"
             }
+
+            if not compressed:
+                extra_args["ContentEncoding"] = "gzip"
 
             if not pretend:
                 s3_client.upload_fileobj(

--- a/tools/tests/test_deploy_s3.py
+++ b/tools/tests/test_deploy_s3.py
@@ -105,7 +105,7 @@ def test_deploy_to_s3_overwrite(tmp_path, capsys):
 @mock_s3
 def test_deploy_to_s3_mime_type(tmp_path, capsys):
     """Test that we set the correct MIME type for each file extension"""
-    for ext in ["whl", "tar", "zip", "js", "ts", "json", "ttf", "a", "mjs.map", "mjs"]:
+    for ext in ["whl", "tar", "zip", "js", "ts", "json", "ttf", "a", "mjs.map", "mjs", "tar.gz", "tar.bz2"]:
         (tmp_path / f"a.{ext}").write_text("a")
 
     bucket_name = "mybucket"
@@ -129,6 +129,8 @@ def test_deploy_to_s3_mime_type(tmp_path, capsys):
         return res["ResponseMetadata"]["HTTPHeaders"][field]
 
     assert get_header("a.js", "content-encoding") == "gzip"
+    assert get_header("a.tar.gz", "content-encoding") == "identity"
+    assert get_header("a.tar.bz2", "content-encoding") == "identity"
 
     # These  MIME types we set explicitly for better CDN compression
     assert get_header("a.whl") == "application/wasm"
@@ -150,3 +152,7 @@ def test_deploy_to_s3_mime_type(tmp_path, capsys):
     with gzip.GzipFile(fileobj=res["Body"], mode="r") as fh:
         shutil.copyfileobj(fh, stream)
     assert stream.getvalue() == b"a"
+
+    res = s3_client.get_object(Bucket=bucket_name, Key="a.tar.bz2")
+    data = res["Body"].read()  # Should not raise an exception
+    assert data == b"a"

--- a/tools/tests/test_deploy_s3.py
+++ b/tools/tests/test_deploy_s3.py
@@ -126,11 +126,11 @@ def test_deploy_to_s3_mime_type(tmp_path, capsys):
 
     def get_header(key, field="content-type"):
         res = s3_client.get_object(Bucket=bucket_name, Key=key)
-        return res["ResponseMetadata"]["HTTPHeaders"][field]
+        return res["ResponseMetadata"]["HTTPHeaders"].get(field)
 
     assert get_header("a.js", "content-encoding") == "gzip"
-    assert get_header("a.tar.gz", "content-encoding") == "identity"
-    assert get_header("a.tar.bz2", "content-encoding") == "identity"
+    assert get_header("a.tar.gz", "content-encoding") is None
+    assert get_header("a.tar.bz2", "content-encoding") is None
 
     # These  MIME types we set explicitly for better CDN compression
     assert get_header("a.whl") == "application/wasm"


### PR DESCRIPTION
Follow up of #3766. This prevents compressing tar.gz / tar.bz2 archives with gzip again.

I accidentally pushed a couple of times to the upstream repo (not in the main branch) instead of my fork, sorry if I made your notifications noisy.