### PR TITLE
Don't remove build logs after build failure

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -426,13 +426,7 @@ def compile(
         from .pypabuild import build
 
         outpath = srcpath / "dist"
-        try:
-            build(srcpath, outpath, build_env, backend_flags)
-        except BaseException:
-            build_log_path = Path("build.log")
-            if build_log_path.exists():
-                build_log_path.unlink()
-            raise
+        build(srcpath, outpath, build_env, backend_flags)
 
 
 def replace_so_abi_tags(wheel_dir: Path) -> None:


### PR DESCRIPTION
Fix #3770 (it is already closed, but anyway)

The reason why no logs are being printed when a build fails was quite interesting:

1. There is a code that deletes a build log when a build fails (This PR removes it).
2. That code was not working before #3746, since we changed the working directory into srcpath.
3. After #3746, that code started to "work", so the build log gets deleted when a build fails.

I think we definitely don't want to delete the build log. So this PR removes it.


