### PR TITLE
Add protobuf package

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -36,7 +36,7 @@ myst:
   {pr}`3331`.
 - New packages: sourmash {pr}`3635`, screed {pr}`3635`, bitstring {pr}`3635`,
   deprecation {pr}`3635`, cachetools {pr}`3635`, xyzservices {pr}`3786`,
-  simplejson {pr}`3801`.
+  simplejson {pr}`3801`, protobuf {pr}`3813`.
 - Upgraded libmpfr to 4.2.0 {pr}`3756`.
 - Upgraded scipy to 1.10.1 {pr}`3794`
 

--- a/packages/protobuf/meta.yaml
+++ b/packages/protobuf/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: protobuf
+  version: 4.22.3
+  top-level:
+    - google
+
+source:
+  url: https://files.pythonhosted.org/packages/e2/86/44a1e4990a81cb4248a2091a182bb76a6417fddcaff560ceb6b44eb05c55/protobuf-4.22.3.tar.gz
+  sha256: 23452f2fdea754a8251d0fc88c0317735ae47217e0d27bf330a30eec2848811a
+
+about:
+  home: https://github.com/protocolbuffers/protobuf
+  PyPI: https://pypi.org/project/protobuf
+  summary: Protocol Buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data
+  license: Custom

--- a/packages/protobuf/test_protobuf.py
+++ b/packages/protobuf/test_protobuf.py
@@ -1,0 +1,13 @@
+
+# mypy: ignore-errors
+from pytest_pyodide.decorator import run_in_pyodide
+
+
+@run_in_pyodide(packages=["protobuf"])
+def test_protobuf(selenium):
+    from google.protobuf.descriptor_pb2 import FieldDescriptorProto
+    from google.protobuf.proto_builder import MakeSimpleProtoClass
+
+
+    MakeSimpleProtoClass({"field1": FieldDescriptorProto.TYPE_INT64,
+                          "field2": FieldDescriptorProto.TYPE_INT64})

--- a/packages/protobuf/test_protobuf.py
+++ b/packages/protobuf/test_protobuf.py
@@ -1,4 +1,3 @@
-
 # mypy: ignore-errors
 from pytest_pyodide.decorator import run_in_pyodide
 
@@ -8,6 +7,9 @@ def test_protobuf(selenium):
     from google.protobuf.descriptor_pb2 import FieldDescriptorProto
     from google.protobuf.proto_builder import MakeSimpleProtoClass
 
-
-    MakeSimpleProtoClass({"field1": FieldDescriptorProto.TYPE_INT64,
-                          "field2": FieldDescriptorProto.TYPE_INT64})
+    MakeSimpleProtoClass(
+        {
+            "field1": FieldDescriptorProto.TYPE_INT64,
+            "field2": FieldDescriptorProto.TYPE_INT64,
+        }
+    )

--- a/packages/protobuf/test_protobuf.py
+++ b/packages/protobuf/test_protobuf.py
@@ -5,7 +5,11 @@ from pytest_pyodide.decorator import run_in_pyodide
 @run_in_pyodide(packages=["protobuf"])
 def test_protobuf(selenium):
     from google.protobuf.descriptor_pb2 import FieldDescriptorProto
+    from google.protobuf.internal import api_implementation
     from google.protobuf.proto_builder import MakeSimpleProtoClass
+
+    _message = api_implementation._c_module
+    assert _message is not None  # check presence of binary component
 
     MakeSimpleProtoClass(
         {


### PR DESCRIPTION
Adds the Python `protobuf` package. I'll keep it marked as a draft until I'm sure it's okay and actually works as intended.

Having this package in place would open up a lot of possibilities for other packages. Backwards compatibility of protobufs seems okay, so I don't see any dangers for compatibility in having the newest release included in Pyodide. See related discussion in: https://github.com/pyodide/pyodide/issues/3424

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
