### PR TITLE
fix: drop some no-longer-needed bits from pydodide build

### DIFF
--- a/pyodide-build/MANIFEST.in
+++ b/pyodide-build/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE

--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -1,4 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
-
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"

--- a/pyodide-build/setup.py
+++ b/pyodide-build/setup.py
@@ -1,5 +1,0 @@
-# Needed for editable install
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup()


### PR DESCRIPTION
### Description

A few things here aren't really needed:

* `"wheel"` is injected via a PEP 517 hook when building wheels for all versions of setuptools that support PEP 517.
* `LICENSE` is already included, no need for a MANIFEST.in. You can compare SDist and Git via `pipx run check-sdist`.
* Recent-ish versions of Pip and Setuptools now support editable installs without setup.py

