### PR TITLE
Sqlite swap order of embuilder arguments

### DIFF
--- a/packages/sqlite3/meta.yaml
+++ b/packages/sqlite3/meta.yaml
@@ -23,7 +23,7 @@ build:
       "Modules/_sqlite/util.c"
     )
 
-    embuilder build --pic sqlite3
+    embuilder build sqlite3 --pic
 
     for file in "${FILES[@]}"; do
       emcc $STDLIB_MODULE_CFLAGS -c "${file}" -o "${file/.c/.o}"  \


### PR DESCRIPTION
Since Emscripten 3.1.35 or 3.1.36, the argument order of embuilder matters

Thanks to @katietz
