### PR TITLE
POC: build recipes in seperate repository

### DIFF
--- a/packages/mypy/meta.yaml
+++ b/packages/mypy/meta.yaml
@@ -5,12 +5,12 @@ package:
     - mypyc
     - mypy
 source:
-  url: https://files.pythonhosted.org/packages/62/54/be80f8d01f5cf72f774a77f9f750527a6fa733f09f78b1da30e8fa3914e6/mypy-1.1.1.tar.gz
-  sha256: ae9ceae0f5b9059f33dbc62dea087e942c0ccab4b7a003719cb70f9b8abfa32f
-build:
-  script: |
-    export MYPY_USE_MYPYC=1
-    export MYPYC_OPT_LEVEL=3
+  url: https://github.com/ryanking13/pyodide-recipes-mirror/releases/download/20230503/mypy-1.1.1-cp311-cp311-emscripten_3_1_32_wasm32.whl
+  sha256: f6103543a6612116b6fcbde63fd6de07e79f3d1c16e3bbd5585d77585bf23a9d
+# build:
+#   script: |
+#     export MYPY_USE_MYPYC=1
+#     export MYPYC_OPT_LEVEL=3
 about:
   home: http://www.mypy-lang.org/
   PyPI: https://pypi.org/project/mypy

--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -78,7 +78,9 @@ def install_reqs(env: IsolatedEnv, reqs: set[str]) -> None:
     pinned_reqs = {
         # Remove this when mypy releases a new version
         # https://github.com/python/mypy/pull/14788
-        "types-setuptools": "types-setuptools<67.4.0.2"
+        "types-setuptools": "types-setuptools<67.4.0.2",
+        # https://github.com/pyodide/pyodide/issues/3816
+        "pythran>=0.12.0,<0.13.0": "gast!=0.5.4",
     }
 
     for pkg, req in pinned_reqs.items():

--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -78,9 +78,7 @@ def install_reqs(env: IsolatedEnv, reqs: set[str]) -> None:
     pinned_reqs = {
         # Remove this when mypy releases a new version
         # https://github.com/python/mypy/pull/14788
-        "types-setuptools": "types-setuptools<67.4.0.2",
-        # https://github.com/pyodide/pyodide/issues/3816
-        "pythran>=0.12.0,<0.13.0": "gast!=0.5.4",
+        "types-setuptools": "types-setuptools<67.4.0.2"
     }
 
     for pkg, req in pinned_reqs.items():


### PR DESCRIPTION
This is a proof-of-concept of building recipes in a separate repository, using tot xbuildenv. You can see how the packages are built in: https://github.com/ryanking13/pyodide-recipes-mirror

We are getting more and more packages, and therefore CI timeouts often, so we need a workaround. Probably this PR cannot be a long-term solution but can work as a workaround until PyPI supports uploading Pyodide wheels.

Of course, this PR will increase the maintenance burden: we will have to maintain two slightly different recipes. I think it would be possible to automate some parts of recipe updates... but it will definitely be less convenient than managing recipes in one place.

I don't think we should move out all recipes, but maybe we can think of moving some packages based on criteria. In this PR, I selected mypy. mypy 1) takes long time to build (~10min), 2) and it has no dependencies, so it is a good candidate I think. 

- Related: https://github.com/pyodide/pyodide/issues/3341
- Related: #3336

WDYT?