### PR TITLE
use cmake instead of configure for zlib.

### DIFF
--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -9,5 +9,16 @@ source:
 build:
   type: static_library
   script: |
-    CFLAGS="-fPIC" emconfigure ./configure --prefix=${WASM_LIBRARY_DIR}
-    emmake make install -j ${PYODIDE_JOBS:-3}
+    mkdir -p "build"
+    pushd "build"
+    LDFLAGS="${SIDE_MODULE_LDFLAGS}" emcmake cmake \
+      -DBUILD_TESTING=OFF \
+      -DBUILD_BENCHMARKS=OFF \
+      -DBUILD_DOCUMENTATION=OFF \
+      -DCMAKE_C_FLAGS="-fPIC -Wno-deprecated-non-prototype" \
+      -DCMAKE_CXX_FLAGS="-fPIC -Wno-deprecated-non-prototype" \
+      -DCMAKE_INSTALL_PREFIX=${WASM_LIBRARY_DIR} \
+      ../
+    emmake make -j ${PYODIDE_JOBS:-3}
+    emmake make install
+    popd


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

the use of configure might lead on specific version of emscripten (seen on 3.1.36) to build failures due libtools inability to check for object file format.
Additionally the switch to CMake agrees more to the way zlib is built nowadays by distributors.
