### PR TITLE
NFC Fix sed patterns

### DIFF
--- a/packages/libf2c/meta.yaml
+++ b/packages/libf2c/meta.yaml
@@ -18,6 +18,9 @@ source:
     - patches/0003-remove-redundant-symbols.patch
     - patches/0004-correct-return-types.patch
     - patches/0005-Remove-symbols-defined-in-OpenBLAS.patch
+    # In CLAPACK's F2CLIBS/libf2c Makefile, some commands are mistakenly (?) hardcoded
+    # instead of using the right variables
+    - patches/0006-adjust-ld-ar-ranlib.patch
 
   extras:
     - [make.inc, make.inc]
@@ -30,12 +33,6 @@ build:
     # we cannot navigate into the folder. Setting it to 0750 makes it
     # easier to debug.
     chmod -R o+rx .
-
-    # In CLAPACK's Makefiles, some commands are mistakenly (?) hardcoded
-    # instead of using the right variables
-    sed -i.bak -e 's/^\t-ranlib /^\t${RANLIB} /g' **/Makefile
-    sed -i.bak 's/^\tar /^\t${AR} /' **/Makefile
-    sed -i.bak 's/^\tld /^\t${LD} /' **/Makefile
 
     emmake make -j ${PYODIDE_JOBS:-3} f2clib
     mkdir -p ${WASM_LIBRARY_DIR}/{lib,include}

--- a/packages/libf2c/meta.yaml
+++ b/packages/libf2c/meta.yaml
@@ -34,6 +34,7 @@ build:
     # easier to debug.
     chmod -R o+rx .
 
+    ARCH="emar" \
     emmake make -j ${PYODIDE_JOBS:-3} f2clib
     mkdir -p ${WASM_LIBRARY_DIR}/{lib,include}
     cp INCLUDE/f2c.h ${WASM_LIBRARY_DIR}/include

--- a/packages/libf2c/meta.yaml
+++ b/packages/libf2c/meta.yaml
@@ -33,9 +33,9 @@ build:
 
     # In CLAPACK's Makefiles, some commands are mistakenly (?) hardcoded
     # instead of using the right variables
-    sed -i 's/^	-ranlib /^	$(RANLIB)/' **/Makefile
-    sed -i 's/^	ar /^	$(ARCH)/' **/Makefile
-    sed -i 's/^	ld /^	$(LD)/' **/Makefile
+    sed -i.bak -e 's/^\t-ranlib /^\t${RANLIB} /g' **/Makefile
+    sed -i.bak 's/^\tar /^\t${AR} /' **/Makefile
+    sed -i.bak 's/^\tld /^\t${LD} /' **/Makefile
 
     emmake make -j ${PYODIDE_JOBS:-3} f2clib
     mkdir -p ${WASM_LIBRARY_DIR}/{lib,include}

--- a/packages/libf2c/patches/0006-adjust-ld-ar-ranlib.patch
+++ b/packages/libf2c/patches/0006-adjust-ld-ar-ranlib.patch
@@ -2,16 +2,7 @@ Index: CLAPACK-3.2.1/F2CLIBS/libf2c/Makefile
 ===================================================================
 --- CLAPACK-3.2.1.orig/F2CLIBS/libf2c/Makefile
 +++ CLAPACK-3.2.1/F2CLIBS/libf2c/Makefile
-@@ -20,7 +20,7 @@ include $(TOPDIR)/make.inc
- # compile, then strip unnecessary symbols
- .c.o:
- 	$(CC) -c -DSkip_f2c_Undefs $(CFLAGS) $*.c
--	ld -r -x -o $*.xxx $*.o
-+	$(LD) -r -x -o $*.xxx $*.o
- 	mv $*.xxx $*.o
- ## Under Solaris (and other systems that do not understand ld -x),
- ## omit -x in the ld line above.
-@@ -72,8 +72,8 @@ OFILES = $(MISC) $(POW) $(CX) $(DCX) $(R
+@@ -70,8 +70,8 @@ OFILES = $(MISC) $(POW) $(CX) $(DCX) $(R
  all: f2c.h signal1.h sysdep1.h libf2c.a clapack_install
  
  libf2c.a: $(OFILES)
@@ -22,7 +13,16 @@ Index: CLAPACK-3.2.1/F2CLIBS/libf2c/Makefile
  
  ## Shared-library variant: the following rule works on Linux
  ## systems.  Details are system-dependent.  Under Linux, -fPIC
-@@ -119,7 +119,7 @@ sysdep1.h: sysdep1.h0
+@@ -80,7 +80,7 @@ libf2c.a: $(OFILES)
+ ## of "cc -shared".
+ 
+ libf2c.so: $(OFILES)
+-	cc -shared -o libf2c.so $(OFILES)
++	$(CC) -shared -o libf2c.so $(OFILES)
+ 
+ ### If your system lacks ranlib, you don't need it; see README.
+ 
+@@ -117,7 +117,7 @@ sysdep1.h: sysdep1.h0
  
  install: libf2c.a
  	cp libf2c.a $(LIBDIR)

--- a/packages/libf2c/patches/0006-adjust-ld-ar-ranlib.patch
+++ b/packages/libf2c/patches/0006-adjust-ld-ar-ranlib.patch
@@ -1,0 +1,33 @@
+Index: CLAPACK-3.2.1/F2CLIBS/libf2c/Makefile
+===================================================================
+--- CLAPACK-3.2.1.orig/F2CLIBS/libf2c/Makefile
++++ CLAPACK-3.2.1/F2CLIBS/libf2c/Makefile
+@@ -20,7 +20,7 @@ include $(TOPDIR)/make.inc
+ # compile, then strip unnecessary symbols
+ .c.o:
+ 	$(CC) -c -DSkip_f2c_Undefs $(CFLAGS) $*.c
+-	ld -r -x -o $*.xxx $*.o
++	$(LD) -r -x -o $*.xxx $*.o
+ 	mv $*.xxx $*.o
+ ## Under Solaris (and other systems that do not understand ld -x),
+ ## omit -x in the ld line above.
+@@ -72,8 +72,8 @@ OFILES = $(MISC) $(POW) $(CX) $(DCX) $(R
+ all: f2c.h signal1.h sysdep1.h libf2c.a clapack_install
+ 
+ libf2c.a: $(OFILES)
+-	ar r libf2c.a $?
+-	-ranlib libf2c.a
++	$(AR) r libf2c.a $?
++	$(RANLIB) libf2c.a
+ 
+ ## Shared-library variant: the following rule works on Linux
+ ## systems.  Details are system-dependent.  Under Linux, -fPIC
+@@ -119,7 +119,7 @@ sysdep1.h: sysdep1.h0
+ 
+ install: libf2c.a
+ 	cp libf2c.a $(LIBDIR)
+-	-ranlib $(LIBDIR)/libf2c.a
++	$(RANLIB) $(LIBDIR)/libf2c.a
+ 
+ clapack_install: libf2c.a
+ 	mv libf2c.a ..

--- a/packages/libf2c/patches/0006-adjust-ld-ar-ranlib.patch
+++ b/packages/libf2c/patches/0006-adjust-ld-ar-ranlib.patch
@@ -17,7 +17,7 @@ Index: CLAPACK-3.2.1/F2CLIBS/libf2c/Makefile
  libf2c.a: $(OFILES)
 -	ar r libf2c.a $?
 -	-ranlib libf2c.a
-+	$(AR) r libf2c.a $?
++	$(ARCH) r libf2c.a $?
 +	$(RANLIB) libf2c.a
  
  ## Shared-library variant: the following rule works on Linux


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Use of sed code is actually pretty OS sepcific.  Therefore I replaced indicated changes by a patch file instead.
Underlying issue for this change was that all patterns in SED commands weren't replaced multiple times.  (see that final 'g' was missing in SED pattern.
That led to broken archives for emscripten vs native use of ranlib/ar tool

### Checklists
