### PR TITLE
Use gfortran instead of gcc for preprocessing in replay_f2c

### DIFF
--- a/packages/openblas/meta.yaml
+++ b/packages/openblas/meta.yaml
@@ -8,6 +8,7 @@ source:
   patches:
     - patches/0001-Add-Wno-return-type-flag.patch
     - patches/0002-Align-xerbla_array-signature-with-scipy-expectation.patch
+    - patches/0003-fix-cmake-ar-use.patch
 
 build:
   type: shared_library
@@ -28,7 +29,7 @@ build:
     sed -ri 's@int ([cz](dotc|dotu|ladiv))@void \1@g' lapack-netlib/SRC/*.c\
         lapack-netlib/SRC/DEPRECATED/*.c
 
-    make libs shared CC=emcc HOSTCC=gcc TARGET=RISCV64_GENERIC NOFORTRAN=1 NO_LAPACKE=1 \
+    emmake make libs shared CC=emcc HOSTCC=gcc TARGET=RISCV64_GENERIC NOFORTRAN=1 NO_LAPACKE=1 \
         USE_THREAD=0 LDFLAGS="${SIDE_MODULE_LDFLAGS}"
     mkdir -p dist
     # Add libf2c symbols to libopenblas.so

--- a/packages/openblas/patches/0003-fix-cmake-ar-use.patch
+++ b/packages/openblas/patches/0003-fix-cmake-ar-use.patch
@@ -1,0 +1,24 @@
+Index: openblas-0.3.23/CMakeLists.txt
+===================================================================
+--- openblas-0.3.23.orig/CMakeLists.txt
++++ openblas-0.3.23/CMakeLists.txt
+@@ -252,15 +252,15 @@ if (APPLE AND DYNAMIC_ARCH AND BUILD_SHA
+   if (NOT NOFORTRAN)
+   set (CMAKE_Fortran_USE_RESPONSE_FILE_FOR_OBJECTS 1)
+   set (CMAKE_Fortran_CREATE_SHARED_LIBRARY
+- "sh -c 'cat ${CMAKE_BINARY_DIR}/CMakeFiles/openblas_shared.dir/objects*.rsp | xargs -n 1024 ar -ru libopenblas.a && exit 0' "
+- "sh -c 'ar -ru libopenblas.a ${CMAKE_BINARY_DIR}/driver/others/CMakeFiles/driver_others.dir/xerbla.c.o && exit 0' "
++ "sh -c 'cat ${CMAKE_BINARY_DIR}/CMakeFiles/openblas_shared.dir/objects*.rsp | xargs -n 1024 emar -ru libopenblas.a && exit 0' "
++ "sh -c 'emar -ru libopenblas.a ${CMAKE_BINARY_DIR}/driver/others/CMakeFiles/driver_others.dir/xerbla.c.o && exit 0' "
+  "sh -c 'echo \"\" | ${CMAKE_Fortran_COMPILER} -o dummy.o -c -x f95-cpp-input - '"
+  "sh -c '${CMAKE_Fortran_COMPILER} -fpic -shared -Wl,-all_load -Wl,-force_load,libopenblas.a -Wl,-noall_load dummy.o -o ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopenblas.${OpenBLAS_MAJOR_VERSION}.${OpenBLAS_MINOR_VERSION}.dylib'"
+  "sh -c 'ls -l ${CMAKE_BINARY_DIR}/lib'")
+   else ()
+   set (CMAKE_C_CREATE_SHARED_LIBRARY
+-   "sh -c 'cat ${CMAKE_BINARY_DIR}/CMakeFiles/openblas_shared.dir/objects*.rsp | xargs -n 1024 ar -ru libopenblas.a && exit 0' "
+-   "sh -c 'ar -ru libopenblas.a ${CMAKE_BINARY_DIR}/driver/others/CMakeFiles/driver_others.dir/xerbla.c.o && exit 0' "
++   "sh -c 'cat ${CMAKE_BINARY_DIR}/CMakeFiles/openblas_shared.dir/objects*.rsp | xargs -n 1024 emar -ru libopenblas.a && exit 0' "
++   "sh -c 'emar -ru libopenblas.a ${CMAKE_BINARY_DIR}/driver/others/CMakeFiles/driver_others.dir/xerbla.c.o && exit 0' "
+    "sh -c '${CMAKE_C_COMPILER} -fpic -shared -Wl,-all_load -Wl,-force_load,libopenblas.a -Wl,-noall_load -o ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopenblas.${OpenBLAS_MAJOR_VERSION}.${OpenBLAS_MINOR_VERSION}.dylib'")
+   endif ()
+ endif()

--- a/packages/openblas/patches/0003-fix-cmake-ar-use.patch
+++ b/packages/openblas/patches/0003-fix-cmake-ar-use.patch
@@ -8,7 +8,7 @@ Index: openblas-0.3.23/CMakeLists.txt
    set (CMAKE_Fortran_CREATE_SHARED_LIBRARY
 - "sh -c 'cat ${CMAKE_BINARY_DIR}/CMakeFiles/openblas_shared.dir/objects*.rsp | xargs -n 1024 ar -ru libopenblas.a && exit 0' "
 - "sh -c 'ar -ru libopenblas.a ${CMAKE_BINARY_DIR}/driver/others/CMakeFiles/driver_others.dir/xerbla.c.o && exit 0' "
-+ "sh -c 'cat ${CMAKE_BINARY_DIR}/CMakeFiles/openblas_shared.dir/objects*.rsp | xargs -n 1024 emar -ru libopenblas.a && exit 0' "
++ "sh -c 'cat ${CMAKE_BINARY_DIR}/CMakeFiles/openblas_shared.dir/objects*.rsp | xargs -n 1024 ${CMAKE_AR} -ru libopenblas.a && exit 0' "
 + "sh -c 'emar -ru libopenblas.a ${CMAKE_BINARY_DIR}/driver/others/CMakeFiles/driver_others.dir/xerbla.c.o && exit 0' "
   "sh -c 'echo \"\" | ${CMAKE_Fortran_COMPILER} -o dummy.o -c -x f95-cpp-input - '"
   "sh -c '${CMAKE_Fortran_COMPILER} -fpic -shared -Wl,-all_load -Wl,-force_load,libopenblas.a -Wl,-noall_load dummy.o -o ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libopenblas.${OpenBLAS_MAJOR_VERSION}.${OpenBLAS_MINOR_VERSION}.dylib'"

--- a/packages/rebound/meta.yaml
+++ b/packages/rebound/meta.yaml
@@ -15,7 +15,7 @@ source:
   url: https://files.pythonhosted.org/packages/5c/66/7564ac591bb088d7f35a59d560b5c26426bb8ef5415522232819fe11c45a/rebound-3.24.2.tar.gz
   sha256: a3c5d4c6a10b9c1538e1051edcd6341ef3d13142b698ee9c4a1f112d9684d803
   patches:
-    - 0001-fix-install_name.patch
+    - patches/0001-fix-install_name.patch
 
 requirements:
   run:

--- a/packages/rebound/meta.yaml
+++ b/packages/rebound/meta.yaml
@@ -14,6 +14,9 @@ build:
 source:
   url: https://files.pythonhosted.org/packages/5c/66/7564ac591bb088d7f35a59d560b5c26426bb8ef5415522232819fe11c45a/rebound-3.24.2.tar.gz
   sha256: a3c5d4c6a10b9c1538e1051edcd6341ef3d13142b698ee9c4a1f112d9684d803
+  patches:
+    - 0001-fix-install_name.patch
+
 requirements:
   run:
     - numpy

--- a/packages/rebound/patches/0001-fix-install_name.patch
+++ b/packages/rebound/patches/0001-fix-install_name.patch
@@ -1,0 +1,15 @@
+Index: rebound-3.24.2/setup.py
+===================================================================
+--- rebound-3.24.2.orig/setup.py
++++ rebound-3.24.2/setup.py
+@@ -23,8 +23,8 @@ extra_link_args=[]
+ if sys.platform == 'darwin':
+     from distutils import sysconfig
+     vars = sysconfig.get_config_vars()
+-    vars['LDSHARED'] = vars['LDSHARED'].replace('-bundle', '-shared')
+-    extra_link_args=['-Wl,-install_name,@rpath/librebound'+suffix]
++    # vars['LDSHARED'] = vars['LDSHARED'].replace('-bundle', '-shared')
++    # extra_link_args=['-Wl,-install_name,@rpath/librebound'+suffix]
+     
+ libreboundmodule = Extension('librebound',
+                     sources = [ 'src/rebound.c',

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -111,9 +111,11 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                 if arg.endswith(".F"):
                     # .F files apparently expect to be run through the C
                     # preprocessor (they have #ifdef's in them)
+                    # Use gfortran frontend, as gcc frontend might not be
+                    # present ...
                     subprocess.check_call(
                         [
-                            "gcc",
+                            "gfortran",
                             "-E",
                             "-C",
                             "-P",
@@ -521,9 +523,9 @@ def handle_command_generate_args(
     if cmd == "ar":
         line[0] = "emar"
         return line
-    elif cmd == "c++" or cmd == "g++":
+    elif cmd == "c++" or cmd == "g++" of cmd == "clang++":
         new_args = ["em++"]
-    elif cmd == "cc" or cmd == "gcc" or cmd == "ld":
+    elif cmd == "cc" or cmd == "gcc" or cmd == "ld" or cmd == "clang":
         new_args = ["emcc"]
         # distutils doesn't use the c++ compiler when compiling c++ <sigh>
         if any(arg.endswith((".cpp", ".cc")) for arg in line):
@@ -549,6 +551,9 @@ def handle_command_generate_args(
         return line
     elif cmd == "strip":
         line[0] = "emstrip"
+        return line
+    elif cmd == "nm":
+        line[0] = "emnm"
         return line
     else:
         return line

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -523,9 +523,9 @@ def handle_command_generate_args(
     if cmd == "ar":
         line[0] = "emar"
         return line
-    elif cmd == "c++" or cmd == "g++" or cmd == "clang++":
+    elif cmd == "c++" or cmd == "g++":
         new_args = ["em++"]
-    elif cmd == "cc" or cmd == "gcc" or cmd == "ld" or cmd == "clang":
+    elif cmd == "cc" or cmd == "gcc" or cmd == "ld":
         new_args = ["emcc"]
         # distutils doesn't use the c++ compiler when compiling c++ <sigh>
         if any(arg.endswith((".cpp", ".cc")) for arg in line):

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -523,7 +523,7 @@ def handle_command_generate_args(
     if cmd == "ar":
         line[0] = "emar"
         return line
-    elif cmd == "c++" or cmd == "g++" of cmd == "clang++":
+    elif cmd == "c++" or cmd == "g++" or cmd == "clang++":
         new_args = ["em++"]
     elif cmd == "cc" or cmd == "gcc" or cmd == "ld" or cmd == "clang":
         new_args = ["emcc"]

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -478,7 +478,7 @@ def get_export_flags(
     yield f"-sEXPORTED_FUNCTIONS={prefixed_exports!r}"
 
 
-def handle_command_generate_args(
+def handle_command_generate_args(  # noqa: C901
     line: list[str], build_args: BuildArgs, is_link_command: bool
 ) -> list[str]:
     """

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -552,9 +552,6 @@ def handle_command_generate_args(  # noqa: C901
     elif cmd == "strip":
         line[0] = "emstrip"
         return line
-    elif cmd == "nm":
-        line[0] = "emnm"
-        return line
     else:
         return line
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

This PR fixes some issues regarding OSX build.  As gcc is not necessarily available nativly on osx, we need to use instead gfortran frontend for preprocessing.  Later is also the thing we probe for, so it is even more direct
Additionally this PR removes use of linker-option -install_name, which might be introduces on darwin OS.  For now I just did so for rebound package.
openblas needs some adjustments for use of em<tools> instead of native ones.  Additional it adds a patch we makes sure it will make use of emar in cmake.

### Checklists
