### PR TITLE
Fix llvm-readobj when emscipten is installed with emsdk out of tree

### DIFF
--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -10,8 +10,6 @@ emsdk/.complete: ../Makefile.envs $(wildcard patches/*.patch)
 	cd emsdk/upstream/emscripten/ && cat ../../../patches/*.patch | patch -p1 --verbose
 	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION) ccache-git-emscripten-64bit
 	cd emsdk && ./emsdk activate --embedded --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
-	# Put llvm-readobj on the path, needed by pywasmcross
-	ln emsdk/upstream/bin/llvm-readobj emsdk
 	touch emsdk/.complete
 
 clean:

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -53,6 +53,7 @@ if IS_COMPILER_INVOCATION:
 
 
 import dataclasses
+import shutil
 import subprocess
 from collections.abc import Iterable, Iterator
 from typing import Literal, NoReturn
@@ -390,8 +391,14 @@ def _calculate_object_exports_readobj_parse(output: str) -> list[str]:
 
 
 def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
+    readobj_path = shutil.which("llvm-readobj")
+    if not readobj_path:
+        which_emcc = shutil.which("emcc")
+        assert which_emcc
+        emcc = Path(which_emcc)
+        readobj_path = str((emcc / "../../bin/llvm-readobj").resolve())
     args = [
-        "llvm-readobj",
+        readobj_path,
         "--section-details",
         "-st",
     ] + objects


### PR DESCRIPTION
Thanks to @ryanking13 for pointing out that my previous patch breaks out of tree builds.