### PR TITLE
Support Fortran-file preprocessing on case-insensitive file-system

### DIFF
--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -151,7 +151,9 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                     if os.path.isfile(filepath):
                         os.remove(filepath)
                     if os.path.isfile(filepath.with_suffix(".oldF")):
-                        shutil.move(filepath.with_suffix(".oldF"), filepath.with_suffix(".F"))
+                        shutil.move(
+                            filepath.with_suffix(".oldF"), filepath.with_suffix(".F")
+                        )
             new_args.append(arg[:-2] + ".c")
             found_source = True
         else:

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -10,8 +10,6 @@ cross-compiling and then pass the command long to emscripten.
 """
 import json
 import os
-import re
-import shutil
 import sys
 from pathlib import Path
 
@@ -54,6 +52,8 @@ if IS_COMPILER_INVOCATION:
 
 
 import dataclasses
+import re
+import shutil
 import subprocess
 from collections.abc import Iterable, Iterator
 from typing import Literal, NoReturn

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -126,7 +126,7 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                             filepathwith_suffix(".f77"),
                         ]
                     )
-                    filepath = filepath.with_suffix(".fi77")
+                    filepath = filepath.with_suffix(".f77")
                 # -R flag is important, it means that Fortran functions that
                 # return real e.g. sdot will be transformed into C functions
                 # that return float. For historic reasons, by default f2c

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -138,8 +138,10 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                 # Fortran files, see
                 # https://github.com/xianyi/OpenBLAS/pull/3539#issuecomment-1493897254
                 # for more details
-                with open(filepath) as input_pipe:
-                    with open(filepath.with_suffix(".c"), "w") as output_pipe:
+                with (
+                    open(filepath) as input_pipe,
+                    open(filepath.with_suffix(".c"), "w") as output_pipe,
+                ):
                         subprocess.check_call(
                             ["f2c", "-R"],
                             stdin=input_pipe,

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -136,9 +136,14 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                 # Fortran files, see
                 # https://github.com/xianyi/OpenBLAS/pull/3539#issuecomment-1493897254
                 # for more details
-                with open(filepath, "r") as input_pipe:
+                with open(filepath) as input_pipe:
                     with open(filepath.with_suffix(".c"), "w") as output_pipe:
-                        subprocess.check_call(["f2c", "-R" ], stdin=input_pipe, stdout=output_pipe, cwd=filepath.parent)
+                        subprocess.check_call(
+                            ["f2c", "-R"],
+                            stdin=input_pipe,
+                            stdout=output_pipe,
+                            cwd=filepath.parent,
+                        )
                 fix_f2c_output(arg[:-2] + ".c")
                 # if files where renamed, restore old naming
             new_args.append(arg[:-2] + ".c")

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -108,13 +108,17 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
         if arg.endswith(".f") or arg.endswith(".F"):
             filepath = Path(arg).resolve()
             if not dryrun:
+                # flag to indicate that renaming during preprocessing for
+                # .F files happened
+                redo_renaming = False
                 fix_f2c_input(arg)
                 if arg.endswith(".F"):
                     # .F files apparently expect to be run through the C
                     # preprocessor (they have #ifdef's in them)
-                    # File-system might be not case-sensitiv,
-                    # so take care to use a new extension to avoid
-                    # conflicts.
+                    # The file-system might be not case-sensitiv,
+                    # so take care to handle this by renaming.
+                    # For preprocessing and further operation the
+                    # expected file-name and extension needs to be preserved.
                     subprocess.check_call(
                         [
                             "gfortran",
@@ -126,7 +130,12 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                             filepath.with_suffix(".f77"),
                         ]
                     )
-                    filepath = filepath.with_suffix(".f77")
+                    # restore old names later ...
+                    redo_renaming = True
+                    shutil.move(filepath, filepath.with_suffix(".oldF"))
+                    filepath = filepath.with_suffix(".f")
+                    # f2c needs either .F or .f file extension ...
+                    shutil.move(filepath.with_suffix(".f77"), filepath)
                 # -R flag is important, it means that Fortran functions that
                 # return real e.g. sdot will be transformed into C functions
                 # that return float. For historic reasons, by default f2c
@@ -137,6 +146,14 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                 # for more details
                 subprocess.check_call(["f2c", "-R", filepath.name], cwd=filepath.parent)
                 fix_f2c_output(arg[:-2] + ".c")
+                # if files where renamed, restore old naming
+                if redo_renaming:
+                    if os.path.isfile(filepath):
+                        os.remove(filepath)
+                    if os.path.isfile(filepath.with_suffix(".oldF")):
+                        shutil.move(
+                            filepath.with_suffix(".oldF"), filepath.with_suffix(".F")
+                        )
             new_args.append(arg[:-2] + ".c")
             found_source = True
         else:

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -149,7 +149,6 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                             cwd=filepath.parent,
                         )
                 fix_f2c_output(arg[:-2] + ".c")
-                # if files where renamed, restore old naming
             new_args.append(arg[:-2] + ".c")
             found_source = True
         else:

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -108,9 +108,6 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
         if arg.endswith(".f") or arg.endswith(".F"):
             filepath = Path(arg).resolve()
             if not dryrun:
-                # flag to indicate that renaming during preprocessing for
-                # .F files happened
-                redo_renaming = False
                 fix_f2c_input(arg)
                 if arg.endswith(".F"):
                     # .F files apparently expect to be run through the C
@@ -130,12 +127,7 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                             filepath.with_suffix(".f77"),
                         ]
                     )
-                    # restore old names later ...
-                    redo_renaming = True
-                    shutil.move(filepath, filepath.with_suffix(".oldF"))
-                    filepath = filepath.with_suffix(".f")
-                    # f2c needs either .F or .f file extension ...
-                    shutil.move(filepath.with_suffix(".f77"), filepath)
+                    filepath = filepath.with_suffix(".f77")
                 # -R flag is important, it means that Fortran functions that
                 # return real e.g. sdot will be transformed into C functions
                 # that return float. For historic reasons, by default f2c
@@ -144,16 +136,11 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                 # Fortran files, see
                 # https://github.com/xianyi/OpenBLAS/pull/3539#issuecomment-1493897254
                 # for more details
-                subprocess.check_call(["f2c", "-R", filepath.name], cwd=filepath.parent)
+                with open(filepath, "r") as input_pipe:
+                    with open(filepath.with_suffix(".c"), "w") as output_pipe:
+                        subprocess.check_call(["f2c", "-R" ], stdin=input_pipe, stdout=output_pipe, cwd=filepath.parent)
                 fix_f2c_output(arg[:-2] + ".c")
                 # if files where renamed, restore old naming
-                if redo_renaming:
-                    if os.path.isfile(filepath):
-                        os.remove(filepath)
-                    if os.path.isfile(filepath.with_suffix(".oldF")):
-                        shutil.move(
-                            filepath.with_suffix(".oldF"), filepath.with_suffix(".F")
-                        )
             new_args.append(arg[:-2] + ".c")
             found_source = True
         else:

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -115,7 +115,7 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                 if arg.endswith(".F"):
                     # .F files apparently expect to be run through the C
                     # preprocessor (they have #ifdef's in them)
-                    # The file-system might be not case-sensitiv,
+                    # The file-system might be not case-sensitive,
                     # so take care to handle this by renaming.
                     # For preprocessing and further operation the
                     # expected file-name and extension needs to be preserved.

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -123,7 +123,7 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                             "-P",
                             filepath,
                             "-o",
-                            filepathwith_suffix(".f77"),
+                            filepath.with_suffix(".f77"),
                         ]
                     )
                     filepath = filepath.with_suffix(".f77")

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -112,6 +112,8 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                 if arg.endswith(".F"):
                     # .F files apparently expect to be run through the C
                     # preprocessor (they have #ifdef's in them)
+                    # Use gfortran frontend, as gcc frontend might not be
+                    # present on osx
                     # The file-system might be not case-sensitive,
                     # so take care to handle this by renaming.
                     # For preprocessing and further operation the

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -11,8 +11,8 @@ cross-compiling and then pass the command long to emscripten.
 import json
 import os
 import re
-import sys
 import shutil
+import sys
 from pathlib import Path
 
 from __main__ import __file__ as INVOKED_PATH_STR

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -142,12 +142,12 @@ def replay_f2c(args: list[str], dryrun: bool = False) -> list[str] | None:
                     open(filepath) as input_pipe,
                     open(filepath.with_suffix(".c"), "w") as output_pipe,
                 ):
-                        subprocess.check_call(
-                            ["f2c", "-R"],
-                            stdin=input_pipe,
-                            stdout=output_pipe,
-                            cwd=filepath.parent,
-                        )
+                    subprocess.check_call(
+                        ["f2c", "-R"],
+                        stdin=input_pipe,
+                        stdout=output_pipe,
+                        cwd=filepath.parent,
+                    )
                 fix_f2c_output(arg[:-2] + ".c")
             new_args.append(arg[:-2] + ".c")
             found_source = True


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description


### Checklists

On case-insensitive file-systems - eg like MacOS standard Extended file-system (not APFS), FAT, etc - it is problematic if for files with .F extension the output is written as file with .f extension, as both actually are referring to the same file.
After the operation of f2c, the original file is restored to its original name.

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->
