### PR TITLE
Skip deno lock validation

### DIFF
--- a/src/test-deno/deno.json
+++ b/src/test-deno/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "test": "deno task setup && deno task smoke-test",
-    "setup": "deno task cache:validate && deno task node-modules:clear && deno task node-modules:setup && deno task node-modules:setup-local-pyodide",
+    "setup": "deno task node-modules:clear && deno task node-modules:setup && deno task node-modules:setup-local-pyodide",
     "cache:validate": "deno cache --lock=/tmp/pyodide-deno.lock --lock-write smoke-test.ts && diff -u deno.lock /tmp/pyodide-deno.lock",
     "cache:update": "deno cache smoke-test.ts",
     "node-modules:clear": "rm -rf node_modules",


### PR DESCRIPTION
### Description

Deno lockfile validation is causing a build failures. See https://github.com/pyodide/pyodide/issues/3847

This PR disables the lock file validation temporarily to prevent CI errors.

### Checklists

- Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry. reason: CI only change
- Add / update tests
- Add new / update outdated documentation
