### PR TITLE
Docs: recommend rustup `stable` when building Rust packages

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -381,7 +381,7 @@ imports are synchronous so it is impossible to load `.so` files lazily.
 We currently build `cryptography` which is a Rust extension built with PyO3 and
 `setuptools-rust`. It should be reasonably easy to build other Rust extensions.
 If you want to build a package with Rust extension, you will need Rust >= 1.41,
-and you need to set the rustup toolchain to `nightly`, and the target to
+and you can set the rustup toolchain to `stable`, and the target to
 `wasm32-unknown-emscripten` in the build script
 [as shown here](https://github.com/pyodide/pyodide/blob/main/packages/cryptography/meta.yaml),
 but other than that there may be no other issues if you are lucky.


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Apparently it might not be needed to set `rustup` to target `nightly` anymore.

cc @manonmarchand who was recently looking into this

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
