### PR TITLE
Add scikit-bio v0.5.8

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -37,7 +37,7 @@ myst:
   {pr}`3331`.
 - New packages: sourmash {pr}`3635`, screed {pr}`3635`, bitstring {pr}`3635`,
   deprecation {pr}`3635`, cachetools {pr}`3635`, xyzservices {pr}`3786`,
-  simplejson {pr}`3801`, protobuf {pr}`3813`.
+  simplejson {pr}`3801`, protobuf {pr}`3813`, scikit-bio {pr}3858.
 - Upgraded libmpfr to 4.2.0 {pr}`3756`.
 - Upgraded scipy to 1.10.1 {pr}`3794`
 

--- a/packages/scikit-bio/meta.yaml
+++ b/packages/scikit-bio/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - scipy
     - joblib
     - threadpoolctl
-    - requests
+    - pyodide_http
 
 test:
   imports:

--- a/packages/scikit-bio/meta.yaml
+++ b/packages/scikit-bio/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: scikit-bio
+  version: 0.5.8
+  tag:
+    - min-scipy-stack
+  top-level:
+    - skbio
+source:
+  url: https://files.pythonhosted.org/packages/f3/5b/7ae2c3cca0cee7825a24b9c68d7ba0893ef816c41e43aeccf9ca3bc63cb7/scikit-bio-0.5.8.tar.gz
+  sha256: d55a83c3e5f2ca1132744e1409233fb61d9af0c5a95deb7b291e6e340712b86b
+
+build:
+  cflags: -Wno-implicit-function-declaration
+
+requirements:
+  host:
+    - numpy
+    - scipy
+  run:
+    - scipy
+    - joblib
+    - threadpoolctl
+
+test:
+  imports:
+    - skbio
+    - skbio.alignment
+    - skbio.alignment._lib
+    - skbio.alignment.tests
+    - skbio.diversity
+    - skbio.diversity.alpha
+    - skbio.diversity.alpha.tests
+    - skbio.diversity.beta
+    - skbio.diversity.beta.tests
+    - skbio.diversity.tests
+    - skbio.io
+    - skbio.io.format
+    - skbio.io.format.tests
+    - skbio.io.tests
+    - skbio.sequence
+    - skbio.sequence.tests
+    - skbio.stats
+    - skbio.stats.distance
+    - skbio.stats.distance.tests
+    - skbio.stats.evolve
+    - skbio.stats.evolve.tests
+    - skbio.stats.ordination
+    - skbio.stats.ordination.tests
+    - skbio.stats.tests
+    - skbio.tests
+    - skbio.tree
+    - skbio.tree.tests
+    - skbio.util
+    - skbio.util.tests
+
+about:
+  home: http://scikit-bio.org
+  PyPI: https://pypi.org/project/scikit-bio/
+  summary: Data structures, algorithms and educational resources for bioinformatics
+  license: new BSD

--- a/packages/scikit-bio/meta.yaml
+++ b/packages/scikit-bio/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - scipy
     - joblib
     - threadpoolctl
+    - requests
 
 test:
   imports:

--- a/packages/scikit-bio/test_scikit-bio.py
+++ b/packages/scikit-bio/test_scikit-bio.py
@@ -1,0 +1,20 @@
+import pytest
+from pytest_pyodide.fixture import selenium_context_manager
+
+
+@pytest.mark.driver_timeout(40)
+@pytest.mark.xfail_browsers(
+    chrome="Times out in chrome", firefox="Times out in firefox"
+)
+def test_scikit_bio(selenium_module_scope):
+    with selenium_context_manager(selenium_module_scope) as selenium:
+        selenium.load_package("scikit-bio")
+        assert (
+            selenium.run(
+                """
+                import numpy as np
+                import skbio
+                """
+            )
+            > 0
+        )


### PR DESCRIPTION
### Description

I would like to add a recipe for scikit-bio (https://scikit-bio.org/), which provides a number of extremely useful functions for bioinformatics.
Because the dependencies for scikit-bio largely mirror those for scikit-learn (which has already been built for Pyodide), I was hoping that this would be relatively straightforward.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
