### PR TITLE
Export emscripten specific sysconfigdata to host's python

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -36,6 +36,8 @@ $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB)
 	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
 	mkdir -p $(SYSCONFIGDATA_DIR)
 	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(SYSCONFIGDATA_DIR)
+	# make sure host python knows about new sysconfig too
+	cp -f $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(HOSTPYTHONROOT)/lib/python$(PYMAJOR).$(PYMINOR)
 	rm -rf $(PYBUILDDIR)
 	rm pybuilddir.txt
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

we need to make sure that host's python has the emscripten related sysconfigdata-file at its python-related location installed, so that later use of _PYTHON_SYSCONFIGDATA_NAME is actually working as expected.

### Checklists

