### PR TITLE
MAINT Move some flags from LDFLAGS_BASE to LDFLAGS_MAIN

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -92,8 +92,6 @@ export LDFLAGS_BASE=\
 	$(OPTFLAGS) \
 	$(DBGFLAGS) \
 	$(DBG_LDFLAGS) \
-	-s MODULARIZE=1 \
-	-s LZ4=1 \
 	-L $(CPYTHONROOT)/installs/python-$(PYVERSION)/lib/ \
 	-s WASM_BIGINT \
 	$(EXTRA_LDFLAGS)
@@ -104,6 +102,8 @@ export CXXFLAGS_BASE=\
 export SIDE_MODULE_LDFLAGS=	$(LDFLAGS_BASE) -s SIDE_MODULE=1
 export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-s MAIN_MODULE=1 \
+	-s MODULARIZE=1 \
+	-s LZ4=1 \
 	-s EXPORT_NAME="'_createPyodideModule'" \
 	-s EXPORT_EXCEPTION_HANDLING_HELPERS \
 	-s EXCEPTION_CATCHING_ALLOWED=['we only want to allow exception handling in side modules'] \


### PR DESCRIPTION
These flags are not needed when building packages.