### PR TITLE
Fix benchmark-stack-size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
             make npm-link
             pip install -r requirements.txt
             npm install -g node-fetch@2
-            pytest -s benchmark/stack_usage.py --rt node chrome firefox | sed -n 's/## //pg'
+            pytest -s benchmark/stack_usage.py --rt node,chrome,firefox | sed -n 's/## //pg'
 
   test-js:
     <<: *defaults


### PR DESCRIPTION
This fixes benchmark-stack-size which seems to have been broken by the upgrade to pytest-pyodide 0.52.