### PR TITLE
python3.12-compatibile python2js bigint conversion

### DIFF
--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -99,7 +99,11 @@ _python2js_long(PyObject* x)
     if (!overflow) {
       FAIL_IF_ERR_OCCURRED();
     } else {
-      size_t ndigits = Py_ABS(Py_SIZE(x));
+      // We want to group into u32 chunks for convenience of
+      // hiwire_int_from_digits. If the number of bits is evenly divisible by
+      // 32, we overestimate the number of needed u32s by one.
+      size_t nbits = _PyLong_NumBits(x);
+      size_t ndigits = (nbits >> 5) + 1;
       unsigned int digits[ndigits];
       FAIL_IF_MINUS_ONE(_PyLong_AsByteArray((PyLongObject*)x,
                                             (unsigned char*)digits,


### PR DESCRIPTION
Using `Py_SIZE` on `PyLongObject` is no longer allowed in Python 3.12. Less importantly, we are minorly overestimating the size of very large numbers here since each digit has only 30 bits, so a 16 digit number has 480 bits and fits into 15 u32s. 