### PR TITLE
Switch _PyArg_Parser usage to be forwards compatible with Python 3.12

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2138,7 +2138,10 @@ JsMap_get(PyObject* self,
           PyObject* kwnames)
 {
   static const char* const _keywords[] = { "key", "default", 0 };
-  static struct _PyArg_Parser _parser = { "O|O:get", _keywords, 0 };
+  static struct _PyArg_Parser _parser = {
+    .format = "O|O:get",
+    .keywords = _keywords,
+  };
   PyObject* key;
   PyObject* default_ = Py_None;
   if (!_PyArg_ParseStackAndKeywords(
@@ -2168,7 +2171,10 @@ JsMap_pop(PyObject* self,
           PyObject* kwnames)
 {
   static const char* const _keywords[] = { "key", "default", 0 };
-  static struct _PyArg_Parser _parser = { "O|O:get", _keywords, 0 };
+  static struct _PyArg_Parser _parser = {
+    .format = "O|O:pop",
+    .keywords = _keywords,
+  };
   PyObject* key;
   PyObject* default_ = NULL;
   if (!_PyArg_ParseStackAndKeywords(
@@ -2282,7 +2288,10 @@ JsMap_setdefault(PyObject* self,
                  PyObject* kwnames)
 {
   static const char* const _keywords[] = { "key", "default", 0 };
-  static struct _PyArg_Parser _parser = { "O|O:get", _keywords, 0 };
+  static struct _PyArg_Parser _parser = {
+    .format = "O|O:setdefault",
+    .keywords = _keywords,
+  };
   PyObject* key;
   PyObject* default_ = Py_None;
   if (!_PyArg_ParseStackAndKeywords(
@@ -2383,7 +2392,10 @@ JsProxy_toPy(PyObject* self,
              PyObject* kwnames)
 {
   static const char* const _keywords[] = { "depth", "default_converter", 0 };
-  static struct _PyArg_Parser _parser = { "|$iO:to_py", _keywords, 0 };
+  static struct _PyArg_Parser _parser = {
+    .format = "|$iO:to_py",
+    .keywords = _keywords,
+  };
   int depth = -1;
   PyObject* default_converter = NULL;
   if (!_PyArg_ParseStackAndKeywords(
@@ -2647,7 +2659,10 @@ JsProxy_as_object_map(PyObject* self,
                       PyObject* kwnames)
 {
   static const char* const _keywords[] = { "hereditary", 0 };
-  static struct _PyArg_Parser _parser = { "|$p:as_object_map", _keywords, 0 };
+  static struct _PyArg_Parser _parser = {
+    .format = "|$p:as_object_map",
+    .keywords = _keywords,
+  };
   bool hereditary = false;
   if (!_PyArg_ParseStackAndKeywords(
         args, nargs, kwnames, &_parser, &hereditary)) {
@@ -3626,7 +3641,10 @@ JsBuffer_tostring(PyObject* self,
                   PyObject* kwnames)
 {
   static const char* const _keywords[] = { "encoding", 0 };
-  static struct _PyArg_Parser _parser = { "|s:to_string", _keywords, 0 };
+  static struct _PyArg_Parser _parser = {
+    .format = "|s:to_string",
+    .keywords = _keywords,
+  };
   char* encoding = NULL;
   if (!_PyArg_ParseStackAndKeywords(
         args, nargs, kwnames, &_parser, &encoding)) {

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1365,7 +1365,10 @@ create_proxy(PyObject* self,
   bool capture_this = false;
   bool roundtrip = true;
   PyObject* obj;
-  static struct _PyArg_Parser _parser = { "O|$pp:create_proxy", _keywords, 0 };
+  static struct _PyArg_Parser _parser = {
+    .format = "O|$pp:create_proxy",
+    .keywords = _keywords,
+  };
   if (!_PyArg_ParseStackAndKeywords(
         args, nargs, kwnames, &_parser, &obj, &capture_this, &roundtrip)) {
     return NULL;

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -776,7 +776,8 @@ to_js(PyObject* self,
   //      OOO       - PyObject* arguments for pyproxies, dict_converter, and
   //      default_converter.
   //         :to_js - name of this function for error messages
-  static struct _PyArg_Parser _parser = { "O|$ipOOO:to_js", _keywords, 0 };
+  static struct _PyArg_Parser _parser = { .format = "O|$ipOOO:to_js",
+                                          .keywords = _keywords };
   if (!_PyArg_ParseStackAndKeywords(args,
                                     nargs,
                                     kwnames,


### PR DESCRIPTION
In Python 3.12 it's required to use designated initializers for `_PyArg_Parser`.