### PR TITLE
Only check if key in obj if obj[key] returns undefined

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -966,12 +966,15 @@ EM_JS(int, normalizeReservedWords, (int word), {
 });
 
 EM_JS_REF(JsRef, JsObject_GetString, (JsRef idobj, const char* ptrkey), {
-  let jsobj = Hiwire.get_value(idobj);
-  let jskey = normalizeReservedWords(UTF8ToString(ptrkey));
-  if (jskey in jsobj) {
-    return Hiwire.new_value(jsobj[jskey]);
+  const jsobj = Hiwire.get_value(idobj);
+  const jskey = normalizeReservedWords(UTF8ToString(ptrkey));
+  const result = jsobj[jskey];
+  // clang-format off
+  if (result === undefined && !(jskey in jsobj)) {
+    // clang-format on
+    return ERROR_REF;
   }
-  return ERROR_REF;
+  return Hiwire.new_value(result);
 });
 
 // clang-format off


### PR DESCRIPTION
This is a minor optimization in `JsObject_GetString`. We only need to check if `key in obj` when `obj[key]` returns `undefined` to distinguish between missing and present but set to `undefined`.

@WebReflection

- [x] Add test