### PR TITLE
Allow customizing cache location for packages in Node

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,9 @@ myst:
 
 ## Unreleased
 
+- {{ Enhancement }} Allow customizing installation location for packages
+  {pr}`3967`
+
 - {{ Enhancement }} ABI Break: Updated Emscripten to version 3.1.39
   {pr}`3665`, {pr}`3659`, {pr}`3822`, {pr}`3889`, {pr}`3890`
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -214,11 +214,11 @@ function recursiveDependencies(
 
 /**
  * Download a package. If `channel` is `DEFAULT_CHANNEL`, look up the wheel URL
- * relative to packageCacheDir from `pyodide-lock.json`, otherwise use the URL specified by
+ * relative to packageCacheDir(when IN_NODE), or indexURL from `pyodide-lock.json`, otherwise use the URL specified by
  * `channel`.
  * @param name The name of the package
  * @param channel Either `DEFAULT_CHANNEL` or the absolute URL to the
- * wheel or the path to the wheel relative to packageCacheDir.
+ * wheel or the path to the wheel relative to packageCacheDir(when IN_NODE), or indexURL.
  * @param checkIntegrity Whether to check the integrity of the downloaded
  * package.
  * @returns The binary data for the package
@@ -229,11 +229,15 @@ async function downloadPackage(
   channel: string,
   checkIntegrity: boolean = true,
 ): Promise<Uint8Array> {
+  let installBaseUrl: string;
   if (IN_NODE) {
+    installBaseUrl = API.config.packageCacheDir;
     // ensure that the directory exists before trying to download files into it
     await nodeFsPromisesMod.mkdir(API.config.packageCacheDir, {
       recursive: true,
     });
+  } else {
+    installBaseUrl = API.config.indexURL;
   }
 
   let file_name, uri, file_sub_resource_hash;
@@ -242,7 +246,7 @@ async function downloadPackage(
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.lockfile_packages[name].file_name;
-    uri = resolvePath(file_name, API.config.packageCacheDir);
+    uri = resolvePath(file_name, installBaseUrl);
     file_sub_resource_hash = API.package_loader.sub_resource_hash(
       API.lockfile_packages[name].sha256,
     );

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -214,11 +214,11 @@ function recursiveDependencies(
 
 /**
  * Download a package. If `channel` is `DEFAULT_CHANNEL`, look up the wheel URL
- * relative to packageCacheDir(when IN_NODE), or indexURL from `pyodide-lock.json`, otherwise use the URL specified by
+ * relative to packageCacheDir (when IN_NODE), or indexURL from `pyodide-lock.json`, otherwise use the URL specified by
  * `channel`.
  * @param name The name of the package
  * @param channel Either `DEFAULT_CHANNEL` or the absolute URL to the
- * wheel or the path to the wheel relative to packageCacheDir(when IN_NODE), or indexURL.
+ * wheel or the path to the wheel relative to packageCacheDir (when IN_NODE), or indexURL.
  * @param checkIntegrity Whether to check the integrity of the downloaded
  * package.
  * @returns The binary data for the package

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -214,11 +214,11 @@ function recursiveDependencies(
 
 /**
  * Download a package. If `channel` is `DEFAULT_CHANNEL`, look up the wheel URL
- * relative to installURL from `pyodide-lock.json`, otherwise use the URL specified by
+ * relative to packageCacheDir from `pyodide-lock.json`, otherwise use the URL specified by
  * `channel`.
  * @param name The name of the package
  * @param channel Either `DEFAULT_CHANNEL` or the absolute URL to the
- * wheel or the path to the wheel relative to installURL.
+ * wheel or the path to the wheel relative to packageCacheDir.
  * @param checkIntegrity Whether to check the integrity of the downloaded
  * package.
  * @returns The binary data for the package
@@ -235,7 +235,7 @@ async function downloadPackage(
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.lockfile_packages[name].file_name;
-    uri = resolvePath(file_name, API.config.installURL);
+    uri = resolvePath(file_name, API.config.packageCacheDir);
     file_sub_resource_hash = API.package_loader.sub_resource_hash(
       API.lockfile_packages[name].sha256,
     );

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -214,11 +214,11 @@ function recursiveDependencies(
 
 /**
  * Download a package. If `channel` is `DEFAULT_CHANNEL`, look up the wheel URL
- * relative to indexURL from `pyodide-lock.json`, otherwise use the URL specified by
+ * relative to installURL from `pyodide-lock.json`, otherwise use the URL specified by
  * `channel`.
  * @param name The name of the package
  * @param channel Either `DEFAULT_CHANNEL` or the absolute URL to the
- * wheel or the path to the wheel relative to indexURL.
+ * wheel or the path to the wheel relative to installURL.
  * @param checkIntegrity Whether to check the integrity of the downloaded
  * package.
  * @returns The binary data for the package
@@ -235,7 +235,7 @@ async function downloadPackage(
       throw new Error(`Internal error: no entry for package named ${name}`);
     }
     file_name = API.lockfile_packages[name].file_name;
-    uri = resolvePath(file_name, API.config.indexURL);
+    uri = resolvePath(file_name, API.config.installURL);
     file_sub_resource_hash = API.package_loader.sub_resource_hash(
       API.lockfile_packages[name].sha256,
     );

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -229,6 +229,13 @@ async function downloadPackage(
   channel: string,
   checkIntegrity: boolean = true,
 ): Promise<Uint8Array> {
+  if (IN_NODE) {
+    // ensure that the directory exists before trying to download files into it
+    await nodeFsPromisesMod.mkdir(API.config.packageCacheDir, {
+      recursive: true,
+    });
+  }
+
   let file_name, uri, file_sub_resource_hash;
   if (channel === DEFAULT_CHANNEL) {
     if (!(name in API.lockfile_packages)) {

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -210,7 +210,7 @@ export async function loadPyodide(
      */
     indexURL?: string;
 
-    /*
+    /**
      * The base URL for where new packages will be downloaded.
      * Only applies when running in node.js. Ignored in browsers.
      *

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -212,6 +212,7 @@ export async function loadPyodide(
 
     /*
      * The base URL for where new packages will be downloaded.
+     * Only applies when running in node.js. Ignored in browsers.
      *
      * Default: same as indexURL
      */

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -211,7 +211,9 @@ export async function loadPyodide(
     indexURL?: string;
 
     /**
-     * The base URL for where new packages will be downloaded.
+     * The file path where packages will be cached in `node.js`. If a package
+     * exists in `packageCacheDir` it is loaded from there, otherwise it is
+     * downloaded from the JsDelivr CDN and then cached into `packageCacheDir`.
      * Only applies when running in node.js. Ignored in browsers.
      *
      * Default: same as indexURL

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -295,7 +295,6 @@ export async function loadPyodide(
     indexURL += "/";
   }
   options.indexURL = indexURL;
-  options.packageCacheDir = options.packageCacheDir ?? indexURL;
 
   const default_config = {
     fullStdLib: false,
@@ -305,6 +304,7 @@ export async function loadPyodide(
     args: [],
     _node_mounts: [],
     env: {},
+    packageCacheDir: indexURL,
   };
   const config = Object.assign(default_config, options) as ConfigType;
   if (options.homedir) {

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -177,6 +177,7 @@ function calculateIndexURL(): string {
  */
 export type ConfigType = {
   indexURL: string;
+  installURL: string;
   lockFileURL: string;
   homedir: string;
   fullStdLib?: boolean;
@@ -208,6 +209,13 @@ export async function loadPyodide(
      * (``pyodide.js`` or ``pyodide.mjs``) removed.
      */
     indexURL?: string;
+
+    /*
+     * The base URL for where new packages will be loaded.
+     *
+     * Default: same as indexURL
+     */
+    installURL?: string;
 
     /**
      * The URL from which Pyodide will load the Pyodide ``pyodide-lock.json`` lock
@@ -284,6 +292,7 @@ export async function loadPyodide(
     indexURL += "/";
   }
   options.indexURL = indexURL;
+  options.installURL = options.installURL ?? indexURL;
 
   const default_config = {
     fullStdLib: false,

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -177,7 +177,7 @@ function calculateIndexURL(): string {
  */
 export type ConfigType = {
   indexURL: string;
-  installURL: string;
+  packageCacheDir: string;
   lockFileURL: string;
   homedir: string;
   fullStdLib?: boolean;
@@ -211,11 +211,11 @@ export async function loadPyodide(
     indexURL?: string;
 
     /*
-     * The base URL for where new packages will be loaded.
+     * The base URL for where new packages will be downloaded.
      *
      * Default: same as indexURL
      */
-    installURL?: string;
+    packageCacheDir?: string;
 
     /**
      * The URL from which Pyodide will load the Pyodide ``pyodide-lock.json`` lock
@@ -292,7 +292,7 @@ export async function loadPyodide(
     indexURL += "/";
   }
   options.indexURL = indexURL;
-  options.installURL = options.installURL ?? indexURL;
+  options.packageCacheDir = options.packageCacheDir ?? indexURL;
 
   const default_config = {
     fullStdLib: false,


### PR DESCRIPTION
This change allows users to customize where the `.whl` files are downloaded to.
This is important in the context of docker images, but also in cases where the `node_modules` folder isn't writable once the application (that uses pyodide) is shipped.

This change is backward-compatible, as `installURL` still defaults to `indexURL`.

This fixes https://github.com/pyodide/pyodide/discussions/3950

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry

