### PR TITLE
FIX Version cap pydantic<2

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,9 @@ myst:
 
 ## Unreleased
 
+- {{ Fix }} Pin `pydantic` to `<2`.
+  {pr}`3971`
+
 - {{ Enhancement }} Allow customizing installation location for packages
   {pr}`3967`
 

--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "tomli",
     "build==0.7.0",
     "virtualenv",
-    "pydantic>=1.10.2",
+    "pydantic>=1.10.2,<2",
     "pyodide-cli~=0.2.1",
     "cmake>=3.24",
     "unearth~=0.6",


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry



---

e.g. latest pyodide build https://github.com/pyodide/pyodide/actions/runs/5427229660/jobs/9870260314

```
  File "/opt/hostedtoolcache/Python/3.11.2/x64/lib/python3.11/site-packages/pyodide_build/io.py", line 30, in _SourceSpec
    @pydantic.root_validator
     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.2/x64/lib/python3.11/site-packages/pydantic/deprecated/class_validators.py", line 222, in root_validator
    return root_validator()(*__args)  # type: ignore
           ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.2/x64/lib/python3.11/site-packages/pydantic/deprecated/class_validators.py", line 228, in root_validator
    raise PydanticUserError(
pydantic.errors.PydanticUserError: If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.

```