### PR TITLE
Add a exports/types field to package.json

### DIFF
--- a/src/js/package.json
+++ b/src/js/package.json
@@ -42,7 +42,8 @@
   "exports": {
     ".": {
       "require": "./pyodide.js",
-      "import": "./pyodide.mjs"
+      "import": "./pyodide.mjs",
+      "types": "./pyodide.d.ts"
     },
     "./pyodide.asm.wasm": "./pyodide.asm.wasm",
     "./pyodide.asm.js": "./pyodide.asm.js",


### PR DESCRIPTION
Forgive me if this isn't right, but don't we need to export the types as well?

### Description

I was having trouble in VSCode with no type hints

### Solution

Add `"types": "./pyodide.d.ts"` to the exports definition.