### PR TITLE
Implement PEP 658: .whl.metadata files

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -68,6 +68,13 @@ myst:
 - Upgraded scikit-learn to 1.3.0 {pr}`3976`
 - Upgraded pyodide-http to 0.2.1
 
+### CLI
+
+- {{ Enhancement }} `pyodide build-recipes` now accepts a `--metadata-files`
+  option to install `*.whl.metadata` files as specified in
+  [PEP 658](https://peps.python.org/pep-0658/).
+  {pr}`3981`
+
 ## Version 0.23.4
 
 _July 6, 2023_

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -10,6 +10,7 @@ all:
 	--recipe-dir=./ \
 	--install \
 	--install-dir=../dist \
+	--metadata-files \
 	--n-jobs $${PYODIDE_JOBS:-4} \
 	--log-dir=./build-logs \
 	--compression-level "$(PYODIDE_ZIP_COMPRESSION_LEVEL)"

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -806,7 +806,10 @@ def install_packages(
 
     logger.info(f"Copying built packages to {output_dir}")
     copy_packages_to_dist_dir(
-        pkg_map.values(), output_dir, compression_level=compression_level, metadata_files=metadata_files,
+        pkg_map.values(),
+        output_dir,
+        compression_level=compression_level,
+        metadata_files=metadata_files,
     )
 
     lockfile_path = output_dir / "pyodide-lock.json"

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -725,9 +725,9 @@ def copy_packages_to_dist_dir(
 
         if metadata_files and dist_artifact_path.suffix == ".whl":
             with ZipFile(dist_artifact_path, mode="r") as wheel:
-                name, ver, _ = wheel.name.split("-", 2)
+                name, ver, _ = dist_artifact_path.name.split("-", 2)
                 metadata_path = str(Path(f"{name}-{ver}.dist-info") / "METADATA")
-                wheel.getinfo(metadata_path).filename = f"{wheel.name}.metadata"
+                wheel.getinfo(metadata_path).filename = f"{dist_artifact_path.name}.metadata"
                 wheel.extract(metadata_path, output_dir)
 
         test_path = pkg.tests_path()

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -724,11 +724,10 @@ def copy_packages_to_dist_dir(
         )
 
         if metadata_files and dist_artifact_path.suffix == ".whl":
-            if not extract_wheel_metadata_file(
+            extract_wheel_metadata_file(
                 dist_artifact_path,
                 output_dir / f"{dist_artifact_path.name}.metadata",
-            ):
-                logger.warning(f"Warning: {pkg.name} has no METADATA file")
+            )
 
         test_path = pkg.tests_path()
         if test_path:

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -30,6 +30,7 @@ from rich.table import Table
 from . import build_env, recipe
 from .buildpkg import needs_rebuild
 from .common import (
+    extract_wheel_metadata_file,
     find_matching_wheels,
     find_missing_executables,
     repack_zip_archive,
@@ -724,13 +725,10 @@ def copy_packages_to_dist_dir(
         )
 
         if metadata_files and dist_artifact_path.suffix == ".whl":
-            with ZipFile(dist_artifact_path, mode="r") as wheel:
-                name, ver, _ = dist_artifact_path.name.split("-", 2)
-                metadata_path = str(Path(f"{name}-{ver}.dist-info") / "METADATA")
-                wheel.getinfo(
-                    metadata_path
-                ).filename = f"{dist_artifact_path.name}.metadata"
-                wheel.extract(metadata_path, output_dir)
+            if not extract_wheel_metadata_file(
+                dist_artifact_path, output_dir / f"{dist_artifact_path.name}.metadata",
+            ):
+                logger.warning(f"Warning: {pkg.name} has no METADATA file")
 
         test_path = pkg.tests_path()
         if test_path:

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -727,7 +727,9 @@ def copy_packages_to_dist_dir(
             with ZipFile(dist_artifact_path, mode="r") as wheel:
                 name, ver, _ = dist_artifact_path.name.split("-", 2)
                 metadata_path = str(Path(f"{name}-{ver}.dist-info") / "METADATA")
-                wheel.getinfo(metadata_path).filename = f"{dist_artifact_path.name}.metadata"
+                wheel.getinfo(
+                    metadata_path
+                ).filename = f"{dist_artifact_path.name}.metadata"
                 wheel.extract(metadata_path, output_dir)
 
         test_path = pkg.tests_path()

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -18,7 +18,6 @@ from queue import PriorityQueue, Queue
 from threading import Lock, Thread
 from time import perf_counter, sleep
 from typing import Any
-from zipfile import ZipFile
 
 from pyodide_lock import PyodideLockSpec
 from pyodide_lock.spec import PackageSpec as PackageLockSpec
@@ -726,7 +725,8 @@ def copy_packages_to_dist_dir(
 
         if metadata_files and dist_artifact_path.suffix == ".whl":
             if not extract_wheel_metadata_file(
-                dist_artifact_path, output_dir / f"{dist_artifact_path.name}.metadata",
+                dist_artifact_path,
+                output_dir / f"{dist_artifact_path.name}.metadata",
             ):
                 logger.warning(f"Warning: {pkg.name} has no METADATA file")
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -149,7 +149,8 @@ class Package(BasePackage):
                 # been updated and should be rebuilt even though its own
                 # files haven't been updated.
                 "--force-rebuild",
-            ] + (["--metadata-file"] if extract_metadata_file else []),
+            ]
+            + (["--metadata-file"] if extract_metadata_file else []),
             check=False,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -707,7 +708,9 @@ def generate_lockfile(
 
 
 def copy_packages_to_dist_dir(
-    packages: Iterable[BasePackage], output_dir: Path, compression_level: int = 6,
+    packages: Iterable[BasePackage],
+    output_dir: Path,
+    compression_level: int = 6,
 ) -> None:
     for pkg in packages:
         if pkg.package_type == "static_library":
@@ -775,7 +778,10 @@ def copy_logs(pkg_map: dict[str, BasePackage], log_dir: Path) -> None:
 
 
 def install_packages(
-    pkg_map: dict[str, BasePackage], output_dir: Path, compression_level: int = 6, metadata_files: bool = False
+    pkg_map: dict[str, BasePackage],
+    output_dir: Path,
+    compression_level: int = 6,
+    metadata_files: bool = False,
 ) -> None:
     """
     Install packages into the output directory.

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -41,7 +41,7 @@ from .common import (
     find_matching_wheels,
     find_missing_executables,
     make_zip_archive,
-    modify_wheel
+    modify_wheel,
 )
 from .io import MetaConfig, _BuildSpec, _SourceSpec
 from .logger import logger

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -554,7 +554,10 @@ def package_wheel(
             unpack_wheel(wheel, Path(temp_dir))
             name, ver, _ = wheel.name.split("-", 2)
             wheel_dist_info_dir_name = f"{name}-{ver}.dist-info"
-            shutil.copy2(Path(temp_dir) / wheel_dist_info_dir_name / "METADATA",distdir / f"{wheel.name}.metadata")
+            shutil.copy2(
+                Path(temp_dir) / wheel_dist_info_dir_name / "METADATA",
+                distdir / f"{wheel.name}.metadata",
+            )
 
 
 def unvendor_tests(install_prefix: Path, test_install_prefix: Path) -> int:
@@ -763,7 +766,12 @@ def _build_package_inner(
                 )
 
             package_wheel(
-                name, srcpath, build_metadata, bash_runner, build_args.host_install_dir, extract_metadata_file,
+                name,
+                srcpath,
+                build_metadata,
+                bash_runner,
+                build_args.host_install_dir,
+                extract_metadata_file,
             )
             shutil.rmtree(dist_dir, ignore_errors=True)
             shutil.copytree(src_dist_dir, dist_dir)
@@ -975,7 +983,13 @@ def main(args: argparse.Namespace) -> None:
         target_install_dir=args.target_install_dir,
         host_install_dir=args.host_install_dir,
     )
-    build_package(args.package[0], build_args, args.metadata_file, args.force_rebuild, args.continue_)
+    build_package(
+        args.package[0],
+        build_args,
+        args.metadata_file,
+        args.force_rebuild,
+        args.continue_,
+    )
 
 
 if __name__ == "__main__":

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -753,11 +753,7 @@ def _build_package_inner(
                 )
 
             package_wheel(
-                name,
-                srcpath,
-                build_metadata,
-                bash_runner,
-                build_args.host_install_dir,
+                name, srcpath, build_metadata, bash_runner, build_args.host_install_dir
             )
             shutil.rmtree(dist_dir, ignore_errors=True)
             shutil.copytree(src_dist_dir, dist_dir)
@@ -960,12 +956,7 @@ def main(args: argparse.Namespace) -> None:
         target_install_dir=args.target_install_dir,
         host_install_dir=args.host_install_dir,
     )
-    build_package(
-        args.package[0],
-        build_args,
-        args.force_rebuild,
-        args.continue_,
-    )
+    build_package(args.package[0], build_args, args.force_rebuild, args.continue_)
 
 
 if __name__ == "__main__":

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -18,6 +18,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from textwrap import dedent
 from types import TracebackType
 from typing import Any, TextIO, cast

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -118,7 +118,7 @@ def recipe(
             targets = ",".join(packages)
 
         pkg_map = buildall.build_packages(
-            recipe_dir_, targets, build_args, n_jobs, force_rebuild
+            recipe_dir_, targets, build_args, metadata_files, n_jobs, force_rebuild
         )
 
         if log_dir_:
@@ -126,5 +126,5 @@ def recipe(
 
         if install:
             buildall.install_packages(
-                pkg_map, install_dir_, compression_level=compression_level
+                pkg_map, install_dir_, compression_level=compression_level, metadata_files=metadata_files,
             )

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -30,6 +30,11 @@ def recipe(
         help="Path to install built packages and pyodide-lock.json. "
         "If not specified, the default is `./dist`.",
     ),
+    metadata_files: bool = typer.Option(
+        False, help="If true, extract the METADATA file from the built wheels "
+        "to a matching *.whl.metadata file. "
+        "If false, no *.whl.metadata file is produced.",
+    ),
     cflags: str = typer.Option(
         None, help="Extra compiling flags. Default: SIDE_MODULE_CFLAGS"
     ),
@@ -99,7 +104,7 @@ def recipe(
         # TODO: use multiprocessing?
         for package in packages:
             package_path = recipe_dir_ / package
-            buildpkg.build_package(package_path, build_args, force_rebuild, continue_)
+            buildpkg.build_package(package_path, build_args, metadata_files, force_rebuild, continue_)
 
     else:
         if len(packages) == 1 and "," in packages[0]:

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -105,9 +105,7 @@ def recipe(
         # TODO: use multiprocessing?
         for package in packages:
             package_path = recipe_dir_ / package
-            buildpkg.build_package(
-                package_path, build_args, force_rebuild, continue_
-            )
+            buildpkg.build_package(package_path, build_args, force_rebuild, continue_)
 
     else:
         if len(packages) == 1 and "," in packages[0]:

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -126,5 +126,8 @@ def recipe(
 
         if install:
             buildall.install_packages(
-                pkg_map, install_dir_, compression_level=compression_level, metadata_files=metadata_files,
+                pkg_map,
+                install_dir_,
+                compression_level=compression_level,
+                metadata_files=metadata_files,
             )

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -31,7 +31,8 @@ def recipe(
         "If not specified, the default is `./dist`.",
     ),
     metadata_files: bool = typer.Option(
-        False, help="If true, extract the METADATA file from the built wheels "
+        False,
+        help="If true, extract the METADATA file from the built wheels "
         "to a matching *.whl.metadata file. "
         "If false, no *.whl.metadata file is produced.",
     ),
@@ -104,7 +105,9 @@ def recipe(
         # TODO: use multiprocessing?
         for package in packages:
             package_path = recipe_dir_ / package
-            buildpkg.build_package(package_path, build_args, metadata_files, force_rebuild, continue_)
+            buildpkg.build_package(
+                package_path, build_args, metadata_files, force_rebuild, continue_
+            )
 
     else:
         if len(packages) == 1 and "," in packages[0]:

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -129,7 +129,7 @@ def recipe(
                 compression_level=compression_level,
                 metadata_files=metadata_files,
             )
-        else:
+        elif metadata_files:
             logger.warning(
                 "WARNING: when --install is not set, the --metadata-files parameter is ignored",
             )

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -97,16 +97,16 @@ def recipe(
     build_args = buildall.set_default_build_args(build_args)
 
     if no_deps:
-        if install or log_dir_:
+        if install or log_dir_ or metadata_files:
             logger.warning(
-                "WARNING: when --no-deps is set, --install and --log-dir parameters are ignored",
+                "WARNING: when --no-deps is set, the --install, --log-dir, and --metadata-files parameters are ignored",
             )
 
         # TODO: use multiprocessing?
         for package in packages:
             package_path = recipe_dir_ / package
             buildpkg.build_package(
-                package_path, build_args, metadata_files, force_rebuild, continue_
+                package_path, build_args, force_rebuild, continue_
             )
 
     else:
@@ -118,7 +118,7 @@ def recipe(
             targets = ",".join(packages)
 
         pkg_map = buildall.build_packages(
-            recipe_dir_, targets, build_args, metadata_files, n_jobs, force_rebuild
+            recipe_dir_, targets, build_args, n_jobs, force_rebuild
         )
 
         if log_dir_:
@@ -130,4 +130,8 @@ def recipe(
                 install_dir_,
                 compression_level=compression_level,
                 metadata_files=metadata_files,
+            )
+        else:
+            logger.warning(
+                "WARNING: when --install is not set, the --metadata-files parameter is ignored",
             )

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -328,7 +328,7 @@ def extract_wheel_metadata_file(wheel_path: Path, output_path: Path):
     https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-contents
     """
     with ZipFile(wheel_path, mode="r") as wheel:
-        pkg_name = wheel_path.split('-', 1)[0]
+        pkg_name = wheel_path.split("-", 1)[0]
         dist_info_dir = get_wheel_dist_info_dir(wheel, pkg_name)
         metadata_path = f"{dist_info_dir}/METADATA"
         try:
@@ -349,18 +349,20 @@ def get_wheel_dist_info_dir(wheel: ZipFile, pkg_name: str) -> str:
     """
 
     # Zip file path separators must be /
-    subdirs = { name.split("/", 1)[0] for name in source.namelist() }
-    info_dirs = [ subdir for subdir in subdirs if subdir.endswith(".dist-info") ]
+    subdirs = {name.split("/", 1)[0] for name in source.namelist()}
+    info_dirs = [subdir for subdir in subdirs if subdir.endswith(".dist-info")]
 
     if len(info_dirs) == 0:
         raise Exception(f".dist-info directory not found for {pkg_name}")
 
     if len(info_dirs) > 1:
         raise Exception(
-            "multiple .dist-info directories found for {}: {}".format(pkg_name, ", ".join(info_dirs))
+            "multiple .dist-info directories found for {}: {}".format(
+                pkg_name, ", ".join(info_dirs)
+            )
         )
 
-    info_dir, = info_dirs
+    (info_dir,) = info_dirs
 
     info_dir_name = _canonicalize_package_name(info_dir)
     canonical_name = _canonicalize_package_name(pkg_name)

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -5,7 +5,6 @@
 import contextlib
 import hashlib
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -20,7 +19,8 @@ from typing import Any, NoReturn
 from zipfile import ZipFile
 
 from packaging.tags import Tag
-from packaging.utils import parse_wheel_filename, canonicalize_name as canonicalize_package_name
+from packaging.utils import canonicalize_name as canonicalize_package_name
+from packaging.utils import parse_wheel_filename
 
 from .logger import logger
 

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -316,7 +316,7 @@ def modify_wheel(wheel: Path) -> Iterator[Path]:
         pack_wheel(wheel_dir, wheel.parent)
 
 
-def extract_wheel_metadata_file(wheel_path: Path, output_path: Path):
+def extract_wheel_metadata_file(wheel_path: Path, output_path: Path) -> None:
     """Extracts the METADATA file from the given wheel and writes it to the
     output path.
 
@@ -328,7 +328,7 @@ def extract_wheel_metadata_file(wheel_path: Path, output_path: Path):
     https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-contents
     """
     with ZipFile(wheel_path, mode="r") as wheel:
-        pkg_name = wheel_path.split("-", 1)[0]
+        pkg_name = wheel_path.name.split("-", 1)[0]
         dist_info_dir = get_wheel_dist_info_dir(wheel, pkg_name)
         metadata_path = f"{dist_info_dir}/METADATA"
         try:

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -334,8 +334,8 @@ def extract_wheel_metadata_file(wheel_path: Path, output_path: Path):
         try:
             wheel.getinfo(metadata_path).filename = output_path.name
             wheel.extract(metadata_path, output_path.parent)
-        except KeyError:
-            raise Exception(f"METADATA file not found for {pkg_name}")
+        except KeyError as err:
+            raise Exception(f"METADATA file not found for {pkg_name}") from err
 
 
 def get_wheel_dist_info_dir(wheel: ZipFile, pkg_name: str) -> str:
@@ -349,7 +349,7 @@ def get_wheel_dist_info_dir(wheel: ZipFile, pkg_name: str) -> str:
     """
 
     # Zip file path separators must be /
-    subdirs = {name.split("/", 1)[0] for name in source.namelist()}
+    subdirs = {name.split("/", 1)[0] for name in wheel.namelist()}
     info_dirs = [subdir for subdir in subdirs if subdir.endswith(".dist-info")]
 
     if len(info_dirs) == 0:

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -344,7 +344,7 @@ def get_wheel_dist_info_dir(wheel: ZipFile, pkg_name: str) -> str:
     Raises an Exception if the directory is not found, more than
     one is found, or it does not match the provided `pkg_name`.
 
-    Adapated from:
+    Adapted from:
     https://github.com/pypa/pip/blob/ea727e4d6ab598f34f97c50a22350febc1214a97/src/pip/_internal/utils/wheel.py#L38
     """
 

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -329,9 +329,7 @@ def extract_wheel_metadata_file(wheel_path: Path, output_path: Path) -> bool:
         name, ver, _ = wheel_path.name.split("-", 2)
         metadata_path = str(Path(f"{name}-{ver}.dist-info") / "METADATA")
         try:
-            wheel.getinfo(
-                metadata_path
-            ).filename = output_path.name
+            wheel.getinfo(metadata_path).filename = output_path.name
             wheel.extract(metadata_path, output_path.parent)
         except KeyError:
             return False

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -144,7 +144,6 @@ def test_extract_wheel_metadata_file(tmp_path):
     # Test extraction if metadata is missing
 
     input_path_empty = tmp_path / "pkg-0.2-abc.whl"
-    metadata_path_empty = "pkg-0.2.dist-info/METADATA"
 
     with zipfile.ZipFile(input_path_empty, "w") as fh:
         pass

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyodide_build.common import (
     environment_substitute_args,
+    extract_wheel_metadata_file,
     find_missing_executables,
     get_num_cores,
     make_zip_archive,
@@ -123,3 +124,31 @@ def test_repack_zip_archive(
         assert fh.namelist() == ["a/b.txt", "a/b/c.txt"]
         assert fh.getinfo("a/b.txt").compress_type == expected_compression_type
     assert input_path.stat().st_size == expected_size
+
+
+def test_extract_wheel_metadata_file(tmp_path):
+    # Test extraction if metadata exists
+
+    input_path = tmp_path / "pkg-0.1-abc.whl"
+    metadata_path = "pkg-0.1.dist-info/METADATA"
+    metadata_str = "This is METADATA"
+
+    with zipfile.ZipFile(input_path, "w") as fh:
+        fh.writestr(metadata_path, metadata_str)
+
+    output_path = tmp_path / f"{input_path.name}.metadata"
+
+    assert extract_wheel_metadata_file(input_path, output_path)
+    assert output_path.read_text() == metadata_str
+
+    # Test extraction if metadata is missing
+
+    input_path_empty = tmp_path / "pkg-0.2-abc.whl"
+    metadata_path_empty = "pkg-0.2.dist-info/METADATA"
+
+    with zipfile.ZipFile(input_path_empty, "w") as fh:
+        pass
+
+    output_path_empty = tmp_path / f"{input_path_empty.name}.metadata"
+
+    assert not extract_wheel_metadata_file(input_path_empty, output_path_empty)

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -138,7 +138,7 @@ def test_extract_wheel_metadata_file(tmp_path):
 
     output_path = tmp_path / f"{input_path.name}.metadata"
 
-    assert extract_wheel_metadata_file(input_path, output_path)
+    extract_wheel_metadata_file(input_path, output_path)
     assert output_path.read_text() == metadata_str
 
     # Test extraction if metadata is missing
@@ -150,4 +150,9 @@ def test_extract_wheel_metadata_file(tmp_path):
 
     output_path_empty = tmp_path / f"{input_path_empty.name}.metadata"
 
-    assert not extract_wheel_metadata_file(input_path_empty, output_path_empty)
+    try:
+        extract_wheel_metadata_file(input_path_empty, output_path_empty)
+    except Exception:
+        pass
+    else:
+        assert False

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -150,9 +150,5 @@ def test_extract_wheel_metadata_file(tmp_path):
 
     output_path_empty = tmp_path / f"{input_path_empty.name}.metadata"
 
-    try:
+    with pytest.raises(Exception):
         extract_wheel_metadata_file(input_path_empty, output_path_empty)
-    except Exception:
-        pass
-    else:
-        raise AssertionError()

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -155,4 +155,4 @@ def test_extract_wheel_metadata_file(tmp_path):
     except Exception:
         pass
     else:
-        assert False
+        raise AssertionError()

--- a/tools/deploy_s3.py
+++ b/tools/deploy_s3.py
@@ -137,6 +137,8 @@ def deploy_to_s3_main(
                 # However, JsDelivr will currently not serve .ts file in the
                 # custom CDN configuration, so it does not really matter.
                 content_type = "text/x.typescript"
+            elif file_path.suffix == ".metadata":
+                content_type = "text/plain"
             else:
                 content_type = mimetypes.guess_type(file_path)[0]
                 if content_type is None:

--- a/tools/deploy_s3.py
+++ b/tools/deploy_s3.py
@@ -137,7 +137,7 @@ def deploy_to_s3_main(
                 # However, JsDelivr will currently not serve .ts file in the
                 # custom CDN configuration, so it does not really matter.
                 content_type = "text/x.typescript"
-            elif file_path.suffix == ".metadata":
+            elif file_path.name.endswith(".whl.metadata"):
                 content_type = "text/plain"
             else:
                 content_type = mimetypes.guess_type(file_path)[0]


### PR DESCRIPTION
### Description

To make Simple JSON API more useful (https://github.com/pyodide/micropip/issues/62, https://github.com/pyodide/pyodide/issues/3979), we now deploy the .whl.metadata files per [PEP 658](https://peps.python.org/pep-0658/), so that Python packages manager could more easily identify dependencies.

A `--metadata-files` boolean option is added to the `pyodide build-recipes` command, which defaults to `False` for backward compatibility. When the option is passed alongside the `--install` option and without the `--no_deps` option, the METADATA file of each wheel file `FILENAME.whl` is now installed alongside in `FILENAME.whl.metadata`.

Fixes #3980

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
