### PR TITLE
Removed raise if failed check from the json and string response returns

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -50,6 +50,10 @@ myst:
   `pyodide-lock.json`
   {pr}`3824`
 
+- {{ Breaking }} Changed the FetchResponse body getter methods to no longer
+  throw an OSError exception for 400 and above response status codes
+  {pr}`3986`
+
 ### Packages
 
 - OpenBLAS has been added and scipy now uses OpenBLAS rather than CLAPACK

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -126,10 +126,6 @@ class FetchResponse:
         return self.js_response.url
 
     def _raise_if_failed(self) -> None:
-        if self.js_response.status >= 400:
-            raise OSError(
-                f"Request for {self._url} failed with status {self.status}: {self.status_text}"
-            )
         if self.js_response.bodyUsed:
             raise OSError("Response body is already used")
 
@@ -153,6 +149,7 @@ class FetchResponse:
 
     async def string(self) -> str:
         """Return the response body as a string"""
+        self._raise_if_failed()
         return await self.js_response.text()
 
     async def json(self, **kwargs: Any) -> Any:
@@ -161,6 +158,7 @@ class FetchResponse:
 
         Any keyword arguments are passed to :py:func:`json.loads`.
         """
+        self._raise_if_failed()
         return json.loads(await self.string(), **kwargs)
 
     async def memoryview(self) -> memoryview:

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -153,7 +153,6 @@ class FetchResponse:
 
     async def string(self) -> str:
         """Return the response body as a string"""
-        self._raise_if_failed()
         return await self.js_response.text()
 
     async def json(self, **kwargs: Any) -> Any:
@@ -162,7 +161,6 @@ class FetchResponse:
 
         Any keyword arguments are passed to :py:func:`json.loads`.
         """
-        self._raise_if_failed()
         return json.loads(await self.string(), **kwargs)
 
     async def memoryview(self) -> memoryview:

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -35,6 +35,15 @@ async def test_pyfetch_create_file(selenium):
 
 
 @run_in_pyodide
+async def test_pyfetch_return_400_status_body(selenium):
+    from pyodide.http import pyfetch
+
+    resp = await pyfetch("http://httpstat.us/404")
+    body = await resp.string()
+    assert body == "404 Not Found"
+
+
+@run_in_pyodide
 async def test_pyfetch_unpack_archive(selenium):
     import pathlib
 

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -2,6 +2,17 @@ import pytest
 from pytest_pyodide import run_in_pyodide
 
 
+@pytest.fixture
+def url_notfound(httpserver):
+    httpserver.expect_request("/data").respond_with_data(
+        b"404 Not Found",
+        content_type="text/text",
+        headers={"Access-Control-Allow-Origin": "*"},
+        status=404,
+    )
+    return httpserver.url_for("/data")
+
+
 @pytest.mark.xfail_browsers(node="XMLHttpRequest is not available in node")
 def test_open_url(selenium, httpserver):
     httpserver.expect_request("/data").respond_with_data(
@@ -35,10 +46,10 @@ async def test_pyfetch_create_file(selenium):
 
 
 @run_in_pyodide
-async def test_pyfetch_return_400_status_body(selenium):
+async def test_pyfetch_return_400_status_body(selenium, url_notfound):
     from pyodide.http import pyfetch
 
-    resp = await pyfetch("http://httpstat.us/404")
+    resp = await pyfetch(url_notfound)
     body = await resp.string()
     assert body == "404 Not Found"
 


### PR DESCRIPTION
### Description

The previous logic was raising an OSError if a response returned a status code at 400 or greater but there are valid reasons to retrieve the bodies from such responses as they often contain additional information about the error that can be useful to the client - see issue [3974](https://github.com/pyodide/pyodide/issues/3974).

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
