### PR TITLE
Only schedule Python coroutine if it's the result of calling an async function

### DIFF
--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -700,6 +700,8 @@ finally:
 bool
 _iscoroutinefunction(PyObject* f)
 {
+  _Py_IDENTIFIER(_is_coroutine_marker);
+
   // Some fast paths for common cases to avoid calling into Python
   if (PyMethod_Check(f)) {
     f = PyMethod_GET_FUNCTION(f);
@@ -709,7 +711,7 @@ _iscoroutinefunction(PyObject* f)
   // to make sure we don't accidentally return false negatives when we update to
   // 3.12.
   if (PyFunction_Check(f) &&
-      !PyObject_HasAttrString(f, "_is_coroutine_marker")) {
+      !PyObject_HasAttr(f, _PyUnicode_FromId(&PyId__is_coroutine_marker))) {
     PyFunctionObject* func = (PyFunctionObject*)f;
     PyCodeObject* code = (PyCodeObject*)PyFunction_GET_CODE(func);
     return (code->co_flags) & CO_COROUTINE;

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -445,7 +445,12 @@ Module.callPyObjectKwargs = function (
   let result = Hiwire.pop_value(idresult);
   // Automatically schedule coroutines
   if (result && result.type === "coroutine" && result._ensure_future) {
-    result._ensure_future();
+    Py_ENTER();
+    let is_coroutine = Module.__iscoroutinefunction(ptrobj);
+    Py_EXIT();
+    if (is_coroutine) {
+      result._ensure_future();
+    }
   }
   return result;
 };


### PR DESCRIPTION
When we call a Python function from JavaScript, if the result is a coroutine we have logic to automatically schedule it. This is so that a coroutine function can be used as an event handler or otherwise as a drop in replacement for a JS async function: when a JS async function is called, its execution is automatically scheduled, whereas in Python an async function must be awaited or scheduled with `create_task`. Contexts that expect JS async functions may not do any of these things but still want the function to execute.

A confusing edge case that arises is when a coroutine is returned from a function which is not a Python async function. This most often happens by accident, for example
 with `eval_code`. It's perhaps slightly unexpected that we schedule it in this case.
This PR adjusts it so that if a non-async python is called and it returns a coroutine, we no longer schedule it.

One edge case that's still here is that if an async function returns a coroutine, that coroutine will get automatically scheduled:

```js
pyodide.runPython(`
async def f():
   return g()

async def g():
   print("This is executed")
`);
pyodide.globals.get("g")()
```

This is because we attach the coroutine to a JS promise and if a JS promise resolves to a thenable, the thenable is automatically thened. If we were sufficiently upset about this, we could use a custom thenable that doesn't have this flattening behavior.

@antocuni 

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
