### PR TITLE
Disable pyproj

### DIFF
--- a/packages/pyproj/meta.yaml
+++ b/packages/pyproj/meta.yaml
@@ -1,6 +1,7 @@
 package:
   name: pyproj
   version: 3.4.1
+  _disabled: true
   top-level:
     - pyproj
 source:


### PR DESCRIPTION
There seems to be some cython related build failure. Maybe we need to cap cython?