### PR TITLE
Add support for the @example JSDoc directive

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,7 +15,7 @@ myst:
 
 ## Unreleased
 
-  - {{ Enhancement }} Make it possible to use the @example JSDoc directive.
+- {{ Enhancement }} Make it possible to use the @example JSDoc directive.
   {pr}`4009`
 
 - {{ Enhancement }} ABI Break: Updated Emscripten to version 3.1.39

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,9 @@ myst:
 
 ## Unreleased
 
+  - {{ Enhancement }} Make it possible to use the @example JSDoc directive.
+  {pr}`4009`
+
 - {{ Enhancement }} ABI Break: Updated Emscripten to version 3.1.39
   {pr}`3665`, {pr}`3659`, {pr}`3822`, {pr}`3889`, {pr}`3890`
 

--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -190,9 +190,9 @@ def _convert_node(self: TsAnalyzer, node: dict[str, Any]) -> Any:
     if not converted:
         return converted, more_todo
     converted.is_private = node.get("flags", {}).get("isPrivate", False)
-    if kind in ['Call signature', 'Constructor signature']:
-        tags = node.get('comment', {}).get('tags', [])
-        converted.examples = [tag['text'] for tag in tags if tag['tag'] == 'example']    
+    if kind in ["Call signature", "Constructor signature"]:
+        tags = node.get("comment", {}).get("tags", [])
+        converted.examples = [tag["text"] for tag in tags if tag["tag"] == "example"]
     return converted, more_todo
 
 

--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -187,8 +187,12 @@ def _convert_node(self: TsAnalyzer, node: dict[str, Any]) -> Any:
     # See docstring for destructure_param
     fix_up_inline_object_signature(self, node)
     converted, more_todo = _orig_convert_node(self, node)
-    if converted:
-        converted.is_private = node.get("flags", {}).get("isPrivate", False)
+    if not converted:
+        return converted, more_todo
+    converted.is_private = node.get("flags", {}).get("isPrivate", False)
+    if kind in ['Call signature', 'Constructor signature']:
+        tags = node.get('comment', {}).get('tags', [])
+        converted.examples = [tag['text'] for tag in tags if tag['tag'] == 'example']    
     return converted, more_todo
 
 


### PR DESCRIPTION
### Description

Adds support for the [`@example`](https://jsdoc.app/tags-example.html) directive in JSDoc. This makes it possible to add code examples to JS functions.

This is what the code example looks like:
![image](https://github.com/pyodide/pyodide/assets/8739637/3beb73f0-1d7f-44a2-a84d-676b4a93c867)
