### PR TITLE
Add examples for runPython()

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,7 +15,7 @@ myst:
 
 ## Unreleased
 
-  - {{ Enhancement }} Add examples for `pyodide.runPython`.
+- {{ Enhancement }} Add examples for `pyodide.runPython`.
   {pr}`4011`
 
 - {{ Enhancement }} Make it possible to use the @example JSDoc directive.

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,9 @@ myst:
 
 ## Unreleased
 
+  - {{ Enhancement }} Add examples for `pyodide.runPython`.
+  {pr}`4011`
+
 - {{ Enhancement }} Make it possible to use the @example JSDoc directive.
   {pr}`4009`
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -224,6 +224,21 @@ export class PyodideAPI {
    *        Defaults to the same as ``globals``.
    * @returns The result of the Python code translated to JavaScript. See the
    *          documentation for :py:func:`~pyodide.code.eval_code` for more info.
+   * @example
+   * async function main(){
+   *   const pyodide = await loadPyodide();
+   *   console.log(pyodide.runPython("1 + 2"));
+   *   // 3
+   *
+   *   const globals = pyodide.toPy({ x: 3 });
+   *   console.log(pyodide.runPython("x + 1", { globals }));
+   *   // 4
+   *
+   *   const locals = pyodide.toPy({ arr: [1, 2, 3] });
+   *   console.log(pyodide.runPython("sum(arr)", { locals }));
+   *   // 6
+   * }
+   * main();
    */
   static runPython(
     code: string,


### PR DESCRIPTION
### Description

#1955

Adds some examples for the `pyodide.runPython()` JS function

![image](https://github.com/pyodide/pyodide/assets/8739637/95918ba6-f58f-4196-8586-3103a2d456af)
