### PR TITLE
Add examples for loadPyodide()

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,8 +15,8 @@ myst:
 
 ## Unreleased
 
- - {{ Enhancement }} Add an example for `loadPyodide`.
-   {pr}`4012`
+- {{ Enhancement }} Add an example for `loadPyodide`.
+  {pr}`4012`
 
 - {{ Enhancement }} Make it possible to use the @example JSDoc directive.
   {pr}`4009`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,9 @@ myst:
 
 ## Unreleased
 
+ - {{ Enhancement }} Add an example for `loadPyodide`.
+   {pr}`4012`
+
 - {{ Enhancement }} Make it possible to use the @example JSDoc directive.
   {pr}`4009`
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,7 +16,7 @@ myst:
 ## Unreleased
 
 - {{ Enhancement }} Add an example for `loadPyodide` and `pyodide.runPython
-  {pr}`4012`, {pr}`4011`
+{pr}`4012`, {pr}`4011`
 
 - {{ Enhancement }} Make it possible to use the @example JSDoc directive.
   {pr}`4009`

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -197,6 +197,16 @@ export type ConfigType = {
  * @returns The :ref:`js-api-pyodide` module.
  * @memberof globalThis
  * @async
+ * @example
+ * async function main() {
+ *   const pyodide = await loadPyodide({
+ *     fullStdLib: true,
+ *     homedir: "/pyodide",
+ *     stdout: (msg) => console.log(`Pyodide: ${msg}`),
+ *   });
+ *   console.log("Loaded Pyodide");
+ * }
+ * main();
  */
 export async function loadPyodide(
   options: {


### PR DESCRIPTION
### Description

#1955 

Adds an example for the `loadPyodide()` JS function

![image](https://github.com/pyodide/pyodide/assets/8739637/dec1cca1-e644-43be-bd7a-39c4d63da8d7)
