### PR TITLE
ENH (perf) Use weakmap instead of attribute access for $$ 

### DIFF
--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -115,7 +115,7 @@ JS_FILE(js2python_init, () => {
     } else if (value === false) {
       return __js2python_false();
     } else if (API.isPyProxy(value)) {
-      if (value.$$.ptr == 0) {
+      if (!pyproxy_lookup.has(value)) {
         // Make sure to throw an error!
         Module.PyProxy_getPtr(value);
       }

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -50,3 +50,5 @@ function hasMethod(obj, prop) {
     return false;
   }
 }
+
+const pyproxy_lookup = new WeakMap();

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -310,7 +310,7 @@ EM_JS(JsRef, proxy_cache_get, (JsRef proxyCacheId, PyObject* descr), {
     return undefined;
   }
   // Okay found a proxy. Is it alive?
-  if (Hiwire.get_value(proxyId).$$.ptr) {
+  if (pyproxy_lookup.has(Hiwire.get_value(proxyId))) {
     return proxyId;
   } else {
     // It's dead, tidy up


### PR DESCRIPTION
We've received user feedback recently that Python => JS calls are a bit slow when the arguments are proxied (from @DerThorsten and @laffra). Profiling showed that 90% of the time was being spent in destroying the pyproxies. The line profiles showed that every time we accessed `pyproxy.$$` it was very slow. For normal JS objects, attribute access is very efficient but for Proxy exotic objects with `get` traps it's pretty slow. The cool kids use `WeakMap` to avoid this problem.

This patch was enough to bring the time spent in destroy_proxy down from 90% to 6% of the runtime for the following profile:
```py
from pyodide.ffi import create_proxy
from pyodide.code import run_js
from timeit import timeit
n = 100000

jsf = run_js("() => {}")
a = object()

timeit("jsf(a, a, a, a)", number=n, globals={"jsf": jsf, "a": a}) / n * 1e6
```

To keep this patch small, I left in the old ways of accessing the `$$` object via `pyproxy.$$`. In a followup we should switch everything else over to using the map, and also move `$$flags` and `$$props` into the map.
