### PR TITLE
Add .so WASM Compatibility Check

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -17,7 +17,7 @@ myst:
 
 - {{ Enhancement }} Adds `check_wasm_magic_number` function to validate `.so`
   files for WebAssembly (WASM) compatibility.
-  {pr}`4017`
+  {pr}`4018`
 
 - {{ Enhancement }} Add an example for `loadPyodide` and `pyodide.runPython
 {pr}`4012`, {pr}`4011`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,10 @@ myst:
 
 ## Unreleased
 
+- {{ Enhancement }} Adds `check_wasm_magic_number` function to validate `.so`
+  files for WebAssembly (WASM) compatibility.
+  {pr}`4017`
+
 - {{ Enhancement }} Add an example for `loadPyodide` and `pyodide.runPython
 {pr}`4012`, {pr}`4011`
 

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -373,8 +373,7 @@ def get_wheel_dist_info_dir(wheel: ZipFile, pkg_name: str) -> str:
     return info_dir
 
 
-def check_wacm_magic_number(file_path: Path):
+def check_wacm_magic_number(file_path: Path) -> bool:
     WASM_BINARY_MAGIC = b"\0asm"
     with file_path.open(mode="rb") as file:
         return file.read(4) == WASM_BINARY_MAGIC
-    

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -373,7 +373,7 @@ def get_wheel_dist_info_dir(wheel: ZipFile, pkg_name: str) -> str:
     return info_dir
 
 
-def check_wacm_magic_number(file_path: Path) -> bool:
+def check_wasm_magic_number(file_path: Path) -> bool:
     WASM_BINARY_MAGIC = b"\0asm"
     with file_path.open(mode="rb") as file:
         return file.read(4) == WASM_BINARY_MAGIC

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -371,3 +371,10 @@ def get_wheel_dist_info_dir(wheel: ZipFile, pkg_name: str) -> str:
         )
 
     return info_dir
+
+
+def check_wacm_magic_number(file_path: Path):
+    WASM_BINARY_MAGIC = b"\0asm"
+    with file_path.open(mode="rb") as file:
+        return file.read(4) == WASM_BINARY_MAGIC
+    

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -152,3 +152,11 @@ def test_extract_wheel_metadata_file(tmp_path):
 
     with pytest.raises(Exception):
         extract_wheel_metadata_file(input_path_empty, output_path_empty)
+        
+        
+def test_check_wasm_number(tmp_path):
+    (tmp_path/"goodfile.so").write_bytes(b'\x00asm\x01\x00\x00\x00\x00\x11')
+    assert check_wasm_number("goodfile.so") == True
+    (tmp_path/"goodfile.so").write_bytes(b'\x00asm\x01\x00\x00\x00\x00\x11')
+    
+    # pytest <path to test_common.py> -k <testfuncname>

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -3,7 +3,7 @@ import zipfile
 import pytest
 
 from pyodide_build.common import (
-    check_wacm_magic_number,
+    check_wasm_magic_number,
     environment_substitute_args,
     extract_wheel_metadata_file,
     find_missing_executables,
@@ -160,7 +160,7 @@ def test_check_wasm_magic_number(tmp_path):
     not_wasm_magic_number = b"\x7fELF\x02\x01\x01\x00\x00\x00"
 
     (tmp_path / "goodfile.so").write_bytes(wasm_magic_number)
-    assert check_wacm_magic_number(tmp_path / "goodfile.so") is True
+    assert check_wasm_magic_number(tmp_path / "goodfile.so") is True
 
     (tmp_path / "badfile.so").write_bytes(not_wasm_magic_number)
-    assert check_wacm_magic_number(tmp_path / "badfile.so") is False
+    assert check_wasm_magic_number(tmp_path / "badfile.so") is False

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -10,6 +10,7 @@ from pyodide_build.common import (
     make_zip_archive,
     parse_top_level_import_name,
     repack_zip_archive,
+    check_wacm_magic_number,
 )
 
 
@@ -152,11 +153,14 @@ def test_extract_wheel_metadata_file(tmp_path):
 
     with pytest.raises(Exception):
         extract_wheel_metadata_file(input_path_empty, output_path_empty)
-        
-        
-def test_check_wasm_number(tmp_path):
-    (tmp_path/"goodfile.so").write_bytes(b'\x00asm\x01\x00\x00\x00\x00\x11')
-    assert check_wasm_number("goodfile.so") == True
-    (tmp_path/"goodfile.so").write_bytes(b'\x00asm\x01\x00\x00\x00\x00\x11')
-    
-    # pytest <path to test_common.py> -k <testfuncname>
+
+
+def test_check_wasm_magic_number(tmp_path):
+    wasm_magic_number = b"\x00asm\x01\x00\x00\x00\x00\x11"
+    not_wasm_magic_number = b"\x7fELF\x02\x01\x01\x00\x00\x00"
+
+    (tmp_path/"goodfile.so").write_bytes(wasm_magic_number)
+    assert check_wacm_magic_number(tmp_path/"goodfile.so") is True
+
+    (tmp_path/"badfile.so").write_bytes(not_wasm_magic_number)
+    assert check_wacm_magic_number(tmp_path/"badfile.so") is False

--- a/pyodide-build/pyodide_build/tests/test_common.py
+++ b/pyodide-build/pyodide_build/tests/test_common.py
@@ -3,6 +3,7 @@ import zipfile
 import pytest
 
 from pyodide_build.common import (
+    check_wacm_magic_number,
     environment_substitute_args,
     extract_wheel_metadata_file,
     find_missing_executables,
@@ -10,7 +11,6 @@ from pyodide_build.common import (
     make_zip_archive,
     parse_top_level_import_name,
     repack_zip_archive,
-    check_wacm_magic_number,
 )
 
 
@@ -159,8 +159,8 @@ def test_check_wasm_magic_number(tmp_path):
     wasm_magic_number = b"\x00asm\x01\x00\x00\x00\x00\x11"
     not_wasm_magic_number = b"\x7fELF\x02\x01\x01\x00\x00\x00"
 
-    (tmp_path/"goodfile.so").write_bytes(wasm_magic_number)
-    assert check_wacm_magic_number(tmp_path/"goodfile.so") is True
+    (tmp_path / "goodfile.so").write_bytes(wasm_magic_number)
+    assert check_wacm_magic_number(tmp_path / "goodfile.so") is True
 
-    (tmp_path/"badfile.so").write_bytes(not_wasm_magic_number)
-    assert check_wacm_magic_number(tmp_path/"badfile.so") is False
+    (tmp_path / "badfile.so").write_bytes(not_wasm_magic_number)
+    assert check_wacm_magic_number(tmp_path / "badfile.so") is False


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

This adds `check_wasm_magic_number` function to verify .so files for WASM compatibility. The function checks the first 4 bytes for the WASM binary magic number, `b"\0asm"`.
Includes tests for validation.

Feedback appreciated. Thanks!

Resolves #4017

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests

