### PR TITLE
DOCS Add examples for setStdout & setStderr

### DIFF
--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -285,8 +285,8 @@ function setDefaultStdout() {
  *   pyodide.setStdout({ raw: (byte) => console.log(byte) });
  *   pyodide.runPython("print('ABC')");
  *   // 65
- *   // 66 
- *   // 67 
+ *   // 66
+ *   // 67
  *   // 10 (the ascii values for 'ABC' including a new line character)
  * }
  * main();
@@ -360,7 +360,10 @@ function setDefaultStderr() {
  *   // 'ABC'
  *   pyodide.setStderr({ raw: (byte) => console.warn(byte) });
  *   pyodide.runPython("import sys; print('ABC', file=sys.stderr)");
- *   // 65 66 67 10 (ascii values for 'ABC' including a new line character)
+ *   // 65
+ *   // 66
+ *   // 67
+ *   // 10 (the ascii values for 'ABC' including a new line character)
  * }
  * main();
  */

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -276,6 +276,17 @@ function setDefaultStdout() {
  * @param options.isatty Should :py:func:`isatty(stdout) <os.isatty>` return
  * ``true`` or ``false``. Can only be set to ``true`` if a raw handler is
  * provided (default ``false``).
+ * @example
+ * async function main(){
+ *   const pyodide = await loadPyodide();
+ *   pyodide.setStdout({ batched: (msg) => console.log(msg) });
+ *   pyodide.runPython("print('ABC')");
+ *   // 'ABC'
+ *   pyodide.setStdout({ raw: (byte) => console.log(byte) });
+ *   pyodide.runPython("print('ABC')");
+ *   // 65 66 67 10 (ascii values for 'ABC' including a new line character)
+ * }
+ * main();
  */
 export function setStdout(
   options: {
@@ -338,6 +349,17 @@ function setDefaultStderr() {
  * @param options.isatty Should :py:func:`isatty(stderr) <os.isatty>` return
  * ``true`` or ``false``. Can only be set to ``true`` if a raw handler is
  * provided (default ``false``).
+ * @example
+ * async function main(){
+ *   const pyodide = await loadPyodide();
+ *   pyodide.setStderr({ batched: (msg) => console.warn(msg) });
+ *   pyodide.runPython("import sys; print('ABC', file=sys.stderr)");
+ *   // 'ABC'
+ *   pyodide.setStderr({ raw: (byte) => console.warn(byte) });
+ *   pyodide.runPython("import sys; print('ABC', file=sys.stderr)");
+ *   // 65 66 67 10 (ascii values for 'ABC' including a new line character)
+ * }
+ * main();
  */
 export function setStderr(
   options: {

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -284,7 +284,10 @@ function setDefaultStdout() {
  *   // 'ABC'
  *   pyodide.setStdout({ raw: (byte) => console.log(byte) });
  *   pyodide.runPython("print('ABC')");
- *   // 65 66 67 10 (ascii values for 'ABC' including a new line character)
+ *   // 65
+ *   // 66 
+ *   // 67 
+ *   // 10 (the ascii values for 'ABC' including a new line character)
  * }
  * main();
  */


### PR DESCRIPTION
### Description

Adds examples for `pyodide.setStdout` & `pyodide.setStderr`. Feedback welcome!

![image](https://github.com/pyodide/pyodide/assets/8739637/a7d4fb24-9384-4cc9-ac1c-b5e30c983ab6)

![image](https://github.com/pyodide/pyodide/assets/8739637/640f5dcb-3125-4b58-a4d6-aef20195775f)

