### PR TITLE
PERF Only gc register proxies if not destroyed at end of function call

### DIFF
--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1254,12 +1254,12 @@ success:
 // clang-format off
 EM_JS_REF(JsRef,
 pyproxy_new_ex,
-(PyObject * ptrobj, bool capture_this, bool roundtrip, bool gc_register),
+(PyObject * ptrobj, bool capture_this, bool roundtrip, bool gcRegister),
 {
   return Hiwire.new_value(
     Module.pyproxy_new(ptrobj, {
       props: { captureThis: !!capture_this, roundtrip: !!roundtrip },
-      dontGCRegister: !gc_register,
+      gcRegister,
     })
   );
 });

--- a/src/core/pyproxy.h
+++ b/src/core/pyproxy.h
@@ -11,7 +11,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
 JsRef
-pyproxy_new_ex(PyObject* obj, bool capture_this, bool roundtrip);
+pyproxy_new_ex(PyObject* obj, bool capture_this, bool roundtrip, bool register);
 
 JsRef
 pyproxy_new(PyObject* obj);
@@ -37,6 +37,9 @@ pyproxy_AsPyObject(JsRef x);
  */
 void
 destroy_proxies(JsRef proxies_id, char* msg);
+
+void
+gc_register_proxies(JsRef proxies_id);
 
 /**
  * Destroy a PyProxy.

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -269,6 +269,12 @@ function pyproxy_new(
 }
 Module.pyproxy_new = pyproxy_new;
 
+Module.gc_register_proxy = function (proxy: PyProxy) {
+  const $$ = proxy.$$;
+  const $$copy = Object.assign({}, $$);
+  Module.finalizationRegistry.register($$, $$copy, $$);
+};
+
 function _getPtr(jsobj: any) {
   let ptr: number = jsobj.$$.ptr;
   if (ptr === 0) {

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -193,7 +193,7 @@ function pyproxy_new(
     gcRegister?: boolean;
   } = {},
 ): PyProxy {
-  if(gcRegister === undefined) {
+  if (gcRegister === undefined) {
     // register by default
     gcRegister = true;
   }

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -184,15 +184,19 @@ function pyproxy_new(
     cache,
     props,
     $$,
-    dontGCRegister,
+    gcRegister,
   }: {
     flags?: number;
     cache?: PyProxyCache;
     $$?: any;
     props?: any;
-    dontGCRegister?: boolean;
+    gcRegister?: boolean;
   } = {},
 ): PyProxy {
+  if(gcRegister === undefined) {
+    // register by default
+    gcRegister = true;
+  }
   const flags =
     flags_arg !== undefined ? flags_arg : Module._pyproxy_getflags(ptrobj);
   if (flags === -1) {
@@ -252,7 +256,7 @@ function pyproxy_new(
     target,
     is_sequence ? PyProxySequenceHandlers : PyProxyHandlers,
   );
-  if (!isAlias && !dontGCRegister) {
+  if (!isAlias && gcRegister) {
     // we need to register only once for a set of aliases. we can't register the
     // proxy directly since that isn't shared between aliases. The aliases all
     // share $$ so we can register that. They also need access to the data in

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -501,7 +501,7 @@ _python2js(ConversionContext context, PyObject* x)
     if (context.default_converter) {
       return python2js__default_converter(context.jscontext, x);
     }
-    return python2js_track_proxies(x, context.proxies);
+    return python2js_track_proxies(x, context.proxies, true);
   } else {
     context.depth--;
     return _python2js_deep(context, x);
@@ -516,7 +516,7 @@ finally:
  *
  */
 JsRef
-python2js_inner(PyObject* x, JsRef proxies, bool track_proxies)
+python2js_inner(PyObject* x, JsRef proxies, bool track_proxies, bool gc_register)
 {
   RETURN_IF_HAS_VALUE(_python2js_immutable(x));
   RETURN_IF_HAS_VALUE(_python2js_proxy(x));
@@ -524,7 +524,7 @@ python2js_inner(PyObject* x, JsRef proxies, bool track_proxies)
     PyErr_SetString(conversion_error, "No conversion known for x.");
     FAIL();
   }
-  JsRef proxy = pyproxy_new(x);
+  JsRef proxy = pyproxy_new_ex(x, false, false, gc_register);
   FAIL_IF_NULL(proxy);
   if (track_proxies) {
     JsArray_Push_unchecked(proxies, proxy);
@@ -552,9 +552,9 @@ finally:
  * of creating a proxy.
  */
 JsRef
-python2js_track_proxies(PyObject* x, JsRef proxies)
+python2js_track_proxies(PyObject* x, JsRef proxies, bool gc_register)
 {
-  return python2js_inner(x, proxies, true);
+  return python2js_inner(x, proxies, true, gc_register);
 }
 
 /**
@@ -564,7 +564,7 @@ python2js_track_proxies(PyObject* x, JsRef proxies)
 JsRef
 python2js(PyObject* x)
 {
-  return python2js_inner(x, NULL, false);
+  return python2js_inner(x, NULL, false, true);
 }
 
 // taking function pointers to EM_JS functions leads to linker errors.

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -24,7 +24,7 @@ python2js(PyObject* x);
  * the proxy to the array if one is created.
  */
 JsRef
-python2js_track_proxies(PyObject* x, JsRef proxies);
+python2js_track_proxies(PyObject* x, JsRef proxies, bool gc_register);
 
 /**
  * Convert a Python object to a JavaScript object, copying standard collections


### PR DESCRIPTION
`finalizationRegistry.register` is expensive. This PR avoids calling it when converting function arguments. If the function returns a promise or generator and the lifetime of the arguments is extended, then we register all the arguments in the `finalizationRegistry`. Otherwise, we immediately destroy the arguments so they don't need to be registered.
