### PR TITLE
Bump typing-extensions  4.7.1

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -77,6 +77,7 @@ myst:
 - Upgraded scikit-image to 0.21 {pr}`3874`
 - Upgraded scikit-learn to 1.3.0 {pr}`3976`
 - Upgraded pyodide-http to 0.2.1
+- Upgraded typing-extensions to 4.7.12 {pr}`4026`
 
 ### CLI
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -77,7 +77,7 @@ myst:
 - Upgraded scikit-image to 0.21 {pr}`3874`
 - Upgraded scikit-learn to 1.3.0 {pr}`3976`
 - Upgraded pyodide-http to 0.2.1
-- Upgraded typing-extensions to 4.7.12 {pr}`4026`
+- Upgraded typing-extensions to 4.7.1 {pr}`4026`
 
 ### CLI
 

--- a/packages/typing-extensions/meta.yaml
+++ b/packages/typing-extensions/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: typing-extensions
-  version: 4.5.0
+  version: 4.7.1
   top-level:
     - typing_extensions
 source:

--- a/packages/typing-extensions/meta.yaml
+++ b/packages/typing-extensions/meta.yaml
@@ -4,5 +4,5 @@ package:
   top-level:
     - typing_extensions
 source:
-  url: https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl
-  sha256: fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4
+  url: https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl
+  sha256: 440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Bumps the version of `typing-extensions` from 4.5.0 to the latest 4.7.1.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
