### PR TITLE
ENH Improve PyProxy handling of read only properties

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,11 @@ myst:
 
 ## Unreleased
 
+- {{ Fix }} Fixed adding getters/setters to a `PyProxy` with
+  `Object.defineProperty` and improved compliance with JavaScript rules around
+  Proxy traps.
+  {pr}`4033`
+
 - {{ Enhancement }} Adds `check_wasm_magic_number` function to validate `.so`
   files for WebAssembly (WASM) compatibility.
   {pr}`4018`

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -2157,7 +2157,7 @@ const PyProxyHandlers = {
       return false;
     }
     // python_setattr will crash if given a Symbol.
-    if (typeof jskey === "symbol") {
+    if (typeof jskey === "symbol" || filteredHasKey(jsobj, jskey, true)) {
       return Reflect.set(jsobj, jskey, jsval);
     }
     if (jskey.startsWith("$")) {
@@ -2169,17 +2169,21 @@ const PyProxyHandlers = {
   deleteProperty(jsobj: PyProxy, jskey: string | symbol): boolean {
     let descr = Object.getOwnPropertyDescriptor(jsobj, jskey);
     if (descr && !descr.configurable) {
+      // Must return "false" if "jskey" is a nonconfigurable own property.
+      // Otherwise JavaScript will throw a TypeError.
+      // Strict mode JS will throw an error here saying that the property cannot
+      // be deleted. It's good to leave everything alone so that the behavior is
+      // consistent with the error message.
       return false;
     }
-    if (typeof jskey === "symbol") {
+    if (typeof jskey === "symbol" || filteredHasKey(jsobj, jskey, true)) {
       return Reflect.deleteProperty(jsobj, jskey);
     }
     if (jskey.startsWith("$")) {
       jskey = jskey.slice(1);
     }
     python_delattr(jsobj, jskey);
-    // Must return "false" if "jskey" is a nonconfigurable own property.
-    // Otherwise JavaScript will throw a TypeError.
+
     return !descr || !!descr.configurable;
   },
   ownKeys(jsobj: PyProxy): (string | symbol)[] {

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -2153,8 +2153,8 @@ const PyProxyHandlers = {
   },
   set(jsobj: PyProxy, jskey: string | symbol, jsval: any): boolean {
     let descr = Object.getOwnPropertyDescriptor(jsobj, jskey);
-    if (descr && !descr.writable) {
-      throw new TypeError(`Cannot set read only field '${String(jskey)}'`);
+    if (descr && !descr.writable && !descr.set) {
+      return false;
     }
     // python_setattr will crash if given a Symbol.
     if (typeof jskey === "symbol") {
@@ -2168,8 +2168,8 @@ const PyProxyHandlers = {
   },
   deleteProperty(jsobj: PyProxy, jskey: string | symbol): boolean {
     let descr = Object.getOwnPropertyDescriptor(jsobj, jskey);
-    if (descr && !descr.writable) {
-      throw new TypeError(`Cannot delete read only field '${String(jskey)}'`);
+    if (descr && !descr.configurable) {
+      return false;
     }
     if (typeof jskey === "symbol") {
       return Reflect.deleteProperty(jsobj, jskey);

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -2183,8 +2183,7 @@ const PyProxyHandlers = {
       jskey = jskey.slice(1);
     }
     python_delattr(jsobj, jskey);
-
-    return !descr || !!descr.configurable;
+    return true;
   },
   ownKeys(jsobj: PyProxy): (string | symbol)[] {
     let ptrobj = _getPtr(jsobj);

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -595,7 +595,8 @@ def test_pyproxy_mixins32(selenium, configurable, writable):
             assertThrows(() => delete d.x, "TypeError", "%s");
         }
         d.destroy();
-        """ % (setText, deleteText)
+        """
+        % (setText, deleteText)
     )
 
 

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -514,15 +514,15 @@ def test_pyproxy_mixins31(selenium):
         pyodide.runPython("assert Test.name == 7");
         pyodide.runPython("assert Test.length == 7");
         // prototype cannot be removed once added because it is nonconfigurable...
-        assertThrows(() => delete Test.prototype, "TypeError", /^'deleteProperty' on proxy: trap returned falsish for property 'prototype'/);
+        assertThrows(() => delete Test.prototype, "TypeError", "");
         delete Test.name;
         delete Test.length;
         pyodide.runPython(`assert Test.prototype == 7`);
         pyodide.runPython(`assert not hasattr(Test, "name")`);
         pyodide.runPython(`assert not hasattr(Test, "length")`);
 
-        assertThrows(() => Test.$$ = 7, "TypeError", /^'set' on proxy: trap returned falsish for property '\\$\\$'/);
-        assertThrows(() => delete Test.$$, "TypeError", /^'deleteProperty' on proxy: trap returned falsish for property '\\$\\$'/);
+        assertThrows(() => Test.$$ = 7, "TypeError", "");
+        assertThrows(() => delete Test.$$, "TypeError", "");
 
         Test.$a = 7;
         Object.defineProperty(Test, "a", {
@@ -537,14 +537,14 @@ def test_pyproxy_mixins31(selenium):
         Test.a = 9;
         assert(() => Test.a === 10);
         pyodide.runPython("assert Test.a == 9")
-        assertThrows(() => delete Test.a, "TypeError", //);
+        assertThrows(() => delete Test.a, "TypeError", "");
 
         Object.defineProperty(Test, "b", {
             get(){ return Test.$a + 2; },
         });
         assert(() => Test.b === 11);
-        assertThrows(() => Test.b = 7,"TypeError", //);
-        assertThrows(() => delete Test.b, "TypeError", //);
+        assertThrows(() => Test.b = 7,"TypeError", "");
+        assertThrows(() => delete Test.b, "TypeError", "");
         Test.destroy();
         t.destroy();
         """


### PR DESCRIPTION
A descriptor is *writable* if either writable is true or it has a setter. A descriptor is *deletable* if it is configurable. Also, the normal JS behavior here is to return false, not to throw.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
