### PR TITLE
DOCS Mark pyodide APIs as not static

### DIFF
--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -575,6 +575,7 @@ class PyodideAnalyzer:
             if doclet.name in FFI_FIELDS and not has_tag(doclet, "alias"):
                 items["pyodide.ffi"].append(doclet)
             else:
+                doclet.is_static = False
                 items["pyodide"].append(doclet)
 
         for cls in pyproxy_subclasses:


### PR DESCRIPTION
This removes several confusing `static` markers and fixes the xrefs for the async functions defined in api.ts.

### Before: 

The entries for `loadPackagesFromImports` and `mountNativeFS` went missing:

![Screenshot from 2023-08-04 13-40-39](https://github.com/pyodide/pyodide/assets/8739626/f4fa4fb4-1d71-415c-a1c0-973873aa0ff1)

### After:

It's fixed:

![Screenshot from 2023-08-04 13-43-07](https://github.com/pyodide/pyodide/assets/8739626/67e682ee-4ad7-4338-9070-710d3b43220e)
