### PR TITLE
ENH Add `response.text` to `pyodide.http.FetchResponse`

### DIFF
--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -160,7 +160,18 @@ class FetchResponse:
         return await self.js_response.arrayBuffer()
 
     async def string(self) -> str:
-        """Return the response body as a string"""
+        """Return the response body as a string
+
+        Does the same thing as :py:meth:`Response.text`.
+        """
+        self._raise_if_failed()
+        return await self.js_response.text()
+
+    async def text(self) -> str:
+        """Return the response body as a string
+
+        Does the same thing as :py:meth:`Response.string`.
+        """
         self._raise_if_failed()
         return await self.js_response.text()
 


### PR DESCRIPTION
We've received feedback from users that use other requests APIs that they expect the method to be called `response.text` instead of `response.string`. Indeed both the Fetch response API and the Python requests library use this convention:

https://developer.mozilla.org/en-US/docs/Web/API/Response/text https://requests.readthedocs.io/en/latest/api/#requests.Response.text

This adds `response.text` to `FetchResponse`. It is a synonym for `response.string`. 

We could also deprecate `response.string` but I don't see any immediate need to do so.

cc @pelson who suggested this change.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation
