### PR TITLE
PERF Don't repeat conversion of destroyed messages

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -98,10 +98,10 @@ static PyObject* Sequence;
 static PyObject* MutableMapping;
 static PyObject* Mapping;
 
-static char* PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL =
-  "This borrowed proxy was automatically destroyed at the "
-  "end of a function call. Try using "
-  "create_proxy or create_once_callable.";
+Js_static_string(PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL,
+                 "This borrowed proxy was automatically destroyed at the "
+                 "end of a function call. Try using "
+                 "create_proxy or create_once_callable.");
 
 ////////////////////////////////////////////////////////////
 // JsProxy
@@ -523,9 +523,9 @@ handle_next_result(JsRef next_res, PyObject** result, bool obj_map_hereditary){
   }
   FAIL_IF_NULL(*result);
   if(pyproxy_Check(idresult)) {
-    destroy_proxy(idresult,
-                  "This borrowed proxy was automatically destroyed at the end"
-                  " of a generator");
+    Js_static_string(msg, "This borrowed proxy was automatically destroyed at the end"
+                          " of a generator");
+    destroy_proxy(idresult, &msg);
   }
 
   res = done ? PYGEN_RETURN : PYGEN_NEXT;
@@ -556,7 +556,7 @@ JsProxy_am_send(PyObject* self, PyObject* arg, PyObject** result)
   ret = handle_next_result(next_res, result, JsObjMap_HEREDITARY(self));
 finally:
   if (proxies) {
-    destroy_proxies(proxies, PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
+    destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
   }
   hiwire_CLEAR(proxies);
   hiwire_CLEAR(jsarg);
@@ -905,9 +905,11 @@ _agen_handle_result_js_c(PyObject* set_result,
   }
 
   if (status == 1 && pyproxy_Check(jsvalue)) {
-    destroy_proxy(jsvalue,
-                  "This borrowed proxy was automatically destroyed at the end"
-                  " of an async generator");
+    Js_static_string(
+      msg,
+      "This borrowed proxy was automatically destroyed at the end"
+      " of a async generator");
+    destroy_proxy(jsvalue, &msg);
   }
 
   if (status == 0) {
@@ -1064,7 +1066,7 @@ JsGenerator_asend(PyObject* self, PyObject* arg)
 
 finally:
   if (proxies) {
-    destroy_proxies(proxies, PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
+    destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
   }
   hiwire_CLEAR(proxies);
   hiwire_CLEAR(jsarg);
@@ -3129,7 +3131,7 @@ finally:
       // TODO: don't destroy proxies with roundtrip = true?
       JsArray_Push_unchecked(proxies, idresult);
     }
-    destroy_proxies(proxies, PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
+    destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
   } else {
     gc_register_proxies(proxies);
   }
@@ -3176,9 +3178,10 @@ JsMethod_Construct(PyObject* self,
   success = true;
 finally:
   Py_LeaveRecursiveCall(/* " in JsMethod_Construct" */);
-  destroy_proxies(proxies,
-                  "This borrowed proxy was automatically destroyed. Try using "
-                  "create_proxy or create_once_callable.");
+  Js_static_string(msg,
+                   "This borrowed proxy was automatically destroyed. Try using "
+                   "create_proxy or create_once_callable.");
+  destroy_proxies(proxies, &msg);
   hiwire_CLEAR(proxies);
   hiwire_CLEAR(idargs);
   hiwire_CLEAR(idresult);

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -62,10 +62,10 @@ EM_JS(PyObject*, pyproxy_AsPyObject, (JsRef x), {
   return Module.PyProxy_getPtr(val);
 });
 
-EM_JS(void, destroy_proxies, (JsRef proxies_id, char* msg_ptr), {
+EM_JS(void, destroy_proxies, (JsRef proxies_id, Js_Identifier* msg_ptr), {
   let msg = undefined;
   if (msg_ptr) {
-    msg = UTF8ToString(msg_ptr);
+    msg = _JsString_FromId(msg_ptr);
   }
   let proxies = Hiwire.get_value(proxies_id);
   for (let px of proxies) {
@@ -80,7 +80,7 @@ EM_JS(void, gc_register_proxies, (JsRef proxies_id), {
   }
 });
 
-EM_JS(void, destroy_proxy, (JsRef proxy_id, char* msg_ptr), {
+EM_JS(void, destroy_proxy, (JsRef proxy_id, Js_Identifier* msg_ptr), {
   const px = Module.hiwire.get_value(proxy_id);
   const { shared, props } = Module.PyProxy_getAttrsQuiet(px);
   if (!shared.ptr) {
@@ -93,7 +93,7 @@ EM_JS(void, destroy_proxy, (JsRef proxy_id, char* msg_ptr), {
   }
   let msg = undefined;
   if (msg_ptr) {
-    msg = UTF8ToString(msg_ptr);
+    msg = _JsString_FromId(msg_ptr);
   }
   Module.pyproxy_destroy(px, msg, false);
 });

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -65,7 +65,7 @@ EM_JS(PyObject*, pyproxy_AsPyObject, (JsRef x), {
 EM_JS(void, destroy_proxies, (JsRef proxies_id, Js_Identifier* msg_ptr), {
   let msg = undefined;
   if (msg_ptr) {
-    msg = _JsString_FromId(msg_ptr);
+    msg = Hiwire.get_value(_JsString_FromId(msg_ptr));
   }
   let proxies = Hiwire.get_value(proxies_id);
   for (let px of proxies) {
@@ -93,7 +93,7 @@ EM_JS(void, destroy_proxy, (JsRef proxy_id, Js_Identifier* msg_ptr), {
   }
   let msg = undefined;
   if (msg_ptr) {
-    msg = _JsString_FromId(msg_ptr);
+    msg = Hiwire.get_value(_JsString_FromId(msg_ptr));
   }
   Module.pyproxy_destroy(px, msg, false);
 });

--- a/src/core/pyproxy.h
+++ b/src/core/pyproxy.h
@@ -36,7 +36,7 @@ pyproxy_AsPyObject(JsRef x);
  * Destroy a list of PyProxies.
  */
 void
-destroy_proxies(JsRef proxies_id, char* msg);
+destroy_proxies(JsRef proxies_id, Js_Identifier* msg);
 
 void
 gc_register_proxies(JsRef proxies_id);
@@ -45,7 +45,7 @@ gc_register_proxies(JsRef proxies_id);
  * Destroy a PyProxy.
  */
 void
-destroy_proxy(JsRef proxy, char* msg);
+destroy_proxy(JsRef proxy, Js_Identifier* msg);
 
 /**
  * Wrap a Python callable in a JavaScript function that can be called once.


### PR DESCRIPTION
This converts `destroy_proxy` and `destroy_proxies` to take static js strings so that we don't repeatedly convert them.