### PR TITLE
Correct conda activate commands in building from sources docs

### DIFF
--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -95,7 +95,7 @@ You would need a working native compiler toolchain, enough to build
 Then install the required Python version and other build dependencies in a separate conda environment,
 
     conda env create -f environment.yml
-    conda activate conda-forge
+    conda activate pyodide-env
 
 ```
 ```{tab-item} MacOS with conda
@@ -109,7 +109,7 @@ You would need,
 Then install the required Python version and other build dependencies in a separate conda environment,
 
     conda env create -f environment.yml
-    conda activate conda-forge
+    conda activate pyodide-env
 
 ```
 


### PR DESCRIPTION
Whilst following the "Building from sources" section of the latest docs I came across two incorrect `conda activate conda-forge` commands which should be `conda activate pyodide-env`. This PR corrects them.
