### PR TITLE
Docs: add reference to removed std lib pkgs

### DIFF
--- a/docs/usage/wasm-constraints.md
+++ b/docs/usage/wasm-constraints.md
@@ -55,13 +55,21 @@ since they currently wouldn't work in the WebAssembly VM,
 - curses
 - dbm
 - ensurepip
+- fcntl
+- grp
 - idlelib
 - lib2to3
+- msvcrt
+- pwd
+- resource
+- syslog
+- termios
 - tkinter
 - turtle.py
 - turtledemo
 - venv
-- pwd
+- winreg
+- winsound
 
 ### Included but not working modules
 
@@ -72,3 +80,8 @@ The following modules can be imported, but are not functional due to the limitat
 - sockets
 
 as well as any functionality that requires these.
+
+The following are present but cannot be imported due to a dependency on the termios package which has been removed:
+
+- pty
+- tty


### PR DESCRIPTION
### Description

Several Python Standard Library packages that were also removed for common sense reasons are not available but were missing from the documents.

This PR only impacts documentation.

### Checklists

- [X] Add new / update outdated documentation
