### PR TITLE
Add comment that WSL 2 is needed on Windows

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -33,7 +33,9 @@ is a Python package without C extensions):
   the wheel.
 
 If however the package has C extensions or its code requires patching, then
-continue to the next steps.
+continue to the next steps. 
+
+If you are on Windows, you will need to use WSL 2.
 
 ```{note}
 To determine if a package has C extensions, check if its `setup.py` contains


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description
I think the tutorial under https://pyodide.org/en/stable/development/new-packages.html currently is not compatible with Windows (The build-recipes command calls make and has a Makefile.envs that contains Linux-specific code like `export HOSTPYTHONROOT=$(shell python${PYMAJOR}.${PYMINOR} -c "import sys; print(sys.prefix)"))`, so we should mention it in the docs. Please correct me if I am wrong.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->
