### PR TITLE
PERF Preload wasm to improve load time

### DIFF
--- a/src/js/constants.ts
+++ b/src/js/constants.ts
@@ -4,6 +4,7 @@ import { defines } from "./generated_struct_info32.json";
 declare global {
   export const cDefs: typeof defines;
   export const DEBUG: boolean;
+  export const SOURCEMAP: boolean;
   export var Module: OrigModule;
   export var API: any;
 }

--- a/src/js/esbuild.config.mjs
+++ b/src/js/esbuild.config.mjs
@@ -4,6 +4,9 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { build } from "esbuild";
 
 const DEBUG = !!process.env.PYODIDE_DEBUG_JS;
+const SOURCEMAP = !!(
+  process.env.PYODIDE_SOURCEMAP || process.env.PYODIDE_SYMBOLS
+);
 
 const __dirname = dirname(new URL(import.meta.url).pathname);
 
@@ -27,7 +30,6 @@ const outputs = [
 ];
 
 const dest = (output) => join(__dirname, "..", "..", output);
-const DEFINES = { DEBUG: DEBUG.toString() };
 
 function toDefines(o, path = "") {
   return Object.entries(o).flatMap(([x, v]) => {
@@ -46,8 +48,8 @@ function toDefines(o, path = "") {
 
 const cdefsFile = join(__dirname, "generated_struct_info32.json");
 const origConstants = JSON.parse(readFileSync(cdefsFile));
-const constants = { cDefs: origConstants.defines };
-Object.assign(DEFINES, Object.fromEntries(toDefines(constants)));
+const constants = { DEBUG, SOURCEMAP, cDefs: origConstants.defines };
+const DEFINES = Object.fromEntries(toDefines(constants));
 
 const config = ({ input, output, format, name: globalName }) => ({
   entryPoints: [join(__dirname, input + ".ts")],

--- a/src/js/module.ts
+++ b/src/js/module.ts
@@ -96,6 +96,13 @@ export interface Module {
   removeRunDependency: (id: string) => void;
   reportUndefinedSymbols: () => void;
   ERRNO_CODES: { [k: string]: number };
+  instantiateWasm?: (
+    imports: { [key: string]: any },
+    successCallback: (
+      instance: WebAssembly.Instance,
+      module: WebAssembly.Module,
+    ) => void,
+  ) => void;
 }
 
 /**
@@ -218,4 +225,45 @@ export function initializeFileSystem(Module: Module, config: ConfigType) {
   setEnvironment(Module, config.env);
   mountLocalDirectories(Module, config._node_mounts);
   Module.preRun.push(() => initializeNativeFS(Module));
+}
+
+export function preloadWasm(Module: Module, indexURL: string) {
+  if (SOURCEMAP) {
+    // According to the docs:
+    //
+    // "Sanitizers or source map is currently not supported if overriding
+    // WebAssembly instantiation with Module.instantiateWasm."
+    // https://emscripten.org/docs/api_reference/module.html?highlight=instantiatewasm#Module.instantiateWasm
+    return;
+  }
+  const wasmResponse = fetch(indexURL! + "pyodide.asm.wasm");
+  Module.instantiateWasm = function (
+    imports: { [key: string]: any },
+    successCallback: (
+      instance: WebAssembly.Instance,
+      module: WebAssembly.Module,
+    ) => void,
+  ) {
+    (async function () {
+      try {
+        const { module, instance } = await WebAssembly.instantiateStreaming(
+          wasmResponse,
+          imports,
+        );
+        // When overriding instantiateWasm, in asan builds, we also need
+        // to take care of creating the WasmOffsetConverter
+        // @ts-ignore
+        if (typeof WasmOffsetConverter != "undefined") {
+          // @ts-ignore
+          wasmOffsetConverter = new WasmOffsetConverter(wasmBinary, module);
+        }
+        successCallback(instance, module);
+      } catch (e) {
+        console.warn("wasm instantiation failed!");
+        console.warn(e);
+      }
+    })();
+
+    return {}; // Compiling asynchronously, no exports.
+  };
 }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -4,7 +4,7 @@
 import ErrorStackParser from "error-stack-parser";
 import { loadScript, initNodeModules, pathSep, resolvePath } from "./compat";
 
-import { createModule, initializeFileSystem } from "./module";
+import { createModule, initializeFileSystem, preloadWasm } from "./module";
 import { version } from "./version";
 
 import type { PyodideInterface } from "./api.js";
@@ -335,9 +335,11 @@ export async function loadPyodide(
   Module.print = config.stdout;
   Module.printErr = config.stderr;
   Module.arguments = config.args;
+
   const API: any = { config };
   Module.API = API;
 
+  preloadWasm(Module, indexURL);
   initializeFileSystem(Module, config);
 
   const moduleLoaded = new Promise((r) => (Module.postRun = r));


### PR DESCRIPTION
This uses `Module.instantiateWasm` to fetch `pyodide.asm.wasm` at the same time as `pyodide.asm.js`.
