### PR TITLE
Add contourpy 1.0.7 package

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -102,7 +102,7 @@ myst:
   deprecation {pr}`3635`, cachetools {pr}`3635`, xyzservices {pr}`3786`,
   simplejson {pr}`3801`, protobuf {pr}`3813`, peewee {pr}`3897`,
   Cartopy {pr}`3909`, pyshp {pr}`3909`, netCDF4 {pr}`3910`, igraph {pr}`3991`,
-  CoolProp {pr}`4028`.
+  CoolProp {pr}`4028`, contourpy {pr}`4102`.
 - Upgraded libmpfr to 4.2.0 {pr}`3756`.
 - Upgraded scipy to 1.11.1 {pr}`3794`, {pr}`3996`
 - Upgraded scikit-image to 0.21 {pr}`3874`

--- a/packages/contourpy/meta.yaml
+++ b/packages/contourpy/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0.7
   top-level:
     - contourpy
-    
+
 source:
   url: https://files.pythonhosted.org/packages/b4/9b/6edb9d3e334a70a212f66a844188fcb57ddbd528cbc3b1fe7abfc317ddd7/contourpy-1.0.7.tar.gz
   sha256: d8165a088d31798b59e91117d1f5fc3df8168d8b48c4acc10fc0df0d0bdbcc5e

--- a/packages/contourpy/meta.yaml
+++ b/packages/contourpy/meta.yaml
@@ -1,0 +1,19 @@
+package:
+  name: contourpy
+  version: 1.0.7
+  top-level:
+    - contourpy
+    
+source:
+  url: https://files.pythonhosted.org/packages/b4/9b/6edb9d3e334a70a212f66a844188fcb57ddbd528cbc3b1fe7abfc317ddd7/contourpy-1.0.7.tar.gz
+  sha256: d8165a088d31798b59e91117d1f5fc3df8168d8b48c4acc10fc0df0d0bdbcc5e
+
+requirements:
+  run:
+    - numpy
+
+about:
+  home: https://github.org/contourpy/contourpy
+  PyPI: https://pypi.org/project/contourpy
+  summary: Python library for calculating contours of 2D quadrilateral grids
+  license: BSD-3-Clause

--- a/packages/contourpy/test_contourpy.py
+++ b/packages/contourpy/test_contourpy.py
@@ -1,0 +1,172 @@
+import pytest
+from pytest_pyodide import run_in_pyodide
+
+
+@pytest.mark.parametrize("name, line_type", [
+    ("mpl2005", "SeparateCode"),
+    ("mpl2014", "SeparateCode"),
+    ("serial", "Separate"),
+    ("serial", "SeparateCode"),
+    ("serial", "ChunkCombinedCode"),
+    ("serial", "ChunkCombinedOffset"),
+    ("threaded", "Separate"),
+    ("threaded", "SeparateCode"),
+    ("threaded", "ChunkCombinedCode"),
+    ("threaded", "ChunkCombinedOffset"),
+])
+@run_in_pyodide(packages=["contourpy", "numpy"])
+def test_line(selenium, name, line_type):
+    from contourpy import LineType, contour_generator
+    import numpy as np
+    from numpy.testing import assert_array_equal, assert_array_almost_equal
+
+    z = [[1.5, 1.5, 0.9, 0.0],
+         [1.5, 2.8, 0.4, 0.8],
+         [0.0, 0.0, 0.8, 6.0]]
+
+    cont_gen = contour_generator(z=z, name=name, line_type=line_type)
+    assert cont_gen.line_type.name == line_type
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
+
+    lines = cont_gen.lines(2.0)
+
+    expect0 = [[0.38461538, 1.0], [1.0, 0.38461538], [1.33333333, 1.0], [1.0, 1.28571429],
+               [0.38461538, 1.0]]
+    if name in ("mpl2005", "mpl2014"):
+        expect0 = np.vstack((expect0[1:], expect0[1]))  # Starts with index 1
+
+    expect1 = [[2.23076923, 2.0], [3.0, 1.23076923]]
+    if name == "mpl2005":
+        expect1 = expect1[::-1]
+
+    if cont_gen.line_type == LineType.Separate:
+        points = lines
+        assert len(points) == 2
+        assert_array_almost_equal(points[0], expect0)
+        assert_array_almost_equal(points[1], expect1)
+    elif cont_gen.line_type == LineType.SeparateCode:
+        points, codes = lines
+        assert len(points) == 2
+        if name == "mpl2014":
+            points = points[::-1]
+            codes = codes[::-1]
+        assert_array_almost_equal(points[0], expect0)
+        assert_array_almost_equal(points[1], expect1)
+        assert_array_equal(codes[0], [1, 2, 2, 2, 79])
+        assert_array_equal(codes[1], [1, 2])
+    elif cont_gen.line_type == LineType.ChunkCombinedCode:
+        assert len(lines[0]) == 1  # Single chunk.
+        points, codes = lines[0][0], lines[1][0]
+        assert points.shape == (7, 2)
+        assert_array_almost_equal(points[:5], expect0)
+        assert_array_almost_equal(points[5:], expect1)
+        assert_array_equal(codes, [1, 2, 2, 2, 79, 1, 2])
+    elif cont_gen.line_type == LineType.ChunkCombinedOffset:
+        assert len(lines[0]) == 1  # Single chunk.
+        points, offsets = lines[0][0], lines[1][0]
+        assert points.shape == (7, 2)
+        assert_array_almost_equal(points[:5], expect0)
+        assert_array_almost_equal(points[5:], expect1)
+        assert_array_equal(offsets, [0, 5, 7])
+    else:
+        raise RuntimeError(f"Unexpect line_type {line_type}")
+
+
+@pytest.mark.parametrize("name, fill_type", [
+    ("mpl2005", "OuterCode"),
+    ("mpl2014", "OuterCode"),
+    ("serial", "OuterCode"),
+    ("serial", "OuterOffset"),
+    ("serial", "ChunkCombinedCode"),
+    ("serial", "ChunkCombinedOffset"),
+    ("serial", "ChunkCombinedCodeOffset"),
+    ("serial", "ChunkCombinedOffsetOffset"),
+    ("threaded", "OuterCode"),
+    ("threaded", "OuterOffset"),
+    ("threaded", "ChunkCombinedCode"),
+    ("threaded", "ChunkCombinedOffset"),
+    ("threaded", "ChunkCombinedCodeOffset"),
+    ("threaded", "ChunkCombinedOffsetOffset"),
+])
+@run_in_pyodide(packages=["contourpy", "numpy"])
+def test_fill(selenium, name, fill_type):
+    from contourpy import FillType, contour_generator
+    import numpy as np
+    from numpy.testing import assert_array_equal, assert_array_almost_equal
+
+    z = [[1.5, 1.5, 0.9, 0.0],
+         [1.5, 2.8, 0.4, 0.8],
+         [0.0, 0.0, 0.8, 1.9]]
+
+    cont_gen = contour_generator(z=z, name=name, fill_type=fill_type)
+    assert cont_gen.fill_type.name == fill_type
+    assert cont_gen.chunk_count == (1, 1)
+    assert cont_gen.thread_count == 1
+
+    filled = cont_gen.filled(1.0, 2.0)
+
+    expect0 = [[0.0, 0.0], [1.0, 0.0], [1.83333333, 0.0], [1.75, 1.0], [1.0, 1.64285714],
+               [0.0, 1.33333333], [0.0, 1.0], [0.0, 0.0], [1.0, 0.38461538], [0.38461538, 1.0],
+               [1.0, 1.28571429], [1.33333333, 1.0], [1.0, 0.38461538]]
+    if name == "mpl2014":
+        expect0 = np.vstack((expect0[1:8], expect0[1], expect0[9:], expect0[9]))
+
+    expect1 = [[2.18181818, 2.0], [3.0, 1.18181818], [3.0, 2.0], [2.18181818, 2.0]]
+    if name in ("mpl2005", "mpl2014"):
+        expect1 = np.vstack((expect1[1:], expect1[1]))  # Starts with index 1
+
+    # Helper functions to avoid code duplication for the different FillTypes.
+    def assert_outer_points(points) -> None:
+        assert isinstance(points, list) and len(points) == 2
+        assert_array_almost_equal(points[0], expect0)
+        assert_array_almost_equal(points[1], expect1)
+
+    def assert_chunk_points(points):
+        assert isinstance(points, list) and len(points) == 1
+        assert points[0].shape == (17, 2)
+        assert_array_almost_equal(points[0][:13], expect0)
+        assert_array_almost_equal(points[0][13:], expect1)
+
+    def assert_chunk_codes(codes):
+        assert isinstance(codes, list) and len(codes) == 1
+        assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
+
+    def assert_chunk_offsets(offsets):
+        assert isinstance(offsets, list) and len(offsets) == 1
+        assert_array_equal(offsets[0], [0, 8, 13, 17])
+
+    if cont_gen.fill_type == FillType.OuterCode:
+        assert_outer_points(filled[0])
+        codes = filled[1]
+        assert isinstance(codes, list) and len(codes) == 2
+        assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79])
+        assert_array_equal(codes[1], [1, 2, 2, 79])
+    elif cont_gen.fill_type == FillType.OuterOffset:
+        assert_outer_points(filled[0])
+        offsets = filled[1]
+        assert isinstance(offsets, list) and len(offsets) == 2
+        assert_array_equal(offsets[0], [0, 8, 13])
+        assert_array_equal(offsets[1], [0, 4])
+    elif cont_gen.fill_type == FillType.ChunkCombinedCode:
+        assert_chunk_points(filled[0])
+        assert_chunk_codes(filled[1])
+    elif cont_gen.fill_type == FillType.ChunkCombinedOffset:
+        assert_chunk_points(filled[0])
+        assert_chunk_offsets(filled[1])
+    elif cont_gen.fill_type == FillType.ChunkCombinedCodeOffset:
+        assert_chunk_points(filled[0])
+        assert_chunk_codes(filled[1])
+
+        outer_offsets = filled[2]
+        assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
+        assert_array_equal(outer_offsets[0], [0, 13, 17])
+    elif cont_gen.fill_type == FillType.ChunkCombinedOffsetOffset:
+        assert_chunk_points(filled[0])
+        assert_chunk_offsets(filled[1])
+
+        outer_offsets = filled[2]
+        assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
+        assert_array_equal(outer_offsets[0], [0, 2, 3])
+    else:
+        raise RuntimeError(f"Unexpect fill_type {fill_type}")

--- a/packages/contourpy/test_contourpy.py
+++ b/packages/contourpy/test_contourpy.py
@@ -2,27 +2,28 @@ import pytest
 from pytest_pyodide import run_in_pyodide
 
 
-@pytest.mark.parametrize("name, line_type", [
-    ("mpl2005", "SeparateCode"),
-    ("mpl2014", "SeparateCode"),
-    ("serial", "Separate"),
-    ("serial", "SeparateCode"),
-    ("serial", "ChunkCombinedCode"),
-    ("serial", "ChunkCombinedOffset"),
-    ("threaded", "Separate"),
-    ("threaded", "SeparateCode"),
-    ("threaded", "ChunkCombinedCode"),
-    ("threaded", "ChunkCombinedOffset"),
-])
+@pytest.mark.parametrize(
+    "name, line_type",
+    [
+        ("mpl2005", "SeparateCode"),
+        ("mpl2014", "SeparateCode"),
+        ("serial", "Separate"),
+        ("serial", "SeparateCode"),
+        ("serial", "ChunkCombinedCode"),
+        ("serial", "ChunkCombinedOffset"),
+        ("threaded", "Separate"),
+        ("threaded", "SeparateCode"),
+        ("threaded", "ChunkCombinedCode"),
+        ("threaded", "ChunkCombinedOffset"),
+    ],
+)
 @run_in_pyodide(packages=["contourpy", "numpy"])
 def test_line(selenium, name, line_type):
-    from contourpy import LineType, contour_generator
     import numpy as np
-    from numpy.testing import assert_array_equal, assert_array_almost_equal
+    from contourpy import LineType, contour_generator
+    from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-    z = [[1.5, 1.5, 0.9, 0.0],
-         [1.5, 2.8, 0.4, 0.8],
-         [0.0, 0.0, 0.8, 6.0]]
+    z = [[1.5, 1.5, 0.9, 0.0], [1.5, 2.8, 0.4, 0.8], [0.0, 0.0, 0.8, 6.0]]
 
     cont_gen = contour_generator(z=z, name=name, line_type=line_type)
     assert cont_gen.line_type.name == line_type
@@ -31,8 +32,13 @@ def test_line(selenium, name, line_type):
 
     lines = cont_gen.lines(2.0)
 
-    expect0 = [[0.38461538, 1.0], [1.0, 0.38461538], [1.33333333, 1.0], [1.0, 1.28571429],
-               [0.38461538, 1.0]]
+    expect0 = [
+        [0.38461538, 1.0],
+        [1.0, 0.38461538],
+        [1.33333333, 1.0],
+        [1.0, 1.28571429],
+        [0.38461538, 1.0],
+    ]
     if name in ("mpl2005", "mpl2014"):
         expect0 = np.vstack((expect0[1:], expect0[1]))  # Starts with index 1
 
@@ -73,31 +79,32 @@ def test_line(selenium, name, line_type):
         raise RuntimeError(f"Unexpect line_type {line_type}")
 
 
-@pytest.mark.parametrize("name, fill_type", [
-    ("mpl2005", "OuterCode"),
-    ("mpl2014", "OuterCode"),
-    ("serial", "OuterCode"),
-    ("serial", "OuterOffset"),
-    ("serial", "ChunkCombinedCode"),
-    ("serial", "ChunkCombinedOffset"),
-    ("serial", "ChunkCombinedCodeOffset"),
-    ("serial", "ChunkCombinedOffsetOffset"),
-    ("threaded", "OuterCode"),
-    ("threaded", "OuterOffset"),
-    ("threaded", "ChunkCombinedCode"),
-    ("threaded", "ChunkCombinedOffset"),
-    ("threaded", "ChunkCombinedCodeOffset"),
-    ("threaded", "ChunkCombinedOffsetOffset"),
-])
+@pytest.mark.parametrize(
+    "name, fill_type",
+    [
+        ("mpl2005", "OuterCode"),
+        ("mpl2014", "OuterCode"),
+        ("serial", "OuterCode"),
+        ("serial", "OuterOffset"),
+        ("serial", "ChunkCombinedCode"),
+        ("serial", "ChunkCombinedOffset"),
+        ("serial", "ChunkCombinedCodeOffset"),
+        ("serial", "ChunkCombinedOffsetOffset"),
+        ("threaded", "OuterCode"),
+        ("threaded", "OuterOffset"),
+        ("threaded", "ChunkCombinedCode"),
+        ("threaded", "ChunkCombinedOffset"),
+        ("threaded", "ChunkCombinedCodeOffset"),
+        ("threaded", "ChunkCombinedOffsetOffset"),
+    ],
+)
 @run_in_pyodide(packages=["contourpy", "numpy"])
 def test_fill(selenium, name, fill_type):
-    from contourpy import FillType, contour_generator
     import numpy as np
-    from numpy.testing import assert_array_equal, assert_array_almost_equal
+    from contourpy import FillType, contour_generator
+    from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-    z = [[1.5, 1.5, 0.9, 0.0],
-         [1.5, 2.8, 0.4, 0.8],
-         [0.0, 0.0, 0.8, 1.9]]
+    z = [[1.5, 1.5, 0.9, 0.0], [1.5, 2.8, 0.4, 0.8], [0.0, 0.0, 0.8, 1.9]]
 
     cont_gen = contour_generator(z=z, name=name, fill_type=fill_type)
     assert cont_gen.fill_type.name == fill_type
@@ -106,9 +113,21 @@ def test_fill(selenium, name, fill_type):
 
     filled = cont_gen.filled(1.0, 2.0)
 
-    expect0 = [[0.0, 0.0], [1.0, 0.0], [1.83333333, 0.0], [1.75, 1.0], [1.0, 1.64285714],
-               [0.0, 1.33333333], [0.0, 1.0], [0.0, 0.0], [1.0, 0.38461538], [0.38461538, 1.0],
-               [1.0, 1.28571429], [1.33333333, 1.0], [1.0, 0.38461538]]
+    expect0 = [
+        [0.0, 0.0],
+        [1.0, 0.0],
+        [1.83333333, 0.0],
+        [1.75, 1.0],
+        [1.0, 1.64285714],
+        [0.0, 1.33333333],
+        [0.0, 1.0],
+        [0.0, 0.0],
+        [1.0, 0.38461538],
+        [0.38461538, 1.0],
+        [1.0, 1.28571429],
+        [1.33333333, 1.0],
+        [1.0, 0.38461538],
+    ]
     if name == "mpl2014":
         expect0 = np.vstack((expect0[1:8], expect0[1], expect0[9:], expect0[9]))
 
@@ -130,7 +149,9 @@ def test_fill(selenium, name, fill_type):
 
     def assert_chunk_codes(codes):
         assert isinstance(codes, list) and len(codes) == 1
-        assert_array_equal(codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79])
+        assert_array_equal(
+            codes[0], [1, 2, 2, 2, 2, 2, 2, 79, 1, 2, 2, 2, 79, 1, 2, 2, 79]
+        )
 
     def assert_chunk_offsets(offsets):
         assert isinstance(offsets, list) and len(offsets) == 1

--- a/packages/contourpy/test_contourpy.py
+++ b/packages/contourpy/test_contourpy.py
@@ -32,17 +32,19 @@ def test_line(selenium, name, line_type):
 
     lines = cont_gen.lines(2.0)
 
-    expect0 = [
-        [0.38461538, 1.0],
-        [1.0, 0.38461538],
-        [1.33333333, 1.0],
-        [1.0, 1.28571429],
-        [0.38461538, 1.0],
-    ]
+    expect0 = np.array(
+        [
+            [0.38461538, 1.0],
+            [1.0, 0.38461538],
+            [1.33333333, 1.0],
+            [1.0, 1.28571429],
+            [0.38461538, 1.0],
+        ]
+    )
     if name in ("mpl2005", "mpl2014"):
         expect0 = np.vstack((expect0[1:], expect0[1]))  # Starts with index 1
 
-    expect1 = [[2.23076923, 2.0], [3.0, 1.23076923]]
+    expect1 = np.array([[2.23076923, 2.0], [3.0, 1.23076923]])
     if name == "mpl2005":
         expect1 = expect1[::-1]
 
@@ -76,7 +78,7 @@ def test_line(selenium, name, line_type):
         assert_array_almost_equal(points[5:], expect1)
         assert_array_equal(offsets, [0, 5, 7])
     else:
-        raise RuntimeError(f"Unexpect line_type {line_type}")
+        raise RuntimeError(f"Unexpected line_type {line_type}")
 
 
 @pytest.mark.parametrize(
@@ -113,30 +115,34 @@ def test_fill(selenium, name, fill_type):
 
     filled = cont_gen.filled(1.0, 2.0)
 
-    expect0 = [
-        [0.0, 0.0],
-        [1.0, 0.0],
-        [1.83333333, 0.0],
-        [1.75, 1.0],
-        [1.0, 1.64285714],
-        [0.0, 1.33333333],
-        [0.0, 1.0],
-        [0.0, 0.0],
-        [1.0, 0.38461538],
-        [0.38461538, 1.0],
-        [1.0, 1.28571429],
-        [1.33333333, 1.0],
-        [1.0, 0.38461538],
-    ]
+    expect0 = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.83333333, 0.0],
+            [1.75, 1.0],
+            [1.0, 1.64285714],
+            [0.0, 1.33333333],
+            [0.0, 1.0],
+            [0.0, 0.0],
+            [1.0, 0.38461538],
+            [0.38461538, 1.0],
+            [1.0, 1.28571429],
+            [1.33333333, 1.0],
+            [1.0, 0.38461538],
+        ]
+    )
     if name == "mpl2014":
         expect0 = np.vstack((expect0[1:8], expect0[1], expect0[9:], expect0[9]))
 
-    expect1 = [[2.18181818, 2.0], [3.0, 1.18181818], [3.0, 2.0], [2.18181818, 2.0]]
+    expect1 = np.array(
+        [[2.18181818, 2.0], [3.0, 1.18181818], [3.0, 2.0], [2.18181818, 2.0]]
+    )
     if name in ("mpl2005", "mpl2014"):
         expect1 = np.vstack((expect1[1:], expect1[1]))  # Starts with index 1
 
     # Helper functions to avoid code duplication for the different FillTypes.
-    def assert_outer_points(points) -> None:
+    def assert_outer_points(points):
         assert isinstance(points, list) and len(points) == 2
         assert_array_almost_equal(points[0], expect0)
         assert_array_almost_equal(points[1], expect1)
@@ -190,4 +196,4 @@ def test_fill(selenium, name, fill_type):
         assert isinstance(outer_offsets, list) and len(outer_offsets) == 1
         assert_array_equal(outer_offsets[0], [0, 2, 3])
     else:
-        raise RuntimeError(f"Unexpect fill_type {fill_type}")
+        raise RuntimeError(f"Unexpected fill_type {fill_type}")


### PR DESCRIPTION
### Description

This PR adds the ContourPy package, which is a C++ extension that is a compulsory dependency of Matplotlib >= 3.6.0 and Bokeh >= 3.0.0. I haven't updated the Matplotlib or Bokeh recipes yet,  I (or someone else?) will do so separately.

This builds, runs and passes the tests for me locally using the docker image.

Note that this is the previous version (1.0.7) of ContourPy, not the latest one (1.1.0) that uses Meson as I am still trying to get that to build with the correct compiler flags.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
