### PR TITLE
Add note about forwarding docker port

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -151,9 +151,9 @@ and see if there are any errors.
 If the build succeeds you can try to load the package:
 
 1. Serve the dist directory with `python -m http.server --directory ./dist`.
-If you use docker, you can execute this either outside of the docker container or
-make sure to forward a port by setting the environment variable
-PYODIDE_SYSTEM_PORT or starting docker with `./run_docker -p <port>`.
+   If you use docker, you can execute this either outside of the docker container or
+   make sure to forward a port by setting the environment variable
+   PYODIDE_SYSTEM_PORT or starting docker with `./run_docker -p <port>`.
 2. Open `localhost:<port>/console.html` and try to import the package.
 3. You can test the package in the repl.
 

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -73,9 +73,7 @@ use the `pyodide-env` docker container with:
 
 This will mount the current working directory as `/src` within the container so
 if you build the package within the container the files created will persist in
-the directory after you exit the container. For local testing purposes, make
-sure to forward a port by setting the environment variable PYODIDE_SYSTEM_PORT or
-starting docker with `./run_docker -p <port>`.
+the directory after you exit the container.
 
 You should install `pyodide-build`:
 
@@ -152,9 +150,12 @@ and see if there are any errors.
 
 If the build succeeds you can try to load the package:
 
-1. Serve the dist directory with `python -m http.server --directory ./dist`
-2. Open `localhost:<port>/console.html` and try to import the package
-3. You can test the package in the repl
+1. Serve the dist directory with `python -m http.server --directory ./dist`.
+If you use docker, you can execute this either outside of the docker container or
+make sure to forward a port by setting the environment variable
+PYODIDE_SYSTEM_PORT or starting docker with `./run_docker -p <port>`.
+2. Open `localhost:<port>/console.html` and try to import the package.
+3. You can test the package in the repl.
 
 ### Fixing build issues
 

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -73,7 +73,9 @@ use the `pyodide-env` docker container with:
 
 This will mount the current working directory as `/src` within the container so
 if you build the package within the container the files created will persist in
-the directory after you exit the container.
+the directory after you exit the container. For local testing purposes, make
+sure to forward a port by setting the environment variable PYODIDE_SYSTEM_PORT or
+starting docker with `./run_docker -p <port>`.
 
 You should install `pyodide-build`:
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

I think the docs should contain this note about forwarding the docker ports. (Or correct me if I'm misunderstanding something.)
