### PR TITLE
Docs: Install pyodide-build from source tree

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -78,7 +78,7 @@ the directory after you exit the container.
 You should install `pyodide-build`:
 
 ```bash
-pip install -e pyodide-build
+pip install -e pyodide-build --pre
 ```
 
 If you want to build the package, you will need to build Python which you can do

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -78,7 +78,7 @@ the directory after you exit the container.
 You should install `pyodide-build`:
 
 ```bash
-pip install -e pyodide-build --pre
+pip install -e ./pyodide-build
 ```
 
 If you want to build the package, you will need to build Python which you can do


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

I think when one clones the pyodide git repo one always wants the newest version of pyodide-build. When I installed pyodide-build without enabled prereleases (--pre) I got an error because of a version mismatch of emscripten when testing my packages.