### PR TITLE
ENH Print helpful error if ccache was linked against too new glibc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CXX=em++
 
 
 all: check \
+	check-emcc \
 	dist/pyodide.asm.js \
 	dist/pyodide.js \
 	dist/pyodide.d.ts \
@@ -267,6 +268,10 @@ FORCE:
 
 check:
 	./tools/dependency-check.sh
+
+
+check-emcc: emsdk/emsdk/.complete
+	python3 tools/check_ccache.py
 
 
 debug :

--- a/tools/check_ccache.py
+++ b/tools/check_ccache.py
@@ -1,0 +1,24 @@
+import re
+import subprocess
+import sys
+
+
+def main():
+    result = subprocess.run(["emcc", "--version"], capture_output=True, encoding="utf8")
+    if result.returncode == 0:
+        return 0
+    if re.search("GLIBC.*not found.*ccache", result.stderr):
+        print(
+            "Emscripten ccache was linked against an incompatible version of glibc.\n"
+            "Run `make -C emsdk clean` and try again.\n"
+            "If this error persists, please open an issue to ask for help."
+        )
+    else:
+        print("Something is wrong but I'm not sure what.")
+        print("Info:")
+        print(result)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Resolves https://github.com/pyodide/pyodide/issues/4126. 
If someone builds emsdk outside of the docker image and then attempts to use it inside, there will be an error. This detects it and tells people to clean emsdk.
