### PR TITLE
Make loadPyodide global in console.html

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -90,6 +90,8 @@
           }
         }
         const { loadPyodide } = await import(indexURL + "pyodide.mjs");
+        // to facilitate debugging
+        globalThis.loadPyodide = loadPyodide;
 
         let term;
         globalThis.pyodide = await loadPyodide({


### PR DESCRIPTION
So it's easier to test something about `loadPyodide` in a `console.html` page which is already deployed.