### PR TITLE
Don't use importlib.metadata during initialisation

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,6 +14,14 @@ myst:
 
 # Change Log
 
+## Unreleased
+
+### Load time & size optimizations
+
+- {{ Performance }} Do not use `importlib.metadata` when identifying installed packages,
+  which reduces the time to load Pyodide.
+  {pr}`4147`
+
 ## Version 0.24.0
 
 _September 13, 2023_

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -2,7 +2,6 @@ import re
 import shutil
 import sys
 import sysconfig
-import tarfile
 from collections.abc import Iterable
 from importlib.machinery import EXTENSION_SUFFIXES
 from pathlib import Path
@@ -309,6 +308,8 @@ def get_dynlibs(archive: IO[bytes], suffix: str, target_dir: Path) -> list[str]:
         The list of paths to dynamic libraries ('.so' files) that were in the archive,
         but adjusted to point to their unpacked locations.
     """
+    import tarfile
+    
     dynlib_paths_iter: Iterable[str]
     if suffix in ZIP_TYPES:
         dynlib_paths_iter = ZipFile(archive).namelist()

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -357,5 +357,6 @@ def init_loaded_packages() -> None:
     doesn't install over them.
     """
     for dist_path in SITE_PACKAGES.glob("*.dist-info"):
-        dist_name = dist_path.name.replace(".dist-info", "")
+        # Strip version (PEP 440)
+        dist_name = dist_path.name.replace(".dist-info", "").rpartition("-")[0]
         setattr(loadedPackages, dist_name, get_dist_source(dist_path))

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -309,7 +309,7 @@ def get_dynlibs(archive: IO[bytes], suffix: str, target_dir: Path) -> list[str]:
         but adjusted to point to their unpacked locations.
     """
     import tarfile
-    
+
     dynlib_paths_iter: Iterable[str]
     if suffix in ZIP_TYPES:
         dynlib_paths_iter = ZipFile(archive).namelist()

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -498,7 +498,7 @@ result_dist_pairs = [
     ),
     ("pip (index unknown)", DummyDistribution("F", installer="pip")),
     ("other (index unknown)", DummyDistribution("G", installer="other")),
-    ("Unknown", DummyDistribution("H")),
+    ("Unknown", DummyDistribution("H-H")),
 ]
 
 
@@ -519,6 +519,7 @@ def test_init_loaded_packages(monkeypatch, tmp_path):
 
     loadedPackages = loadedPackagesCls()
     monkeypatch.setattr(_package_loader, "SITE_PACKAGES", tmp_path)
+    monkeypatch.setattr(_package_loader, "loadedPackages", loadedPackages)
     dists = [dist for [_, dist] in result_dist_pairs]
     for dist in dists:
         dist.write(tmp_path)

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -1,4 +1,5 @@
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -432,8 +433,10 @@ class DummyDistribution:
         source: str | None = None,
         direct_url: dict[str, str] | None = None,
         installer: str | None = None,
+        version: str = "0.0.1",
     ):
         self.name = name
+        self.version = version
         direct_url_json = json.dumps(direct_url) if direct_url else None
         self._files: dict[str, str | None] = {
             "PYODIDE_SOURCE": source,
@@ -441,8 +444,23 @@ class DummyDistribution:
             "INSTALLER": installer,
         }
 
-    def read_text(self, key: str) -> str | None:
-        return self._files.get(key)
+    @property
+    def dist_info_name(self):
+        # https://packaging.python.org/en/latest/specifications/name-normalization/#normalization
+        normalized_name = re.sub(r"[-_.]+", "-", self.name).lower()
+        return f"{normalized_name}-{self.version}.dist-info"
+
+    def write(self, base_dir: Path) -> None:
+        dist_info_dir = base_dir / self.dist_info_name
+        dist_info_dir.mkdir(exist_ok=True)
+        for key, value in self._files.items():
+            if value is not None:
+                (dist_info_dir / key).write_text(value)
+        with (dist_info_dir / "METADATA").open("w") as f:
+            f.write(
+                f"Metadata-Version: 2.1\nName: {self.name}\n"
+                f"Version: {self.version}\n"
+            )
 
     def __repr__(self):
         return self.name
@@ -485,22 +503,25 @@ result_dist_pairs = [
 
 
 @pytest.mark.parametrize("result,dist", result_dist_pairs)
-def test_get_dist_source(result, dist):
+def test_get_dist_source(result, dist, tmp_path):
     from pyodide._package_loader import get_dist_source
 
-    assert result == get_dist_source(dist)
+    dist.write(tmp_path)
+
+    assert (dist.name, result) == get_dist_source(tmp_path / dist.dist_info_name)
 
 
-def test_init_loaded_packages(monkeypatch):
+def test_init_loaded_packages(monkeypatch, tmp_path):
     from pyodide import _package_loader
 
     class loadedPackagesCls:
         pass
 
     loadedPackages = loadedPackagesCls()
-    monkeypatch.setattr(_package_loader, "loadedPackages", loadedPackages)
+    monkeypatch.setattr(_package_loader, "SITE_PACKAGES", tmp_path)
     dists = [dist for [_, dist] in result_dist_pairs]
-    monkeypatch.setattr(_package_loader, "importlib_distributions", lambda: dists)
+    for dist in dists:
+        dist.write(tmp_path)
     _package_loader.init_loaded_packages()
 
     for [result, dist] in result_dist_pairs:


### PR DESCRIPTION
Closes https://github.com/pyodide/pyodide/issues/4144

So we manually identify the packages installed based on their `.dist-info/*` files instead of relying on `importlib.metadata`. This also probably does much less work that `importlib.metadata` e.g. no need to parse all the metadata fields, we only need the package name.

Code wise it's not that much complex, the question is how robust this is. In particular, this assumes that `*.dist-info/METADATA` files do exist to get the non-normalized package name. [It should](https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-dist-info-directory)  with installers that respect the spec, but I don't know if in practice there are some edge cases that we could be missing.