### PR TITLE
Fix the indent of the document for GitHub Actions in out-of-tree build page

### DIFF
--- a/docs/development/building-and-testing-packages.md
+++ b/docs/development/building-and-testing-packages.md
@@ -152,13 +152,13 @@ runs-on: ubuntu-22.04
   steps:
   - uses: actions/checkout@v3
   - uses: actions/setup-python@v4
-     with:
+    with:
        python-version: 3.11.2
   - run: |
       pip install pyodide-build>=0.23.0
       echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
   - uses: mymindstorm/setup-emsdk@v12
-     with:
+    with:
        version: ${{ env.EMSCRIPTEN_VERSION }}
   - run: pyodide build
 ```


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

When I try to setup GitHub Actions based on the document <https://pyodide.org/en/stable/development/building-and-testing-packages.html#build-github-actions-example>, I found some indent are broken as YAML and not work. This PR fixes them.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- ~~Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry~~
- ~~Add / update tests~~
- ~~Add new / update outdated documentation~~