### PR TITLE
FIX Don't crash if checkInterrupt() is called with gil released and no ib

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -29,6 +29,8 @@ myst:
 
 - Upgraded scipy to 1.11.2 {pr}`4156`
 
+- Upgraded scikit-learn to 1.3.1 {pr}`4161`
+
 ## Version 0.24.0
 
 _September 13, 2023_

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,8 +16,13 @@ myst:
 
 ## Unreleased
 
-- {{ Fix }} Fixed `LONG_BIT definition appears wrong for platform` error happened in out-of-tree build.
+- {{ Fix }} Fixed `LONG_BIT definition appears wrong for platform` error
+  happened in out-of-tree build. 
   {pr}`4136`
+
+- {{ Fix }} `pyodide.checkInterrupt` works when there is no interrupt buffer and
+  the gil is not held.
+  {pr}`4164`
 
 ### Load time & size optimizations
 

--- a/packages/scikit-learn/meta.yaml
+++ b/packages/scikit-learn/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: scikit-learn
-  version: 1.3.0
+  version: 1.3.1
   tag:
     - min-scipy-stack
   top-level:
     - sklearn
 source:
-  url: https://files.pythonhosted.org/packages/72/cd/4761675df1b3dd93072c89697278f3ed3dc004a60c034cd2603c43ff64b5/scikit-learn-1.3.0.tar.gz
-  sha256: 8be549886f5eda46436b6e555b0e4873b4f10aa21c07df45c4bc1735afbccd7a
+  url: https://files.pythonhosted.org/packages/4b/49/4b3e90399f49e875a1a6a0e72bb99d7e8fe808fcfe0a6a12b43a77e7d64d/scikit-learn-1.3.1.tar.gz
+  sha256: 1a231cced3ee3fa04756b4a7ab532dc9417acd581a330adff5f2c01ac2831fcf
 
 build:
   cflags: -Wno-implicit-function-declaration

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -558,7 +558,8 @@ export class PyodideAPI {
       // GIL not held. This is very likely because we're in a IO handler. If
       // buffer has a 2, throwing EINTR quits out from the IO handler and tells
       // the calling context to call `PyErr_CheckSignals`.
-      if (Module.Py_EmscriptenSignalBuffer[0] === 2) {
+      const buf = Module.Py_EmscriptenSignalBuffer;
+      if (buf && buf[0] === 2) {
         throw new Module.FS.ErrnoError(cDefs.EINTR);
       }
     }

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -419,6 +419,15 @@ def test_run_python_last_exc(selenium):
 
 
 def test_check_interrupt(selenium):
+    # First make sure checkInterrupt works when interrupt buffer is undefined.
+    # It should just do nothing in this case.
+    selenium.run_js(
+        """
+        pyodide.setInterruptBuffer(undefined);
+        pyodide.checkInterrupt();
+        """
+    )
+
     assert selenium.run_js(
         """
         let buffer = new Uint8Array(1);
@@ -459,6 +468,41 @@ def test_check_interrupt(selenium):
         console.log({err_code, err_occurred});
         pyodide._module._PyErr_Clear();
         return buffer[0] === 0 && err_code === -1 && err_occurred !== 0;
+        """
+    )
+
+
+def test_check_interrupt_no_gil(selenium):
+    """Check interrupt has a special case for GIL not held.
+    Make sure that it works.
+    """
+    assert selenium.run_js(
+        """
+        // release GIL
+        const tstate = pyodide._module._PyEval_SaveThread();
+
+        try {
+            // check that checkInterrupt works when interrupt buffer not defined
+            // it should do nothing.
+            pyodide.setInterruptBuffer(undefined);
+            pyodide.checkInterrupt();
+            ib = new Int32Array(1);
+            pyodide.setInterruptBuffer(ib);
+            pyodide.checkInterrupt();
+
+            ib[0] = 2;
+            let err;
+            try {
+                pyodide.checkInterrupt();
+            } catch(e) {
+                err = e;
+            }
+            assert(() => err instanceof pyodide.FS.ErrnoError);
+            assert(() => err.errno === pyodide.ERRNO_CODES.EINTR);
+        } finally {
+            // acquire GIL
+            pyodide._module._PyEval_RestoreThread(tstate)
+        }
         """
     )
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -499,6 +499,8 @@ def test_check_interrupt_no_gil(selenium):
             }
             assert(() => err instanceof pyodide.FS.ErrnoError);
             assert(() => err.errno === pyodide.ERRNO_CODES.EINTR);
+            assert(() => ib[0] === 2);
+            ib[0] = 0;
         } finally {
             // acquire GIL
             pyodide._module._PyEval_RestoreThread(tstate)

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -476,7 +476,7 @@ def test_check_interrupt_no_gil(selenium):
     """Check interrupt has a special case for GIL not held.
     Make sure that it works.
     """
-    assert selenium.run_js(
+    selenium.run_js(
         """
         // release GIL
         const tstate = pyodide._module._PyEval_SaveThread();

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -926,30 +926,33 @@ def test_nogil(selenium):
             Temp()
         `);
         // release GIL
-        const tstate = pyodide._module._PyEval_SaveThread()
+        const tstate = pyodide._module._PyEval_SaveThread();
 
-        assertThrows(() => t.x, "NoGilError", "");
         try {
-            t.x;
-        } catch(e){
-            assert(() => e instanceof pyodide._api.NoGilError);
-        }
-        assertThrows(() => t.x = 2, "NoGilError", "");
-        assertThrows(() => delete t.x, "NoGilError", "");
-        assertThrows(() => Object.getOwnPropertyNames(t), "NoGilError", "");
-        assertThrows(() => t(), "NoGilError", "");
-        assertThrows(() => t.get(1), "NoGilError", "");
-        assertThrows(() => t.set(1, 2), "NoGilError", "");
-        assertThrows(() => t.delete(1), "NoGilError", "");
-        assertThrows(() => t.has(1), "NoGilError", "");
-        assertThrows(() => t.length, "NoGilError", "");
-        assertThrows(() => t.toString(), "NoGilError", "");
-        assertThrows(() => Array.from(t), "NoGilError", "");
-        await assertThrowsAsync(async () => await t, "NoGilError", "");
-        assertThrows(() => t.destroy(), "NoGilError", "");
+            assertThrows(() => t.x, "NoGilError", "");
+            try {
+                t.x;
+            } catch(e){
+                assert(() => e instanceof pyodide._api.NoGilError);
+            }
+            assertThrows(() => t.x = 2, "NoGilError", "");
+            assertThrows(() => delete t.x, "NoGilError", "");
+            assertThrows(() => Object.getOwnPropertyNames(t), "NoGilError", "");
+            assertThrows(() => t(), "NoGilError", "");
+            assertThrows(() => t.get(1), "NoGilError", "");
+            assertThrows(() => t.set(1, 2), "NoGilError", "");
+            assertThrows(() => t.delete(1), "NoGilError", "");
+            assertThrows(() => t.has(1), "NoGilError", "");
+            assertThrows(() => t.length, "NoGilError", "");
+            assertThrows(() => t.toString(), "NoGilError", "");
+            assertThrows(() => Array.from(t), "NoGilError", "");
+            await assertThrowsAsync(async () => await t, "NoGilError", "");
+            assertThrows(() => t.destroy(), "NoGilError", "");
+        } finally {
+            // acquire GIL
+            pyodide._module._PyEval_RestoreThread(tstate)
 
-        // acquire GIL
-        pyodide._module._PyEval_RestoreThread(tstate)
+        }
         """
     )
 


### PR DESCRIPTION
`Py_EmscriptenSignalBuffer` could be undefined

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
