### PR TITLE
CI Change macos resource class to gen2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ jobs:
         description: pytest-cache-dir.
         type: string
         default: ""
-    resource_class: medium
+    resource_class: macos.m1.medium.gen1
     macos:
       xcode: 14.3.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ jobs:
         description: pytest-cache-dir.
         type: string
         default: ""
-    resource_class: macos.m1.medium.gen1
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: 14.3.1
 


### PR DESCRIPTION
Following the deprecation notice from Circie CI: https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

Let's see if Pyodide runs well with m1...