### PR TITLE
Update pypa/build version to 1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
           - types-setuptools
           - types-requests
           - numpy
-          - build~=1.0.0
+          - build
           - pytest
           - pydantic<2
           - unearth

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
           - types-setuptools
           - types-requests
           - numpy
-          - build==0.7.0
+          - build~=1.0.0
           - pytest
           - pydantic<2
           - unearth

--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -13,7 +13,7 @@ from pathlib import Path
 if sys.version_info < (3, 11, 0):
     import tomli as tomllib
 else:
-    import tomllib  # type: ignore[no-redef]
+    import tomllib
 
 from packaging.tags import Tag, compatible_tags, cpython_tags
 

--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "packaging",
     "wheel",
     "tomli",
-    "build",
+    "build>=1.0.0",
     "virtualenv",
     "pydantic>=1.10.2,<2",
     "pyodide-cli~=0.2.1",

--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "packaging",
     "wheel",
     "tomli",
-    "build~=1.0.0",
+    "build",
     "virtualenv",
     "pydantic>=1.10.2,<2",
     "pyodide-cli~=0.2.1",

--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "packaging",
     "wheel",
     "tomli",
-    "build==0.7.0",
+    "build~=1.0.0",
     "virtualenv",
     "pydantic>=1.10.2,<2",
     "pyodide-cli~=0.2.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
   # lint
   pre-commit
   # testing
-  build==0.7.0
+  build==1.0.3
   sphinx-click
   hypothesis
   pytest


### PR DESCRIPTION
Resolve https://github.com/pyodide/pyodide/issues/4155

Updates pypa/build version used in pyodide-build to `~1.0.0`.