### PR TITLE
use emscripten llvm-readobj by default

### DIFF
--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -413,12 +413,21 @@ def _calculate_object_exports_readobj_parse(output: str) -> list[str]:
 
 
 def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
-    readobj_path = shutil.which("llvm-readobj")
-    if not readobj_path:
-        which_emcc = shutil.which("emcc")
-        assert which_emcc
-        emcc = Path(which_emcc)
-        readobj_path = str((emcc / "../../bin/llvm-readobj").resolve())
+    which_emcc = shutil.which("emcc")
+    assert which_emcc
+    emcc = Path(which_emcc)
+    readobj = (emcc / "../../bin/llvm-readobj").resolve()
+    if readobj.exists():
+        readobj_path=str(readobj)
+    else:
+        readobj_path = shutil.which("llvm-readobj")
+    assert(readobj_path)
+    args = [
+        readobj_path,
+        "--section-details",
+        "-st",
+    ] + objects
+
     args = [
         readobj_path,
         "--section-details",

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -418,10 +418,11 @@ def calculate_object_exports_readobj(objects: list[str]) -> list[str] | None:
     emcc = Path(which_emcc)
     readobj = (emcc / "../../bin/llvm-readobj").resolve()
     if readobj.exists():
-        readobj_path=str(readobj)
+        readobj_path:str|None = str(readobj)
     else:
         readobj_path = shutil.which("llvm-readobj")
     assert(readobj_path)
+
     args = [
         readobj_path,
         "--section-details",


### PR DESCRIPTION
`pywasmcross` uses llvm-readobj. Currently it first checks if there's one on the path, and falls back to emscripten's version.

This means `pyodide build` fails if you have a system with an old llvm installed on the path.

This change makes it use the correct one from emsdk for preference.