### PR TITLE
DOCS Some minor tuneups

### DIFF
--- a/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/jsdoc.py
@@ -594,7 +594,7 @@ class PyodideAnalyzer:
 
         for key, value in items.items():
             for obj in sorted(value, key=attrgetter("name")):
-                _, kind = get_tag(obj, "doc_kind")
+                _, kind = get_tag(obj, "dockind")
                 if kind:
                     obj.kind = kind
                 elif isinstance(obj, Class):

--- a/docs/usage/api/js-api.md
+++ b/docs/usage/api/js-api.md
@@ -42,6 +42,9 @@ import type { PyProxy } from "pyodide/ffi";
 
 This provides APIs to set a canvas for rendering graphics.
 
+For example, you need to set a canvas if you want to use the SDL library. See
+:ref:`using-sdl` for more information.
+
 ```{eval-rst}
 .. js-doc-summary:: pyodide.canvas
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -114,10 +114,8 @@ export class PyodideAPI {
   static PATH = {} as any;
 
   /**
-   * This provides APIs to set a canvas for rendering graphics.
-   *
-   * For example, you need to set a canvas if you want to use the
-   * SDL library. See :ref:`using-sdl` for more information.
+   * See :ref:`js-api-pyodide-canvas`.
+   * @hidetype
    */
   static canvas: CanvasInterface = canvas;
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -583,7 +583,7 @@ export class PyodideAPI {
    *
    * @hidetype
    * @alias
-   * @doc_kind class
+   * @dockind class
    * @deprecated
    */
   static get PyBuffer() {
@@ -599,7 +599,7 @@ export class PyodideAPI {
    *
    * @hidetype
    * @alias
-   * @doc_kind class
+   * @dockind class
    * @deprecated
    */
 
@@ -616,7 +616,7 @@ export class PyodideAPI {
    *
    * @hidetype
    * @alias
-   * @doc_kind class
+   * @dockind class
    * @deprecated
    */
   static get PythonError() {

--- a/src/js/canvas.ts
+++ b/src/js/canvas.ts
@@ -5,7 +5,7 @@ declare var Module: any;
  *
  * As of now, Emscripten uses Module.canvas to get the canvas element.
  * This might change in the future, so we abstract it here.
- * @private
+ * @hidden
  */
 export interface CanvasInterface {
   setCanvas2D(canvas: HTMLCanvasElement): void;
@@ -17,7 +17,7 @@ export interface CanvasInterface {
 // We define methods here to make sphinx-js generate documentation for them.
 
 /**
- * @param canvas The HTML5 canvas element to use for 2D rendering. For now,
+ * Set the HTML5 canvas element to use for 2D rendering. For now,
  * Emscripten only supports one canvas element, so setCanvas2D and setCanvas3D
  * are the same.
  */
@@ -31,8 +31,7 @@ export const setCanvas2D = (canvas: HTMLCanvasElement) => {
   Module.canvas = canvas;
 };
 /**
- *
- * @returns The HTML5 canvas element used for 2D rendering. For now,
+ * Get the HTML5 canvas element used for 2D rendering. For now,
  * Emscripten only supports one canvas element, so getCanvas2D and getCanvas3D
  * are the same.
  */
@@ -40,7 +39,7 @@ export const getCanvas2D = (): HTMLCanvasElement | undefined => {
   return Module.canvas;
 };
 /**
- * @param canvas The HTML5 canvas element to use for 3D rendering. For now,
+ * Set the HTML5 canvas element to use for 3D rendering. For now,
  * Emscripten only supports one canvas element, so setCanvas2D and setCanvas3D
  * are the same.
  */
@@ -48,8 +47,7 @@ export const setCanvas3D = (canvas: HTMLCanvasElement) => {
   setCanvas2D(canvas);
 };
 /**
- *
- * @returns The HTML5 canvas element used for 3D rendering. For now,
+ * Get the HTML5 canvas element used for 3D rendering. For now,
  * Emscripten only supports one canvas element, so getCanvas2D and getCanvas3D
  * are the same.
  */

--- a/src/js/ffi.ts
+++ b/src/js/ffi.ts
@@ -16,6 +16,8 @@ export type {
   PyBuffer,
   PyBufferView,
   TypedArray,
+  PySequence,
+  PyMutableSequence,
 } from "./pyproxy.gen";
 
 export type { PythonError } from "./error_handling.gen";

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -323,8 +323,7 @@ type StdinOptions = {
  *
  *    If a string is returned, it is encoded into a buffer using
  *    :js:class:`TextEncoder`. By default, an EOF is appended after each string
- *    or buffer returned. If this behavior is not desired, pass `autoEOF:
- *    false`.
+ *    or buffer returned. If this behavior is not desired, pass `autoEOF: false`.
  *
  * @param options.stdin A stdin handler
  * @param options.read A read handler


### PR DESCRIPTION
1. Future versions of typedoc don't allow tags to contain _ so change `@doc_type` ==> `@doctype`
2. `Sequence` and `MutableSequence` are miscategorized because we forgot to export them from `ffi.ts`. TODO: Make it so we don't need to do this??
3. For the canvas getters/setters I moved the documentation into the top level. This means that the APIs get a summary in the summary table.
4. Also, `private` stops working for certain things in future typedoc versions, so replace it with `@hidden`
