### PR TITLE
Some changes to make it easier to build with dead code elimination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ src/core/pyodide_pre.o: src/js/_pyodide.out.js src/core/pre.js
 	cat tmp.dat  | xxd -i - >> src/core/pyodide_pre.gen.c
 	# Add a null byte to terminate the string
 	echo ', 0};' >> src/core/pyodide_pre.gen.c
+	echo "#include <emscripten.h>" >> src/core/pyodide_pre.gen.c
+	echo "void pyodide_js_init(void) EM_IMPORT(pyodide_js_init);" >> src/core/pyodide_pre.gen.c
+	echo "EMSCRIPTEN_KEEPALIVE void pyodide_export(void) { pyodide_js_init(); }" >> src/core/pyodide_pre.gen.c
 
 	rm tmp.dat
 	emcc -c src/core/pyodide_pre.gen.c -o src/core/pyodide_pre.o

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -41,7 +41,7 @@ EM_JS(void, console_error_obj, (JsRef obj), {
  * are fairly strong guarantees about the ABI stability, but even so writing
  * HEAP32[err/4 + 1] is a bit opaque.
  */
-void
+EMSCRIPTEN_KEEPALIVE void
 set_error(PyObject* err)
 {
   PyErr_SetObject((PyObject*)Py_TYPE(err), err);
@@ -246,7 +246,7 @@ EM_JS(void, log_python_error, (JsRef jserror), {
 /**
  * Convert the current Python error to a javascript error and throw it.
  */
-void _Py_NO_RETURN
+EMSCRIPTEN_KEEPALIVE void _Py_NO_RETURN
 pythonexc2js()
 {
   JsRef jserror = wrap_exception();

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -11,6 +11,10 @@
 #define ERROR_REF (0)
 #define ERROR_NUM (-1)
 
+#ifdef DEBUG_F
+int tracerefs = 0;
+#endif
+
 // For when the return value would be Option<JsRef>
 // we use the largest possible immortal reference so that `get_value` on it will
 // always raise an error.
@@ -25,7 +29,8 @@ const JsRef Js_novalue = ((JsRef)(2147483644));
 // we use HIWIRE_INIT_CONSTS once in C and once inside JS with different
 // definitions of HIWIRE_INIT_CONST to ensure everything lines up properly
 // C definition:
-#define HIWIRE_INIT_CONST(js_value) const JsRef Js_##js_value;
+#define HIWIRE_INIT_CONST(js_value)                                            \
+  EMSCRIPTEN_KEEPALIVE const JsRef Js_##js_value;
 HIWIRE_INIT_CONSTS();
 
 #undef HIWIRE_INIT_CONST
@@ -933,7 +938,7 @@ EM_JS_REF(JsRef, JsString_InternFromCString, (const char* str), {
   return Hiwire.intern_object(jsstring);
 })
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 JsString_FromId(Js_Identifier* id)
 {
   if (!id->object) {

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -11,38 +11,38 @@
 #include "pyproxy.h"
 
 // PyUnicodeDATA is a macro, we need to access it from JavaScript
-void*
+EMSCRIPTEN_KEEPALIVE void*
 PyUnicode_Data(PyObject* obj)
 {
   return PyUnicode_DATA(obj);
 }
 
-PyObject*
+EMSCRIPTEN_KEEPALIVE PyObject*
 _js2python_none()
 {
   Py_RETURN_NONE;
 }
 
-PyObject*
+EMSCRIPTEN_KEEPALIVE PyObject*
 _js2python_true()
 {
   Py_RETURN_TRUE;
 }
 
-PyObject*
+EMSCRIPTEN_KEEPALIVE PyObject*
 _js2python_false()
 {
   Py_RETURN_FALSE;
 }
 
-PyObject*
+EMSCRIPTEN_KEEPALIVE PyObject*
 _js2python_pyproxy(PyObject* val)
 {
   Py_INCREF(val);
   return val;
 }
 
-EM_JS_REF(PyObject*, js2python_immutable, (JsRef id), {
+EM_JS_REF(PyObject*, js2python_immutable_js, (JsRef id), {
   let value = Hiwire.get_value(id);
   let result = Module.js2python_convertImmutable(value, id);
   // clang-format off
@@ -53,7 +53,13 @@ EM_JS_REF(PyObject*, js2python_immutable, (JsRef id), {
   return 0;
 });
 
-EM_JS_REF(PyObject*, js2python, (JsRef id), {
+EMSCRIPTEN_KEEPALIVE PyObject*
+js2python_immutable(JsRef id)
+{
+  return js2python_immutable_js(id);
+}
+
+EM_JS_REF(PyObject*, js2python_js, (JsRef id), {
   let value = Hiwire.get_value(id);
   let result = Module.js2python_convertImmutable(value, id);
   // clang-format off
@@ -63,6 +69,12 @@ EM_JS_REF(PyObject*, js2python, (JsRef id), {
   }
   return _JsProxy_create(id);
 })
+
+EMSCRIPTEN_KEEPALIVE PyObject*
+js2python(JsRef id)
+{
+  return js2python_js(id);
+}
 
 /**
  * Convert a JavaScript object to Python to a given depth. This is the

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -4305,7 +4305,7 @@ JsProxy_create_with_this(JsRef object, JsRef this)
   return JsProxy_create_with_type(type_flags, object, this);
 }
 
-PyObject*
+EMSCRIPTEN_KEEPALIVE PyObject*
 JsProxy_create(JsRef object)
 {
   return JsProxy_create_with_this(object, NULL);

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -247,7 +247,7 @@ static int dict_flags;
 static int tuple_flags;
 static int list_flags;
 
-int
+EMSCRIPTEN_KEEPALIVE int
 pyproxy_getflags(PyObject* pyobj)
 {
   // Fast paths for some common cases
@@ -309,7 +309,7 @@ finally:
 //  logic is very boilerplatey, so there isn't much surprising code hidden
 //  somewhere else.
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_repr(PyObject* pyobj)
 {
   PyObject* repr_py = NULL;
@@ -337,13 +337,13 @@ finally:
  *
  * `type(x).__name__`
  */
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_type(PyObject* ptrobj)
 {
   return hiwire_string_utf8(Py_TYPE(ptrobj)->tp_name);
 }
 
-int
+EMSCRIPTEN_KEEPALIVE int
 _pyproxy_hasattr(PyObject* pyobj, JsRef idkey)
 {
   PyObject* pykey = NULL;
@@ -397,7 +397,7 @@ proxy_cache_set,
 })
 // clang-format on
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_getattr(PyObject* pyobj, JsRef idkey, JsRef proxyCache)
 {
   bool success = false;
@@ -457,7 +457,7 @@ finally:
   return idresult;
 };
 
-int
+EMSCRIPTEN_KEEPALIVE int
 _pyproxy_setattr(PyObject* pyobj, JsRef idkey, JsRef idval)
 {
   bool success = false;
@@ -477,7 +477,7 @@ finally:
   return success ? 0 : -1;
 }
 
-int
+EMSCRIPTEN_KEEPALIVE int
 _pyproxy_delattr(PyObject* pyobj, JsRef idkey)
 {
   bool success = false;
@@ -493,7 +493,7 @@ finally:
   return success ? 0 : -1;
 }
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_getitem(PyObject* pyobj, JsRef idkey)
 {
   bool success = false;
@@ -522,7 +522,7 @@ finally:
   return result;
 };
 
-int
+EMSCRIPTEN_KEEPALIVE int
 _pyproxy_setitem(PyObject* pyobj, JsRef idkey, JsRef idval)
 {
   bool success = false;
@@ -542,7 +542,7 @@ finally:
   return success ? 0 : -1;
 }
 
-int
+EMSCRIPTEN_KEEPALIVE int
 _pyproxy_delitem(PyObject* pyobj, JsRef idkey)
 {
   bool success = false;
@@ -558,7 +558,7 @@ finally:
   return success ? 0 : -1;
 }
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_slice_assign(PyObject* pyobj,
                       Py_ssize_t start,
                       Py_ssize_t stop,
@@ -594,7 +594,7 @@ finally:
   return jsresult;
 }
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_pop(PyObject* pyobj, bool pop_start)
 {
   bool success = false;
@@ -629,7 +629,7 @@ finally:
   return jsresult;
 }
 
-int
+EMSCRIPTEN_KEEPALIVE int
 _pyproxy_contains(PyObject* pyobj, JsRef idkey)
 {
   PyObject* pykey = NULL;
@@ -644,7 +644,7 @@ finally:
   return result;
 }
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_ownKeys(PyObject* pyobj)
 {
   bool success = false;
@@ -705,7 +705,7 @@ finally:
  *
  *   Returns: The return value translated to JavaScript.
  */
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_apply(PyObject* callable,
                JsRef jsargs,
                size_t numposargs,
@@ -765,7 +765,7 @@ finally:
   return idresult;
 }
 
-bool
+EMSCRIPTEN_KEEPALIVE bool
 _iscoroutinefunction(PyObject* f)
 {
   _Py_IDENTIFIER(_is_coroutine_marker);
@@ -795,7 +795,7 @@ _iscoroutinefunction(PyObject* f)
   return ret;
 }
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_iter_next(PyObject* iterator)
 {
   PyObject* item = PyIter_Next(iterator);
@@ -807,7 +807,7 @@ _pyproxy_iter_next(PyObject* iterator)
   return result;
 }
 
-PySendResult
+EMSCRIPTEN_KEEPALIVE PySendResult
 _pyproxyGen_Send(PyObject* receiver, JsRef jsval, JsRef* result)
 {
   bool success = false;
@@ -833,7 +833,7 @@ finally:
   return status;
 }
 
-PySendResult
+EMSCRIPTEN_KEEPALIVE PySendResult
 _pyproxyGen_return(PyObject* receiver, JsRef jsval, JsRef* result)
 {
   bool success = false;
@@ -869,7 +869,7 @@ finally:
   return status;
 }
 
-PySendResult
+EMSCRIPTEN_KEEPALIVE PySendResult
 _pyproxyGen_throw(PyObject* receiver, JsRef jsval, JsRef* result)
 {
   bool success = false;
@@ -906,7 +906,7 @@ finally:
   return status;
 }
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxyGen_asend(PyObject* receiver, JsRef jsval)
 {
   PyObject* v = NULL;
@@ -964,7 +964,7 @@ finally:
   return jsresult;
 }
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxyGen_athrow(PyObject* receiver, JsRef jsval)
 {
   PyObject* v = NULL;
@@ -995,7 +995,7 @@ finally:
   return jsresult;
 }
 
-JsRef
+EMSCRIPTEN_KEEPALIVE JsRef
 _pyproxy_aiter_next(PyObject* aiterator)
 {
   PyTypeObject* t;
@@ -1153,7 +1153,7 @@ FutureDoneCallback_cnew(JsRef resolve_handle, JsRef reject_handle)
  * :param reject_handle: The reject javascript method for a promise
  * :return: 0 on success, -1 on failure
  */
-int
+EMSCRIPTEN_KEEPALIVE int
 _pyproxy_ensure_future(PyObject* pyobject,
                        JsRef resolve_handle,
                        JsRef reject_handle)
@@ -1238,7 +1238,7 @@ size_t buffer_struct_size = sizeof(buffer_struct);
  * We also put the various other metadata about the buffer that we want to share
  * into buffer_struct.
  */
-int
+EMSCRIPTEN_KEEPALIVE int
 _pyproxy_get_buffer(buffer_struct* target, PyObject* ptrobj)
 {
   Py_buffer view;

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -620,7 +620,7 @@ EM_JS_REF(JsRef, _JsArray_PostProcess_helper, (JsRef jscontext, JsRef array), {
 // clang-format off
 EM_JS_REF(
 JsRef,
-python2js__default_converter,
+python2js__default_converter_js,
 (JsRef jscontext, PyObject* object),
 {
   let context = Hiwire.get_value(jscontext);
@@ -634,6 +634,12 @@ python2js__default_converter,
   return Hiwire.new_value(result);
 })
 // clang-format on
+
+JsRef
+python2js__default_converter(JsRef jscontext, PyObject* object)
+{
+  return python2js__default_converter_js(jscontext, object);
+}
 
 static JsRef
 _JsArray_PostProcess(ConversionContext context, JsRef array)


### PR DESCRIPTION
This forces a bunch of things to be exported so someday we can build with -sMAIN_MODULE=2 or make no dynamic linking builds.
