### PR TITLE
Add zengl 1.16.0

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -24,6 +24,8 @@ myst:
 
 - Added `frozenlist` {pr}`4231`
 
+- Added `zengl` version 1.16.0 {pr}`4208`
+
 ### Load time & size optimizations
 
 - {{ Performance }} Do not use `importlib.metadata` when identifying installed packages,

--- a/packages/zengl/meta.yaml
+++ b/packages/zengl/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: zengl
+  version: 1.16.0
+  top-level:
+    - zengl
+    - _zengl
+
+source:
+  url: https://files.pythonhosted.org/packages/d9/cd/c30359142f5ff049e224fbd07ff219c13532b764b9e0b33de95251953bf7/zengl-1.16.0.tar.gz
+  sha256: 2f13badccdf66297778c08ea1ab295f04a9889988d25510217835297709ceace
+
+about:
+  home: https://github.com/szabolcsdombi/zengl/
+  PyPI: https://pypi.org/project/zengl
+  summary: Self-Contained OpenGL Rendering Pipelines for Python
+  license: MIT

--- a/packages/zengl/test_zengl.py
+++ b/packages/zengl/test_zengl.py
@@ -1,0 +1,38 @@
+import pytest
+from pytest_pyodide import run_in_pyodide
+
+
+@pytest.mark.driver_timeout(60)
+@pytest.mark.xfail_browsers(node="this supposed to render into a canvas DOM element")
+@run_in_pyodide(packages=["zengl"])
+def test_render_with_webgl2(selenium):
+    import zengl
+
+    import js
+    import pyodide_js
+
+    canvas = js.document.createElement("canvas")
+    canvas.id = "canvas"
+    canvas.width = 320
+    canvas.height = 240
+
+    canvas.style.position = "fixed"
+    canvas.style.bottom = "10px"
+    canvas.style.right = "10px"
+
+    gl = canvas.getContext(
+        "webgl2",
+        powerPreference="high-performance",
+        premultipliedAlpha=False,
+        antialias=False,
+        alpha=False,
+        depth=False,
+        stencil=False,
+    )
+    js.document.body.appendChild(canvas)
+
+    if gl:
+        setup_gl = js.eval(zengl.setup_gl)
+        setup_gl(pyodide_js._module, gl)
+
+        zengl.context()

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1049,6 +1049,8 @@ class InternalError(Exception):
 
 
 class JsDomElement(JsProxy):
+    id: str
+
     @property
     def tagName(self) -> str:
         return ""
@@ -1064,6 +1066,10 @@ class JsDomElement(JsProxy):
         pass
 
     def removeEventListener(self, event: str, listener: Callable[[Any], None]) -> None:
+        pass
+
+    @property
+    def style(self) -> Any:
         pass
 
 

--- a/src/py/js.pyi
+++ b/src/py/js.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import Any, Literal, overload
 
 from _pyodide._core_docs import _JsProxyMetaClass
 from pyodide.ffi import (
@@ -87,10 +87,29 @@ class JSON(_JsObject):
 class document(_JsObject):
     body: JsDomElement
     children: list[JsDomElement]
+    @overload
+    @staticmethod
+    def createElement(tagName: Literal["canvas"]) -> JsCanvasElement: ...
+    @overload
     @staticmethod
     def createElement(tagName: str) -> JsDomElement: ...
     @staticmethod
     def appendChild(child: JsDomElement) -> None: ...
+
+class JsCanvasElement(JsDomElement):
+    width: int | float
+    height: int | float
+    def getContext(
+        self,
+        ctxType: str,
+        *,
+        powerPreference: str = "",
+        premultipliedAlpha: bool = False,
+        antialias: bool = False,
+        alpha: bool = False,
+        depth: bool = False,
+        stencil: bool = False
+    ) -> Any: ...
 
 class ArrayBuffer(_JsObject):
     @staticmethod


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Added zengl 1.16.0

ZenGL provides OpenGL binding for Python.
The same code that runs natively also runs in the browser as-is without modifications.
It does not depend on SDL, emscripten GLES or anything else.
It binds directly to WebGL2.

Working demo: https://szabolcsdombi.github.io/zengl/

![image](https://github.com/pyodide/pyodide/assets/11232402/a72dae12-1fa4-430a-83c2-7f48f1e8a6d1)

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
