### PR TITLE
Add `sisl` package

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,8 @@ myst:
 
 - Added river version 0.19.0 {pr}`4197`
 
+- Added `sisl` version 0.14.2 {pr}`4210`
+
 ### Load time & size optimizations
 
 - {{ Performance }} Do not use `importlib.metadata` when identifying installed packages,

--- a/packages/sisl/meta.yaml
+++ b/packages/sisl/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: sisl
+  version: 0.14.2
+  top-level:
+    - sisl_toolbox
+    - sisl
+source:
+  url: https://github.com/zerothi/sisl/archive/refs/tags/v0.14.2.zip
+  sha256: 8616b8ef253e72efe4ff508017052359325264383eade85af64f5e22e306190b
+
+about:
+  home: ""
+  PyPI: https://pypi.org/project/sisl
+  summary: ""
+  license: MPL-2.0
+
+requirements:
+  host:
+    - numpy
+    - pyparsing
+  run:
+    - pyparsing
+    - numpy
+    - scipy
+    - tqdm
+    - xarray
+    - pandas
+    - matplotlib
+
+build:
+  script: |
+    export CMAKE_ARGS="-DWITH_FORTRAN=OFF"

--- a/packages/sisl/test_sisl.py
+++ b/packages/sisl/test_sisl.py
@@ -1,0 +1,39 @@
+import pytest
+from pytest_pyodide import run_in_pyodide
+
+@pytest.mark.driver_timeout(40)
+@run_in_pyodide(packages=["sisl-tests", "pytest"])
+def test_version(selenium):
+    import sisl
+
+    assert sisl.__version__ == "0.14.2"
+
+@run_in_pyodide(packages=["sisl-tests", "pytest"])
+def test_nodes(selenium):
+    import pytest
+
+    pytest.main(["--pyargs", "sisl.nodes"])
+
+@run_in_pyodide(packages=["sisl-tests", "pytest"])
+def test_geom(selenium):
+    import pytest
+
+    pytest.main(["--pyargs", "sisl.geom"])
+
+@run_in_pyodide(packages=["sisl-tests", "pytest"])
+def test_linalg(selenium):
+    import pytest
+
+    pytest.main(["--pyargs", "sisl.linalg"])
+
+@run_in_pyodide(packages=["sisl-tests", "pytest"])
+def test_sparse(selenium):
+    import pytest
+
+    pytest.main(["--pyargs", "sisl.tests.test_sparse"])
+
+@run_in_pyodide(packages=["sisl-tests", "pytest"])
+def test_physics_sparse(selenium):
+    import pytest
+
+    pytest.main(["--pyargs", "sisl.physics.tests.test_physics_sparse"])

--- a/packages/sisl/test_sisl.py
+++ b/packages/sisl/test_sisl.py
@@ -1,6 +1,7 @@
 import pytest
 from pytest_pyodide import run_in_pyodide
 
+
 @pytest.mark.driver_timeout(40)
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_version(selenium):
@@ -8,11 +9,13 @@ def test_version(selenium):
 
     assert sisl.__version__ == "0.14.2"
 
+
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_nodes(selenium):
     import pytest
 
     pytest.main(["--pyargs", "sisl.nodes"])
+
 
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_geom(selenium):
@@ -20,17 +23,20 @@ def test_geom(selenium):
 
     pytest.main(["--pyargs", "sisl.geom"])
 
+
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_linalg(selenium):
     import pytest
 
     pytest.main(["--pyargs", "sisl.linalg"])
 
+
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_sparse(selenium):
     import pytest
 
     pytest.main(["--pyargs", "sisl.tests.test_sparse"])
+
 
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_physics_sparse(selenium):


### PR DESCRIPTION
### Description

This PR adds the [sisl](https://github.com/zerothi/sisl) package, a scientific package for electronic structure simulations. It would be very cool to have it on `pyodide` so that we can design a standalone web application with it.

The package has C and fortran sources and it is built with `scikit-build-core`. For now, I turned off the fortran functionality since it is only IO of fortran files, which probably would be complicated to make it work with the browser's virtual filesystem anyway (?).

I don't know how to add and check the tests, since when I run `pytest` from `pyodide`'s directory on the docker image package tests are skipped saying that the package is not built (it is in `dist` and also in `packages/sisl/dist`, and I get the error also for the other built packages). If someone could help me with that it would be great.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
