### PR TITLE
CI Use xcode 15.0.0 for Safari tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
         default: ""
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: 14.3.1
+      xcode: 15.0.0
 
     working_directory: ~/repo
     steps:


### PR DESCRIPTION
It seems that there is a bug in table instructions in Safari 16.3 which is used in the safari tests but that Safari 16.4 has fixed it. xcode 15.0.0 uses Safari 16.6 which does not have the bug.