### PR TITLE
Bumping numpy 1.25.2 > 1.26.1

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -19,6 +19,7 @@ myst:
 ### Packages
 
 - Added river version 0.19.0 {pr}`4197`
+- Upgraded numpy to 1.26.0 {pr} `4217`
 
 ### Load time & size optimizations
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -19,7 +19,7 @@ myst:
 ### Packages
 
 - Added river version 0.19.0 {pr}`4197`
-- Upgraded numpy to 1.26.0 {pr} `4217`
+- Upgraded numpy to 1.26.1 {pr} `4217`
 
 - Added `sisl` version 0.14.2 {pr}`4210`
 

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: numpy
-  version: 1.25.2
+  version: 1.26.0
   tag:
     - min-scipy-stack
   top-level:

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -7,7 +7,7 @@ package:
     - numpy
 source:
   url: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz
-  sha256: 6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f
+  sha256: c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe
 
 build:
   backend-flags: --disable-optimization

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -6,7 +6,7 @@ package:
   top-level:
     - numpy
 source:
-  url: https://files.pythonhosted.org/packages/a0/41/8f53eff8e969dd8576ddfb45e7ed315407d27c7518ae49418be8ed532b07/numpy-1.25.2.tar.gz
+  url: https://files.pythonhosted.org/packages/55/b3/b13bce39ba82b7398c06d10446f5ffd5c07db39b09bd37370dc720c7951c/numpy-1.26.0.tar.gz
   sha256: fd608e19c8d7c55021dffd43bfe5492fab8cc105cc8986f813f8c3c048b38760
 
 build:

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -7,7 +7,7 @@ package:
     - numpy
 source:
   url: https://files.pythonhosted.org/packages/55/b3/b13bce39ba82b7398c06d10446f5ffd5c07db39b09bd37370dc720c7951c/numpy-1.26.0.tar.gz
-  sha256: fd608e19c8d7c55021dffd43bfe5492fab8cc105cc8986f813f8c3c048b38760
+  sha256: f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf
 
 build:
   backend-flags: --disable-optimization

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: numpy
-  version: 1.26.0
+  version: 1.26.1
   tag:
     - min-scipy-stack
   top-level:
     - numpy
 source:
-  url: https://files.pythonhosted.org/packages/55/b3/b13bce39ba82b7398c06d10446f5ffd5c07db39b09bd37370dc720c7951c/numpy-1.26.0.tar.gz
-  sha256: f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf
+  url: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz
+  sha256: 6965888d65d2848e8768824ca8288db0a81263c1efccec881cb35a0d805fcd2f
 
 build:
   backend-flags: --disable-optimization


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->
Closes #4213 

### Description

I've a package I wish to setup a JupyterLite Notebook for people to run, one of the dependencies is `numpy-1.26.0` but currently only `numpy-1.25.2` is available for Pyodide (see #4213).

I've bumped the version in the relevant `meta.yaml` and tried building locally but failed, figured a PR to bump the version might be useful.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
