### PR TITLE
Add brief documentation section on how to upgrade packages

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -254,7 +254,7 @@ Because this does not handle package dependencies, you have to manually check
 whether the `requirements` section of the `meta.yaml` file needs to be updated
 for updated dependencies.
 
-Upgrading a package's version may lead to new buid issues that need to be resolved
+Upgrading a package's version may lead to new build issues that need to be resolved
 (see above) and any patches need to be checked and potentially migrated (see below).
 
 ### Migrating Patches

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -250,11 +250,11 @@ To upgrade a package's version to the latest one available on PyPI, do
 pyodide skeleton pypi <package-name> --update
 ```
 
-Because this does not handle package dependencies, you have to manually check 
-whether the `requirements` section of the `meta.yaml` file needs to be updated 
+Because this does not handle package dependencies, you have to manually check
+whether the `requirements` section of the `meta.yaml` file needs to be updated
 for updated dependencies.
 
-Upgrading a package's version may lead to new buid issues that need to be resolved 
+Upgrading a package's version may lead to new buid issues that need to be resolved
 (see above) and any patches need to be checked and potentially migrated (see below).
 
 ### Migrating Patches

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -242,6 +242,21 @@ the `patches` key:
 find patches/ -type f | sed 's/^/    - /g'
 ```
 
+### Upgrading a package
+
+To upgrade a package's version to the latest one available on PyPI, do
+
+```
+pyodide skeleton pypi <package-name> --update
+```
+
+Because this does not handle package dependencies, you have to manually check 
+whether the `requirements` section of the `meta.yaml` file needs to be updated 
+for updated dependencies.
+
+Upgrading a package's version may lead to new buid issues that need to be resolved 
+(see above) and any patches need to be checked and potentially migrated (see below).
+
 ### Migrating Patches
 
 When you want to upgrade the version of a package, you will need to migrate the


### PR DESCRIPTION
### Description

I have myself struggled upgrading package versions even though it's straightforward, so I added a very brief section to the new-packages.md page on how to upgrade a package's version.

### Checklists

- ~Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry~ --> not added, because doc changes do not seem to get changelog entries
- [x] Add new / update outdated documentation
