### PR TITLE
Fix Emscripten.cmake not vendored in pyodide-build wheel

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -28,6 +28,16 @@ myst:
   which reduces the time to load Pyodide.
   {pr}`4147`
 
+### Build system
+
+- {{ Fix }} Fixed `Emscripten.cmake` not vendored in pyodide-build since 0.24.0.
+  {pr}`4223`
+
+- {{ Fix }} pyodide-build now does not override `CMAKE_CONFIG_FILE` and `PYO3_CONFIG_FILE`
+  env variables if provided by user.
+  {pr}`4223`
+
+
 ## Version 0.24.1
 
 _September 25, 2023_

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -37,7 +37,6 @@ myst:
   env variables if provided by user.
   {pr}`4223`
 
-
 ## Version 0.24.1
 
 _September 25, 2023_

--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -175,7 +175,7 @@ def get_build_environment_vars() -> dict[str, str]:
         env["CMAKE_TOOLCHAIN_FILE"] = str(
             tools_dir / "cmake/Modules/Platform/Emscripten.cmake"
         )
-    
+
     if "PYO3_CONFIG_FILE" not in env:
         env["PYO3_CONFIG_FILE"] = str(tools_dir / "pyo3_config.ini")
 

--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -62,6 +62,8 @@ BUILD_VARS: set[str] = {
     "SYSCONFIG_NAME",
     "TARGETINSTALLDIR",
     "WASM_LIBRARY_DIR",
+    "CMAKE_TOOLCHAIN_FILE",
+    "PYO3_CONFIG_FILE",
 }
 
 
@@ -169,10 +171,13 @@ def get_build_environment_vars() -> dict[str, str]:
 
     tools_dir = Path(__file__).parent / "tools"
 
-    env["CMAKE_TOOLCHAIN_FILE"] = str(
-        tools_dir / "cmake/Modules/Platform/Emscripten.cmake"
-    )
-    env["PYO3_CONFIG_FILE"] = str(tools_dir / "pyo3_config.ini")
+    if "CMAKE_TOOLCHAIN_FILE" not in env:
+        env["CMAKE_TOOLCHAIN_FILE"] = str(
+            tools_dir / "cmake/Modules/Platform/Emscripten.cmake"
+        )
+    
+    if "PYO3_CONFIG_FILE" not in env:
+        env["PYO3_CONFIG_FILE"] = str(tools_dir / "pyo3_config.ini")
 
     hostsitepackages = env["HOSTSITEPACKAGES"]
     pythonpath = [

--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -76,12 +76,12 @@ include-package-data = false
 
 [tool.setuptools.packages.find]
 where = ["."]
-exclude = ["pyodide_build.tests"]
+exclude = ["pyodide_build.tests*"]
 namespaces = true
 
 [tool.setuptools.package-data]
 "pyodide_build.tools" = ["*.ini"]
-"pyodide_build.tools.cmake.modules.platform" = ["*.cmake"]
+"pyodide_build.tools.cmake.Modules.Platform" = ["*.cmake"]
 
 [tool.setuptools.dynamic]
 version = {attr = "pyodide_build.__version__"}


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Resolve #4216

This PR fixes a bug where Emscripten.cmake is not vendored in pyodide-build wheel since 0.24.0.

This was caused by https://github.com/pyodide/pyodide/pull/3947, where `ini2toml` changed all keys to lowercase but the setuptools is case sensitive...

This PR also changes the `CMAKE_TOOLCHAIN_FILE` and `PYO3_CONFIG_FILE` environment variables to allow them to be overwritten by the user.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
