### PR TITLE
Use JsVal instead of JsRef in more places (nr. 5)

### DIFF
--- a/src/core/_pyodide_core.c
+++ b/src/core/_pyodide_core.c
@@ -61,7 +61,6 @@ PyInit__pyodide_core(void)
   bool success = false;
   PyObject* _pyodide = NULL;
   PyObject* core_module = NULL;
-  JsRef _pyodide_proxy = NULL;
 
   _pyodide = PyImport_ImportModule("_pyodide");
   if (_pyodide == NULL) {
@@ -75,6 +74,7 @@ PyInit__pyodide_core(void)
 
   TRY_INIT_WITH_CORE_MODULE(error_handling);
   TRY_INIT(hiwire);
+  TRY_INIT(jslib);
   TRY_INIT(docstring);
   TRY_INIT(js2python);
   TRY_INIT_WITH_CORE_MODULE(python2js);
@@ -89,7 +89,7 @@ PyInit__pyodide_core(void)
   }
 
   // Enable JavaScript access to the _pyodide module.
-  _pyodide_proxy = python2js(_pyodide);
+  JsRef _pyodide_proxy = python2js(_pyodide);
   if (_pyodide_proxy == NULL) {
     FATAL_ERROR("Failed to create _pyodide proxy.");
   }

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -56,75 +56,6 @@ EM_JS_NUM(int, hiwire_init_js, (void), {
   Hiwire.pop_value = _hiwire_pop;
   // clang-format on
 
-  // This is factored out primarily for testing purposes.
-  Hiwire.isPromise = function(obj)
-  {
-    try {
-      // clang-format off
-      return !!obj && typeof obj.then === "function";
-      // clang-format on
-    } catch (e) {
-      return false;
-    }
-  };
-
-  /**
-   * Turn any ArrayBuffer view or ArrayBuffer into a Uint8Array.
-   *
-   * This respects slices: if the ArrayBuffer view is restricted to a slice of
-   * the backing ArrayBuffer, we return a Uint8Array that shows the same slice.
-   */
-  API.typedArrayAsUint8Array = function(arg)
-  {
-    if (ArrayBuffer.isView(arg)) {
-      return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength);
-    } else {
-      return new Uint8Array(arg);
-    }
-  };
-
-  {
-    let dtypes_str =
-      [ "b", "B", "h", "H", "i", "I", "f", "d" ].join(String.fromCharCode(0), );
-    let dtypes_ptr = stringToNewUTF8(dtypes_str);
-    let dtypes_map = {};
-    for (let[idx, val] of Object.entries(dtypes_str)) {
-      dtypes_map[val] = dtypes_ptr + Number(idx);
-    }
-
-    let buffer_datatype_map = new Map([
-      [ "Int8Array", [ dtypes_map["b"], 1, true ] ],
-      [ "Uint8Array", [ dtypes_map["B"], 1, true ] ],
-      [ "Uint8ClampedArray", [ dtypes_map["B"], 1, true ] ],
-      [ "Int16Array", [ dtypes_map["h"], 2, true ] ],
-      [ "Uint16Array", [ dtypes_map["H"], 2, true ] ],
-      [ "Int32Array", [ dtypes_map["i"], 4, true ] ],
-      [ "Uint32Array", [ dtypes_map["I"], 4, true ] ],
-      [ "Float32Array", [ dtypes_map["f"], 4, true ] ],
-      [ "Float64Array", [ dtypes_map["d"], 8, true ] ],
-      // These last two default to Uint8. They have checked : false to allow use
-      // with other types.
-      [ "DataView", [ dtypes_map["B"], 1, false ] ],
-      [ "ArrayBuffer", [ dtypes_map["B"], 1, false ] ],
-    ]);
-
-    /**
-     * This gets the dtype of a ArrayBuffer or ArrayBuffer view. We return a
-     * triple: [char* format_ptr, int itemsize, bool checked] If argument is
-     * untyped (a DataView or ArrayBuffer) then we say it's a Uint8, but we set
-     * the flag checked to false in that case so we allow assignment to/from
-     * anything.
-     *
-     * This is the API for use from JavaScript, there's also an EM_JS
-     * hiwire_get_buffer_datatype wrapper for use from C. Used in js2python and
-     * in jsproxy.c for buffers.
-     */
-    Module.get_buffer_datatype = function(jsobj)
-    {
-      return buffer_datatype_map.get(jsobj.constructor.name) || [ 0, 0, false ];
-    };
-  }
-
   Module.iterObject = function * (object)
   {
     for (let k in object) {
@@ -290,123 +221,9 @@ EM_JS_REF(JsRef, hiwire_construct, (JsRef idobj, JsRef idargs), {
   return Hiwire.new_value(Reflect.construct(jsobj, jsargs));
 });
 
-EM_JS_BOOL(bool, hiwire_has_length, (JsRef idobj), {
-  let val = Hiwire.get_value(idobj);
-  // clang-format off
-  return (typeof val.size === "number") ||
-         (typeof val.length === "number" && typeof val !== "function");
-  // clang-format on
-});
-
-EM_JS_NUM(int, hiwire_get_length_helper, (JsRef idobj), {
-  let val = Hiwire.get_value(idobj);
-  // clang-format off
-  let result;
-  if (typeof val.size === "number") {
-    result = val.size;
-  } else if (typeof val.length === "number") {
-    result = val.length;
-  } else {
-    return -2;
-  }
-  if(result < 0){
-    return -3;
-  }
-  if(result > INT_MAX){
-    return -4;
-  }
-  return result;
-  // clang-format on
-});
-
-// Needed to render the length accurately when there is an error
-EM_JS_REF(char*, hiwire_get_length_string, (JsRef idobj), {
-  const val = Hiwire.get_value(idobj);
-  let result;
-  // clang-format off
-  if (typeof val.size === "number") {
-    result = val.size;
-  } else if (typeof val.length === "number") {
-    result = val.length;
-  }
-  // clang-format on
-  return stringToNewUTF8(" " + result.toString())
-})
-
-int
-hiwire_get_length(JsRef idobj)
-{
-  int result = hiwire_get_length_helper(idobj);
-  if (result >= 0) {
-    return result;
-  }
-  // Something went wrong. Case work:
-  // * -1: Either `val.size` or `val.length` was a getter which managed to raise
-  //    an error. Rude. (Also we don't defend against this in hiwire_has_length)
-  // * -2: Doesn't have a length or size, or they aren't of type "number".
-  //   But `hiwire_has_length` returned true? So it must have changed somehow.
-  // * -3: Length was >= 2^{31}
-  // * -4: Length was negative
-  if (result == -2) {
-    PyErr_SetString(PyExc_TypeError, "object does not have a valid length");
-  }
-  if (result == -1 || result == -2) {
-    return -1;
-  }
-
-  char* length_as_string_alloc = hiwire_get_length_string(idobj);
-  char* length_as_string = length_as_string_alloc;
-  if (length_as_string == NULL) {
-    // Really screwed up.
-    length_as_string = "";
-  }
-  if (result == -3) {
-    PyErr_Format(
-      PyExc_ValueError, "length%s of object is negative", length_as_string);
-  }
-  if (result == -4) {
-    PyErr_Format(PyExc_OverflowError,
-                 "length%s of object is larger than INT_MAX (%d)",
-                 length_as_string,
-                 INT_MAX);
-  }
-  if (length_as_string_alloc != NULL) {
-    free(length_as_string_alloc);
-  }
-  return -1;
-}
-
-EM_JS_BOOL(bool, hiwire_is_generator, (JsRef idobj), {
-  // clang-format off
-  return getTypeTag(Hiwire.get_value(idobj)) === "[object Generator]";
-  // clang-format on
-});
-
-EM_JS_BOOL(bool, hiwire_is_async_generator, (JsRef idobj), {
-  // clang-format off
-  return getTypeTag(Hiwire.get_value(idobj)) === "[object AsyncGenerator]";
-  // clang-format on
-});
-
 EM_JS_BOOL(bool, hiwire_is_comlink_proxy, (JsRef idobj), {
   let value = Hiwire.get_value(idobj);
   return !!(API.Comlink && value[API.Comlink.createEndpoint]);
-});
-
-EM_JS_BOOL(bool, hiwire_is_error, (JsRef idobj), {
-  // From https://stackoverflow.com/a/45496068
-  let value = Hiwire.get_value(idobj);
-  // clang-format off
-  return !!(value && typeof value.stack === "string" &&
-            typeof value.message === "string");
-  // clang-format on
-});
-
-EM_JS_BOOL(bool, hiwire_is_promise, (JsRef idobj), {
-  // clang-format off
-  let obj = Hiwire.get_value(idobj);
-  return Hiwire.isPromise(obj);
-  // clang-format on
 });
 
 EM_JS_REF(JsRef, hiwire_resolve_promise, (JsRef idobj), {
@@ -415,10 +232,6 @@ EM_JS_REF(JsRef, hiwire_resolve_promise, (JsRef idobj), {
   let result = Promise.resolve(obj);
   return Hiwire.new_value(result);
   // clang-format on
-});
-
-EM_JS_REF(JsRef, hiwire_to_string, (JsRef idobj), {
-  return Hiwire.new_value(Hiwire.get_value(idobj).toString());
 });
 
 EM_JS(JsRef, hiwire_typeof, (JsRef idobj), {
@@ -443,88 +256,8 @@ MAKE_OPERATOR(not_equal, !==);
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
-EM_JS_REF(JsRef, hiwire_reversed_iterator, (JsRef idarray), {
-  if (!Module._reversedIterator) {
-    Module._reversedIterator = class ReversedIterator
-    {
-      constructor(array)
-      {
-        this._array = array;
-        this._i = array.length - 1;
-      }
-
-      __length_hint__() { return this._array.length; }
-
-      [Symbol.toStringTag]() { return "ReverseIterator"; }
-
-      next()
-      {
-        const i = this._i;
-        const a = this._array;
-        const done = i < 0;
-        const value = done ? undefined : a[i];
-        this._i--;
-        return { done, value };
-      }
-    };
-  }
-  let array = Hiwire.get_value(idarray);
-
-  return Hiwire.new_value(new Module._reversedIterator(array));
-})
-
-EM_JS_NUM(errcode, hiwire_assign_to_ptr, (JsRef idobj, void* ptr), {
-  let jsobj = Hiwire.get_value(idobj);
-  Module.HEAPU8.set(API.typedArrayAsUint8Array(jsobj), ptr);
-});
-
-EM_JS_NUM(errcode, hiwire_assign_from_ptr, (JsRef idobj, void* ptr), {
-  let jsobj = Hiwire.get_value(idobj);
-  API.typedArrayAsUint8Array(jsobj).set(
-    Module.HEAPU8.subarray(ptr, ptr + jsobj.byteLength));
-});
-
-EM_JS_NUM(errcode, hiwire_read_from_file, (JsRef idobj, int fd), {
-  let jsobj = Hiwire.get_value(idobj);
-  let uint8_buffer = API.typedArrayAsUint8Array(jsobj);
-  let stream = Module.FS.streams[fd];
-  Module.FS.read(stream, uint8_buffer, 0, uint8_buffer.byteLength);
-});
-
-EM_JS_NUM(errcode, hiwire_write_to_file, (JsRef idobj, int fd), {
-  let jsobj = Hiwire.get_value(idobj);
-  let uint8_buffer = API.typedArrayAsUint8Array(jsobj);
-  let stream = Module.FS.streams[fd];
-  Module.FS.write(stream, uint8_buffer, 0, uint8_buffer.byteLength);
-});
-
-EM_JS_NUM(errcode, hiwire_into_file, (JsRef idobj, int fd), {
-  let jsobj = Hiwire.get_value(idobj);
-  let uint8_buffer = API.typedArrayAsUint8Array(jsobj);
-  let stream = Module.FS.streams[fd];
-  // set canOwn param to true, leave position undefined.
-  Module.FS.write(
-    stream, uint8_buffer, 0, uint8_buffer.byteLength, undefined, true);
-});
-
 // clang-format off
-EM_JS_UNCHECKED(
-void,
-hiwire_get_buffer_info, (JsRef idobj,
-                         Py_ssize_t* byteLength_ptr,
-                         char** format_ptr,
-                         Py_ssize_t* size_ptr,
-                         bool* checked_ptr),
-{
-  let jsobj = Hiwire.get_value(idobj);
-  let byteLength = jsobj.byteLength;
-  let [format_utf8, size, checked] = Module.get_buffer_datatype(jsobj);
-  // Store results into arguments
-  DEREF_U32(byteLength_ptr, 0) = byteLength;
-  DEREF_U32(format_ptr, 0) = format_utf8;
-  DEREF_U32(size_ptr, 0) = size;
-  DEREF_U8(checked_ptr, 0) = checked;
-});
+
 // clang-format on
 
 EM_JS_REF(JsRef, hiwire_subarray, (JsRef idarr, int start, int end), {

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -239,32 +239,6 @@ EM_JS_REF(JsRef,
 });
 // clang-format on
 
-// Either syncifyHandler will get filled in by stack_switching/suspenders.mjs or
-// stack switching is not available so syncify will always return an error in
-// JsProxy.c and syncifyHandler will never be called.
-EMSCRIPTEN_KEEPALIVE JsRef (*syncifyHandler)(JsRef idpromise) = NULL;
-
-EM_JS(void, hiwire_syncify_handle_error, (void), {
-  if (!Module.syncify_error) {
-    // In this case we tried to syncify in a context where there is no
-    // suspender. JsProxy.c checks for this case and sets the error flag
-    // appropriately.
-    return;
-  }
-  Module.handle_js_error(Module.syncify_error);
-  delete Module.syncify_error;
-})
-
-JsRef
-hiwire_syncify(JsRef idpromise)
-{
-  JsRef result = syncifyHandler(idpromise);
-  if (result == 0) {
-    hiwire_syncify_handle_error();
-  }
-  return result;
-}
-
 EM_JS_BOOL(bool, hiwire_HasMethod, (JsRef obj_id, JsRef name), {
   // clang-format off
   let obj = Hiwire.get_value(obj_id);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -154,13 +154,6 @@ JsRef
 hiwire_construct(JsRef idobj, JsRef idargs);
 
 /**
- * Test if the object has a `size` or `length` member which is a number. As a
- * special case, if the object is a function the `length` field is ignored.
- */
-bool
-hiwire_has_length(JsRef idobj);
-
-/**
  * Returns the value of the `size` or `length` member on a JavaScript object.
  * Prefers the `size` member if present and a number to the `length` field. If
  * both `size` and `length` are missing or not a number, returns `-1` to
@@ -176,34 +169,10 @@ bool
 hiwire_get_bool(JsRef idobj);
 
 /**
- * Check if the object is a function.
- */
-bool
-hiwire_is_function(JsRef idobj);
-
-bool
-hiwire_is_generator(JsRef idobj);
-
-bool
-hiwire_is_async_generator(JsRef idobj);
-
-/**
  * Check if the object is a comlink proxy.
  */
 bool
 hiwire_is_comlink_proxy(JsRef idobj);
-
-/**
- * Check if the object is an error.
- */
-bool
-hiwire_is_error(JsRef idobj);
-
-/**
- * Returns true if the object is a promise.
- */
-bool
-hiwire_is_promise(JsRef idobj);
 
 /**
  * Returns Promise.resolve(obj)
@@ -212,22 +181,6 @@ hiwire_is_promise(JsRef idobj);
  */
 JsRef
 hiwire_resolve_promise(JsRef idobj);
-
-/**
- * Gets the string representation of an object by calling `toString`.
- *
- * Returns: New reference to JavaScript string
- */
-JsRef
-hiwire_to_string(JsRef idobj);
-
-/**
- * Gets the `typeof` string for a value.
- *
- * Returns: New reference to JavaScript string
- */
-JsRef
-hiwire_typeof(JsRef idobj);
 
 /**
  * Gets `value.constructor.name`.
@@ -272,48 +225,6 @@ hiwire_greater_than(JsRef ida, JsRef idb);
  */
 bool
 hiwire_greater_than_equal(JsRef ida, JsRef idb);
-
-/**
- * Returns the reversed iterator associated with an array.
- */
-JsRef
-hiwire_reversed_iterator(JsRef idobj);
-
-/**
- * Copies the buffer contents of a given ArrayBuffer view or ArrayBuffer into
- * the memory at ptr.
- */
-errcode WARN_UNUSED
-hiwire_assign_to_ptr(JsRef idobj, void* ptr);
-
-/**
- * Copies the memory at ptr into a given ArrayBuffer view or ArrayBuffer.
- */
-errcode WARN_UNUSED
-hiwire_assign_from_ptr(JsRef idobj, void* ptr);
-
-errcode
-hiwire_write_to_file(JsRef idobj, int fd);
-
-errcode
-hiwire_read_from_file(JsRef idobj, int fd);
-
-/**
- * Convert a buffer into a file in a copy-free manner using "canOwn" parameter.
- * Cannot directly use the buffer anymore after using this.
- */
-errcode
-hiwire_into_file(JsRef idobj, int fd);
-
-/**
- * Get a data type identifier for a given typedarray.
- */
-void
-hiwire_get_buffer_info(JsRef idobj,
-                       Py_ssize_t* byteLength_ptr,
-                       char** format_ptr,
-                       Py_ssize_t* size_ptr,
-                       bool* check_assignments);
 
 /**
  * Get a subarray from a TypedArray

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -119,12 +119,6 @@ hiwire_call_OneArg(JsRef idobj, JsRef idarg);
 JsRef
 hiwire_call_bound(JsRef idfunc, JsRef idthis, JsRef idargs);
 
-/**
- * Use stack switching to get the result of the promise synchronously.
- */
-JsRef
-hiwire_syncify(JsRef idpromise);
-
 bool
 hiwire_HasMethod(JsRef obj, JsRef name);
 

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -255,7 +255,7 @@ JS_FILE(js2python_init, () => {
    * should only be used on values for which js2python_convertImmutable
    * returned `undefined`.
    */
-  function js2python_convertOther(id, value, context) {
+  function js2python_convertOther(value, context) {
     let typeTag = getTypeTag(value);
     if (
       Array.isArray(value) ||
@@ -281,7 +281,7 @@ JS_FILE(js2python_init, () => {
     if (typeTag === "[object ArrayBuffer]" || ArrayBuffer.isView(value)) {
       let [format_utf8, itemsize] = Module.get_buffer_datatype(value);
       return _JsBuffer_CopyIntoMemoryView(
-        id,
+        value,
         value.byteLength,
         format_utf8,
         itemsize,
@@ -309,7 +309,7 @@ JS_FILE(js2python_init, () => {
     }
     context.depth--;
     try {
-      result = js2python_convertOther(id, value, context);
+      result = js2python_convertOther(value, context);
       if (result !== undefined) {
         return result;
       }

--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -37,6 +37,8 @@ EM_JS(JsVal, JsvInt, (int x), { return x; })
 
 EM_JS(bool, Jsv_to_bool, (JsVal x), { return !!x; })
 
+EM_JS(JsVal, Jsv_typeof, (JsVal x), { return typeof x; })
+
 // ==================== Strings API  ====================
 
 // clang-format off
@@ -188,6 +190,11 @@ EM_JS_VAL(JsVal, JsvObject_Values, (JsVal obj), {
   return Object.values(obj);
 });
 
+EM_JS_VAL(JsVal,
+JsvObject_toString, (JsVal obj), {
+  return obj.toString();
+});
+
 
 EM_JS_VAL(JsVal, JsvObject_CallMethod, (JsVal obj, JsVal meth, JsVal args), {
   return nullToUndefined(obj[meth](... args));
@@ -262,7 +269,7 @@ JsvFunction_Construct,
 
 EM_JS_BOOL(bool, JsvPromise_Check, (JsVal obj), {
   // clang-format off
-  return Hiwire.isPromise(obj);
+  return isPromise(obj);
   // clang-format on
 });
 
@@ -298,6 +305,36 @@ JsvPromise_Syncify(JsVal promise)
   return result;
 }
 
+// Buffers
+
+EM_JS_NUM(errcode, JsvBuffer_assignToPtr, (JsVal buf, void* ptr), {
+  Module.HEAPU8.set(bufferAsUint8Array(buf), ptr);
+});
+
+EM_JS_NUM(errcode, JsvBuffer_assignFromPtr, (JsVal buf, void* ptr), {
+  bufferAsUint8Array(buf).set(
+    Module.HEAPU8.subarray(ptr, ptr + buf.byteLength));
+});
+
+EM_JS_NUM(errcode, JsvBuffer_readFromFile, (JsVal buf, int fd), {
+  let uint8_buf = bufferAsUint8Array(buf);
+  let stream = Module.FS.streams[fd];
+  Module.FS.read(stream, uint8_buf, 0, uint8_buf.byteLength);
+});
+
+EM_JS_NUM(errcode, JsvBuffer_writeToFile, (JsVal buf, int fd), {
+  let uint8_buf = bufferAsUint8Array(buf);
+  let stream = Module.FS.streams[fd];
+  Module.FS.write(stream, uint8_buf, 0, uint8_buf.byteLength);
+});
+
+EM_JS_NUM(errcode, JsvBuffer_intoFile, (JsVal buf, int fd), {
+  let uint8_buf = bufferAsUint8Array(buf);
+  let stream = Module.FS.streams[fd];
+  // set canOwn param to true, leave position undefined.
+  Module.FS.write(stream, uint8_buf, 0, uint8_buf.byteLength, undefined, true);
+});
+
 // ==================== Miscellaneous  ====================
 
 EM_JS_BOOL(bool, JsvGenerator_Check, (JsVal obj), {
@@ -313,3 +350,42 @@ EM_JS_BOOL(bool, JsvAsyncGenerator_Check, (JsVal obj), {
 });
 
 EM_JS(void _Py_NO_RETURN, JsvError_Throw, (JsVal e), { throw e; })
+
+EM_JS_NUM(errcode, jslib_init, (), {
+  const dtypes_str =
+    [ "b", "B", "h", "H", "i", "I", "f", "d" ].join(String.fromCharCode(0));
+  const dtypes_ptr = stringToNewUTF8(dtypes_str);
+  const dtypes_map = Object.fromEntries(Object.entries(dtypes_str).map(([idx, val]) => [val, dtypes_ptr + (+idx)]));
+
+  const buffer_datatype_map = new Map([
+    [ "Int8Array", [ dtypes_map["b"], 1, true ] ],
+    [ "Uint8Array", [ dtypes_map["B"], 1, true ] ],
+    [ "Uint8ClampedArray", [ dtypes_map["B"], 1, true ] ],
+    [ "Int16Array", [ dtypes_map["h"], 2, true ] ],
+    [ "Uint16Array", [ dtypes_map["H"], 2, true ] ],
+    [ "Int32Array", [ dtypes_map["i"], 4, true ] ],
+    [ "Uint32Array", [ dtypes_map["I"], 4, true ] ],
+    [ "Float32Array", [ dtypes_map["f"], 4, true ] ],
+    [ "Float64Array", [ dtypes_map["d"], 8, true ] ],
+    // These last two default to Uint8. They have checked : false to allow use
+    // with other types.
+    [ "DataView", [ dtypes_map["B"], 1, false ] ],
+    [ "ArrayBuffer", [ dtypes_map["B"], 1, false ] ],
+  ]);
+
+  /**
+   * This gets the dtype of a ArrayBuffer or ArrayBuffer view. We return a
+   * triple: [char* format_ptr, int itemsize, bool checked] If argument is
+   * untyped (a DataView or ArrayBuffer) then we say it's a Uint8, but we set
+   * the flag checked to false in that case so we allow assignment to/from
+   * anything.
+   *
+   * This is the API for use from JavaScript, there's also an EM_JS
+   * hiwire_get_buffer_datatype wrapper for use from C. Used in js2python and
+   * in jsproxy.c for buffers.
+   */
+  Module.get_buffer_datatype = function(jsobj)
+  {
+    return buffer_datatype_map.get(jsobj.constructor.name) || [ 0, 0, false ];
+  }
+})

--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -272,6 +272,32 @@ EM_JS_VAL(JsVal, JsvPromise_Resolve, (JsVal obj), {
   // clang-format on
 });
 
+// Either syncifyHandler will get filled in by stack_switching/suspenders.mjs or
+// stack switching is not available so syncify will always return an error in
+// JsProxy.c and syncifyHandler will never be called.
+EMSCRIPTEN_KEEPALIVE JsVal (*syncifyHandler)(JsVal promise) = NULL;
+
+EM_JS(void, JsvPromise_Syncify_handleError, (void), {
+  if (!Module.syncify_error) {
+    // In this case we tried to syncify in a context where there is no
+    // suspender. JsProxy.c checks for this case and sets the error flag
+    // appropriately.
+    return;
+  }
+  Module.handle_js_error(Module.syncify_error);
+  delete Module.syncify_error;
+})
+
+JsVal
+JsvPromise_Syncify(JsVal promise)
+{
+  JsVal result = syncifyHandler(promise);
+  if (JsvNull_Check(result)) {
+    JsvPromise_Syncify_handleError();
+  }
+  return result;
+}
+
 // ==================== Miscellaneous  ====================
 
 EM_JS_BOOL(bool, JsvGenerator_Check, (JsVal obj), {

--- a/src/core/jslib.h
+++ b/src/core/jslib.h
@@ -28,6 +28,9 @@ bool
 Jsv_to_bool(JsVal x);
 
 JsVal
+Jsv_typeof(JsVal x);
+
+JsVal
 JsvUTF8ToString(const char*);
 
 JsRef
@@ -83,6 +86,9 @@ JsVal JsvObject_Keys(JsVal);
 
 JsVal JsvObject_Values(JsVal);
 
+JsVal
+JsvObject_toString(JsVal obj);
+
 int
 JsvObject_SetAttr(JsVal obj, JsVal attr, JsVal value);
 
@@ -127,7 +133,7 @@ JsvFunction_CallBound(JsVal func, JsVal this, JsVal args);
 JsVal
 JsvFunction_Construct(JsVal func, JsVal args);
 
-// ==================== Miscellaneous  ====================
+// ==================== Promises  ====================
 
 bool
 JsvPromise_Check(JsVal obj);
@@ -137,6 +143,25 @@ JsvPromise_Resolve(JsVal obj);
 
 JsVal
 JsvPromise_Syncify(JsVal promise);
+
+// ==================== Buffers  ====================
+
+errcode
+JsvBuffer_assignToPtr(JsVal buf, void* ptr);
+
+errcode
+JsvBuffer_assignFromPtr(JsVal buf, void* ptr);
+
+errcode
+JsvBuffer_readFromFile(JsVal buf, int fd);
+
+errcode
+JsvBuffer_writeToFile(JsVal buf, int fd);
+
+errcode
+JsvBuffer_intoFile(JsVal buf, int fd);
+
+// ==================== Miscellaneous  ====================
 
 bool
 JsvGenerator_Check(JsVal obj);

--- a/src/core/jslib.h
+++ b/src/core/jslib.h
@@ -135,6 +135,9 @@ JsvPromise_Check(JsVal obj);
 JsVal
 JsvPromise_Resolve(JsVal obj);
 
+JsVal
+JsvPromise_Syncify(JsVal promise);
+
 bool
 JsvGenerator_Check(JsVal obj);
 

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -265,16 +265,14 @@ finally:
 static PyObject*
 JsProxy_Repr(PyObject* self)
 {
-  JsRef idrepr = hiwire_to_string(JsProxy_REF(self));
-  if (idrepr == NULL) {
+  JsVal repr = JsvObject_toString(JsProxy_VAL(self));
+  if (JsvNull_Check(repr)) {
     PyErr_Format(PyExc_TypeError,
                  "Pyodide cannot generate a repr for this Javascript object "
                  "because it has no 'toString' method");
     return NULL;
   }
-  PyObject* pyrepr = js2python(idrepr);
-  hiwire_decref(idrepr);
-  return pyrepr;
+  return js2python_val(repr);
 }
 
 /**
@@ -283,10 +281,7 @@ JsProxy_Repr(PyObject* self)
 static PyObject*
 JsProxy_typeof(PyObject* self, void* _unused)
 {
-  JsRef idval = hiwire_typeof(JsProxy_REF(self));
-  PyObject* result = js2python(idval);
-  hiwire_decref(idval);
-  return result;
+  return js2python_val(Jsv_typeof(JsProxy_VAL(self)));
 }
 
 static PyObject*
@@ -511,9 +506,8 @@ JsProxy_RichCompare(PyObject* a, PyObject* b, int op)
   }
 }
 
-EM_JS_REF(JsRef, JsProxy_GetIter_js, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  return Hiwire.new_value(jsobj[Symbol.iterator]());
+EM_JS_VAL(JsVal, JsProxy_GetIter_js, (JsVal obj), {
+  return obj[Symbol.iterator]();
 });
 
 /**
@@ -523,13 +517,11 @@ EM_JS_REF(JsRef, JsProxy_GetIter_js, (JsRef idobj), {
 static PyObject*
 JsProxy_GetIter(PyObject* self)
 {
-  JsRef iditer = JsProxy_GetIter_js(JsProxy_REF(self));
-  if (iditer == NULL) {
-    return NULL;
-  }
-  PyObject* result = js2python(iditer);
-  hiwire_decref(iditer);
-  return result;
+  JsVal iter = JsProxy_GetIter_js(JsProxy_VAL(self));
+  FAIL_IF_JS_NULL(iter);
+  return js2python_val(iter);
+finally:
+  return NULL;
 }
 
 // clang-format off
@@ -579,9 +571,7 @@ handle_next_result(JsVal next_res, PyObject** result, bool obj_map_hereditary){
   // so pyvalue will be set to Py_None.
   *result = js2python_immutable_val(jsresult);
   if (!*result) {
-    JsRef idresult = hiwire_new(jsresult);
-    *result = JsProxy_create_objmap(idresult, obj_map_hereditary);
-    hiwire_decref(idresult);
+    *result = JsProxy_create_objmap_val(jsresult, obj_map_hereditary);
   }
   FAIL_IF_NULL(*result);
   if(pyproxy_Check(jsresult)) {
@@ -600,25 +590,23 @@ finally:
 PySendResult
 JsProxy_am_send(PyObject* self, PyObject* arg, PyObject** result)
 {
-  JsRef jsarg = Js_undefined;
   *result = NULL;
   PySendResult ret = PYGEN_ERROR;
 
-  JsVal proxies;
+  JsVal proxies = JsvArray_New();
+  JsVal jsarg = hiwire_get(Js_undefined);
   if (arg) {
-    proxies = JsvArray_New();
-    jsarg = python2js_track_proxies(arg, proxies, true);
-    FAIL_IF_NULL(jsarg);
+    jsarg = JsRef_pop(python2js_track_proxies(arg, proxies, true));
+    FAIL_IF_JS_NULL(jsarg);
   }
-  JsVal next_res = JsvObject_CallMethodId_OneArg(
-    JsProxy_VAL(self), &JsId_next, hiwire_get(jsarg));
+  JsVal next_res =
+    JsvObject_CallMethodId_OneArg(JsProxy_VAL(self), &JsId_next, jsarg);
   FAIL_IF_JS_NULL(next_res);
   ret = handle_next_result(next_res, result, JsObjMap_HEREDITARY(self));
 finally:
   if (arg) {
     destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
   }
-  hiwire_CLEAR(jsarg);
   return ret;
 }
 
@@ -710,15 +698,17 @@ JsException_js_error_getter(PyObject* self, void* closure)
   return self;
 }
 
-EM_JS_REF(JsRef,
-          JsException_new_helper,
-          (char* name_ptr, char* message_ptr, char* stack_ptr),
-          {
-            let name = UTF8ToString(name_ptr);
-            let message = UTF8ToString(message_ptr);
-            let stack = UTF8ToString(stack_ptr);
-            return Hiwire.new_value(API.deserializeError(name, message, stack));
-          });
+// clang-format off
+EM_JS_VAL(JsVal,
+JsException_new_helper,
+(char* name_ptr, char* message_ptr, char* stack_ptr),
+{
+  let name = UTF8ToString(name_ptr);
+  let message = UTF8ToString(message_ptr);
+  let stack = UTF8ToString(stack_ptr);
+  return API.deserializeError(name, message, stack);
+});
+// clang-format on
 
 // We use this to unpickle JsException objects.
 static PyObject*
@@ -732,11 +722,11 @@ JsException_new(PyTypeObject* subtype, PyObject* args, PyObject* kwds)
         args, kwds, "s|ss:__new__", kwlist, &name, &message, &stack)) {
     return NULL;
   }
-  JsRef result = JsException_new_helper(name, message, stack);
-  if (result == NULL) {
-    return NULL;
-  }
-  return js2python(result);
+  JsVal result = JsException_new_helper(name, message, stack);
+  FAIL_IF_JS_NULL(result);
+  return js2python_val(result);
+finally:
+  return NULL;
 }
 
 static int
@@ -901,9 +891,8 @@ static PyMethodDef JsGenerator_close_MethodDef = {
   METH_NOARGS,
 };
 
-EM_JS_REF(JsRef, JsProxy_GetAsyncIter_js, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  return Hiwire.new_value(jsobj[Symbol.asyncIterator]());
+EM_JS_VAL(JsVal, JsProxy_GetAsyncIter_js, (JsVal obj), {
+  return obj[Symbol.asyncIterator]();
 });
 
 /**
@@ -914,13 +903,11 @@ EM_JS_REF(JsRef, JsProxy_GetAsyncIter_js, (JsRef idobj), {
 static PyObject*
 JsProxy_GetAsyncIter(PyObject* self)
 {
-  JsRef iditer = JsProxy_GetAsyncIter_js(JsProxy_REF(self));
-  if (iditer == NULL) {
-    return NULL;
-  }
-  PyObject* result = js2python(iditer);
-  hiwire_decref(iditer);
-  return result;
+  JsVal iter = JsProxy_GetAsyncIter_js(JsProxy_VAL(self));
+  FAIL_IF_JS_NULL(iter);
+  return js2python_val(iter);
+finally:
+  return NULL;
 }
 
 /**
@@ -1099,17 +1086,16 @@ finally:
 static PyObject*
 JsGenerator_asend(PyObject* self, PyObject* arg)
 {
-  JsRef jsarg = Js_undefined;
   PyObject* result = NULL;
 
-  JsVal proxies;
+  JsVal proxies = JsvArray_New();
+  JsVal jsarg = hiwire_get(Js_undefined);
   if (arg != NULL) {
-    proxies = JsvArray_New();
-    jsarg = python2js_track_proxies(arg, proxies, true);
-    FAIL_IF_NULL(jsarg);
+    jsarg = JsRef_pop(python2js_track_proxies(arg, proxies, true));
+    FAIL_IF_JS_NULL(jsarg);
   }
-  JsVal next_res = JsvObject_CallMethodId_OneArg(
-    JsProxy_VAL(self), &JsId_next, hiwire_get(jsarg));
+  JsVal next_res =
+    JsvObject_CallMethodId_OneArg(JsProxy_VAL(self), &JsId_next, jsarg);
   FAIL_IF_JS_NULL(next_res);
   result = _agen_handle_result(next_res, false);
 
@@ -1117,7 +1103,6 @@ finally:
   if (arg) {
     destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
   }
-  hiwire_CLEAR(jsarg);
   return result;
 }
 
@@ -1239,15 +1224,90 @@ static PyMethodDef JsProxy_object_values_MethodDef = {
   METH_NOARGS,
 };
 
+EM_JS_NUM(int, get_length_helper, (JsVal val), {
+  // clang-format off
+  let result;
+  if (typeof val.size === "number") {
+    result = val.size;
+  } else if (typeof val.length === "number") {
+    result = val.length;
+  } else {
+    return -2;
+  }
+  if(result < 0){
+    return -3;
+  }
+  if(result > INT_MAX){
+    return -4;
+  }
+  return result;
+  // clang-format on
+});
+
+// Needed to render the length accurately when there is an error
+EM_JS_REF(char*, get_length_string, (JsVal val), {
+  let result;
+  // clang-format off
+  if (typeof val.size === "number") {
+    result = val.size;
+  } else if (typeof val.length === "number") {
+    result = val.length;
+  }
+  // clang-format on
+  return stringToNewUTF8(" " + result.toString())
+})
+
+static int
+get_length(JsVal obj)
+{
+  int result = get_length_helper(obj);
+  if (result >= 0) {
+    return result;
+  }
+  // Something went wrong. Case work:
+  // * -1: Either `val.size` or `val.length` was a getter which managed to raise
+  //    an error. Rude. (Also we don't defend against this in hiwire_has_length)
+  // * -2: Doesn't have a length or size, or they aren't of type "number".
+  //   But `hiwire_has_length` returned true? So it must have changed somehow.
+  // * -3: Length was >= 2^{31}
+  // * -4: Length was negative
+  if (result == -2) {
+    PyErr_SetString(PyExc_TypeError, "object does not have a valid length");
+  }
+  if (result == -1 || result == -2) {
+    return -1;
+  }
+
+  char* length_as_string_alloc = get_length_string(obj);
+  char* length_as_string = length_as_string_alloc;
+  if (length_as_string == NULL) {
+    // Really screwed up.
+    length_as_string = "";
+  }
+  if (result == -3) {
+    PyErr_Format(
+      PyExc_ValueError, "length%s of object is negative", length_as_string);
+  }
+  if (result == -4) {
+    PyErr_Format(PyExc_OverflowError,
+                 "length%s of object is larger than INT_MAX (%d)",
+                 length_as_string,
+                 INT_MAX);
+  }
+  if (length_as_string_alloc != NULL) {
+    free(length_as_string_alloc);
+  }
+  return -1;
+}
+
 /**
  * len(proxy) overload for proxies of Js objects with `length` or `size` fields.
  * Prefers `object.size` over `object.length`. Controlled by HAS_LENGTH.
  */
 static Py_ssize_t
-JsProxy_length(PyObject* o)
+JsProxy_length(PyObject* self)
 {
-  JsProxy* self = (JsProxy*)o;
-  return hiwire_get_length(self->js);
+  return get_length(JsProxy_VAL(self));
 }
 
 static PyObject*
@@ -1276,7 +1336,7 @@ JsArray_subscript(PyObject* o, PyObject* item)
     if (i == -1)
       FAIL_IF_ERR_OCCURRED();
     if (i < 0) {
-      int length = hiwire_get_length(self->js);
+      int length = get_length(JsProxy_VAL(self));
       FAIL_IF_MINUS_ONE(length);
       i += length;
     }
@@ -1293,7 +1353,7 @@ JsArray_subscript(PyObject* o, PyObject* item)
   if (PySlice_Check(item)) {
     Py_ssize_t start, stop, step;
     FAIL_IF_MINUS_ONE(PySlice_Unpack(item, &start, &stop, &step));
-    int length = hiwire_get_length(self->js);
+    int length = get_length(JsProxy_VAL(self));
     FAIL_IF_MINUS_ONE(length);
     // PySlice_AdjustIndices is "Always successful" per the docs.
     Py_ssize_t slicelength = PySlice_AdjustIndices(length, &start, &stop, step);
@@ -1403,7 +1463,7 @@ JsArray_ass_subscript(PyObject* o, PyObject* item, PyObject* pyvalue)
   if (PySlice_Check(item)) {
     Py_ssize_t start, stop, step, slicelength;
     FAIL_IF_MINUS_ONE(PySlice_Unpack(item, &start, &stop, &step));
-    int length = hiwire_get_length(self->js);
+    int length = get_length(JsProxy_VAL(self));
     FAIL_IF_MINUS_ONE(length);
     // PySlice_AdjustIndices is "Always successful" per the docs.
     slicelength = PySlice_AdjustIndices(length, &start, &stop, step);
@@ -1457,7 +1517,7 @@ JsArray_ass_subscript(PyObject* o, PyObject* item, PyObject* pyvalue)
     if (i == -1)
       FAIL_IF_ERR_OCCURRED();
     if (i < 0) {
-      int length = hiwire_get_length(self->js);
+      int length = get_length(JsProxy_VAL(self));
       FAIL_IF_MINUS_ONE(length);
       i += length;
     }
@@ -1627,37 +1687,32 @@ static PyObject*
 JsArray_sq_inplace_concat(PyObject* self, PyObject* other)
 {
   PyObject* result = JsArray_extend_meth(self, other);
-  if (result == NULL)
-    return NULL;
+  FAIL_IF_NULL(result);
   Py_DECREF(result);
   Py_INCREF(self);
   return self;
+finally:
+  return NULL;
 }
 
-EM_JS_REF(JsRef, JsArray_repeat_js, (JsRef oid, Py_ssize_t count), {
-  const o = Hiwire.get_value(oid);
+EM_JS_VAL(JsVal, JsArray_repeat_js, (JsVal o, Py_ssize_t count), {
   // clang-format off
-  return Hiwire.new_value(Array.from({ length : count }, () => o).flat())
+  return Array.from({ length : count }, () => o).flat();
   // clang-format on
 })
 
 static PyObject*
 JsArray_sq_repeat(PyObject* o, Py_ssize_t count)
 {
-  JsRef jsresult = NULL;
-  PyObject* pyresult = NULL;
-
-  jsresult = JsArray_repeat_js(JsProxy_REF(o), count);
-  FAIL_IF_NULL(jsresult);
-  pyresult = js2python(jsresult);
+  JsVal jsresult = JsArray_repeat_js(JsProxy_Val(o), count);
+  FAIL_IF_JS_NULL(jsresult);
+  return js2python_val(jsresult);
 
 finally:
-  hiwire_CLEAR(jsresult);
-  return pyresult;
+  return NULL;
 }
 
-EM_JS_NUM(errcode, JsArray_inplace_repeat_js, (JsRef oid, Py_ssize_t count), {
-  const o = Hiwire.get_value(oid);
+EM_JS_NUM(errcode, JsArray_inplace_repeat_js, (JsVal o, Py_ssize_t count), {
   // clang-format off
   o.splice(0, o.length, ... Array.from({ length : count }, () => o).flat());
   // clang-format on
@@ -1666,7 +1721,7 @@ EM_JS_NUM(errcode, JsArray_inplace_repeat_js, (JsRef oid, Py_ssize_t count), {
 static PyObject*
 JsArray_sq_inplace_repeat(PyObject* o, Py_ssize_t count)
 {
-  FAIL_IF_MINUS_ONE(JsArray_inplace_repeat_js(JsProxy_REF(o), count));
+  FAIL_IF_MINUS_ONE(JsArray_inplace_repeat_js(JsProxy_VAL(o), count));
   Py_INCREF(o);
   return o;
 finally:
@@ -1731,7 +1786,7 @@ JsArray_pop(PyObject* o, PyObject* const* args, Py_ssize_t nargs)
     }
   }
 
-  int length = hiwire_get_length(self->js);
+  int length = get_length(JsProxy_VAL(self));
   FAIL_IF_MINUS_ONE(length);
 
   if (length == 0) {
@@ -1761,18 +1816,45 @@ static PyMethodDef JsArray_pop_MethodDef = {
   METH_FASTCALL,
 };
 
-static PyObject*
-JsArray_reversed(PyObject* o, PyObject* ignored)
+EM_JS(JsVal, JsArray_reversed_iterator, (JsVal array), {
+  return new ReversedIterator(array);
+}
+class ReversedIterator
 {
-  JsProxy* self = (JsProxy*)o;
+  constructor(array)
+  {
+    this._array = array;
+    this._i = array.length - 1;
+}
 
-  JsRef iditer = hiwire_reversed_iterator(self->js);
-  if (iditer == NULL) {
-    return NULL;
-  }
-  PyObject* result = js2python(iditer);
-  hiwire_decref(iditer);
-  return result;
+__length_hint__()
+{
+  return this._array.length;
+}
+
+[Symbol.toStringTag]() { return "ReverseIterator"; }
+
+next()
+{
+  const i = this._i;
+  const a = this._array;
+  const done = i < 0;
+  const value = done ? undefined : a[i];
+  this._i--;
+  return { done, value };
+}
+}
+;
+)
+
+static PyObject*
+JsArray_reversed(PyObject* self, PyObject* ignored)
+{
+  JsVal iter = JsArray_reversed_iterator(JsProxy_VAL(self));
+  FAIL_IF_JS_NULL(iter);
+  return js2python_val(iter);
+finally:
+  return NULL;
 }
 
 static PyMethodDef JsArray_reversed_MethodDef = {
@@ -1783,11 +1865,9 @@ static PyMethodDef JsArray_reversed_MethodDef = {
 
 // clang-format off
 EM_JS_NUM(int,
-JsArray_index_helper,
-(JsRef list, JsRef value, int start, int stop),
+JsArray_index_js,
+(JsVal o, JsVal v, int start, int stop),
 {
-  let o = Hiwire.get_value(list);
-  let v = Hiwire.get_value(value);
   for (let i = start; i < stop; i++) {
     if (o[i] === v) {
       return i;
@@ -1798,9 +1878,8 @@ JsArray_index_helper,
 // clang-format on
 
 static PyObject*
-JsArray_index(PyObject* o, PyObject* args)
+JsArray_index(PyObject* self, PyObject* args)
 {
-  JsProxy* self = (JsProxy*)o;
   PyObject* value;
   Py_ssize_t start = 0;
   Py_ssize_t stop = PY_SSIZE_T_MAX;
@@ -1808,7 +1887,7 @@ JsArray_index(PyObject* o, PyObject* args)
     return NULL;
   }
 
-  int length = JsProxy_length(o);
+  int length = JsProxy_length(self);
   if (length == -1) {
     return NULL;
   }
@@ -1826,8 +1905,8 @@ JsArray_index(PyObject* o, PyObject* args)
     stop = length;
   }
 
-  JsRef jsvalue = python2js_track_proxies(value, JS_NULL, true);
-  if (jsvalue == NULL) {
+  JsVal jsvalue = JsRef_pop(python2js_track_proxies(value, JS_NULL, true));
+  if (JsvNull_Check(jsvalue)) {
     PyErr_Clear();
     for (int i = start; i < stop; i++) {
       JsVal jsobj = JsvArray_Get(JsProxy_VAL(self), i);
@@ -1846,8 +1925,7 @@ JsArray_index(PyObject* o, PyObject* args)
         return NULL;
     }
   } else {
-    int result = JsArray_index_helper(self->js, jsvalue, start, stop);
-    hiwire_decref(jsvalue);
+    int result = JsArray_index_js(JsProxy_VAL(self), jsvalue, start, stop);
     if (result != -1) {
       return PyLong_FromSsize_t(result);
     }
@@ -1866,11 +1944,9 @@ static PyMethodDef JsArray_index_MethodDef = {
 
 // clang-format off
 EM_JS_NUM(int,
-JsArray_count_helper,
-(JsRef list, JsRef value),
+JsArray_count_js,
+(JsVal o, JsVal v),
 {
-  let o = Hiwire.get_value(list);
-  let v = Hiwire.get_value(value);
   let result = 0;
   for (let i = 0; i < o.length; i++) {
     if (o[i] === v) {
@@ -1885,8 +1961,8 @@ static PyObject*
 JsArray_count(PyObject* o, PyObject* value)
 {
   JsProxy* self = (JsProxy*)o;
-  JsRef jsvalue = python2js_track_proxies(value, JS_NULL, true);
-  if (jsvalue == NULL) {
+  JsVal jsvalue = JsRef_pop(python2js_track_proxies(value, JS_NULL, true));
+  if (JsvNull_Check(jsvalue)) {
     PyErr_Clear();
     int result = 0;
     Py_ssize_t stop = JsProxy_length(o);
@@ -1911,8 +1987,7 @@ JsArray_count(PyObject* o, PyObject* value)
     }
     return PyLong_FromSsize_t(result);
   } else {
-    int result = JsArray_count_helper(self->js, jsvalue);
-    hiwire_decref(jsvalue);
+    int result = JsArray_count_js(JsProxy_VAL(self), jsvalue);
     if (result == -1) {
       return NULL;
     } else {
@@ -1927,15 +2002,12 @@ static PyMethodDef JsArray_count_MethodDef = {
   METH_O,
 };
 
-EM_JS_NUM(errcode, JsArray_reverse_helper, (JsRef arrayid), {
-  Hiwire.get_value(arrayid).reverse();
-})
+EM_JS_NUM(errcode, JsArray_reverse_js, (JsVal array), { array.reverse(); })
 
 static PyObject*
-JsArray_reverse(PyObject* o, PyObject* _ignored)
+JsArray_reverse(PyObject* self, PyObject* _ignored)
 {
-  JsProxy* self = (JsProxy*)o;
-  if (JsArray_reverse_helper(self->js) == -1) {
+  if (JsArray_reverse_js(JsProxy_Val(self)) == -1) {
     return NULL;
   }
   Py_RETURN_NONE;
@@ -1948,9 +2020,7 @@ static PyMethodDef JsArray_reverse_MethodDef = {
 };
 
 // A helper method for jsproxy_subscript.
-EM_JS_REF(JsRef, JsProxy_subscript_js, (JsRef idobj, JsRef idkey), {
-  let obj = Hiwire.get_value(idobj);
-  let key = Hiwire.get_value(idkey);
+EM_JS_VAL(JsVal, JsProxy_subscript_js, (JsVal obj, JsVal key), {
   let result = obj.get(key);
   // clang-format off
   if (result === undefined) {
@@ -1959,11 +2029,11 @@ EM_JS_REF(JsRef, JsProxy_subscript_js, (JsRef idobj, JsRef idkey), {
     // key is missing. Otherwise, assume key present and value was undefined.
     // TODO: in absence of a "has" method, should we return None or KeyError?
     if (obj.has && typeof obj.has === "function" && !obj.has(key)) {
-      return 0;
+      return null;
     }
   }
   // clang-format on
-  return Hiwire.new_value(result);
+  return nullToUndefined(result);
 });
 
 /**
@@ -1971,28 +2041,20 @@ EM_JS_REF(JsRef, JsProxy_subscript_js, (JsRef idobj, JsRef idkey), {
  * obj.get(key). Controlled by HAS_GET
  */
 static PyObject*
-JsProxy_subscript(PyObject* o, PyObject* pyidx)
+JsProxy_subscript(PyObject* self, PyObject* pyidx)
 {
-  JsProxy* self = (JsProxy*)o;
-  JsRef ididx = NULL;
-  JsRef idresult = NULL;
-  PyObject* pyresult = NULL;
-
-  ididx = python2js(pyidx);
-  FAIL_IF_NULL(ididx);
-  idresult = JsProxy_subscript_js(self->js, ididx);
-  if (idresult == NULL) {
+  JsVal idx = python2js_val(pyidx);
+  FAIL_IF_JS_NULL(idx);
+  JsVal result = JsProxy_subscript_js(JsProxy_VAL(self), idx);
+  if (JsvNull_Check(result)) {
     if (!PyErr_Occurred()) {
       PyErr_SetObject(PyExc_KeyError, pyidx);
     }
     FAIL();
   }
-  pyresult = js2python(idresult);
-
+  return js2python_val(result);
 finally:
-  hiwire_CLEAR(ididx);
-  hiwire_CLEAR(idresult);
-  return pyresult;
+  return NULL;
 }
 
 /**
@@ -2071,17 +2133,16 @@ finally:
   return result;
 }
 
-EM_JS_REF(JsRef, JsMap_GetIter_js, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
+EM_JS_REF(JsVal, JsMap_GetIter_js, (JsVal obj), {
   let result;
   // clang-format off
-  if(typeof jsobj.keys === 'function') {
+  if(typeof obj.keys === 'function') {
     // clang-format on
-    result = jsobj.keys();
+    result = obj.keys();
   } else {
-    result = jsobj[Symbol.iterator]();
+    result = obj[Symbol.iterator]();
   }
-  return Hiwire.new_value(result);
+  return result;
 })
 
 /**
@@ -2090,17 +2151,13 @@ EM_JS_REF(JsRef, JsMap_GetIter_js, (JsRef idobj), {
  * Prefers to iterate using map.keys() over map[Symbol.iterator]().
  */
 static PyObject*
-JsMap_GetIter(PyObject* o)
+JsMap_GetIter(PyObject* self)
 {
-  JsProxy* self = (JsProxy*)o;
-
-  JsRef iditer = JsMap_GetIter_js(self->js);
-  if (iditer == NULL) {
-    return NULL;
-  }
-  PyObject* result = js2python(iditer);
-  hiwire_decref(iditer);
-  return result;
+  JsVal iter = JsMap_GetIter_js(JsProxy_VAL(self));
+  FAIL_IF_JS_NULL(iter);
+  return js2python_val(iter);
+finally:
+  return NULL;
 }
 
 static PyObject*
@@ -2225,12 +2282,11 @@ static PyMethodDef JsMap_popitem_MethodDef = {
   METH_NOARGS,
 };
 
-EM_JS_NUM(int, JsMap_clear_js, (JsRef idmap), {
-  const map = Hiwire.get_value(idmap);
+EM_JS_NUM(int, JsMap_clear_js, (JsVal map), {
   // clang-format off
-  if(idmap && typeof idmap.clear === "function") {
+  if(map && typeof map.clear === "function") {
     // clang-format on
-    idmap.clear();
+    map.clear();
     return 1;
   }
   return 0;
@@ -2240,7 +2296,7 @@ static PyObject*
 JsMap_clear(PyObject* self, PyObject* Py_UNUSED(ignored))
 {
   // If the map has a JavaScript "clear" function, use that.
-  int status = JsMap_clear_js(JsProxy_REF(self));
+  int status = JsMap_clear_js(JsProxy_VAL(self));
   if (status == -1) {
     return NULL;
   }
@@ -2536,12 +2592,12 @@ finally:
  * Controlled by IS_AWAITABLE.
  */
 static PyObject*
-JsProxy_Await(JsProxy* self)
+JsProxy_Await(PyObject* self)
 {
-  if (!hiwire_is_promise(self->js)) {
+  if (!JsvPromise_Check(JsProxy_VAL(self))) {
     // This error is unlikely to be hit except in cases of intentional mischief.
     // Such mischief is conducted in test_jsproxy:test_mixins_errors_2
-    PyObject* str = JsProxy_Repr((PyObject*)self);
+    PyObject* str = PyObject_Repr(self);
     const char* str_utf8 = PyUnicode_AsUTF8(str);
     PyErr_Format(PyExc_TypeError,
                  "object %s can't be used in 'await' expression",
@@ -2654,8 +2710,6 @@ static PyMethodDef JsProxy_catch_MethodDef = {
 static PyObject*
 JsProxy_finally(JsProxy* self, PyObject* onfinally)
 {
-  PyObject* result = NULL;
-
   JsVal promise = JsvPromise_Resolve(JsProxy_VAL(self));
   FAIL_IF_JS_NULL(promise);
   // Finally method is called no matter what so we can use
@@ -2669,12 +2723,9 @@ JsProxy_finally(JsProxy* self, PyObject* onfinally)
     FAIL();
   }
 
-  JsRef result_promise_ref = hiwire_new(result_promise);
-  result = JsProxy_create(result_promise_ref);
-  hiwire_CLEAR(result_promise_ref);
-
+  return JsProxy_create_val(result_promise);
 finally:
-  return result;
+  return NULL;
 }
 
 static PyMethodDef JsProxy_finally_MethodDef = {
@@ -2716,27 +2767,23 @@ static PyMethodDef JsProxy_as_object_map_MethodDef = {
   METH_FASTCALL | METH_KEYWORDS
 };
 
-EM_JS_REF(JsRef, JsObjMap_GetIter_js, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
-  return Hiwire.new_value(Module.iterObject(jsobj));
+EM_JS_VAL(JsVal, JsObjMap_GetIter_js, (JsVal obj), {
+  return Module.iterObject(obj);
 })
 
 static PyObject*
 JsObjMap_GetIter(PyObject* self)
 {
-  JsRef iditer = JsObjMap_GetIter_js(JsProxy_REF(self));
-  if (iditer == NULL) {
-    return NULL;
-  }
-  PyObject* result = js2python(iditer);
-  hiwire_decref(iditer);
-  return result;
+  JsVal iter = JsObjMap_GetIter_js(JsProxy_VAL(self));
+  FAIL_IF_JS_NULL(iter);
+  return js2python_val(iter);
+finally:
+  return NULL;
 }
 
-EM_JS_NUM(int, JsObjMap_length_js, (JsRef idobj), {
-  let jsobj = Hiwire.get_value(idobj);
+EM_JS_NUM(int, JsObjMap_length_js, (JsVal obj), {
   let length = 0;
-  for (let _ of Module.iterObject(jsobj)) {
+  for (let _ of Module.iterObject(obj)) {
     length++;
   }
   return length;
@@ -2745,17 +2792,15 @@ EM_JS_NUM(int, JsObjMap_length_js, (JsRef idobj), {
 static int
 JsObjMap_length(PyObject* self)
 {
-  return JsObjMap_length_js(JsProxy_REF(self));
+  return JsObjMap_length_js(JsProxy_VAL(self));
 }
 
 // A helper method for JsObjMap_subscript.
-EM_JS_REF(JsRef, JsObjMap_subscript_js, (JsRef idobj, JsRef idkey), {
-  let obj = Hiwire.get_value(idobj);
-  let key = Hiwire.get_value(idkey);
+EM_JS_VAL(JsVal, JsObjMap_subscript_js, (JsVal obj, JsVal key), {
   if (!Object.prototype.hasOwnProperty.call(obj, key)) {
-    return 0;
+    return null;
   }
-  return Hiwire.new_value(obj[key]);
+  return obj[key];
 });
 
 static PyObject*
@@ -2766,27 +2811,23 @@ JsObjMap_subscript(PyObject* self, PyObject* pyidx)
     return NULL;
   }
 
-  JsRef idkey = NULL;
-  JsRef idresult = NULL;
   PyObject* pyresult = NULL;
 
-  idkey = python2js(pyidx);
-  FAIL_IF_NULL(idkey);
-  idresult = JsObjMap_subscript_js(JsProxy_REF(self), idkey);
-  if (idresult == NULL) {
+  JsVal key = python2js_val(pyidx);
+  FAIL_IF_JS_NULL(key);
+  JsVal result = JsObjMap_subscript_js(JsProxy_VAL(self), key);
+  if (JsvNull_Check(result)) {
     if (!PyErr_Occurred()) {
       PyErr_SetObject(PyExc_KeyError, pyidx);
     }
     FAIL();
   }
-  pyresult = js2python_immutable(idresult);
+  pyresult = js2python_immutable_val(result);
   if (pyresult == NULL) {
-    pyresult = JsProxy_create_objmap(idresult, JsObjMap_HEREDITARY(self));
+    pyresult = JsProxy_create_objmap_val(result, JsObjMap_HEREDITARY(self));
   }
 
 finally:
-  hiwire_CLEAR(idresult);
-  hiwire_CLEAR(idkey);
   return pyresult;
 }
 
@@ -2794,17 +2835,15 @@ finally:
 // clang-format off
 EM_JS_NUM(int,
 JsObjMap_ass_subscript_js,
-(JsRef idobj, JsRef idkey, JsRef idvalue),
+(JsVal obj, JsVal key, JsVal value),
 {
-  let obj = Hiwire.get_value(idobj);
-  let key = Hiwire.get_value(idkey);
-  if(idvalue === 0) {
+  if(value === null) {
     if (!Object.prototype.hasOwnProperty.call(obj, key)) {
       return -1;
     }
     delete obj[key];
   } else {
-    obj[key] = Hiwire.get_value(idvalue);
+    obj[key] = value;
   }
   return 0;
 });
@@ -2825,14 +2864,13 @@ JsObjMap_ass_subscript(PyObject* self, PyObject* pykey, PyObject* pyvalue)
   }
 
   bool success = false;
-  JsRef idkey = NULL;
-  JsRef idvalue = NULL;
-  idkey = python2js(pykey);
+  JsVal value = JS_NULL;
+  JsVal key = python2js_val(pykey);
   if (pyvalue != NULL) {
-    idvalue = python2js(pyvalue);
-    FAIL_IF_NULL(idvalue);
+    value = python2js_val(pyvalue);
+    FAIL_IF_JS_NULL(value);
   }
-  int status = JsObjMap_ass_subscript_js(JsProxy_REF(self), idkey, idvalue);
+  int status = JsObjMap_ass_subscript_js(JsProxy_VAL(self), key, value);
   if (status == -1) {
     if (!PyErr_Occurred()) {
       PyErr_SetObject(PyExc_KeyError, pykey);
@@ -2841,14 +2879,10 @@ JsObjMap_ass_subscript(PyObject* self, PyObject* pykey, PyObject* pyvalue)
   }
   success = true;
 finally:
-  hiwire_CLEAR(idvalue);
-  hiwire_CLEAR(idkey);
   return success ? 0 : -1;
 }
 
-EM_JS_NUM(int, JsObjMap_contains_js, (JsRef idobj, JsRef idkey), {
-  let obj = Hiwire.get_value(idobj);
-  let key = Hiwire.get_value(idkey);
+EM_JS_NUM(int, JsObjMap_contains_js, (JsVal obj, JsVal key), {
   return Object.prototype.hasOwnProperty.call(obj, key);
 });
 
@@ -2856,17 +2890,16 @@ static int
 JsObjMap_contains(PyObject* self, PyObject* obj)
 {
   if (!PyUnicode_Check(obj)) {
+    // All keys are strings or symbols so if it's not a string don't check.
+    // TODO: maybe support symbols??
     return 0;
   }
-  int result = -1;
-
-  JsRef jsobj = python2js(obj);
-  FAIL_IF_NULL(jsobj);
-  result = JsObjMap_contains_js(JsProxy_REF(self), jsobj);
+  JsVal jsobj = python2js_val(obj);
+  FAIL_IF_JS_NULL(jsobj);
+  return JsObjMap_contains_js(JsProxy_VAL(self), jsobj);
 
 finally:
-  hiwire_CLEAR(jsobj);
-  return result;
+  return -1;
 }
 
 PyObject*
@@ -2962,15 +2995,13 @@ JsMethod_ConvertArgs(PyObject* const* pyargs,
                      JsVal proxies)
 {
   JsVal jsargs = JS_NULL;
-  JsRef idarg = NULL;
   JsVal kwargs;
 
   jsargs = JsvArray_New();
   for (Py_ssize_t i = 0; i < nargs; ++i) {
-    idarg = python2js_track_proxies(pyargs[i], proxies, false);
-    FAIL_IF_NULL(idarg);
-    JsvArray_Push(jsargs, hiwire_get(idarg));
-    hiwire_CLEAR(idarg);
+    JsVal arg = JsRef_pop(python2js_track_proxies(pyargs[i], proxies, false));
+    FAIL_IF_JS_NULL(arg);
+    JsvArray_Push(jsargs, arg);
   }
 
   bool has_kwargs = false;
@@ -2994,15 +3025,13 @@ JsMethod_ConvertArgs(PyObject* const* pyargs,
   for (Py_ssize_t i = 0, k = nargs; i < nkwargs; ++i, ++k) {
     PyObject* pyname = PyTuple_GET_ITEM(kwnames, i); /* borrowed! */
     JsVal jsname = python2js_val(pyname);
-    idarg = python2js_track_proxies(pyargs[k], proxies, false);
-    FAIL_IF_NULL(idarg);
-    FAIL_IF_MINUS_ONE(JsvObject_SetAttr(kwargs, jsname, hiwire_get(idarg)));
-    hiwire_CLEAR(idarg);
+    JsVal arg = JsRef_pop(python2js_track_proxies(pyargs[k], proxies, false));
+    FAIL_IF_JS_NULL(arg);
+    FAIL_IF_MINUS_ONE(JsvObject_SetAttr(kwargs, jsname, arg));
   }
   JsvArray_Push(jsargs, kwargs);
 
 finally:
-  hiwire_CLEAR(idarg);
   return jsargs;
 }
 
@@ -3410,7 +3439,7 @@ JsBuffer_assign_to(PyObject* obj, PyObject* target)
   bool safe = JsBuffer_CHECK_ASSIGNMENTS(self);
   bool dir = true;
   FAIL_IF_MINUS_ONE(check_buffer_compatibility(self, view, safe, dir));
-  FAIL_IF_MINUS_ONE(hiwire_assign_to_ptr(JsProxy_REF(self), view.buf));
+  FAIL_IF_MINUS_ONE(JsvBuffer_assignToPtr(JsProxy_VAL(self), view.buf));
 
   success = true;
 finally:
@@ -3443,7 +3472,7 @@ JsBuffer_assign(PyObject* obj, PyObject* source)
   bool safe = JsBuffer_CHECK_ASSIGNMENTS(self);
   bool dir = false;
   FAIL_IF_MINUS_ONE(check_buffer_compatibility(self, view, safe, dir));
-  FAIL_IF_MINUS_ONE(hiwire_assign_from_ptr(JsProxy_REF(self), view.buf));
+  FAIL_IF_MINUS_ONE(JsvBuffer_assignFromPtr(JsProxy_VAL(self), view.buf));
 
   success = true;
 finally:
@@ -3475,7 +3504,7 @@ static PyMethodDef JsBuffer_assign_MethodDef = {
  */
 // Used in js2python, intentionally not static
 EMSCRIPTEN_KEEPALIVE PyObject*
-JsBuffer_CopyIntoMemoryView(JsRef jsbuffer,
+JsBuffer_CopyIntoMemoryView(JsVal jsbuffer,
                             Py_ssize_t byteLength,
                             char* format,
                             Py_ssize_t itemsize)
@@ -3487,7 +3516,7 @@ JsBuffer_CopyIntoMemoryView(JsRef jsbuffer,
   buffer = (Buffer*)BufferType.tp_alloc(&BufferType, byteLength);
   FAIL_IF_NULL(buffer);
   FAIL_IF_MINUS_ONE(Buffer_cinit(buffer, byteLength, format, itemsize));
-  FAIL_IF_MINUS_ONE(hiwire_assign_to_ptr(jsbuffer, buffer->data));
+  FAIL_IF_MINUS_ONE(JsvBuffer_assignToPtr(jsbuffer, buffer->data));
   result = PyMemoryView_FromObject((PyObject*)buffer);
   FAIL_IF_NULL(result);
 
@@ -3505,14 +3534,14 @@ finally:
  * ArrayBuffer into it.
  */
 static PyObject*
-JsBuffer_CopyIntoBytes(JsRef jsbuffer, Py_ssize_t byteLength)
+JsBuffer_CopyIntoBytes(JsVal jsbuffer, Py_ssize_t byteLength)
 {
   bool success = false;
 
   PyObject* result = PyBytes_FromStringAndSize(NULL, byteLength);
   FAIL_IF_NULL(result);
   char* data = PyBytes_AS_STRING(result);
-  FAIL_IF_MINUS_ONE(hiwire_assign_to_ptr(jsbuffer, data));
+  FAIL_IF_MINUS_ONE(JsvBuffer_assignToPtr(jsbuffer, data));
   success = true;
 finally:
   if (!success) {
@@ -3530,27 +3559,26 @@ finally:
  * replace with a UnicodeDecodeError
  */
 // clang-format off
-EM_JS_REF(JsRef,
+EM_JS_VAL(JsVal,
 JsBuffer_DecodeString_js,
-(JsRef jsbuffer_id, char* encoding),
+(JsVal buffer, char* encoding),
 {
-  let buffer = Hiwire.get_value(jsbuffer_id);
   let encoding_js;
   if (encoding) {
     encoding_js = UTF8ToString(encoding);
   }
-  let decoder = new TextDecoder(encoding_js, {fatal : true, ignoreBOM: true});
+  const decoder = new TextDecoder(encoding_js, { fatal: true, ignoreBOM: true });
   let res;
   try {
     res = decoder.decode(buffer);
-  } catch(e){
-    if(e instanceof TypeError) {
+  } catch (e) {
+    if (e instanceof TypeError) {
       // Decoding error
-      return 0;
+      return null;
     }
     throw e;
   }
-  return Hiwire.new_value(res);
+  return res;
 })
 // clang-format on
 
@@ -3558,23 +3586,21 @@ JsBuffer_DecodeString_js,
  * Decode the ArrayBuffer into a PyUnicode object.
  */
 static PyObject*
-JsBuffer_ToString(JsRef jsbuffer, char* encoding)
+JsBuffer_ToString(JsVal jsbuffer, char* encoding)
 {
-  JsRef jsresult = NULL;
   PyObject* result = NULL;
 
-  jsresult = JsBuffer_DecodeString_js(jsbuffer, encoding);
-  if (jsresult == NULL && !PyErr_Occurred()) {
+  JsVal jsresult = JsBuffer_DecodeString_js(jsbuffer, encoding);
+  if (JsvNull_Check(jsresult) && !PyErr_Occurred()) {
     PyErr_Format(PyExc_ValueError,
                  "Failed to decode Javascript TypedArray as %s",
                  encoding ? encoding : "utf8");
   }
-  FAIL_IF_NULL(jsresult);
-  result = js2python(jsresult);
+  FAIL_IF_JS_NULL(jsresult);
+  result = js2python_val(jsresult);
   FAIL_IF_NULL(result);
 
 finally:
-  hiwire_CLEAR(jsresult);
   return result;
 }
 
@@ -3582,7 +3608,7 @@ static PyObject*
 JsBuffer_tomemoryview(PyObject* buffer, PyObject* _ignored)
 {
   JsProxy* self = (JsProxy*)buffer;
-  return JsBuffer_CopyIntoMemoryView(self->js,
+  return JsBuffer_CopyIntoMemoryView(JsProxy_VAL(self),
                                      JsBuffer_BYTE_LENGTH(self),
                                      JsBuffer_FORMAT(self),
                                      JsBuffer_ITEMSIZE(self));
@@ -3595,10 +3621,9 @@ static PyMethodDef JsBuffer_tomemoryview_MethodDef = {
 };
 
 static PyObject*
-JsBuffer_tobytes(PyObject* buffer, PyObject* _ignored)
+JsBuffer_tobytes(PyObject* self, PyObject* _ignored)
 {
-  JsProxy* self = (JsProxy*)buffer;
-  return JsBuffer_CopyIntoBytes(self->js, JsBuffer_BYTE_LENGTH(self));
+  return JsBuffer_CopyIntoBytes(JsProxy_VAL(self), JsBuffer_BYTE_LENGTH(self));
 }
 
 static PyMethodDef JsBuffer_tobytes_MethodDef = {
@@ -3618,16 +3643,14 @@ get_fileno(PyObject* file)
 }
 
 static PyObject*
-JsBuffer_write_to_file(PyObject* jsbuffer, PyObject* file)
+JsBuffer_write_to_file(PyObject* self, PyObject* file)
 {
   int fd = get_fileno(file);
-  if (fd == -1) {
-    return NULL;
-  }
-  if (hiwire_write_to_file(JsProxy_REF(jsbuffer), fd)) {
-    return NULL;
-  }
+  FAIL_IF_MINUS_ONE(fd);
+  FAIL_IF_MINUS_ONE(JsvBuffer_writeToFile(JsProxy_VAL(self), fd));
   Py_RETURN_NONE;
+finally:
+  return NULL;
 }
 
 static PyMethodDef JsBuffer_write_to_file_MethodDef = {
@@ -3640,13 +3663,11 @@ static PyObject*
 JsBuffer_read_from_file(PyObject* jsbuffer, PyObject* file)
 {
   int fd = get_fileno(file);
-  if (fd == -1) {
-    return NULL;
-  }
-  if (hiwire_read_from_file(JsProxy_REF(jsbuffer), fd)) {
-    return NULL;
-  }
+  FAIL_IF_MINUS_ONE(fd);
+  FAIL_IF_MINUS_ONE(JsvBuffer_readFromFile(JsProxy_VAL(jsbuffer), fd));
   Py_RETURN_NONE;
+finally:
+  return NULL;
 }
 
 static PyMethodDef JsBuffer_read_from_file_MethodDef = {
@@ -3659,13 +3680,11 @@ static PyObject*
 JsBuffer_into_file(PyObject* jsbuffer, PyObject* file)
 {
   int fd = get_fileno(file);
-  if (fd == -1) {
-    return NULL;
-  }
-  if (hiwire_into_file(JsProxy_REF(jsbuffer), fd)) {
-    return NULL;
-  }
+  FAIL_IF_MINUS_ONE(fd);
+  FAIL_IF_MINUS_ONE(JsvBuffer_intoFile(JsProxy_VAL(jsbuffer), fd));
   Py_RETURN_NONE;
+finally:
+  return NULL;
 }
 
 static PyMethodDef JsBuffer_into_file_MethodDef = {
@@ -3690,7 +3709,7 @@ JsBuffer_tostring(PyObject* self,
         args, nargs, kwnames, &_parser, &encoding)) {
     return NULL;
   }
-  return JsBuffer_ToString(JsProxy_REF(self), encoding);
+  return JsBuffer_ToString(JsProxy_VAL(self), encoding);
 }
 
 static PyMethodDef JsBuffer_tostring_MethodDef = {
@@ -3698,6 +3717,22 @@ static PyMethodDef JsBuffer_tostring_MethodDef = {
   (PyCFunction)JsBuffer_tostring,
   METH_FASTCALL | METH_KEYWORDS,
 };
+
+// clang-format off
+EM_JS_UNCHECKED(void,
+JsBuffer_get_info, (JsVal jsobj,
+                    Py_ssize_t* byteLength_ptr,
+                    char** format_ptr,
+                    Py_ssize_t* size_ptr,
+                    bool* checked_ptr),
+{
+  const [format_utf8, size, checked] = Module.get_buffer_datatype(jsobj);
+  DEREF_U32(byteLength_ptr, 0) = jsobj.byteLength;
+  DEREF_U32(format_ptr, 0) = format_utf8;
+  DEREF_U32(size_ptr, 0) = size;
+  DEREF_U8(checked_ptr, 0) = checked;
+});
+// clang-format on
 
 int
 JsBuffer_cinit(PyObject* obj)
@@ -3707,11 +3742,11 @@ JsBuffer_cinit(PyObject* obj)
   // TODO: should logic here be any different if we're on wasm heap?
   // format string is borrowed from hiwire_get_buffer_datatype, DO NOT
   // DEALLOCATE!
-  hiwire_get_buffer_info(JsProxy_REF(self),
-                         &JsBuffer_BYTE_LENGTH(self),
-                         &JsBuffer_FORMAT(self),
-                         &JsBuffer_ITEMSIZE(self),
-                         &JsBuffer_CHECK_ASSIGNMENTS(self));
+  JsBuffer_get_info(JsProxy_VAL(self),
+                    &JsBuffer_BYTE_LENGTH(self),
+                    &JsBuffer_FORMAT(self),
+                    &JsBuffer_ITEMSIZE(self),
+                    &JsBuffer_CHECK_ASSIGNMENTS(self));
   if (JsBuffer_FORMAT(self) == NULL) {
     char* typename = hiwire_constructor_name(JsProxy_REF(self));
     PyErr_Format(
@@ -3729,14 +3764,14 @@ finally:
   return success ? 0 : -1;
 }
 
-EM_JS_REF(PyObject*, JsDoubleProxy_unwrap_helper, (JsRef id), {
-  return Module.PyProxy_getPtr(Hiwire.get_value(id));
+EM_JS_REF(PyObject*, JsDoubleProxy_unwrap_helper, (JsVal id), {
+  return Module.PyProxy_getPtr(id);
 });
 
 static PyObject*
 JsDoubleProxy_unwrap(PyObject* obj, PyObject* _ignored)
 {
-  PyObject* result = JsDoubleProxy_unwrap_helper(JsProxy_REF(obj));
+  PyObject* result = JsDoubleProxy_unwrap_helper(JsProxy_VAL(obj));
   Py_XINCREF(result);
   return result;
 }
@@ -4313,6 +4348,15 @@ JsProxy_create_objmap(JsRef object, bool objmap)
     typeflags |= IS_OBJECT_MAP;
   }
   return JsProxy_create_with_type(typeflags, object, NULL);
+}
+
+PyObject*
+JsProxy_create_objmap_val(JsVal object, bool objmap)
+{
+  JsRef ref = hiwire_new(object);
+  PyObject* result = JsProxy_create_objmap(ref, objmap);
+  hiwire_decref(ref);
+  return result;
 }
 
 /**

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1283,7 +1283,6 @@ get_length(JsVal obj)
     return -1;
   }
 
-
   char* length_as_string_alloc = get_length_string(obj);
   char* length_as_string = length_as_string_alloc;
   if (length_as_string == NULL) {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2881,20 +2881,18 @@ JsProxy_syncify_not_supported(JsProxy* self, PyObject* Py_UNUSED(ignored))
 PyObject*
 JsProxy_syncify(JsProxy* self, PyObject* Py_UNUSED(ignored))
 {
-  JsRef jsresult = NULL;
   PyObject* result = NULL;
 
-  jsresult = hiwire_syncify(self->js);
-  if (jsresult == NULL) {
+  JsVal jsresult = JsvPromise_Syncify(JsProxy_VAL(self));
+  if (JsvNull_Check(jsresult)) {
     if (!PyErr_Occurred()) {
       PyErr_SetString(PyExc_RuntimeError, "No suspender");
     }
     FAIL();
   }
-  result = js2python(jsresult);
+  result = js2python_val(jsresult);
 
 finally:
-  hiwire_CLEAR(jsresult);
   return result;
 }
 

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -22,6 +22,9 @@ JsProxy_create_with_type(int type_flags, JsRef object, JsRef this);
 PyObject*
 JsProxy_create_objmap(JsRef object, bool objmap);
 
+PyObject*
+JsProxy_create_objmap_val(JsVal object, bool objmap);
+
 /**
  * Make a new JsProxy.
  * @param object The JavaScript object.

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -64,3 +64,30 @@ const errNoRet = () => {
 Module.reportUndefinedSymbols = () => {};
 
 const nullToUndefined = (x) => (x === null ? undefined : x);
+
+// This is factored out for testing purposes.
+function isPromise(obj) {
+  try {
+    // clang-format off
+    return !!obj && typeof obj.then === "function";
+    // clang-format on
+  } catch (e) {
+    return false;
+  }
+}
+API.isPromise = isPromise;
+
+/**
+ * Turn any ArrayBuffer view or ArrayBuffer into a Uint8Array.
+ *
+ * This respects slices: if the ArrayBuffer view is restricted to a slice of
+ * the backing ArrayBuffer, we return a Uint8Array that shows the same slice.
+ */
+function bufferAsUint8Array(arg) {
+  if (ArrayBuffer.isView(arg)) {
+    return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength);
+  } else {
+    return new Uint8Array(arg);
+  }
+}
+API.typedArrayAsUint8Array = bufferAsUint8Array;

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -525,7 +525,7 @@ Module.callPyObjectKwargs = function (
  * Pretty much everything is the same as callPyObjectKwargs except we use the
  * special JSPI-friendly promisingApply wrapper of `__pyproxy_apply`. This
  * causes the VM to invent a suspender and call a wrapper module which stores it
- * into suspenderGlobal (for later use by hiwire_syncify). Then it calls
+ * into suspenderGlobal (for later use by JsvPromise_syncify). Then it calls
  * _pyproxy_apply with the same arguments we gave to `promisingApply`.
  */
 async function callPyObjectKwargsSuspending(

--- a/src/core/stack_switching/wrap_syncifying.wat
+++ b/src/core/stack_switching/wrap_syncifying.wat
@@ -1,24 +1,28 @@
+;; TODO: figure out how to write this in C
+;; Either requires fixes for the following:
+;; https://github.com/emscripten-core/emscripten/issues/20512
+;; Or changing our dynamic wasm generation a bit
 (module
     (global $suspender (import "e" "s") (mut externref))
     ;; Status flag to tell us if suspender is usable
     (global $check (import "e" "c") (mut i32))
     ;; Wrapped syncify function. Expects suspender as a first argument and a
     ;; JsRef to promise as second argument. Returns a JsRef to the result.
-    (import "e" "i" (func $syncify_promise_import (param externref i32) (result i32)))
+    (import "e" "i" (func $syncify_promise_import (param externref externref) (result externref)))
     ;; Wrapped syncify_promise that handles suspender stuff automatically so
     ;; callee doesn't need to worry about it.
     (func $syncify_promise_export (export "o")
-      (param $idpromise i32) (result i32)
+      (param $promise externref) (result externref)
       (global.get $check)
       (i32.eqz)
       if
         ;; We tried to syncify with no valid suspender, return 0.
         ;; JsProxy.c checks for this case and sets Python error flag appropriately.
-        i32.const 0
+        ref.null extern
         return
       end
       (global.get $suspender)
-      (local.get $idpromise)
+      (local.get $promise)
       (call $syncify_promise_import) ;; onwards call args are (suspender, orig argument)
     )
 )

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -326,22 +326,16 @@ def test_hiwire_is_promise(selenium):
         "new Map()",
         "new Set()",
     ]:
-        assert selenium.run_js(
-            f"return pyodide._module.hiwire.isPromise({s}) === false;"
-        )
+        assert selenium.run_js(f"return pyodide._api.isPromise({s}) === false;")
 
     if not selenium.browser == "node":
-        assert selenium.run_js(
-            "return pyodide._module.hiwire.isPromise(document.all) === false;"
-        )
+        assert selenium.run_js("return pyodide._api.isPromise(document.all) === false;")
 
-    assert selenium.run_js(
-        "return pyodide._module.hiwire.isPromise(Promise.resolve()) === true;"
-    )
+    assert selenium.run_js("return pyodide._api.isPromise(Promise.resolve()) === true;")
 
     assert selenium.run_js(
         """
-        return pyodide._module.hiwire.isPromise(new Promise((resolve, reject) => {}));
+        return pyodide._api.isPromise(new Promise((resolve, reject) => {}));
         """
     )
 
@@ -349,7 +343,7 @@ def test_hiwire_is_promise(selenium):
         """
         let d = pyodide.runPython("{}");
         try {
-            return pyodide._module.hiwire.isPromise(d);
+            return pyodide._api.isPromise(d);
         } finally {
             d.destroy();
         }

--- a/src/tests/test_syncify.py
+++ b/src/tests/test_syncify.py
@@ -93,6 +93,30 @@ def test_syncify_error(selenium):
 
 
 @pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+def test_syncify_null(selenium):
+    selenium.run_js(
+        """
+        await pyodide.loadPackage("pytest");
+        await pyodide.runPythonSyncifying(`
+            def temp():
+                from pyodide.code import run_js
+
+                asyncNull = run_js(
+                    '''
+                    (async function asyncThrow(){
+                        await sleep(50);
+                        return null;
+                    })
+                    '''
+                )
+                assert asyncNull().syncify() is None
+            temp()
+        `);
+        """
+    )
+
+
+@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
 def test_syncify_no_suspender(selenium):
     selenium.run_js(
         """


### PR DESCRIPTION
Converts a lot more JsProxy methods to use JsVals.