### PR TITLE
Use JsVal instead of JsRef (nr. 6)

### DIFF
--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -2,7 +2,6 @@ import ErrorStackParser from "../js/node_modules/error-stack-parser/error-stack-
 import "types";
 
 declare var Module: any;
-declare var Hiwire: any;
 declare var Tests: any;
 
 function ensureCaughtObjectIsError(e: any): Error {
@@ -262,11 +261,9 @@ Module.handle_js_error = function (e: any) {
   }
   if (!restored_error) {
     // Wrap the JavaScript error
-    let eidx = Hiwire.new_value(e);
-    let err = _JsProxy_create(eidx);
+    let err = _JsProxy_create_val(e);
     _set_error(err);
     _Py_DecRef(err);
-    Hiwire.decref(eidx);
   }
   if (weirdCatch) {
     // In this case we have no stack frames so we can quit

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -238,28 +238,6 @@ EM_JS(JsRef, hiwire_typeof, (JsRef idobj), {
   return Hiwire.new_value(typeof Hiwire.get_value(idobj));
 });
 
-EM_JS_REF(char*, hiwire_constructor_name, (JsRef idobj), {
-  return stringToNewUTF8(Hiwire.get_value(idobj).constructor.name);
-});
-
-#define MAKE_OPERATOR(name, op)                                                \
-  EM_JS_BOOL(bool, hiwire_##name, (JsRef ida, JsRef idb), {                    \
-    return !!(Hiwire.get_value(ida) op Hiwire.get_value(idb));                 \
-  })
-
-MAKE_OPERATOR(less_than, <);
-MAKE_OPERATOR(less_than_equal, <=);
-// clang-format off
-MAKE_OPERATOR(equal, ===);
-MAKE_OPERATOR(not_equal, !==);
-// clang-format on
-MAKE_OPERATOR(greater_than, >);
-MAKE_OPERATOR(greater_than_equal, >=);
-
-// clang-format off
-
-// clang-format on
-
 EM_JS_REF(JsRef, hiwire_subarray, (JsRef idarr, int start, int end), {
   let jsarr = Hiwire.get_value(idarr);
   let jssub = jsarr.subarray(start, end);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -183,50 +183,6 @@ JsRef
 hiwire_resolve_promise(JsRef idobj);
 
 /**
- * Gets `value.constructor.name`.
- *
- * Returns: New reference to JavaScript string
- */
-char*
-hiwire_constructor_name(JsRef idobj);
-
-/**
- * Returns non-zero if a < b.
- */
-bool
-hiwire_less_than(JsRef ida, JsRef idb);
-
-/**
- * Returns non-zero if a <= b.
- */
-bool
-hiwire_less_than_equal(JsRef ida, JsRef idb);
-
-/**
- * Returns non-zero if a == b.
- */
-bool
-hiwire_equal(JsRef ida, JsRef idb);
-
-/**
- * Returns non-zero if a != b.
- */
-bool
-hiwire_not_equal(JsRef idx, JsRef idb);
-
-/**
- * Returns non-zero if a > b.
- */
-bool
-hiwire_greater_than(JsRef ida, JsRef idb);
-
-/**
- * Returns non-zero if a >= b.
- */
-bool
-hiwire_greater_than_equal(JsRef ida, JsRef idb);
-
-/**
  * Get a subarray from a TypedArray
  */
 JsRef

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -42,7 +42,7 @@ _js2python_pyproxy(PyObject* val)
   return val;
 }
 
-EM_JS_REF(PyObject*, js2python_immutable_val, (JsVal value), {
+EM_JS_REF(PyObject*, js2python_immutable_js, (JsVal value), {
   let result = Module.js2python_convertImmutable(value);
   // clang-format off
   if (result !== undefined) {
@@ -53,13 +53,13 @@ EM_JS_REF(PyObject*, js2python_immutable_val, (JsVal value), {
 });
 
 EMSCRIPTEN_KEEPALIVE PyObject*
-js2python_immutable(JsRef id)
+js2python_immutable(JsVal val)
 {
-  return js2python_immutable_val(hiwire_get(id));
+  return js2python_immutable_js(val);
 }
 
-EM_JS_REF(PyObject*, js2python_val, (JsVal value), {
-  let result = Module.js2python_convertImmutable(value, undefined);
+EM_JS_REF(PyObject*, js2python_js, (JsVal value), {
+  let result = Module.js2python_convertImmutable(value);
   // clang-format off
   if (result !== undefined) {
     // clang-format on
@@ -69,9 +69,9 @@ EM_JS_REF(PyObject*, js2python_val, (JsVal value), {
 })
 
 EMSCRIPTEN_KEEPALIVE PyObject*
-js2python(JsRef id)
+js2python(JsVal val)
 {
-  return js2python_val(hiwire_get(id));
+  return js2python_js(val);
 }
 
 /**
@@ -79,11 +79,8 @@ js2python(JsRef id)
  * implementation of `toJs`.
  */
 // clang-format off
-EM_JS_REF(PyObject*, js2python_convert, (JsRef id, int depth, JsRef default_converter), {
-  let defaultConverter = default_converter
-    ? Module.hiwire.get_value(default_converter)
-    : undefined;
-  return Module.js2python_convert(id, { depth, defaultConverter });
+EM_JS_REF(PyObject*, js2python_convert, (JsVal v, int depth, JsVal defaultConverter), {
+  return Module.js2python_convert(v, { depth, defaultConverter });
 });
 // clang-format on
 

--- a/src/core/js2python.h
+++ b/src/core/js2python.h
@@ -15,19 +15,13 @@
  *    sets the Python error indicator if a conversion error occurs.
  */
 PyObject*
-js2python(JsRef x);
+js2python(JsVal x);
 
 PyObject*
-js2python_val(JsVal x);
+js2python_immutable(JsVal x);
 
 PyObject*
-js2python_immutable(JsRef x);
-
-PyObject*
-js2python_immutable_val(JsVal x);
-
-PyObject*
-js2python_convert(JsRef x, int depth, JsRef defaultConverter);
+js2python_convert(JsVal x, int depth, JsVal defaultConverter);
 
 /** Initialize any global variables used by this module. */
 int

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -79,8 +79,8 @@ JS_FILE(js2python_init, () => {
    * we throw a PropagateError to propagate the error out to C. This causes
    * special handling in the EM_JS wrapper.
    */
-  function js2python_convertImmutable(value, id) {
-    let result = js2python_convertImmutableInner(value, id);
+  function js2python_convertImmutable(value) {
+    let result = js2python_convertImmutableInner(value);
     if (result === 0) {
       throw new PropagateError();
     }
@@ -96,7 +96,7 @@ JS_FILE(js2python_init, () => {
    * If we return 0 it means we tried to convert but an error occurred, if we
    * return undefined, no conversion was attempted.
    */
-  function js2python_convertImmutableInner(value, id) {
+  function js2python_convertImmutableInner(value) {
     let type = typeof value;
     if (type === "string") {
       return js2python_string(value);
@@ -117,10 +117,7 @@ JS_FILE(js2python_init, () => {
     } else if (API.isPyProxy(value)) {
       const { props, shared } = Module.PyProxy_getAttrs(value);
       if (props.roundtrip) {
-        if (id === undefined) {
-          return _JsProxy_create_val(value);
-        }
-        return _JsProxy_create(id);
+        return _JsProxy_create_val(value);
       } else {
         return __js2python_pyproxy(shared.ptr);
       }
@@ -133,25 +130,20 @@ JS_FILE(js2python_init, () => {
     if (list === 0) {
       return 0;
     }
-    let entryid = 0;
     let item = 0;
     try {
       context.cache.set(obj, list);
       for (let i = 0; i < obj.length; i++) {
-        entryid = Hiwire.new_value(obj[i]);
-        item = js2python_convert_with_context(entryid, context);
+        item = js2python_convert_with_context(obj[i], context);
         // PyList_SetItem steals a reference to item no matter what
         _Py_IncRef(item);
         if (_PyList_SetItem(list, i, item) === -1) {
           throw new PropagateError();
         }
-        Hiwire.decref(entryid);
-        entryid = 0;
         _Py_DecRef(item);
         item = 0;
       }
     } catch (e) {
-      Hiwire.decref(entryid);
       _Py_DecRef(item);
       _Py_DecRef(list);
       throw e;
@@ -166,7 +158,6 @@ JS_FILE(js2python_init, () => {
       return 0;
     }
     let key_py = 0;
-    let value_id = 0;
     let value_py = 0;
     try {
       context.cache.set(obj, dict);
@@ -179,22 +170,18 @@ JS_FILE(js2python_init, () => {
             `Cannot use key of type ${key_type} as a key to a Python dict`,
           );
         }
-        value_id = Hiwire.new_value(value_js);
-        value_py = js2python_convert_with_context(value_id, context);
+        value_py = js2python_convert_with_context(value_js, context);
 
         if (_PyDict_SetItem(dict, key_py, value_py) === -1) {
           throw new PropagateError();
         }
         _Py_DecRef(key_py);
         key_py = 0;
-        Hiwire.decref(value_id);
-        value_id = 0;
         _Py_DecRef(value_py);
         value_py = 0;
       }
     } catch (e) {
       _Py_DecRef(key_py);
-      Hiwire.decref(value_id);
       _Py_DecRef(value_py);
       _Py_DecRef(dict);
       throw e;
@@ -293,15 +280,13 @@ JS_FILE(js2python_init, () => {
   /**
    * Convert a JavaScript object to Python to a given depth.
    */
-  function js2python_convert_with_context(id, context) {
-    let value = Hiwire.get_value(id);
-    let result;
-    result = js2python_convertImmutable(value, id);
+  function js2python_convert_with_context(value, context) {
+    let result = js2python_convertImmutable(value);
     if (result !== undefined) {
       return result;
     }
     if (context.depth === 0) {
-      return _JsProxy_create(id);
+      return _JsProxy_create_val(value);
     }
     result = context.cache.get(value);
     if (result !== undefined) {
@@ -314,7 +299,7 @@ JS_FILE(js2python_init, () => {
         return result;
       }
       if (context.defaultConverter === undefined) {
-        return _JsProxy_create(id);
+        return _JsProxy_create_val(value);
       }
       let result_js = context.defaultConverter(
         value,
@@ -328,10 +313,7 @@ JS_FILE(js2python_init, () => {
       if (result !== undefined) {
         return result;
       }
-      let result_id = Module.hiwire.new_value(result_js);
-      result = _JsProxy_create(result_id);
-      Module.hiwire.decref(result_id);
-      return result;
+      return _JsProxy_create_val(result_js);
     } finally {
       context.depth++;
     }
@@ -340,22 +322,14 @@ JS_FILE(js2python_init, () => {
   /**
    * Convert a JavaScript object to Python to a given depth.
    */
-  function js2python_convert(id, { depth, defaultConverter }) {
+  function js2python_convert(val, { depth, defaultConverter }) {
     let context = {
       cache: new Map(),
       depth,
       defaultConverter,
       // arguments for defaultConverter
-      converter(x) {
-        let id = Module.hiwire.new_value(x);
-        try {
-          return Module.pyproxy_new(
-            js2python_convert_with_context(id, context),
-          );
-        } finally {
-          Module.hiwire.decref(id);
-        }
-      },
+      converter: (x) =>
+        Module.pyproxy_new(js2python_convert_with_context(x, context)),
       cacheConversion(input, output) {
         if (API.isPyProxy(output)) {
           context.cache.set(input, Module.PyProxy_getPtr(output));
@@ -364,7 +338,7 @@ JS_FILE(js2python_init, () => {
         }
       },
     };
-    return js2python_convert_with_context(id, context);
+    return js2python_convert_with_context(val, context);
   }
 
   Module.js2python_convert = js2python_convert;

--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -39,6 +39,10 @@ EM_JS(bool, Jsv_to_bool, (JsVal x), { return !!x; })
 
 EM_JS(JsVal, Jsv_typeof, (JsVal x), { return typeof x; })
 
+EM_JS_REF(char*, Jsv_constructorName, (JsVal obj), {
+  return stringToNewUTF8(obj.constructor.name);
+});
+
 // ==================== Strings API  ====================
 
 // clang-format off
@@ -394,10 +398,20 @@ EM_JS_BOOL(bool, JsvAsyncGenerator_Check, (JsVal obj), {
 
 EM_JS(void _Py_NO_RETURN, JsvError_Throw, (JsVal e), { throw e; })
 
-// clang-format off
 errcode
-jslib_init(void) {
+jslib_init(void)
+{
   return jslib_init_buffers();
 }
 
+#define MAKE_OPERATOR(name, op)                                                \
+  EM_JS_BOOL(bool, Jsv_##name, (JsVal a, JsVal b), { return !!(a op b); })
+
+MAKE_OPERATOR(less_than, <);
+MAKE_OPERATOR(less_than_equal, <=);
+// clang-format off
+MAKE_OPERATOR(equal, ===);
+MAKE_OPERATOR(not_equal, !==);
 // clang-format on
+MAKE_OPERATOR(greater_than, >);
+MAKE_OPERATOR(greater_than_equal, >=);

--- a/src/core/jslib.h
+++ b/src/core/jslib.h
@@ -30,6 +30,9 @@ Jsv_to_bool(JsVal x);
 JsVal
 Jsv_typeof(JsVal x);
 
+char*
+Jsv_constructorName(JsVal obj);
+
 JsVal
 JsvUTF8ToString(const char*);
 
@@ -171,5 +174,41 @@ JsvAsyncGenerator_Check(JsVal obj);
 
 void _Py_NO_RETURN
 JsvError_Throw(JsVal e);
+
+/**
+ * Returns non-zero if a < b.
+ */
+bool
+Jsv_less_than(JsVal a, JsVal b);
+
+/**
+ * Returns non-zero if a <= b.
+ */
+bool
+Jsv_less_than_equal(JsVal a, JsVal b);
+
+/**
+ * Returns non-zero if a == b.
+ */
+bool
+Jsv_equal(JsVal a, JsVal b);
+
+/**
+ * Returns non-zero if a != b.
+ */
+bool
+Jsv_not_equal(JsVal x, JsVal b);
+
+/**
+ * Returns non-zero if a > b.
+ */
+bool
+Jsv_greater_than(JsVal a, JsVal b);
+
+/**
+ * Returns non-zero if a >= b.
+ */
+bool
+Jsv_greater_than_equal(JsVal a, JsVal b);
 
 #endif

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -348,7 +348,7 @@ _pyproxy_hasattr(PyObject* pyobj, JsVal jskey)
   PyObject* pykey = NULL;
   int result = -1;
 
-  pykey = js2python_val(jskey);
+  pykey = js2python(jskey);
   FAIL_IF_NULL(pykey);
   result = PyObject_HasAttr(pyobj, pykey);
 
@@ -402,7 +402,7 @@ _pyproxy_getattr(PyObject* pyobj, JsVal key, JsVal proxyCache)
   PyObject* pyresult = NULL;
   JsVal result = JS_NULL;
 
-  pykey = js2python_val(key);
+  pykey = js2python(key);
   FAIL_IF_NULL(pykey);
   // If it's a method, we use the descriptor pointer as the cache key rather
   // than the actual bound method. This allows us to reuse bound methods from
@@ -458,9 +458,9 @@ _pyproxy_setattr(PyObject* pyobj, JsVal key, JsVal value)
   PyObject* pykey = NULL;
   PyObject* pyval = NULL;
 
-  pykey = js2python_val(key);
+  pykey = js2python(key);
   FAIL_IF_NULL(pykey);
-  pyval = js2python_val(value);
+  pyval = js2python(value);
   FAIL_IF_NULL(pyval);
   FAIL_IF_MINUS_ONE(PyObject_SetAttr(pyobj, pykey, pyval));
 
@@ -477,7 +477,7 @@ _pyproxy_delattr(PyObject* pyobj, JsVal idkey)
   bool success = false;
   PyObject* pykey = NULL;
 
-  pykey = js2python_val(idkey);
+  pykey = js2python(idkey);
   FAIL_IF_NULL(pykey);
   FAIL_IF_MINUS_ONE(PyObject_DelAttr(pyobj, pykey));
 
@@ -495,7 +495,7 @@ _pyproxy_getitem(PyObject* pyobj, JsVal jskey)
   PyObject* pyresult = NULL;
   JsVal result;
 
-  pykey = js2python_val(jskey);
+  pykey = js2python(jskey);
   FAIL_IF_NULL(pykey);
   pyresult = PyObject_GetItem(pyobj, pykey);
   FAIL_IF_NULL(pyresult);
@@ -523,9 +523,9 @@ _pyproxy_setitem(PyObject* pyobj, JsVal jskey, JsVal jsval)
   PyObject* pykey = NULL;
   PyObject* pyval = NULL;
 
-  pykey = js2python_val(jskey);
+  pykey = js2python(jskey);
   FAIL_IF_NULL(pykey);
-  pyval = js2python_val(jsval);
+  pyval = js2python(jsval);
   FAIL_IF_NULL(pyval);
   FAIL_IF_MINUS_ONE(PyObject_SetItem(pyobj, pykey, pyval));
 
@@ -542,7 +542,7 @@ _pyproxy_delitem(PyObject* pyobj, JsVal idkey)
   bool success = false;
   PyObject* pykey = NULL;
 
-  pykey = js2python_val(idkey);
+  pykey = js2python(idkey);
   FAIL_IF_NULL(pykey);
   FAIL_IF_MINUS_ONE(PyObject_DelItem(pyobj, pykey));
 
@@ -562,7 +562,7 @@ _pyproxy_slice_assign(PyObject* pyobj,
   PyObject* pyresult = NULL;
   JsVal jsresult = JS_NULL;
 
-  pyval = js2python_val(val);
+  pyval = js2python(val);
 
   Py_ssize_t len = PySequence_Length(pyobj);
   if (len <= stop) {
@@ -616,7 +616,7 @@ _pyproxy_contains(PyObject* pyobj, JsVal idkey)
   PyObject* pykey = NULL;
   int result = -1;
 
-  pykey = js2python_val(idkey);
+  pykey = js2python(idkey);
   FAIL_IF_NULL(pykey);
   result = PySequence_Contains(pyobj, pykey);
 
@@ -702,7 +702,7 @@ _pyproxy_apply(PyObject* callable,
   for (Py_ssize_t i = 0; i < total_args; ++i) {
     JsVal jsitem = JsvArray_Get(jsargs, i);
     // pyitem is moved into pyargs so we don't need to clear it later.
-    PyObject* pyitem = js2python_val(jsitem);
+    PyObject* pyitem = js2python(jsitem);
     if (pyitem == NULL) {
       last_converted_arg = i;
       FAIL();
@@ -715,7 +715,7 @@ _pyproxy_apply(PyObject* callable,
     for (Py_ssize_t i = 0; i < numkwargs; i++) {
       JsVal jsitem = JsvArray_Get(jskwnames, i);
       // pyitem is moved into pykwargs so we don't need to clear it later.
-      PyObject* pyitem = js2python_val(jsitem);
+      PyObject* pyitem = js2python(jsitem);
       PyTuple_SET_ITEM(pykwnames, i, pyitem);
     }
   }
@@ -789,7 +789,7 @@ _pyproxyGen_Send(PyObject* receiver, JsVal jsval)
   PyObject* v = NULL;
   PyObject* retval = NULL;
 
-  v = js2python_val(jsval);
+  v = js2python(jsval);
   FAIL_IF_NULL(v);
   PySendResult status = PyIter_Send(receiver, v, &retval);
   if (status == PYGEN_ERROR) {
@@ -857,7 +857,7 @@ _pyproxyGen_throw(PyObject* receiver, JsVal jsval)
 
   JsVal result;
 
-  pyvalue = js2python_val(jsval);
+  pyvalue = js2python(jsval);
   FAIL_IF_NULL(pyvalue);
   if (!PyExceptionInstance_Check(pyvalue)) {
     /* Not something you can raise.  throw() fails. */
@@ -894,7 +894,7 @@ _pyproxyGen_asend(PyObject* receiver, JsVal jsval)
   PyObject* pyresult = NULL;
   JsVal jsresult = JS_NULL;
 
-  v = js2python_val(jsval);
+  v = js2python(jsval);
   FAIL_IF_NULL(v);
   asend = _PyObject_GetAttrId(receiver, &PyId_asend);
   if (asend) {
@@ -952,7 +952,7 @@ _pyproxyGen_athrow(PyObject* receiver, JsVal jsval)
   PyObject* pyresult = NULL;
   JsVal jsresult = JS_NULL;
 
-  v = js2python_val(jsval);
+  v = js2python(jsval);
   FAIL_IF_NULL(v);
   if (!PyExceptionInstance_Check(v)) {
     /* Not something you can raise.  throw() fails. */
@@ -1162,9 +1162,8 @@ size_t py_buffer_shape_offset = offsetof(Py_buffer, shape);
 /**
  * Convert a C array of Py_ssize_t to JavaScript.
  */
-EM_JS(JsRef, array_to_js, (Py_ssize_t * array, int len), {
-  return Hiwire.new_value(
-    Array.from(HEAP32.subarray(array / 4, array / 4 + len)));
+EM_JS(JsVal, array_to_js, (Py_ssize_t * array, int len), {
+  return Array.from(HEAP32.subarray(array / 4, array / 4 + len));
 })
 
 // The order of these fields has to match the code in getBuffer
@@ -1244,7 +1243,7 @@ _pyproxy_get_buffer(buffer_struct* target, PyObject* ptrobj)
 
   // Because we requested PyBUF_RECORDS_RO I think we can assume that
   // view.shape != NULL.
-  result.shape = array_to_js(view.shape, view.ndim);
+  result.shape = hiwire_new(array_to_js(view.shape, view.ndim));
 
   if (view.strides == NULL) {
     // In this case we are a C contiguous buffer
@@ -1252,7 +1251,7 @@ _pyproxy_get_buffer(buffer_struct* target, PyObject* ptrobj)
     Py_ssize_t strides[view.ndim];
     PyBuffer_FillContiguousStrides(
       view.ndim, view.shape, strides, view.itemsize, 'C');
-    result.strides = array_to_js(strides, view.ndim);
+    result.strides = hiwire_new(array_to_js(strides, view.ndim));
     goto success;
   }
 
@@ -1271,7 +1270,7 @@ _pyproxy_get_buffer(buffer_struct* target, PyObject* ptrobj)
     result.largest_ptr += view.itemsize;
   }
 
-  result.strides = array_to_js(view.strides, view.ndim);
+  result.strides = hiwire_new(array_to_js(view.strides, view.ndim));
   result.c_contiguous = PyBuffer_IsContiguous(&view, 'C');
   result.f_contiguous = PyBuffer_IsContiguous(&view, 'F');
 
@@ -1336,10 +1335,8 @@ EM_JS_REF(JsVal, create_once_callable, (PyObject * obj), {
 static PyObject*
 create_once_callable_py(PyObject* _mod, PyObject* obj)
 {
-  JsRef ref = hiwire_new(create_once_callable(obj));
-  PyObject* result = JsProxy_create(ref);
-  hiwire_decref(ref);
-  return result;
+  JsVal v = create_once_callable(obj);
+  return JsProxy_create_val(v);
 }
 
 // clang-format off

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -845,7 +845,7 @@ to_js(PyObject* self,
     // Oops, just created a PyProxy. Wrap it I guess?
     py_result = JsProxy_create(js_result);
   } else {
-    py_result = js2python(js_result);
+    py_result = js2python(hiwire_get(js_result));
   }
 finally:
   if (pyproxy_Check(JsRef_toVal(js_dict_converter))) {

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -377,36 +377,33 @@ export class PyodideAPI {
     if (!obj || API.isPyProxy(obj)) {
       return obj;
     }
-    let obj_id = 0;
     let py_result = 0;
     let result = 0;
     try {
-      obj_id = Hiwire.new_value(obj);
-      try {
-        py_result = Module.js2python_convert(obj_id, {
-          depth,
-          defaultConverter,
-        });
-      } catch (e) {
-        if (e instanceof Module._PropagatePythonError) {
-          _pythonexc2js();
-        }
-        throw e;
+      py_result = Module.js2python_convert(obj, {
+        depth,
+        defaultConverter,
+      });
+    } catch (e) {
+      if (e instanceof Module._PropagatePythonError) {
+        _pythonexc2js();
       }
+      throw e;
+    }
+    try {
       if (_JsProxy_Check(py_result)) {
         // Oops, just created a JsProxy. Return the original object.
         return obj;
         // return Module.pyproxy_new(py_result);
       }
-      result = _python2js(py_result);
-      if (result === 0) {
+      result = _python2js_val(py_result);
+      if (result === null) {
         _pythonexc2js();
       }
     } finally {
-      Hiwire.decref(obj_id);
       _Py_DecRef(py_result);
     }
-    return Hiwire.pop_value(result);
+    return result;
   }
 
   /**

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -73,12 +73,12 @@ declare global {
   export const _dump_traceback: () => void;
   export const _pythonexc2js: () => void;
   export const _restore_sys_last_exception: (err: number) => boolean;
-  export const _set_error: (hwidx: number) => void;
+  export const _set_error: (pyerr: number) => void;
 
-  export const _JsProxy_create: (hwidx: number) => number;
+  export const _JsProxy_create_val: (obj: any) => number;
   export const _JsProxy_Check: (ptr: number) => number;
 
-  export const _python2js: (pyobj: number) => number;
+  export const _python2js_val: (pyobj: number) => any;
   export const _python2js_custom: (
     obj: number,
     depth: number,


### PR DESCRIPTION
This gets rid of a lot more uses of hiwire from JavaScript. It also finished eliminating the need for
a `js2python` conversion function that takes a `JsRef`, so I renamed the temporary `js2python_val`
back to `js2python`.