### PR TITLE
Use JsVal instead of JsRef (nr. 8)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -251,7 +251,6 @@ def extra_checks_test_wrapper(browser, trace_hiwire_refs, trace_pyproxies):
         a.get_result()
     if browser.force_test_fail:
         raise Exception("Test failure explicitly requested but no error was raised.")
-    assert browser.run_js("return pyodide._module.hiwire.stack_length()") == 0
     if trace_pyproxies and trace_hiwire_refs:
         delta_proxies = browser.get_num_proxies() - init_num_proxies
         delta_keys = browser.get_num_hiwire_keys() - init_num_keys

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -261,7 +261,7 @@ Module.handle_js_error = function (e: any) {
   }
   if (!restored_error) {
     // Wrap the JavaScript error
-    let err = _JsProxy_create_val(e);
+    let err = _JsProxy_create(e);
     _set_error(err);
     _Py_DecRef(err);
   }

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -1,24 +1,12 @@
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
-
 #include "error_handling.h"
 #include <emscripten.h>
 
 #include "hiwire.h"
-#include "jsmemops.h"
-#undef hiwire_incref
-
-#define ERROR_REF (0)
-#define ERROR_NUM (-1)
 
 #ifdef DEBUG_F
 int tracerefs = 0;
 #endif
-
-// For when the return value would be Option<JsRef>
-// we use the largest possible immortal reference so that `get_value` on it will
-// always raise an error.
-const JsRef Js_novalue = ((JsRef)(2147483644));
 
 #define HIWIRE_INIT_CONSTS()                                                   \
   HIWIRE_INIT_CONST(undefined)                                                 \
@@ -40,30 +28,7 @@ HIWIRE_INIT_CONSTS();
 
 EM_JS_NUM(int, hiwire_init_js, (void), {
   HIWIRE_INIT_CONSTS();
-  // clang-format off
-  Hiwire.new_value = _hiwire_new;
-  Hiwire.new_stack = _hiwire_new;
-  Hiwire.intern_object = _hiwire_intern;
   Hiwire.num_keys = _hiwire_num_refs;
-  Hiwire.stack_length = () => 0;
-  Hiwire.get_value = _hiwire_get;
-  Hiwire.incref = (x) =>
-  {
-    _hiwire_incref(x);
-    return x;
-  };
-  Hiwire.decref = _hiwire_decref;
-  Hiwire.pop_value = _hiwire_pop;
-  // clang-format on
-
-  Module.iterObject = function * (object)
-  {
-    for (let k in object) {
-      if (Object.prototype.hasOwnProperty.call(object, k)) {
-        yield k;
-      }
-    }
-  };
   return 0;
 });
 
@@ -80,13 +45,6 @@ hiwire_new_deduplicate(__externref_t v)
   HwRef result = hiwire_incref_deduplicate(id);
   hiwire_decref(id);
   return result;
-}
-
-HwRef
-wrapped_hiwire_incref(HwRef ref)
-{
-  hiwire_incref(ref);
-  return ref;
 }
 
 // Called by libhiwire if an invalid ID is dereferenced.

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -74,6 +74,15 @@ hiwire_init()
 }
 
 HwRef
+hiwire_new_deduplicate(__externref_t v)
+{
+  HwRef id = hiwire_new(v);
+  HwRef result = hiwire_incref_deduplicate(id);
+  hiwire_decref(id);
+  return result;
+}
+
+HwRef
 wrapped_hiwire_incref(HwRef ref)
 {
   hiwire_incref(ref);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -6,7 +6,6 @@
 #include "stdalign.h"
 #include "types.h"
 #define WARN_UNUSED __attribute__((warn_unused_result))
-#define hiwire_incref wrapped_hiwire_incref
 
 typedef HwRef JsRef;
 typedef __externref_t JsVal;
@@ -21,9 +20,6 @@ extern const JsRef Js_undefined;
 extern const JsRef Js_true;
 extern const JsRef Js_false;
 extern const JsRef Js_null;
-
-// For when the return value would be Option<JsRef>
-extern const JsRef Js_novalue;
 
 // A mechanism for handling static JavaScript strings from C
 // This is copied from the Python mechanism for handling static Python strings
@@ -63,7 +59,7 @@ hiwire_init();
  *
  * Returns: The new reference
  */
-JsRef
+void
 hiwire_incref(JsRef idval);
 
 /**

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -80,6 +80,9 @@ hiwire_incref(JsRef idval);
 JsRef
 hiwire_incref_deduplicate(JsRef idval);
 
+HwRef
+hiwire_new_deduplicate(JsVal v);
+
 /**
  * Decrease the reference count on an object.
  */

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -65,7 +65,7 @@ EM_JS_REF(PyObject*, js2python_js, (JsVal value), {
     // clang-format on
     return result;
   }
-  return _JsProxy_create_val(value);
+  return _JsProxy_create(value);
 })
 
 EMSCRIPTEN_KEEPALIVE PyObject*

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -117,7 +117,7 @@ JS_FILE(js2python_init, () => {
     } else if (API.isPyProxy(value)) {
       const { props, shared } = Module.PyProxy_getAttrs(value);
       if (props.roundtrip) {
-        return _JsProxy_create_val(value);
+        return _JsProxy_create(value);
       } else {
         return __js2python_pyproxy(shared.ptr);
       }
@@ -286,7 +286,7 @@ JS_FILE(js2python_init, () => {
       return result;
     }
     if (context.depth === 0) {
-      return _JsProxy_create_val(value);
+      return _JsProxy_create(value);
     }
     result = context.cache.get(value);
     if (result !== undefined) {
@@ -299,7 +299,7 @@ JS_FILE(js2python_init, () => {
         return result;
       }
       if (context.defaultConverter === undefined) {
-        return _JsProxy_create_val(value);
+        return _JsProxy_create(value);
       }
       let result_js = context.defaultConverter(
         value,
@@ -313,7 +313,7 @@ JS_FILE(js2python_init, () => {
       if (result !== undefined) {
         return result;
       }
-      return _JsProxy_create_val(result_js);
+      return _JsProxy_create(result_js);
     } finally {
       context.depth++;
     }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -194,7 +194,7 @@ _Static_assert(sizeof(PyBaseExceptionObject) ==
 #define JsProxy_DICT(x) (((JsProxy*)x)->dict)
 
 #define JsMethod_THIS_REF(x) ((JsProxy*)x)->tf.mf.this_
-#define JsMethod_THIS(x) JsRef_toVal(((JsProxy*)x)->tf.mf.this_)
+#define JsMethod_THIS(x) JsRef_toVal(JsMethod_THIS_REF(x))
 #define JsMethod_VECTORCALL(x) (((JsProxy*)x)->tf.mf.vectorcall)
 
 #define JsException_ARGS(x) (((JsProxy*)x)->tf.ef.args)

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -193,7 +193,8 @@ _Static_assert(sizeof(PyBaseExceptionObject) ==
 #define JsProxy_VAL(x) hiwire_get(JsProxy_REF(x))
 #define JsProxy_DICT(x) (((JsProxy*)x)->dict)
 
-#define JsMethod_THIS(x) ((JsProxy*)x)->tf.mf.this_
+#define JsMethod_THIS_REF(x) ((JsProxy*)x)->tf.mf.this_
+#define JsMethod_THIS(x) JsRef_toVal(((JsProxy*)x)->tf.mf.this_)
 #define JsMethod_VECTORCALL(x) (((JsProxy*)x)->tf.mf.vectorcall)
 
 #define JsException_ARGS(x) (((JsProxy*)x)->tf.ef.args)
@@ -225,8 +226,8 @@ JsProxy_clear(PyObject* self)
   if (flags == -1) {
     return -1;
   }
-  if ((flags & IS_CALLABLE) && (JsMethod_THIS(self) != NULL)) {
-    JsVal this = hiwire_pop(JsMethod_THIS(self));
+  if ((flags & IS_CALLABLE) && (JsMethod_THIS_REF(self) != NULL)) {
+    JsVal this = hiwire_pop(JsMethod_THIS_REF(self));
     if (pyproxy_Check(this)) {
       destroy_proxy(this, NULL);
     }
@@ -396,9 +397,7 @@ JsProxy_GetAttr(PyObject* self, PyObject* attr)
   }
 
   if (!pyproxy_Check(jsresult) && JsvFunction_Check(jsresult)) {
-    JsRef idresult = hiwire_new(jsresult);
-    pyresult = JsProxy_create_with_this(idresult, JsProxy_REF(self));
-    hiwire_decref(idresult);
+    pyresult = JsProxy_create_with_this(jsresult, JsProxy_VAL(self));
   } else {
     pyresult = js2python(jsresult);
   }
@@ -571,7 +570,7 @@ handle_next_result(JsVal next_res, PyObject** result, bool obj_map_hereditary){
   // so pyvalue will be set to Py_None.
   *result = js2python_immutable(jsresult);
   if (!*result) {
-    *result = JsProxy_create_objmap_val(jsresult, obj_map_hereditary);
+    *result = JsProxy_create_objmap(jsresult, obj_map_hereditary);
   }
   FAIL_IF_NULL(*result);
   if(pyproxy_Check(jsresult)) {
@@ -1173,7 +1172,7 @@ JsProxy_object_entries(PyObject* self, PyObject* _args)
 {
   JsVal jsresult = JsvObject_Entries(JsProxy_VAL(self));
   FAIL_IF_JS_NULL(jsresult);
-  return JsProxy_create_val(jsresult);
+  return JsProxy_create(jsresult);
 finally:
   return NULL;
 }
@@ -1193,7 +1192,7 @@ JsProxy_object_keys(PyObject* self, PyObject* _args)
 {
   JsVal jsresult = JsvObject_Keys(JsProxy_VAL(self));
   FAIL_IF_JS_NULL(jsresult);
-  return JsProxy_create_val(jsresult);
+  return JsProxy_create(jsresult);
 finally:
   return NULL;
 }
@@ -1213,7 +1212,7 @@ JsProxy_object_values(PyObject* self, PyObject* _args)
 {
   JsVal jsresult = JsvObject_Values(JsProxy_VAL(self));
   FAIL_IF_JS_NULL(jsresult);
-  return JsProxy_create_val(jsresult);
+  return JsProxy_create(jsresult);
 finally:
   return NULL;
 }
@@ -2659,7 +2658,7 @@ JsProxy_then(JsProxy* self, PyObject* args, PyObject* kwds)
     Py_CLEAR(onrejected);
     FAIL();
   }
-  result = JsProxy_create_val(result_promise);
+  result = JsProxy_create(result_promise);
 
 finally:
   // don't clear onfulfilled, onrejected, they are borrowed from arguments.
@@ -2692,7 +2691,7 @@ JsProxy_catch(JsProxy* self, PyObject* onrejected)
     Py_DECREF(onrejected);
     FAIL();
   }
-  result = JsProxy_create_val(result_promise);
+  result = JsProxy_create(result_promise);
 
 finally:
   return result;
@@ -2727,7 +2726,7 @@ JsProxy_finally(JsProxy* self, PyObject* onfinally)
     FAIL();
   }
 
-  return JsProxy_create_val(result_promise);
+  return JsProxy_create(result_promise);
 finally:
   return NULL;
 }
@@ -2757,7 +2756,7 @@ JsProxy_as_object_map(PyObject* self,
 
   int type_flags = IS_OBJECT_MAP;
   PyObject* proxy = JsProxy_create_with_type(
-    type_flags, JsProxy_REF(self), JsMethod_THIS(self));
+    type_flags, JsProxy_VAL(self), JsMethod_THIS(self));
   FAIL_IF_NULL(proxy);
   JsObjMap_HEREDITARY(proxy) = hereditary;
 
@@ -2828,7 +2827,7 @@ JsObjMap_subscript(PyObject* self, PyObject* pyidx)
   }
   pyresult = js2python_immutable(result);
   if (pyresult == NULL) {
-    pyresult = JsProxy_create_objmap_val(result, JsObjMap_HEREDITARY(self));
+    pyresult = JsProxy_create_objmap(result, JsObjMap_HEREDITARY(self));
   }
 
 finally:
@@ -2967,10 +2966,10 @@ static PyTypeObject JsProxyType = {
 };
 
 static int
-JsProxy_cinit(PyObject* obj, JsRef idobj)
+JsProxy_cinit(PyObject* obj, JsVal val)
 {
   JsProxy* self = (JsProxy*)obj;
-  self->js = hiwire_incref_deduplicate(idobj);
+  self->js = hiwire_new_deduplicate(val);
 #ifdef DEBUG_F
   extern bool tracerefs;
   if (tracerefs) {
@@ -3167,8 +3166,8 @@ JsMethod_Vectorcall(PyObject* self,
   JsVal jsargs =
     JsMethod_ConvertArgs(pyargs, PyVectorcall_NARGS(nargsf), kwnames, proxies);
   FAIL_IF_JS_NULL(jsargs);
-  jsresult = JsvFunction_CallBound(
-    JsProxy_VAL(self), JsRef_toVal(JsMethod_THIS(self)), jsargs);
+  jsresult =
+    JsvFunction_CallBound(JsProxy_VAL(self), JsMethod_THIS(self), jsargs);
   FAIL_IF_JS_NULL(jsresult);
   // various cases where we want to extend the lifetime of the arguments:
   // 1. if the return value is a promise we extend arguments lifetime until the
@@ -3279,18 +3278,16 @@ JsMethod_descr_get(PyObject* self, PyObject* obj, PyObject* type)
 
   JsVal jsobj = python2js(obj);
   FAIL_IF_JS_NULL(jsobj);
-  JsRef jsref = hiwire_new(jsobj);
-  result = JsProxy_create_with_this(JsProxy_REF(self), jsref);
-  hiwire_decref(jsref);
+  result = JsProxy_create_with_this(JsProxy_VAL(self), jsobj);
 
 finally:
   return result;
 }
 
 static int
-JsMethod_cinit(PyObject* self, JsRef this_)
+JsMethod_cinit(PyObject* self, JsVal this_)
 {
-  JsMethod_THIS(self) = hiwire_incref(this_);
+  JsMethod_THIS_REF(self) = JsRef_new(this_);
   JsMethod_VECTORCALL(self) = JsMethod_Vectorcall;
   return 0;
 }
@@ -4307,7 +4304,7 @@ EM_JS_NUM(int, JsProxy_compute_typeflags, (JsVal obj), {
 // Public functions
 
 PyObject*
-JsProxy_create_with_type(int type_flags, JsRef object, JsRef this)
+JsProxy_create_with_type(int type_flags, JsVal object, JsVal this)
 {
   bool success = false;
   PyTypeObject* type = NULL;
@@ -4344,22 +4341,13 @@ finally:
 }
 
 PyObject*
-JsProxy_create_objmap(JsRef object, bool objmap)
+JsProxy_create_objmap(JsVal object, bool objmap)
 {
-  int typeflags = JsProxy_compute_typeflags(hiwire_get(object));
+  int typeflags = JsProxy_compute_typeflags(object);
   if (typeflags == 0 && objmap) {
     typeflags |= IS_OBJECT_MAP;
   }
-  return JsProxy_create_with_type(typeflags, object, NULL);
-}
-
-PyObject*
-JsProxy_create_objmap_val(JsVal object, bool objmap)
-{
-  JsRef ref = hiwire_new(object);
-  PyObject* result = JsProxy_create_objmap(ref, objmap);
-  hiwire_decref(ref);
-  return result;
+  return JsProxy_create_with_type(typeflags, object, JS_NULL);
 }
 
 EM_JS_BOOL(bool, is_comlink_proxy, (JsVal obj), {
@@ -4373,14 +4361,14 @@ EM_JS_BOOL(bool, is_comlink_proxy, (JsVal obj), {
  * appropriate flags, then we get the appropriate type with JsProxy_get_subtype.
  */
 PyObject*
-JsProxy_create_with_this(JsRef object, JsRef this)
+JsProxy_create_with_this(JsVal object, JsVal this)
 {
   int type_flags = 0;
-  if (is_comlink_proxy(hiwire_get(object))) {
+  if (is_comlink_proxy(object)) {
     // Comlink proxies are weird and break our feature detection pretty badly.
     type_flags = IS_CALLABLE | IS_AWAITABLE | IS_ARRAY;
   } else {
-    type_flags = JsProxy_compute_typeflags(hiwire_get(object));
+    type_flags = JsProxy_compute_typeflags(object);
     if (type_flags == -1) {
       fail_test();
       PyErr_SetString(internal_error,
@@ -4392,18 +4380,9 @@ JsProxy_create_with_this(JsRef object, JsRef this)
 }
 
 EMSCRIPTEN_KEEPALIVE PyObject*
-JsProxy_create(JsRef object)
+JsProxy_create(JsVal object)
 {
-  return JsProxy_create_with_this(object, NULL);
-}
-
-EMSCRIPTEN_KEEPALIVE PyObject*
-JsProxy_create_val(JsVal object)
-{
-  JsRef ref = hiwire_new(object);
-  PyObject* result = JsProxy_create(ref);
-  hiwire_decref(ref);
-  return result;
+  return JsProxy_create_with_this(object, JS_NULL);
 }
 
 EMSCRIPTEN_KEEPALIVE bool

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -4391,13 +4391,6 @@ JsProxy_Check(PyObject* x)
   return PyObject_TypeCheck(x, &JsProxyType);
 }
 
-JsRef
-JsProxy_AsJs(PyObject* x)
-{
-  JsProxy* js_proxy = (JsProxy*)x;
-  return hiwire_incref(js_proxy->js);
-}
-
 JsVal
 JsProxy_Val(PyObject* x)
 {

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -48,14 +48,6 @@ JsProxy_create(JsVal v);
 bool
 JsProxy_Check(PyObject* x);
 
-/**
- * Grab the underlying JavaScript object from the JsProxy.
- * @param x The JsProxy object. Will fatally fail if it isn't a JsProxy.
- * @return The JavaScript object.
- */
-JsRef
-JsProxy_AsJs(PyObject* x);
-
 JsVal
 JsProxy_Val(PyObject* x);
 

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -17,13 +17,10 @@ int
 JsProxy_compute_typeflags(JsVal obj);
 
 PyObject*
-JsProxy_create_with_type(int type_flags, JsRef object, JsRef this);
+JsProxy_create_with_type(int type_flags, JsVal object, JsVal this);
 
 PyObject*
-JsProxy_create_objmap(JsRef object, bool objmap);
-
-PyObject*
-JsProxy_create_objmap_val(JsVal object, bool objmap);
+JsProxy_create_objmap(JsVal object, bool objmap);
 
 /**
  * Make a new JsProxy.
@@ -33,7 +30,7 @@ JsProxy_create_objmap_val(JsVal object, bool objmap);
  * @return The Python object wrapping the JavaScript object.
  */
 PyObject*
-JsProxy_create_with_this(JsRef object, JsRef this);
+JsProxy_create_with_this(JsVal object, JsVal this);
 
 /**
  * Make a new JsProxy.
@@ -41,10 +38,7 @@ JsProxy_create_with_this(JsRef object, JsRef this);
  * @return The Python object wrapping the JavaScript object.
  */
 PyObject*
-JsProxy_create(JsRef v);
-
-PyObject*
-JsProxy_create_val(JsVal object);
+JsProxy_create(JsVal v);
 
 /**
  * Check if a Python object is a JsProxy.

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -91,3 +91,11 @@ function bufferAsUint8Array(arg) {
   }
 }
 API.typedArrayAsUint8Array = bufferAsUint8Array;
+
+Module.iterObject = function* (object) {
+  for (let k in object) {
+    if (Object.prototype.hasOwnProperty.call(object, k)) {
+      yield k;
+    }
+  }
+};

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1166,29 +1166,51 @@ EM_JS(JsVal, array_to_js, (Py_ssize_t * array, int len), {
   return Array.from(HEAP32.subarray(array / 4, array / 4 + len));
 })
 
-// The order of these fields has to match the code in getBuffer
-typedef struct
+// A macro to help us keep track of the fields we want to produce for the buffer
+// info. We want to return a JavaScript object with these fields.
+// You might write similar macros if you were not allowed to use structs...
+
+// _pyproxy_get_buffer_result takes this set of arguments (with an extra
+// sentinel to deal with the trailing comma problem). We declare a variable for
+// each of these fields in _pyproxy_get_buffer and then the RESULT macro
+// generates the call to _pyproxy_get_buffer_result which builds the JS object.
+// This object is then destructured and used in pyproxy.ts.
+// clang-format off
+#define FIELDS(x)                                                               \
+  FIELD(x)(void*, start_ptr)                                                    \
+  FIELD(x)(void*, smallest_ptr)                                                 \
+  FIELD(x)(void*, largest_ptr)                                                  \
+  FIELD(x)(int, readonly)                                                       \
+  FIELD(x)(char*, format)                                                       \
+  FIELD(x)(int, itemsize)                                                       \
+  FIELD(x)(JsVal, shape)                                                        \
+  FIELD(x)(JsVal, strides)                                                      \
+  FIELD(x)(Py_buffer*, view)                                                    \
+  FIELD(x)(int, c_contiguous)                                                   \
+  FIELD(x)(int, f_contiguous)                                                   \
+
+#define FIELD(x) FIELD_ ## x
+
+#define FIELD_argspec(a, b) a b,
+#define FIELD_comma_separated(a, b) b,
+#define FIELD_declarations(a, b) a b;
+
+// We have to add an extra sentinel argument because C doesn't like trailing
+// commas
+#define ARGSPEC FIELDS(argspec)         int sentinel
+#define ARGS    FIELDS(comma_separated) 0
+
+EM_JS_MACROS(
+JsVal,
+_pyproxy_get_buffer_result,
+(ARGSPEC),
 {
-  // where is the first entry buffer[0]...[0] (ndim times)?
-  void* start_ptr;
-  // Where is the earliest location in buffer? (If all strides are positive,
-  // this equals start_ptr)
-  void* smallest_ptr;
-  // What is the last location in the buffer (plus one)
-  void* largest_ptr;
+  format = UTF8ToString(format);
+  return { FIELDS(comma_separated) };
+})
+// clang-format on
 
-  int readonly;
-  char* format;
-  int itemsize;
-  JsRef shape;
-  JsRef strides;
-
-  Py_buffer* view;
-  int c_contiguous;
-  int f_contiguous;
-} buffer_struct;
-
-EMSCRIPTEN_KEEPALIVE size_t buffer_struct_size = sizeof(buffer_struct);
+#define RESULT _pyproxy_get_buffer_result(ARGS)
 
 /**
  * This is the C part of the getBuffer method.
@@ -1207,81 +1229,89 @@ EMSCRIPTEN_KEEPALIVE size_t buffer_struct_size = sizeof(buffer_struct);
  * memory). If strides are positive, these are the same but if some strides are
  * negative they will be different.
  *
- * We also put the various other metadata about the buffer that we want to share
- * into buffer_struct.
+ * We put all the metadata about the buffer that we want to share into a JS
+ * object and return it. Syncing up the C variables with the eventual JS array
+ * we want to make is accomplished with the FIELDS macros.
  */
-EMSCRIPTEN_KEEPALIVE int
-_pyproxy_get_buffer(buffer_struct* target, PyObject* ptrobj)
+EMSCRIPTEN_KEEPALIVE JsVal
+_pyproxy_get_buffer(PyObject* ptrobj)
 {
-  Py_buffer view;
+  Py_buffer v;
   // PyBUF_RECORDS_RO requires that suboffsets be NULL but otherwise is the most
   // permissive possible request.
-  if (PyObject_GetBuffer(ptrobj, &view, PyBUF_RECORDS_RO) == -1) {
+  if (PyObject_GetBuffer(ptrobj, &v, PyBUF_RECORDS_RO) == -1) {
     // Buffer cannot be represented without suboffsets. The bf_getbuffer method
     // should have set a PyExc_BufferError saying something to this effect.
-    return -1;
+    return JS_NULL;
   }
 
-  buffer_struct result = { 0 };
-  result.start_ptr = result.smallest_ptr = result.largest_ptr = view.buf;
-  result.readonly = view.readonly;
+  // The following declares a bunch of local variables. We need to fill them in
+  // and use return RESULT; to return a JS object with this info.
+  FIELDS(declarations);
 
-  result.format = view.format;
-  result.itemsize = view.itemsize;
+  start_ptr = smallest_ptr = largest_ptr = v.buf;
 
-  if (view.ndim == 0) {
+  readonly = v.readonly;
+  format = v.format;
+  itemsize = v.itemsize;
+
+  view = (Py_buffer*)PyMem_Malloc(sizeof(Py_buffer));
+  *view = v;
+
+  if (v.ndim == 0) {
     // "If ndim is 0, buf points to a single item representing a scalar. In this
     // case, shape, strides and suboffsets MUST be NULL."
     // https://docs.python.org/3/c-api/buffer.html#c.Py_buffer.ndim
-    result.largest_ptr += view.itemsize;
-    result.shape = hiwire_new(JsvArray_New());
-    result.strides = hiwire_new(JsvArray_New());
-    result.c_contiguous = true;
-    result.f_contiguous = true;
-    goto success;
+    // all zero-dimensional arrays are both c_contiguous and f_contiguous.
+    largest_ptr += v.itemsize;
+    shape = JsvArray_New();
+    strides = JsvArray_New();
+    c_contiguous = true;
+    f_contiguous = true;
+    return RESULT;
   }
 
   // Because we requested PyBUF_RECORDS_RO I think we can assume that
-  // view.shape != NULL.
-  result.shape = hiwire_new(array_to_js(view.shape, view.ndim));
+  // v.shape != NULL.
+  shape = array_to_js(v.shape, v.ndim);
 
-  if (view.strides == NULL) {
+  if (v.strides == NULL) {
     // In this case we are a C contiguous buffer
-    result.largest_ptr += view.len;
-    Py_ssize_t strides[view.ndim];
-    PyBuffer_FillContiguousStrides(
-      view.ndim, view.shape, strides, view.itemsize, 'C');
-    result.strides = hiwire_new(array_to_js(strides, view.ndim));
-    goto success;
+    largest_ptr += v.len;
+    Py_ssize_t cstrides[v.ndim];
+    PyBuffer_FillContiguousStrides(v.ndim, v.shape, cstrides, v.itemsize, 'C');
+    c_contiguous = true;
+    // 1d c_contiguous arrays are also f_contiguous
+    f_contiguous = (v.ndim == 1);
+    strides = array_to_js(cstrides, v.ndim);
+    return RESULT;
   }
 
-  if (view.len != 0) {
+  if (v.len != 0) {
     // Have to be careful to ensure that we handle negative strides correctly.
-    for (int i = 0; i < view.ndim; i++) {
-      // view.strides[i] != 0
-      if (view.strides[i] > 0) {
+    for (int i = 0; i < v.ndim; i++) {
+      // v.strides[i] != 0
+      if (v.strides[i] > 0) {
         // add positive strides to largest_ptr
-        result.largest_ptr += view.strides[i] * (view.shape[i] - 1);
+        largest_ptr += v.strides[i] * (v.shape[i] - 1);
       } else {
         // subtract negative strides from smallest_ptr
-        result.smallest_ptr += view.strides[i] * (view.shape[i] - 1);
+        smallest_ptr += v.strides[i] * (v.shape[i] - 1);
       }
     }
-    result.largest_ptr += view.itemsize;
+    largest_ptr += v.itemsize;
   }
 
-  result.strides = hiwire_new(array_to_js(view.strides, view.ndim));
-  result.c_contiguous = PyBuffer_IsContiguous(&view, 'C');
-  result.f_contiguous = PyBuffer_IsContiguous(&view, 'F');
-
-success:
-  // The result.view memory will be freed when (if?) the user calls
-  // Py_Buffer.release().
-  result.view = (Py_buffer*)PyMem_Malloc(sizeof(Py_buffer));
-  *result.view = view;
-  *target = result;
-  return 0;
+  strides = array_to_js(v.strides, v.ndim);
+  c_contiguous = PyBuffer_IsContiguous(&v, 'C');
+  f_contiguous = PyBuffer_IsContiguous(&v, 'F');
+  return RESULT;
 }
+#undef FIELDS
+#undef FIELD
+#undef ARGSPEC
+#undef ARGS
+#undef RESULT
 
 // clang-format off
 EM_JS_VAL(JsVal,
@@ -1289,9 +1319,9 @@ pyproxy_new_ex,
 (PyObject * ptrobj, bool capture_this, bool roundtrip, bool gcRegister),
 {
   return Module.pyproxy_new(ptrobj, {
-      props: { captureThis: !!capture_this, roundtrip: !!roundtrip },
-      gcRegister,
-    });
+    props: { captureThis: !!capture_this, roundtrip: !!roundtrip },
+    gcRegister,
+  });
 });
 // clang-format on
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1336,7 +1336,7 @@ static PyObject*
 create_once_callable_py(PyObject* _mod, PyObject* obj)
 {
   JsVal v = create_once_callable(obj);
-  return JsProxy_create_val(v);
+  return JsProxy_create(v);
 }
 
 // clang-format off
@@ -1441,7 +1441,7 @@ create_proxy(PyObject* self,
         args, nargs, kwnames, &_parser, &obj, &capture_this, &roundtrip)) {
     return NULL;
   }
-  return JsProxy_create_val(pyproxy_new_ex(obj, capture_this, roundtrip, true));
+  return JsProxy_create(pyproxy_new_ex(obj, capture_this, roundtrip, true));
 }
 
 static PyMethodDef methods[] = {

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -787,7 +787,7 @@ to_js(PyObject* self,
   FAIL_IF_JS_NULL(js_result);
   if (pyproxy_Check(js_result)) {
     // Oops, just created a PyProxy. Wrap it I guess?
-    py_result = JsProxy_create_val(js_result);
+    py_result = JsProxy_create(js_result);
   } else {
     py_result = js2python(js_result);
   }

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -75,7 +75,7 @@ declare global {
   export const _restore_sys_last_exception: (err: number) => boolean;
   export const _set_error: (pyerr: number) => void;
 
-  export const _JsProxy_create_val: (obj: any) => number;
+  export const _JsProxy_create: (obj: any) => number;
   export const _JsProxy_Check: (ptr: number) => number;
 
   export const _python2js: (pyobj: number) => any;
@@ -146,8 +146,7 @@ declare global {
     resolve: (res: any) => void,
     reject: (exc: any) => void,
   ) => number;
-  export const _buffer_struct_size: number;
-  export const __pyproxy_get_buffer: (ptr: number, this_: number) => number;
+  export const __pyproxy_get_buffer: (this_: number) => any;
   export const __pyproxy_apply: (
     ptr: number,
     jsargs: any[],

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -309,15 +309,14 @@ def test_pyproxy_get_buffer(selenium):
                 for(let idx2 = 0; idx2 < 3; idx2++){
                     let v1 = z.data[z.offset + z.strides[0] * idx1 + z.strides[1] * idx2];
                     let v2 = pyodide.runPython(`repr(${x}[${idx1}, ${idx2}])`);
-                    console.log(`${v1}, ${typeof(v1)}, ${v2}, ${typeof(v2)}, ${v1===v2}`);
                     if(v1.toString() !== v2){
                         throw new Error(`Discrepancy ${x}[${idx1}, ${idx2}]: ${v1} != ${v2}`);
                     }
                 }
             }
             z.release();
+            pyodide.runPython(`print("${x}", getrefcount(${x}))`);
             pyodide.runPython(`assert getrefcount(${x}) == 2`);
-            pyodide.runPython(`del ${x}`);
         }
         """
     )

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1177,9 +1177,9 @@ def test_tojs6(selenium):
             b = [a, a, a, a, a]
             [b, b, b, b, b]
         `);
-        let total_refs = pyodide._module.hiwire.num_keys();
+        let total_refs = pyodide._module._hiwire_num_refs();
         let res = respy.toJs();
-        let new_total_refs = pyodide._module.hiwire.num_keys();
+        let new_total_refs = pyodide._module._hiwire_num_refs();
         respy.destroy();
         assert(() => total_refs === new_total_refs);
         assert(() => res[0] === res[1]);
@@ -1199,9 +1199,9 @@ def test_tojs7(selenium):
             a.append(b)
             a
         `);
-        let total_refs = pyodide._module.hiwire.num_keys();
+        let total_refs = pyodide._module._hiwire_num_refs();
         let res = respy.toJs();
-        let new_total_refs = pyodide._module.hiwire.num_keys();
+        let new_total_refs = pyodide._module._hiwire_num_refs();
         respy.destroy();
         assert(() => total_refs === new_total_refs);
         assert(() => res[0][0] === "b");


### PR DESCRIPTION
This is close to finishing the refactor. I removed the last few uses of the `Hiwire` JS APIs from the PyProxy Buffer apis. I reworked all of the `JsProxy_create` family to use `JsVal` everywhere. I removed most of the remaining logic from `hiwire.c`. The only remaining places where `JsRef` is used are in struct fields.

After this, the last steps are to move the remaining constant initialization code from `hiwire.c` to `jslib.c`, and remove then remove our `hiwire.h` completely so we can use the `libhiwire.h` headers directly.