### PR TITLE
Add docstrings for to_js

### DIFF
--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1260,21 +1260,20 @@ def to_js(
     >>> js_object.hasOwnProperty("height")
     False
     
-    >>> js_object = pyodide.ffi.to_js({'age': 20, 'name': 'john'}, dict_converter=Map.new)
+    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Map.new)
     >>> js_object.keys(), js_object.values()
     KeysView([object Map]) ValuesView([object Map])
     >>> [(k, v) for k, v in zip(js_object.keys(), js_object.values())]
     [('age', 20), ('name', 'john')]
     
-    
-    >>> js_object = pyodide.ffi.to_js({'age': 20, 'name': 'john'}, dict_converter=Array.new)
+    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Array.new)
     >>> [item for item in js_object]
     [age,20, name,john]
     >>> js_object.toString()
     age,20,name,john
 
     >>> class Bird: pass
-    >>> converter = lambda value, cache, _: Object.new(size=1, color='red') if isinstance(value, Bird) else None
+    >>> converter = lambda value, convert, cache: Object.new(size=1, color='red') if isinstance(value, Bird) else None
     >>> js_nest = to_js([Bird(), Bird()], default_converter=converter)
     >>> [bird for bird in js_nest]
     [[object Object], [object Object]]

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1226,7 +1226,7 @@ def to_js(
         result of the dict conversion. Some suggested values for this argument:
 
           * ``js.Map.new`` -- similar to the default behavior
-          * ``js.Array.new`` -- convert to an array of entries
+          * ``js.Array.from`` -- convert to an array of entries
           * ``js.Object.fromEntries`` -- convert to a JavaScript object
 
     default_converter:
@@ -1239,34 +1239,36 @@ def to_js(
     Examples
     --------
     >>> from js import Object, Map, Array
-    >>> js_object = pyodide.ffi.to_js({'age': 20, 'name': 'john'}, dict_converter=Object.fromEntries)
+    >>> from pyodide.ffi import to_js
+    >>> js_object = to_js({'age': 20, 'name': 'john'})
+    >>> js_object
+    [object Map]
+    >>> js_object.keys(), js_object.values()
+    KeysView([object Map]) ValuesView([object Map])
+    >>> [(k, v) for k, v in zip(js_object.keys(), js_object.values())]
+    [('age', 20), ('name', 'john')]
+    
+    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Object.fromEntries)
     >>> js_object.age == 20
     True
     >>> js_object.name == 'john'
     True
-    >>> js_object.toString()
+    >>> js_object
     [object Object]
     >>> js_object.hasOwnProperty("age")
     True
     >>> js_object.hasOwnProperty("height")
     False
     
-    >>> js_object = pyodide.ffi.to_js({'age': 20, 'name': 'john'}, dict_converter=Map.new)
-    >>> js_object.keys(), js_object.values()
-    KeysView([object Map]) ValuesView([object Map])
-    >>> [(k, v) for k, v in zip(js_object.keys(), js_object.values())]
-    [('age', 20), ('name', 'john')]
-    
-    
-    >>> js_object = pyodide.ffi.to_js({'age': 20, 'name': 'john'}, dict_converter=Array.new)
+    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Array.from_)
     >>> [item for item in js_object]
-    [age,20,name,john]
+    [age,20, name,john]
     >>> js_object.toString()
     age,20,name,john
     
     >>> class Bird: pass
     >>> converter = lambda value, cache, _: Object.new(size=1, color='red') if isinstance(value, Bird) else None
-    >>> js_nest = pyodide.ffi.to_js([Bird(), Bird()], default_converter=converter)
+    >>> js_nest = to_js([Bird(), Bird()], default_converter=converter)
     >>> [bird for bird in js_nest]
     [[object Object], [object Object]]
     >>> [(bird.size, bird.color) for bird in js_nest]

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1259,14 +1259,8 @@ def to_js(
     True
     >>> js_object.hasOwnProperty("height")
     False
-
-    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Map.new)
-    >>> js_object.keys(), js_object.values()
-    KeysView([object Map]) ValuesView([object Map])
-    >>> [(k, v) for k, v in zip(js_object.keys(), js_object.values())]
-    [('age', 20), ('name', 'john')]
-
-    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Array.new)
+    
+    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Array.from_)
     >>> [item for item in js_object]
     [age,20, name,john]
     >>> js_object.toString()

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1259,7 +1259,7 @@ def to_js(
     True
     >>> js_object.hasOwnProperty("height")
     False
-    
+
     >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Array.from_)
     >>> [item for item in js_object]
     [age,20, name,john]

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1240,38 +1240,38 @@ def to_js(
     --------
     >>> from js import Object, Map, Array
     >>> from pyodide.ffi import to_js
-    >>> js_object = to_js({'age': 20, 'name': 'john'})
-    >>> js_object
+    >>> js_object = to_js({'age': 20, 'name': 'john'}) # doctest: +SKIP
+    >>> js_object # doctest: +SKIP
     [object Map]
-    >>> js_object.keys(), js_object.values()
-    KeysView([object Map]) ValuesView([object Map])
-    >>> [(k, v) for k, v in zip(js_object.keys(), js_object.values())]
+    >>> js_object.keys(), js_object.values() # doctest: +SKIP
+    KeysView([object Map]) ValuesView([object Map]) # doctest: +SKIP
+    >>> [(k, v) for k, v in zip(js_object.keys(), js_object.values())] # doctest: +SKIP
     [('age', 20), ('name', 'john')]
 
-    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Object.fromEntries)
-    >>> js_object.age == 20
+    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Object.fromEntries) # doctest: +SKIP
+    >>> js_object.age == 20 # doctest: +SKIP
     True
-    >>> js_object.name == 'john'
+    >>> js_object.name == 'john' # doctest: +SKIP
     True
-    >>> js_object
+    >>> js_object # doctest: +SKIP
     [object Object]
-    >>> js_object.hasOwnProperty("age")
+    >>> js_object.hasOwnProperty("age") # doctest: +SKIP
     True
-    >>> js_object.hasOwnProperty("height")
+    >>> js_object.hasOwnProperty("height") # doctest: +SKIP
     False
 
-    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Array.from_)
-    >>> [item for item in js_object]
+    >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Array.from_) # doctest: +SKIP
+    >>> [item for item in js_object] # doctest: +SKIP
     [age,20, name,john]
-    >>> js_object.toString()
+    >>> js_object.toString() # doctest: +SKIP
     age,20,name,john
 
-    >>> class Bird: pass
-    >>> converter = lambda value, convert, cache: Object.new(size=1, color='red') if isinstance(value, Bird) else None
-    >>> js_nest = to_js([Bird(), Bird()], default_converter=converter)
-    >>> [bird for bird in js_nest]
+    >>> class Bird: pass # doctest: +SKIP
+    >>> converter = lambda value, convert, cache: Object.new(size=1, color='red') if isinstance(value, Bird) else None # doctest: +SKIP
+    >>> js_nest = to_js([Bird(), Bird()], default_converter=converter) # doctest: +SKIP
+    >>> [bird for bird in js_nest] # doctest: +SKIP
     [[object Object], [object Object]]
-    >>> [(bird.size, bird.color) for bird in js_nest]
+    >>> [(bird.size, bird.color) for bird in js_nest] # doctest: +SKIP
     [(1, 'red'), (1, 'red')]
 
     Here are some examples demonstrating the usage of the ``default_converter``

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1307,7 +1307,8 @@ def to_js(
 
         class Pair:
             def __init__(self, first, second):
-                self.first, self.second = first, second
+                self.first = first
+                self.second = second
 
     We can use the following ``default_converter`` to convert ``Pair`` to
     :js:class:`Array`:

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1238,8 +1238,8 @@ def to_js(
 
     Examples
     --------
-    >>> from js import Object, Map, Array
-    >>> from pyodide.ffi import to_js
+    >>> from js import Object, Map, Array # doctest: +SKIP
+    >>> from pyodide.ffi import to_js # doctest: +SKIP
     >>> js_object = to_js({'age': 20, 'name': 'john'}) # doctest: +SKIP
     >>> js_object # doctest: +SKIP
     [object Map]

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1259,13 +1259,13 @@ def to_js(
     True
     >>> js_object.hasOwnProperty("height")
     False
-    
+
     >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Map.new)
     >>> js_object.keys(), js_object.values()
     KeysView([object Map]) ValuesView([object Map])
     >>> [(k, v) for k, v in zip(js_object.keys(), js_object.values())]
     [('age', 20), ('name', 'john')]
-    
+
     >>> js_object = to_js({'age': 20, 'name': 'john'}, dict_converter=Array.new)
     >>> [item for item in js_object]
     [age,20, name,john]


### PR DESCRIPTION
Add docstring example usage for to_js.

js.Array.from from is an invalid keyword in Python instead js.Array.new to define a new Array

Small Python syntax edits in docstring.

Partially addresses: https://github.com/pyodide/pyodide/issues/1955