### PR TITLE
Changed to sequence check

### DIFF
--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -379,14 +379,14 @@ _python2js_deep(ConversionContext* context, PyObject* x)
 {
   RETURN_IF_HAS_VALUE(_python2js_immutable(x));
   RETURN_IF_HAS_VALUE(_python2js_proxy(x));
-  if (PyList_Check(x) || PyTuple_Check(x)) {
-    return _python2js_sequence(context, x);
-  }
   if (PyDict_Check(x)) {
     return _python2js_dict(context, x);
   }
   if (PySet_Check(x)) {
     return _python2js_set(context, x);
+  }
+  if (PySequence_Check(x)) {
+    return _python2js_sequence(context, x);
   }
   if (PyObject_CheckBuffer(x)) {
     return _python2js_buffer(x);


### PR DESCRIPTION
Changed _python2js_deep

Sequence types for example numpy arrays of objects are treated as buffers.
Sequences in Python are Iterable and have len (sq_length) and get (sq_item).
By checking that the PyObject* passed in is not a dictionary first only valid sequences will be converted as expected.

`// One might consider trying to convert things that satisfy PyMapping_Check to
// maps and things that satisfy PySequence_Check to lists. However
// PyMapping_Check "returns 1 for Python classes with a __getitem__() method"
// and PySequence_Check returns 1 for classes with a __getitem__ method that
// don't subclass dict. For this reason, I think we should stick to subclasses.`

However, by only checking PySequence_Check and checking PyDict_Check before ensures this is not the case.

Addresses issue: https://github.com/pyodide/pyodide/issues/4051 