### PR TITLE
Fix default index url calculation in node ES module

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,9 @@ myst:
   of Node.js might still work, but they are not tested or guaranteed to work.
   {pr}`4269`
 
+- {{ Fix }} Fixed default indexURL calculation in Node.js environment.
+  {pr}`4288`
+
 - {{ Enhancement }} Added experimental support for stack switching.
   {pr}`3957`, {pr}`3964`, {pr}`3987`, {pr}`3990`, {pr}`3210`
 

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -283,13 +283,6 @@ export async function calculateDirname(): Promise<string> {
     return __dirname;
   }
 
-  if (IN_NODE_ESM) {
-    const nodePath = await import("path");
-    const nodeUrl = await import("url");
-
-    return nodeUrl.fileURLToPath(nodePath.dirname(import.meta.url));
-  }
-
   let err: Error;
   try {
     throw new Error();
@@ -297,6 +290,16 @@ export async function calculateDirname(): Promise<string> {
     err = e as Error;
   }
   let fileName = ErrorStackParser.parse(err)[0].fileName!;
+
+  if (IN_NODE_ESM) {
+    const nodePath = await import("path");
+    const nodeUrl = await import("url");
+
+    // FIXME: We would like to use import.meta.url here,
+    // but mocha seems to mess with compiling typescript files to ES6.
+    return nodeUrl.fileURLToPath(nodePath.dirname(fileName));
+  }
+
   const indexOfLastSlash = fileName.lastIndexOf(pathSep);
   if (indexOfLastSlash === -1) {
     throw new Error(

--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -1,12 +1,11 @@
-// Detect if we're in node
-declare var process: any;
-
-export const IN_NODE =
-  typeof process === "object" &&
-  typeof process.versions === "object" &&
-  typeof process.versions.node === "string" &&
-  typeof process.browser ===
-    "undefined"; /* This last condition checks if we run the browser shim of process */
+import ErrorStackParser from "error-stack-parser";
+import {
+  IN_NODE,
+  IN_NODE_ESM,
+  IN_BROWSER_MAIN_THREAD,
+  IN_BROWSER_WEB_WORKER,
+  IN_NODE_COMMONJS,
+} from "./environments";
 
 let nodeUrlMod: any;
 let nodeFetch: any;
@@ -200,10 +199,10 @@ export async function loadBinaryFile(
  */
 export let loadScript: (url: string) => Promise<void>;
 
-if (globalThis.document) {
+if (IN_BROWSER_MAIN_THREAD) {
   // browser
   loadScript = async (url) => await import(/* webpackIgnore: true */ url);
-} else if (globalThis.importScripts) {
+} else if (IN_BROWSER_WEB_WORKER) {
   // webworker
   loadScript = async (url) => {
     try {
@@ -273,4 +272,36 @@ export async function loadLockFile(lockFileURL: string): Promise<any> {
     let response = await fetch(lockFileURL);
     return await response.json();
   }
+}
+
+/**
+ * Calculate the directory name of the current module.
+ * This is used to guess the indexURL when it is not provided.
+ */
+export async function calculateDirname(): Promise<string> {
+  if (IN_NODE_COMMONJS) {
+    return __dirname;
+  }
+
+  if (IN_NODE_ESM) {
+    const nodePath = await import("path");
+    const nodeUrl = await import("url");
+
+    return nodeUrl.fileURLToPath(nodePath.dirname(import.meta.url));
+  }
+
+  let err: Error;
+  try {
+    throw new Error();
+  } catch (e) {
+    err = e as Error;
+  }
+  let fileName = ErrorStackParser.parse(err)[0].fileName!;
+  const indexOfLastSlash = fileName.lastIndexOf(pathSep);
+  if (indexOfLastSlash === -1) {
+    throw new Error(
+      "Could not extract indexURL path from pyodide module location",
+    );
+  }
+  return fileName.slice(0, indexOfLastSlash);
 }

--- a/src/js/environments.ts
+++ b/src/js/environments.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+
+export const IN_NODE =
+  typeof process === "object" &&
+  typeof process.versions === "object" &&
+  typeof process.versions.node === "string" &&
+  typeof process.browser ===
+    "undefined"; /* This last condition checks if we run the browser shim of process */
+
+export const IN_NODE_COMMONJS =
+  IN_NODE &&
+  typeof module !== "undefined" &&
+  typeof module.exports !== "undefined" &&
+  typeof require !== "undefined" &&
+  typeof __dirname !== "undefined";
+
+export const IN_NODE_ESM = IN_NODE && !IN_NODE_COMMONJS;
+
+export const IN_DENO = typeof Deno !== "undefined"; // just in case...
+
+export const IN_BROWSER = !IN_NODE && !IN_DENO && typeof window !== "undefined";
+
+export const IN_BROWSER_MAIN_THREAD =
+  IN_BROWSER &&
+  typeof document !== "undefined" &&
+  typeof document.createElement !== "undefined" &&
+  typeof sessionStorage !== "undefined";
+
+export const IN_BROWSER_WEB_WORKER =
+  IN_BROWSER &&
+  typeof importScripts !== "undefined" &&
+  typeof self !== "undefined";

--- a/src/js/environments.ts
+++ b/src/js/environments.ts
@@ -18,10 +18,11 @@ export const IN_NODE_ESM = IN_NODE && !IN_NODE_COMMONJS;
 
 export const IN_DENO = typeof Deno !== "undefined"; // just in case...
 
-export const IN_BROWSER = !IN_NODE && !IN_DENO && typeof window !== "undefined";
+export const IN_BROWSER = !IN_NODE && !IN_DENO;
 
 export const IN_BROWSER_MAIN_THREAD =
   IN_BROWSER &&
+  typeof window !== "undefined" &&
   typeof document !== "undefined" &&
   typeof document.createElement !== "undefined" &&
   typeof sessionStorage !== "undefined";

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -1,7 +1,7 @@
 import "./constants";
 
+import { IN_NODE } from "./environments";
 import {
-  IN_NODE,
   nodeFsPromisesMod,
   loadBinaryFile,
   initNodeModules,

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -2,6 +2,7 @@
  * The main bootstrap code for loading pyodide.
  */
 import {
+  calculateDirname,
   loadScript,
   initNodeModules,
   resolvePath,

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -1,11 +1,9 @@
 /**
  * The main bootstrap code for loading pyodide.
  */
-import ErrorStackParser from "error-stack-parser";
 import {
   loadScript,
   initNodeModules,
-  pathSep,
   resolvePath,
   loadLockFile,
 } from "./compat";
@@ -35,44 +33,6 @@ export type {
 export { version };
 
 declare function _createPyodideModule(Module: any): Promise<void>;
-
-/**
- *  If indexURL isn't provided, throw an error and catch it and then parse our
- *  file name out from the stack trace.
- *
- *  Question: But getting the URL from error stack trace is well... really
- *  hacky. Can't we use
- *  [`document.currentScript`](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript)
- *  or
- *  [`import.meta.url`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta)
- *  instead?
- *
- *  Answer: `document.currentScript` works for the browser main thread.
- *  `import.meta` works for es6 modules. In a classic webworker, I think there
- *  is no approach that works. Also we would need some third approach for node
- *  when loading a commonjs module using `require`. On the other hand, this
- *  stack trace approach works for every case without any feature detection
- *  code.
- */
-function calculateIndexURL(): string {
-  if (typeof __dirname === "string") {
-    return __dirname;
-  }
-  let err: Error;
-  try {
-    throw new Error();
-  } catch (e) {
-    err = e as Error;
-  }
-  let fileName = ErrorStackParser.parse(err)[0].fileName!;
-  const indexOfLastSlash = fileName.lastIndexOf(pathSep);
-  if (indexOfLastSlash === -1) {
-    throw new Error(
-      "Could not extract indexURL path from pyodide module location",
-    );
-  }
-  return fileName.slice(0, indexOfLastSlash);
-}
 
 /**
  * See documentation for loadPyodide.
@@ -226,7 +186,7 @@ export async function loadPyodide(
   } = {},
 ): Promise<PyodideInterface> {
   await initNodeModules();
-  let indexURL = options.indexURL || calculateIndexURL();
+  let indexURL = options.indexURL || (await calculateDirname());
   indexURL = resolvePath(indexURL); // A relative indexURL causes havoc.
   if (!indexURL.endsWith("/")) {
     indexURL += "/";

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -1,4 +1,4 @@
-import { IN_NODE } from "./compat.js";
+import { IN_NODE } from "./environments.js";
 import "./constants";
 
 import type { FSStream, FSStreamOpsGen } from "./types";


### PR DESCRIPTION
### Description

Resolve https://github.com/pyodide/pyodide/issues/4232

This fixes the default index URL calculation bug in the node environment when using ES modules.

The bug happens because [`__dirname` is not available in ESM module](https://blog.logrocket.com/alternatives-dirname-node-js-es-modules/), hence `calculateIndexURL` returns the incorrect path.

So I used `import.meta.url` to calculate the dirname when the environment is ESM. It looks like `import.meta.dirname` is coming to node (https://github.com/nodejs/node/pull/48740) soon, but we can't use it yet.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
