### PR TITLE
Update ContourPy to 1.2.0

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -69,6 +69,8 @@ myst:
 
 - Added `msgspec` version 0.18.4 {pr}`4265`
 
+- Upgraded `contourpy` to 1.2.0 {pr}`4291`
+
 ### Load time & size optimizations
 
 - {{ Performance }} Do not use `importlib.metadata` when identifying installed packages,

--- a/packages/contourpy/meta.yaml
+++ b/packages/contourpy/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: contourpy
-  version: 1.0.7
+  version: 1.2.0
   top-level:
     - contourpy
 
 source:
-  url: https://files.pythonhosted.org/packages/b4/9b/6edb9d3e334a70a212f66a844188fcb57ddbd528cbc3b1fe7abfc317ddd7/contourpy-1.0.7.tar.gz
-  sha256: d8165a088d31798b59e91117d1f5fc3df8168d8b48c4acc10fc0df0d0bdbcc5e
+  url: https://files.pythonhosted.org/packages/11/a3/48ddc7ae832b000952cf4be64452381d150a41a2299c2eb19237168528d1/contourpy-1.2.0.tar.gz
+  sha256: 171f311cb758de7da13fc53af221ae47a5877be5a0843a9fe150818c51ed276a
 
 requirements:
   run:

--- a/packages/contourpy/meta.yaml
+++ b/packages/contourpy/meta.yaml
@@ -8,6 +8,9 @@ source:
   url: https://files.pythonhosted.org/packages/11/a3/48ddc7ae832b000952cf4be64452381d150a41a2299c2eb19237168528d1/contourpy-1.2.0.tar.gz
   sha256: 171f311cb758de7da13fc53af221ae47a5877be5a0843a9fe150818c51ed276a
 
+  patches:
+    - patches/0001-Install-pybind11-from-github-repo-after-PR-4767.patch
+
 requirements:
   run:
     - numpy

--- a/packages/contourpy/patches/0001-Install-pybind11-from-github-repo-after-PR-4767.patch
+++ b/packages/contourpy/patches/0001-Install-pybind11-from-github-repo-after-PR-4767.patch
@@ -3,6 +3,10 @@ From: Ian Thomas <ianthomas23@gmail.com>
 Date: Sun, 12 Nov 2023 14:34:25 +0000
 Subject: [PATCH] Install pybind11 from github repo after PR 4767
 
+To use pybind11 with clang >= 17 we need pybind11 PR #4767. This isn't in a
+pybind11 release yet, so here installing pybind11 direct from the github commit
+that includes the PR. This patch can be removed after the next pybind11 release.
+
 ---
  pyproject.toml | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
@@ -18,8 +22,8 @@ index bbd535e..5d00911 100644
 -    "pybind11 >= 2.10.4",
 +    "pybind11@git+https://github.com/pybind/pybind11@17b614303f2176398ba3bbcec3c237628447bde5",
  ]
- 
+
  [project]
--- 
+--
 2.40.1
 

--- a/packages/contourpy/patches/0001-Install-pybind11-from-github-repo-after-PR-4767.patch
+++ b/packages/contourpy/patches/0001-Install-pybind11-from-github-repo-after-PR-4767.patch
@@ -1,0 +1,25 @@
+From d5e101ce4575125727cfa5fc2a9cbb829637beab Mon Sep 17 00:00:00 2001
+From: Ian Thomas <ianthomas23@gmail.com>
+Date: Sun, 12 Nov 2023 14:34:25 +0000
+Subject: [PATCH] Install pybind11 from github repo after PR 4767
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index bbd535e..5d00911 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -3,7 +3,7 @@ build-backend = "mesonpy"
+ requires = [
+     "meson >= 1.2.0",
+     "meson-python >= 0.13.1",
+-    "pybind11 >= 2.10.4",
++    "pybind11@git+https://github.com/pybind/pybind11@17b614303f2176398ba3bbcec3c237628447bde5",
+ ]
+ 
+ [project]
+-- 
+2.40.1
+

--- a/packages/contourpy/test_contourpy.py
+++ b/packages/contourpy/test_contourpy.py
@@ -11,10 +11,12 @@ from pytest_pyodide import run_in_pyodide
         ("serial", "SeparateCode"),
         ("serial", "ChunkCombinedCode"),
         ("serial", "ChunkCombinedOffset"),
+        ("serial", "ChunkCombinedNan"),
         ("threaded", "Separate"),
         ("threaded", "SeparateCode"),
         ("threaded", "ChunkCombinedCode"),
         ("threaded", "ChunkCombinedOffset"),
+        ("threaded", "ChunkCombinedNan"),
     ],
 )
 @run_in_pyodide(packages=["contourpy", "numpy"])
@@ -77,6 +79,13 @@ def test_line(selenium, name, line_type):
         assert_array_almost_equal(points[:5], expect0)
         assert_array_almost_equal(points[5:], expect1)
         assert_array_equal(offsets, [0, 5, 7])
+    elif cont_gen.line_type == LineType.ChunkCombinedNan:
+        assert len(lines[0]) == 1  # Single chunk.
+        points = lines[0][0]
+        assert points.shape == (8, 2)
+        assert_array_almost_equal(points[:5], expect0)
+        assert np.all(np.isnan(points[5, :]))
+        assert_array_almost_equal(points[6:], expect1)
     else:
         raise RuntimeError(f"Unexpected line_type {line_type}")
 


### PR DESCRIPTION
Update ContourPy to the latest release, 1.2.0. This uses `meson` and `meson-python` to build, and following the recent improvements to meson-based builds here, such as the automagic use of `emscripten.meson.cross`, this was really easy.

To use `pybind11` with  `clang >= 17` we need pybind/pybind11#4767. This isn't in a `pybind11` release yet, so I have included a patch to install `pybind11` direct from the github commit that includes the PR. This patch can be removed after the next `pybind11` release.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
