### PR TITLE
Keep webpackIgnore comments in pyodide.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__
 .pytest_cache/
 .vscode
 .venv*
+tsconfig.tsbuildinfo
 
 build
 ccache

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ node_modules/.installed : src/js/package.json src/js/package-lock.json
 	touch node_modules/.installed
 
 dist/pyodide.js src/js/generated/_pyodide.out.js: src/js/*.ts src/js/generated/pyproxy.ts node_modules/.installed
-	cd src/js && npm run tsc && node esbuild.config.mjs && cd -
+	cd src/js && npm run build && cd -
 
 src/core/stack_switching/stack_switching.out.js : src/core/stack_switching/*.mjs
 	node src/core/stack_switching/esbuild.config.mjs

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -23,6 +23,9 @@ myst:
 - {{ Fix }} Fixed default indexURL calculation in Node.js environment.
   {pr}`4288`
 
+- {{ Fix }} Fixed a bug that webpack messes up dynamic import of `pyodide.asm.js`.
+  {pr}`4294`
+
 - {{ Enhancement }} Added experimental support for stack switching.
   {pr}`3957`, {pr}`3964`, {pr}`3987`, {pr}`3990`, {pr}`3210`
 

--- a/src/js/esbuild.config.mjs
+++ b/src/js/esbuild.config.mjs
@@ -96,7 +96,14 @@ try {
     );
 
     // inject webpackIgnore comments
+<<<<<<< Updated upstream
     content = content.replace("import(", "import(/* webpackIgnore */");
+=======
+    content = content.replaceAll(
+      "import(",
+      "import(/* webpackIgnore */",
+    );
+>>>>>>> Stashed changes
 
     writeFileSync(outfile, content);
   }

--- a/src/js/esbuild.config.mjs
+++ b/src/js/esbuild.config.mjs
@@ -95,6 +95,12 @@ try {
       `try{Object.assign(exports,${name})}catch(_){}\nglobalThis.${name}=${name}.${name};\n//# sourceMappingURL`,
     );
 
+    // inject webpackIgnore comments
+    content = content.replace(
+      "import(",
+      "import(/* webpackIgnore */",
+    );
+
     writeFileSync(outfile, content);
   }
 } catch ({ message }) {

--- a/src/js/esbuild.config.mjs
+++ b/src/js/esbuild.config.mjs
@@ -96,10 +96,7 @@ try {
     );
 
     // inject webpackIgnore comments
-    content = content.replace(
-      "import(",
-      "import(/* webpackIgnore */",
-    );
+    content = content.replace("import(", "import(/* webpackIgnore */");
 
     writeFileSync(outfile, content);
   }

--- a/src/js/esbuild.config.mjs
+++ b/src/js/esbuild.config.mjs
@@ -96,14 +96,7 @@ try {
     );
 
     // inject webpackIgnore comments
-<<<<<<< Updated upstream
-    content = content.replace("import(", "import(/* webpackIgnore */");
-=======
-    content = content.replaceAll(
-      "import(",
-      "import(/* webpackIgnore */",
-    );
->>>>>>> Stashed changes
+    content = content.replaceAll("import(", "import(/* webpackIgnore */");
 
     writeFileSync(outfile, content);
   }

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -79,6 +79,7 @@
     "ws": false
   },
   "scripts": {
+    "build": "tsc --noEmit && node esbuild.config.mjs",
     "test": "npm-run-all test:*",
     "test:unit": "cross-env TEST_NODE=1 ts-mocha --node-option=experimental-loader=./test/loader.mjs --node-option=experimental-wasm-stack-switching -p tsconfig.test.json test/unit/**/*.test.*",
     "test:node": "cross-env TEST_NODE=1 mocha test/integration/**/*.test.js",

--- a/src/js/tsconfig.json
+++ b/src/js/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "ES2022",
     "moduleResolution": "node",
     "composite": true,
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "strict": true,
     "noUnusedLocals": false,
     "types": ["node"],


### PR DESCRIPTION
### Description

Resolve #4174

After we changed our build system to esbuild (https://github.com/pyodide/pyodide/pull/3679), `/* webpackIgnore */` comments were stripped out after the build.

Since we dynamically import pyodide.asm.js from pyodide.[m]js, this comment is required for webpack bundler (unless we find a better way to deal with this... like merging pyodide.js and pyodide.mjs? I don't know.)

This PR fixes it by putting webpackIgnore comments for every `import()` statement after building pyodide.js.
A user can do this by adding a webpack plugin, as described in [pyodide-webpack-plugin](https://github.com/pyodide/pyodide-webpack-plugin/blob/9112d85cfe45325d43b73301a10c1202f1570f78/README.md?plain=1#L100-L119), but I think it is better if we can handle it.

Related:

- https://github.com/pyodide/pyodide/issues/4004
- https://github.com/pyodide/pyodide/issues/4174
- https://github.com/evanw/esbuild/issues/2721: esbuild added support for preserving magic comments, but it is not compatible with some `minify` flags.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
