### PR TITLE
JSPI Improve support for runtimes that don't allow dynamic eval

### DIFF
--- a/src/core/_pyodide_core.c
+++ b/src/core/_pyodide_core.c
@@ -8,7 +8,11 @@
 
 #define FATAL_ERROR(args...)                                                   \
   do {                                                                         \
-    PyErr_Format(PyExc_ImportError, args);                                     \
+    if (PyErr_Occurred()) {                                                    \
+      _PyErr_FormatFromCause(PyExc_ImportError, args);                         \
+    } else {                                                                   \
+      PyErr_Format(PyExc_ImportError, args);                                   \
+    }                                                                          \
     FAIL();                                                                    \
   } while (0)
 

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -223,7 +223,11 @@ function isPyodideFrame(frame: ErrorStackParser.StackFrame): boolean {
   if (funcName.startsWith("Object.")) {
     funcName = funcName.slice("Object.".length);
   }
-  if (funcName in API.public_api && funcName !== "PythonError") {
+  if (
+    API.public_api &&
+    funcName in API.public_api &&
+    funcName !== "PythonError"
+  ) {
     frame.functionName = funcName;
     return false;
   }

--- a/src/core/stack_switching/stack_switching.mjs
+++ b/src/core/stack_switching/stack_switching.mjs
@@ -14,9 +14,26 @@ export { promisingApply, createPromising } from "./suspenders.mjs";
 
 export { jsWrapperTag };
 
-Module.preRun.push(initSuspenders);
+Module.jspiSupported = false;
+Module.validSuspender = { value: 0 };
 
-if (jsWrapperTag) {
+// wasm-feature-detect uses `"Suspender" in WebAssembly` feature detect JSPI. It
+// is not 100% clear based on the text of the JSPI proposal that this will
+// actually work in the future, but if it breaks we can replace it with
+// something else that does work.
+if ("Suspender" in WebAssembly) {
+  try {
+    // Check that WebAssembly.Module constructor works -- if dynamic eval is
+    // disabled it might raise.
+    // This is the smallest valid wasm module -- only the magic number and wasm
+    // version.
+    new WebAssembly.Module(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]));
+    Module.jspiSupported = true;
+  } catch (e) {}
+}
+
+if (Module.jspiSupported) {
+  Module.preRun.push(initSuspenders);
   Module.adjustWasmImports = adjustWasmImports;
   Module.wrapException = wrapException;
 }

--- a/src/core/stack_switching/suspenders.mjs
+++ b/src/core/stack_switching/suspenders.mjs
@@ -200,19 +200,8 @@ let validSuspender;
  * everything else can work as normal.
  */
 export function initSuspenders() {
-  // This is what wasm-feature-detect uses to feature detect JSPI. It is not
-  // 100% clear based on the text of the JSPI proposal that this will actually
-  // work in the future, but if it breaks we can replace it with something else
-  // that does work.
-  Module.jspiSupported = "Suspender" in WebAssembly;
-
-  if (Module.jspiSupported) {
-    validSuspender = new WebAssembly.Global({ value: "i32", mutable: true }, 0);
-    promisingApplyHandler = createPromising(wasmExports._pyproxy_apply);
-    Module.validSuspender = validSuspender;
-    setSyncifyHandler();
-  } else {
-    // Browser doesn't support JSPI.
-    Module.validSuspender = { value: 0 };
-  }
+  validSuspender = new WebAssembly.Global({ value: "i32", mutable: true }, 0);
+  promisingApplyHandler = createPromising(wasmExports._pyproxy_apply);
+  Module.validSuspender = validSuspender;
+  setSyncifyHandler();
 }

--- a/src/tests/test_syncify.py
+++ b/src/tests/test_syncify.py
@@ -2,12 +2,35 @@ import pytest
 
 
 @pytest.mark.xfail_browsers(node="Scopes don't work as needed")
-def test_syncify_not_supported(selenium_standalone_noload):
+def test_syncify_not_supported1(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     selenium.run_js(
         """
         // Ensure that it's not supported by deleting WebAssembly.Suspender
         delete WebAssembly.Suspender;
+        let pyodide = await loadPyodide({});
+        await assertThrowsAsync(
+          async () => await pyodide.runPythonSyncifying("1+1"),
+          "Error",
+          "WebAssembly stack switching not supported in this JavaScript runtime"
+        );
+        await assertThrows(
+          () => pyodide.runPython("from js import sleep; sleep().syncify()"),
+          "PythonError",
+          "RuntimeError: WebAssembly stack switching not supported in this JavaScript runtime"
+        );
+        """
+    )
+
+
+@pytest.mark.xfail_browsers(node="Scopes don't work as needed")
+def test_syncify_not_supported2(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+    selenium.run_js(
+        """
+        // Disable direct instantation of WebAssembly.Modules
+        // Note: only will work with newer runtimes that have WebAssembly.Function
+        WebAssembly.Module = new Proxy(WebAssembly.Module, {construct(){throw new Error("NOPE!");}});
         let pyodide = await loadPyodide({});
         await assertThrowsAsync(
           async () => await pyodide.runPythonSyncifying("1+1"),

--- a/src/tests/test_syncify.py
+++ b/src/tests/test_syncify.py
@@ -28,7 +28,7 @@ def test_syncify_not_supported2(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     selenium.run_js(
         """
-        // Disable direct instantation of WebAssembly.Modules
+        // Disable direct instantiation of WebAssembly.Modules
         // Note: only will work with newer runtimes that have WebAssembly.Function
         WebAssembly.Module = new Proxy(WebAssembly.Module, {construct(){throw new Error("NOPE!");}});
         let pyodide = await loadPyodide({});


### PR DESCRIPTION
This fixes it so that if `new WebAssembly.Module` fails, we don't try to use it in JSPI. This doesn't 100% fix no-dynamic-eval but it makes it work a lot better.

- [x] Add / update tests
