### PR TITLE
Add --config-setting flag to `pyodide build` command.

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -58,6 +58,10 @@ myst:
   build to set the same variables as in-tree build.
   {pr}`4241`
 
+- {{ Enhancement }} `pyodide build` command now accepts `--config-setting` (`-C`) option
+  to pass flags to the build backend, just like `python -m build` command.
+  {pr}`4308`
+
 ### Packages
 
 - New Packages: `river` {pr}`4197`, `sisl` {pr}`4210`, `frozenlist` {pr}`4231`,

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -423,7 +423,7 @@ def compile(
         target_install_dir=target_install_dir,
         exports=build_metadata.exports,
     )
-    backend_flags = build_metadata.backend_flags
+    config_settings = pypabuild.parse_backend_flags(build_metadata.backend_flags)
 
     with build_env_ctx as build_env:
         if build_metadata.cross_script is not None:
@@ -436,7 +436,7 @@ def compile(
         from .pypabuild import build
 
         outpath = srcpath / "dist"
-        build(srcpath, outpath, build_env, backend_flags)
+        build(srcpath, outpath, build_env, config_settings)
 
 
 def copy_sharedlibs(

--- a/pyodide-build/pyodide_build/cli/build.py
+++ b/pyodide-build/pyodide_build/cli/build.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 import requests
 import typer
+from build import ConfigSettingsType
 
 from ..build_env import check_emscripten_version, get_pyodide_root, init_environment
 from ..io import _BuildSpecExports, _ExportTypes
@@ -18,6 +19,7 @@ from ..out_of_tree.pypi import (
     build_wheels_from_pypi_requirements,
     fetch_pypi_package,
 )
+from ..pypabuild import parse_backend_flags
 
 
 def convert_exports(exports: str) -> _BuildSpecExports:
@@ -38,15 +40,10 @@ def convert_exports(exports: str) -> _BuildSpecExports:
 def pypi(
     package: str,
     output_directory: Path,
-    exports: str = typer.Option(
-        "requested",
-        envvar="PYODIDE_BUILD_EXPORTS",
-        help="Which symbols should be exported when linking .so files?",
-    ),
-    ctx: typer.Context = typer.Context,  # type: ignore[assignment]
+    exports: str,
+    config_settings: ConfigSettingsType,
 ) -> Path:
     """Fetch a wheel from pypi, or build from source if none available."""
-    backend_flags = ctx.args
     with tempfile.TemporaryDirectory() as tmpdir:
         srcdir = Path(tmpdir)
 
@@ -60,7 +57,10 @@ def pypi(
             return dest_file
 
         built_wheel = build.run(
-            srcdir, output_directory, convert_exports(exports), backend_flags
+            srcdir,
+            output_directory,
+            convert_exports(exports),
+            config_settings,
         )
         return built_wheel
 
@@ -80,15 +80,10 @@ def download_url(url: str, output_directory: Path) -> str:
 def url(
     package_url: str,
     output_directory: Path,
-    exports: str = typer.Option(
-        "requested",
-        envvar="PYODIDE_BUILD_EXPORTS",
-        help="Which symbols should be exported when linking .so files?",
-    ),
-    ctx: typer.Context = typer.Context,  # type: ignore[assignment]
+    exports: str,
+    config_settings: ConfigSettingsType,
 ) -> Path:
     """Fetch a wheel or build sdist from url."""
-    backend_flags = ctx.args
     with tempfile.TemporaryDirectory() as tmpdir:
         tmppath = Path(tmpdir)
         filename = download_url(package_url, tmppath)
@@ -103,7 +98,7 @@ def url(
             # unzipped into subfolder
             builddir = files[0]
         wheel_path = build.run(
-            builddir, output_directory, convert_exports(exports), backend_flags
+            builddir, output_directory, convert_exports(exports), config_settings
         )
         return wheel_path
 
@@ -111,17 +106,12 @@ def url(
 def source(
     source_location: Path,
     output_directory: Path,
-    exports: str = typer.Option(
-        "requested",
-        envvar="PYODIDE_BUILD_EXPORTS",
-        help="Which symbols should be exported when linking .so files?",
-    ),
-    ctx: typer.Context = typer.Context,  # type: ignore[assignment]
+    exports: str,
+    config_settings: ConfigSettingsType,
 ) -> Path:
     """Use pypa/build to build a Python package from source"""
-    backend_flags = ctx.args
     built_wheel = build.run(
-        source_location, output_directory, convert_exports(exports), backend_flags
+        source_location, output_directory, convert_exports(exports), config_settings
     )
     return built_wheel
 
@@ -170,6 +160,17 @@ def main(
     compression_level: int = typer.Option(
         6, help="Compression level to use for the created zip file"
     ),
+    config_setting: list[str]
+    | None = typer.Option(
+        None,
+        "--config-setting",
+        "-C",
+        help=(
+            "Settings to pass to the backend. "
+            "Works same as the --config-setting option of pypa/build."
+        ),
+        metavar="KEY[=VALUE]",
+    ),
     ctx: typer.Context = typer.Context,  # type: ignore[assignment]
 ) -> None:
     """Use pypa/build to build a Python package from source, pypi or url."""
@@ -185,6 +186,10 @@ def main(
     outpath = Path(output_directory).resolve()
     outpath.mkdir(exist_ok=True)
     extras: list[str] = []
+
+    # For backward compatibility, in addition to the `--config-setting` arguments, we also support
+    # passing config settings as positional arguments.
+    config_settings = parse_backend_flags((config_setting or []) + ctx.args)
 
     if skip_built_in_packages:
         package_lock_json = get_pyodide_root() / "dist" / "pyodide-lock.json"
@@ -223,7 +228,7 @@ def main(
                 # TODO: should we really use same "exports" value for all of our
                 # dependencies? Not sure this makes sense...
                 convert_exports(exports),
-                ctx.args,
+                config_settings,
                 output_lockfile=output_lockfile,
             )
         except BaseException as e:
@@ -239,15 +244,17 @@ def main(
             source_location = source_location[0 : source_location.find("[")]
     if not source_location:
         # build the current folder
-        wheel = source(Path.cwd(), outpath, exports, ctx)
+        wheel = source(Path.cwd(), outpath, exports, config_settings)
     elif source_location.find("://") != -1:
-        wheel = url(source_location, outpath, exports, ctx)
+        wheel = url(source_location, outpath, exports, config_settings)
     elif Path(source_location).is_dir():
         # a folder, build it
-        wheel = source(Path(source_location).resolve(), outpath, exports, ctx)
+        wheel = source(
+            Path(source_location).resolve(), outpath, exports, config_settings
+        )
     elif source_location.find("/") == -1:
         # try fetch or build from pypi
-        wheel = pypi(source_location, outpath, exports, ctx)
+        wheel = pypi(source_location, outpath, exports, config_settings)
     else:
         raise RuntimeError(f"Couldn't determine source type for {source_location}")
     # now build deps for wheel
@@ -260,7 +267,7 @@ def main(
                 # TODO: should we really use same "exports" value for all of our
                 # dependencies? Not sure this makes sense...
                 convert_exports(exports),
-                ctx.args,
+                config_settings,
                 output_lockfile=output_lockfile,
                 compression_level=compression_level,
             )

--- a/pyodide-build/pyodide_build/cli/build.py
+++ b/pyodide-build/pyodide_build/cli/build.py
@@ -118,7 +118,9 @@ def source(
 
 # simple 'pyodide build' command
 def main(
-    source_location: "Optional[str]" = typer.Argument(
+    source_location: Optional[  # noqa: typer does not accept list[str] | None yet.
+        str
+    ] = typer.Argument(
         "",
         help="Build source, can be source folder, pypi version specification, "
         "or url to a source dist archive or wheel file. If this is blank, it "
@@ -160,8 +162,9 @@ def main(
     compression_level: int = typer.Option(
         6, help="Compression level to use for the created zip file"
     ),
-    config_setting: list[str]
-    | None = typer.Option(
+    config_setting: Optional[  # noqa: typer does not accept list[str] | None yet.
+        list[str]
+    ] = typer.Option(
         None,
         "--config-setting",
         "-C",

--- a/pyodide-build/pyodide_build/out_of_tree/build.py
+++ b/pyodide-build/pyodide_build/out_of_tree/build.py
@@ -1,12 +1,17 @@
 import os
 from pathlib import Path
 
+from build import ConfigSettingsType
+
 from .. import build_env, common, pypabuild
 from ..io import _BuildSpecExports
 
 
 def run(
-    srcdir: Path, outdir: Path, exports: _BuildSpecExports, args: list[str]
+    srcdir: Path,
+    outdir: Path,
+    exports: _BuildSpecExports,
+    config_settings: ConfigSettingsType,
 ) -> Path:
     outdir = outdir.resolve()
     cflags = build_env.get_build_flag("SIDE_MODULE_CFLAGS")
@@ -32,7 +37,7 @@ def run(
     )
 
     with build_env_ctx as env:
-        built_wheel = pypabuild.build(srcdir, outdir, env, " ".join(args))
+        built_wheel = pypabuild.build(srcdir, outdir, env, config_settings)
 
     wheel_path = Path(built_wheel)
     with common.modify_wheel(wheel_path) as wheel_dir:

--- a/pyodide-build/pyodide_build/out_of_tree/pypi.py
+++ b/pyodide-build/pyodide_build/out_of_tree/pypi.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 from zipfile import ZipFile
 
 import requests
+from build import ConfigSettingsType
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import Version
@@ -234,7 +235,7 @@ def get_metadata_for_wheel(url):
 
 
 class PyPIProvider(APBase):
-    BUILD_FLAGS: list[str] = []
+    BUILD_FLAGS: ConfigSettingsType = {}
     BUILD_SKIP: list[str] = []
     BUILD_EXPORTS: _BuildSpecExports = []
 
@@ -378,7 +379,7 @@ def build_wheels_from_pypi_requirements(
     build_dependencies: bool,
     skip_dependency: list[str],
     exports: _BuildSpecExports,
-    build_flags: list[str],
+    config_settings: ConfigSettingsType,
     output_lockfile: str | None,
 ) -> None:
     """
@@ -387,7 +388,7 @@ def build_wheels_from_pypi_requirements(
     """
     _parse_skip_list(skip_dependency)
     PyPIProvider.BUILD_EXPORTS = exports
-    PyPIProvider.BUILD_FLAGS = build_flags
+    PyPIProvider.BUILD_FLAGS = config_settings
     _resolve_and_build(
         reqs,
         target_folder,
@@ -402,7 +403,7 @@ def build_dependencies_for_wheel(
     extras: list[str],
     skip_dependency: list[str],
     exports: _BuildSpecExports,
-    build_flags: list[str],
+    config_settings: ConfigSettingsType,
     output_lockfile: str | None,
     compression_level: int = 6,
 ) -> None:
@@ -417,7 +418,7 @@ def build_dependencies_for_wheel(
     _parse_skip_list(skip_dependency)
 
     PyPIProvider.BUILD_EXPORTS = exports
-    PyPIProvider.BUILD_FLAGS = build_flags
+    PyPIProvider.BUILD_FLAGS = config_settings
     with ZipFile(wheel) as z:
         for n in z.namelist():
             if n.endswith(".dist-info/METADATA"):

--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -161,9 +161,13 @@ def _build_in_isolated_env(
             return builder.build(distribution, outdir, config_settings)
 
 
-def parse_backend_flags(backend_flags: str) -> ConfigSettingsType:
+def parse_backend_flags(backend_flags: str | list[str]) -> ConfigSettingsType:
     config_settings: dict[str, str | list[str]] = {}
-    for arg in backend_flags.split():
+
+    if isinstance(backend_flags, str):
+        backend_flags = backend_flags.split()
+
+    for arg in backend_flags:
         setting, _, value = arg.partition("=")
         if setting not in config_settings:
             config_settings[setting] = value
@@ -272,10 +276,9 @@ def build(
     srcdir: Path,
     outdir: Path,
     build_env: Mapping[str, str],
-    backend_flags: str,
+    config_settings: ConfigSettingsType,
 ) -> str:
     distribution = "wheel"
-    config_settings = parse_backend_flags(backend_flags)
     try:
         with _handle_build_error():
             built = _build_in_isolated_env(

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -455,7 +455,7 @@ def test_build1(selenium, tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert results["srcdir"] == srcdir
     assert results["outdir"] == outdir
-    assert results["backend_flags"] == "x y z"
+    assert results["backend_flags"] == {'x': '', 'y': '', 'z': ''}
 
 
 def test_build2_replace_so_abi_tags(selenium, tmp_path, monkeypatch):

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -455,7 +455,7 @@ def test_build1(selenium, tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert results["srcdir"] == srcdir
     assert results["outdir"] == outdir
-    assert results["backend_flags"] == {'x': '', 'y': '', 'z': ''}
+    assert results["backend_flags"] == {"x": "", "y": "", "z": ""}
 
 
 def test_build2_replace_so_abi_tags(selenium, tmp_path, monkeypatch):


### PR DESCRIPTION
### Description

This PR adds `--config-setting` (`-C`) flag to `pyodide build` command, to make it compatible to [`python -m build`](https://pypa-build.readthedocs.io/en/stable/#python--m-build---config-setting).

Previously, we were passing any extra parameters to config-settings. For example, if someone wanted to run a build command like `python -m build -C--key=value`, they should have to run `pyodide build --key=value`. But now they can do `pyodide build -C--key=value`.

For backward compatibility, this PR does not drop the old behavior. So `pyodide build --key=value` will still work.

Related: https://github.com/numpy/numpy/pull/24603#issuecomment-1713542924

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
