### PR TITLE
FIX Set playwright version cap temporarily

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,6 +178,8 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -e ./pyodide-build
+          # FIXME: pytest-pyodide hangs in playwright==1.40, chromium
+          pip install playwright<1.40
           python -m playwright install
 
       - name: run core tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
           pip install -r requirements.txt
           pip install -e ./pyodide-build
           # FIXME: pytest-pyodide hangs in playwright==1.40, chromium
-          pip install playwright<1.40
+          pip install "playwright<1.40"
           python -m playwright install
 
       - name: run core tests


### PR DESCRIPTION
### Description

`pytest-pyodide` hangs when we run tests with playwright==1.40 (latest release) / chromium.

- CI log: https://github.com/pyodide/pyodide/actions/runs/6985149093/job/19009353722

I'm looking into it to see what the reason is. Setting the version cap while it is resolved.