### PR TITLE
TYPO Fix pyodide.setStdout docstring

### DIFF
--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -450,7 +450,7 @@ function _getStderrDefaults(): StdwriteOpts & Partial<Writer> {
  * works as expected.
  *
  * @param options.batched A batched handler is called with a string whenever a
- * newline character is written is written or stdout is flushed. In the former
+ * newline character is written or stdout is flushed. In the former
  * case, the received line will end with a newline, in the latter case it will
  * not.
  * @param options.raw A raw handler is called with the handler is called with a


### PR DESCRIPTION
### Description

The docstring describing the options.batched argument for pyodide.setStdout contains the words "is written" twice. It should only be written once.

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation
