### PR TITLE
TYPING More accurate type for `JsPromise`

### DIFF
--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -385,7 +385,7 @@ class JsPromise(JsProxy, Generic[T]):
     )
     def then(
         self,
-        onfulfilled: Any = None,
+        onfulfilled: Any,
         onrejected: Any = None,
     ) -> Any:
         """The :js:meth:`Promise.then` API, wrapped to manage the lifetimes of the

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -32,6 +32,7 @@ _save_name = __name__
 __name__ = ""
 
 T = TypeVar("T")
+S = TypeVar("S")
 KT = TypeVar("KT")  # Key type.
 VT = TypeVar("VT")  # Value type.
 Tco = TypeVar("Tco", covariant=True)  # Any type covariant containers.
@@ -339,7 +340,7 @@ class JsDoubleProxy(JsProxy):
         raise NotImplementedError
 
 
-class JsPromise(JsProxy):
+class JsPromise(JsProxy, Generic[T]):
     """A :py:class:`~pyodide.ffi.JsProxy` of a :js:class:`Promise` or some other `thenable
     <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables>`_
     JavaScript object.
@@ -349,27 +350,74 @@ class JsPromise(JsProxy):
 
     _js_type_flags = ["IS_AWAITABLE"]
 
+    @overload
     def then(
-        self, onfulfilled: Callable[[Any], Any], onrejected: Callable[[Any], Any]
-    ) -> "JsPromise":
+        self, onfulfilled: None, onrejected: Callable[[BaseException], Awaitable[S]], /
+    ) -> "JsPromise[S]":
+        ...
+
+    @overload
+    def then(
+        self, onfulfilled: None, onrejected: Callable[[BaseException], S], /
+    ) -> "JsPromise[S]":
+        ...
+
+    @overload
+    def then(
+        self,
+        onfulfilled: Callable[[T], Awaitable[S]],
+        onrejected: Callable[[BaseException], Awaitable[S]] | None = None,
+        /,
+    ) -> "JsPromise[S]":
+        ...
+
+    @overload
+    def then(
+        self,
+        onfulfilled: Callable[[T], S],
+        onrejected: Callable[[BaseException], S] | None = None,
+        /,
+    ) -> "JsPromise[S]":
+        ...
+
+    @docs_argspec(
+        "(self, onfulfilled: Callable[[T], Awaitable[S] | S] | None, onrejected: Callable[[BaseException], Awaitable[S] | S] | None = None, /) -> 'JsPromise[S]'"
+    )
+    def then(
+        self,
+        onfulfilled: Any = None,
+        onrejected: Any = None,
+    ) -> Any:
         """The :js:meth:`Promise.then` API, wrapped to manage the lifetimes of the
         handlers.
-
         Pyodide will automatically release the references to the handlers
         when the promise resolves.
         """
-        raise NotImplementedError
+        pass
 
-    def catch(self, onrejected: Callable[[Any], Any], /) -> "JsPromise":
+    @overload
+    def catch(
+        self, onrejected: Callable[[BaseException], Awaitable[S]], /
+    ) -> "JsPromise[S]":
+        ...
+
+    @overload
+    def catch(self, onrejected: Callable[[BaseException], S], /) -> "JsPromise[S]":
+        ...
+
+    @docs_argspec(
+        "(self, onrejected: Callable[[BaseException], Awaitable[S] | S], /) -> 'JsPromise[S]'"
+    )
+    def catch(self, onrejected: Any, /) -> Any:
         """The :js:meth:`Promise.catch` API, wrapped to manage the lifetimes of the
         handler.
 
         Pyodide will automatically release the references to the handler
         when the promise resolves.
         """
-        raise NotImplementedError
+        pass
 
-    def finally_(self, onfinally: Callable[[], Any], /) -> "JsPromise":
+    def finally_(self, onfinally: Callable[[], None], /) -> "JsPromise[T]":
         """The :js:meth:`Promise.finally` API, wrapped to manage the lifetimes of
         the handler.
 
@@ -377,7 +425,7 @@ class JsPromise(JsProxy):
         when the promise resolves. Note the trailing underscore in the name;
         this is needed because ``finally`` is a reserved keyword in Python.
         """
-        raise NotImplementedError
+        return self
 
 
 class JsBuffer(JsProxy):

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -776,10 +776,12 @@ def test_docstrings_a():
     from _pyodide.docstring import dedent_docstring, get_cmeth_docstring
     from pyodide.ffi import JsPromise
 
-    jsproxy = JsPromise(_instantiate_token)
+    jsproxy: JsPromise[Any] = JsPromise(_instantiate_token)
     c_docstring = get_cmeth_docstring(jsproxy.then)
-    assert c_docstring == "then(onfulfilled, onrejected)\n--\n\n" + dedent_docstring(
-        jsproxy.then.__doc__
+    assert (
+        c_docstring
+        == "then(onfulfilled, onrejected=None)\n--\n\n"
+        + dedent_docstring(jsproxy.then.__doc__)
     )
 
 
@@ -788,9 +790,9 @@ def test_docstrings_b(selenium):
     from _pyodide.docstring import dedent_docstring
     from pyodide.ffi import JsPromise, create_once_callable
 
-    jsproxy = JsPromise(_instantiate_token)
+    jsproxy: JsPromise[Any] = JsPromise(_instantiate_token)
     ds_then_should_equal = dedent_docstring(jsproxy.then.__doc__)
-    sig_then_should_equal = "(onfulfilled, onrejected)"
+    sig_then_should_equal = "(onfulfilled, onrejected=None)"
     ds_once_should_equal = dedent_docstring(create_once_callable.__doc__)
     sig_once_should_equal = "(obj, /)"
     selenium.run_js("self.a = Promise.resolve();")


### PR DESCRIPTION
We gave `PyodideFuture` a very accurate type definition for `then` and `catch`. This copies the same types to `JsPromise`. Unfortunately I was unable to work out a way to share the types between the two of them due to limitations of Python's type system.
