### PR TITLE
Fix stdin reader to avoid treating empty strings as EOF

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -61,6 +61,9 @@ myst:
 - {{ Enhancement }} Added `JsArray.remove` and `JsArray.insert` methods.
   {pr}`4326`
 
+- {{ Fix }} `pyodide.setStdin` now does not consider an empty string as EOF.
+  {pr}`4327`
+
 ### Pyodide CLI
 
 - {{ Enhancement }} `pyodide config` command now show additional config variables:

--- a/docs/usage/streams.md
+++ b/docs/usage/streams.md
@@ -42,7 +42,7 @@ zero-argument function which should return one of:
    appended if it does not already end in one).
 2. An array buffer or Uint8Array containing utf8 encoded characters
 3. A number between 0 and 255 which indicates one byte of input
-4. `undefined` which indicates EOF.
+4. `undefined` or `null` which indicates EOF.
 
 `isatty` is a boolean which
 indicates whether `sys.stdin.isatty()` should return `true` or `false`.

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -567,7 +567,7 @@ class LegacyReader {
     if (typeof val === "number") {
       return val;
     }
-    if (!val) {
+    if (val === undefined || val === null) {
       return undefined;
     }
     if (ArrayBuffer.isView(val)) {

--- a/src/tests/test_streams.py
+++ b/src/tests/test_streams.py
@@ -16,6 +16,7 @@ def test_custom_stdin1(selenium_standalone_noload):
         "pyodidé",
         "碘化物",
         "🐍",
+        "",
     ]
     outstrings: list[str] = sum(
         ((s.removesuffix("\n") + "\n").splitlines(keepends=True) for s in strings), []


### PR DESCRIPTION
### Description

Close #4258

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
