### PR TITLE
DOC Replace minimal supported browser versions with tested browser versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,11 @@ jobs:
             python -m pip install -r requirements.txt
             pip install -e ./pyodide-build
       - run:
+          name: show safari version
+          command: |
+            safari_version=$(defaults read /Applications/Safari.app/Contents/Info.plist CFBundleShortVersionString)
+            echo "Safari Version: $safari_version"
+      - run:
           name: test safari
           command: |
             export PATH="$HOME/miniforge3/bin:$PATH"

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -49,13 +49,11 @@ If you are using an older browser, some features may not work properly.
 Currently, Pyodide is being tested against the following browser versions,
 so we recommend using a browser version at least equal to or higher than these.
 
-| Browser | Version                   | Release date    |
-| ------- | ------------------------- | --------------- |
-| Firefox | 112                       | 11 April 2023 |
-| Chrome  | 112                       | 29 March 2023 |
-| Safari | 16.4                       | 27 March 2023 |
-
-
+| Browser | Version | Release date  |
+| ------- | ------- | ------------- |
+| Firefox | 112     | 11 April 2023 |
+| Chrome  | 112     | 29 March 2023 |
+| Safari  | 16.4    | 27 March 2023 |
 
 ## Web Workers
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -41,34 +41,21 @@ To avoid confusion, note that:
 
 ### Supported browsers
 
-Pyodide works in any modern web browser with WebAssembly support.
+Webassembly support in browsers is evolving very rapidly,
+and we recommend using the latest browsers whenever possible
+to take full advantage of Pyodide and its webassembly features.
+If you are using an older browser, some features may not work properly.
 
-**Tier 1** browsers are tested as part of the test suite with continuous integration,
+Currently, Pyodide is being tested against the following browser versions,
+so we recommend using a browser version at least equal to or higher than these.
 
-| Browser | Minimal supported version | Release date    |
+| Browser | Version                   | Release date    |
 | ------- | ------------------------- | --------------- |
-| Firefox | 70.0                      | 22 October 2019 |
-| Chrome  | 71.0                      | 4 December 2018 |
+| Firefox | 112                       | 11 April 2023 |
+| Chrome  | 112                       | 29 March 2023 |
+| Safari | 16.4                       | 27 March 2023 |
 
-Chrome 89 and 90 have bugs in the webassembly compiler which makes using Pyodide
-with them unstable. Known problems occur in numpy and have been observed
-occasionally in other packages. See {issue}`1384`.
 
-```{note}
-Latest browser versions generally provide more reliable WebAssembly support
-and will run Pyodide faster, so their use is recommended.
-```
-
-**Tier 2** browsers are known to work, but they are not systematically tested in
-Pyodide,
-
-| Browser | Minimal supported version | Release date      |
-| ------- | ------------------------- | ----------------- |
-| Safari  | 14.0                      | 15 September 2020 |
-| Edge    | 80                        | 26 February 2020  |
-
-Other browsers with WebAssembly support might also work however they are not
-officially supported.
 
 ## Web Workers
 


### PR DESCRIPTION
### Description

Close #4293

This PR replaces outdated minimum-supported browser versions with tested browser versions in docs.

According to Caniuse, users update their browser versions very quickly, so I think it's better to specify the version we're testing rather than mentioning a browser version that's 3-4 years old in the documentation.
