### PR TITLE
DOCS Add documentation for JSPI related methods

### DIFF
--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -2368,9 +2368,10 @@ export class PyCallableMethods {
 
   /**
    * Call the function with stack switching enabled. Functions called this way
-   * can use :py:meth:`PyodideFuture.syncify` to block until a
-   * :py:class:`Future` or :js:class:`Promise` is resolved. Only works in
-   * runtimes with JS Promise integration.
+   * can use
+   * :py:meth:`PyodideFuture.syncify() <pyodide.webloop.PyodideFuture.syncify>`
+   * to block until a :py:class:`~asyncio.Future` or :js:class:`Promise` is
+   * resolved. Only works in runtimes with JS Promise integration.
    *
    * .. admonition:: Experimental
    *    :class: warning
@@ -2381,6 +2382,36 @@ export class PyCallableMethods {
    */
   callSyncifying(...jsargs: any) {
     return callPyObjectKwargsSuspending(_getPtr(this), jsargs, {});
+  }
+
+  /**
+   * Call the function with stack switching enabled. The last argument must be
+   * an object with the keyword arguments. Functions called this way can use
+   * :py:meth:`PyodideFuture.syncify() <pyodide.webloop.PyodideFuture.syncify>`
+   * to block until a :py:class:`~asyncio.Future` or :js:class:`Promise` is
+   * resolved. Only works in runtimes with JS Promise integration.
+   *
+   * .. admonition:: Experimental
+   *    :class: warning
+   *
+   *    This feature is not yet stable.
+   *
+   * @experimental
+   */
+  callSyncifyingKwargs(...jsargs: any) {
+    if (jsargs.length === 0) {
+      throw new TypeError(
+        "callKwargs requires at least one argument (the key word argument object)",
+      );
+    }
+    let kwargs = jsargs.pop();
+    if (
+      kwargs.constructor !== undefined &&
+      kwargs.constructor.name !== "Object"
+    ) {
+      throw new TypeError("kwargs argument is not an object");
+    }
+    return callPyObjectKwargsSuspending(_getPtr(this), jsargs, kwargs);
   }
 
   /**

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -2366,6 +2366,19 @@ export class PyCallableMethods {
     return Module.callPyObjectKwargs(_getPtr(this), jsargs, kwargs);
   }
 
+  /**
+   * Call the function with stack switching enabled. Functions called this way
+   * can use :py:meth:`PyodideFuture.syncify` to block until a
+   * :py:class:`Future` or :js:class:`Promise` is resolved. Only works in
+   * runtimes with JS Promise integration.
+   *
+   * .. admonition:: Experimental
+   *    :class: warning
+   *
+   *    This feature is not yet stable.
+   *
+   * @experimental
+   */
   callSyncifying(...jsargs: any) {
     return callPyObjectKwargsSuspending(_getPtr(this), jsargs, {});
   }

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -285,6 +285,30 @@ export class PyodideAPI {
     return await API.pyodide_code.eval_code_async.callKwargs(code, options);
   }
 
+  /**
+   * Runs a Python code string like :js:func:`pyodide.runPython` but with stack
+   * switching enabled. Code executed in this way can use
+   * :py:meth:`PyodideFuture.syncify` to block until a :py:class:`Future` or
+   * :js:class:`Promise` is resolved. Only works in runtimes with JS Promise
+   * Integration enabled.
+   *
+   * .. admonition:: Experimental
+   *    :class: warning
+   *
+   *    This feature is not yet stable.
+   *
+   * @experimental
+   * @param options
+   * @param options.globals An optional Python dictionary to use as the globals.
+   * Defaults to :js:attr:`pyodide.globals`.
+   * @param options.locals An optional Python dictionary to use as the locals.
+   *        Defaults to the same as ``globals``.
+   * @param options.filename An optional string to use as the filename. Defaults
+   *        to "<exec>". If the filename does not start with "<" and end with
+   *        ">", the source code will be added to the Python linecache and
+   *        tracebacks will show source lines.
+   * @returns The result of the Python code translated to JavaScript.
+   */
   static async runPythonSyncifying(
     code: string,
     options: { globals?: PyProxy; locals?: PyProxy } = {},

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -197,16 +197,16 @@ export class PyodideAPI {
    * expression (and the code doesn't end with a semicolon), the value of the
    * expression is returned.
    *
-   * @param code Python code to evaluate
+   * @param code The Python code to run
    * @param options
    * @param options.globals An optional Python dictionary to use as the globals.
    *        Defaults to :js:attr:`pyodide.globals`.
    * @param options.locals An optional Python dictionary to use as the locals.
    *        Defaults to the same as ``globals``.
-   * @param options.filename An optional string to use as the filename. Defaults
-   *        to "<exec>". If the filename does not start with "<" and end with ">",
-   *        the source code will be added to the Python linecache and tracebacks
-   *        will show source lines.
+   * @param options.filename An optional string to use as the file name.
+   *        Defaults to ``"<exec>"``. If a custom file name is given, the
+   *        traceback for any exception that is thrown will show source lines
+   *        (unless the given file name starts with ``<`` and ends with ``>``).
    * @returns The result of the Python code translated to JavaScript. See the
    *          documentation for :py:func:`~pyodide.code.eval_code` for more info.
    * @example
@@ -262,16 +262,16 @@ export class PyodideAPI {
    *    import any python packages referenced via ``import`` statements in your
    *    code. This function will no longer do it for you.
    *
-   * @param code Python code to evaluate
+   * @param code The Python code to run
    * @param options
    * @param options.globals An optional Python dictionary to use as the globals.
    * Defaults to :js:attr:`pyodide.globals`.
    * @param options.locals An optional Python dictionary to use as the locals.
    *        Defaults to the same as ``globals``.
-   * @param options.filename An optional string to use as the filename. Defaults
-   *        to "<exec>". If the filename does not start with "<" and end with ">",
-   *        the source code will be added to the Python linecache and tracebacks
-   *        will show source lines.
+   * @param options.filename An optional string to use as the file name.
+   *        Defaults to ``"<exec>"``. If a custom file name is given, the
+   *        traceback for any exception that is thrown will show source lines
+   *        (unless the given file name starts with ``<`` and ends with ``>``).
    * @returns The result of the Python code translated to JavaScript.
    * @async
    */
@@ -288,9 +288,9 @@ export class PyodideAPI {
   /**
    * Runs a Python code string like :js:func:`pyodide.runPython` but with stack
    * switching enabled. Code executed in this way can use
-   * :py:meth:`PyodideFuture.syncify` to block until a :py:class:`Future` or
-   * :js:class:`Promise` is resolved. Only works in runtimes with JS Promise
-   * Integration enabled.
+   * :py:meth:`PyodideFuture.syncify() <pyodide.webloop.PyodideFuture.syncify>`
+   * to block until a :py:class:`~asyncio.Future` or :js:class:`Promise` is
+   * resolved. Only works in runtimes with JS Promise Integration enabled.
    *
    * .. admonition:: Experimental
    *    :class: warning
@@ -298,29 +298,26 @@ export class PyodideAPI {
    *    This feature is not yet stable.
    *
    * @experimental
+   * @param code The Python code to run
    * @param options
    * @param options.globals An optional Python dictionary to use as the globals.
    * Defaults to :js:attr:`pyodide.globals`.
    * @param options.locals An optional Python dictionary to use as the locals.
    *        Defaults to the same as ``globals``.
-   * @param options.filename An optional string to use as the filename. Defaults
-   *        to "<exec>". If the filename does not start with "<" and end with
-   *        ">", the source code will be added to the Python linecache and
-   *        tracebacks will show source lines.
+   * @param options.filename An optional string to use as the file name.
+   *        Defaults to ``"<exec>"``. If a custom file name is given, the
+   *        traceback for any exception that is thrown will show source lines
+   *        (unless the given file name starts with ``<`` and ends with ``>``).
    * @returns The result of the Python code translated to JavaScript.
    */
   static async runPythonSyncifying(
     code: string,
-    options: { globals?: PyProxy; locals?: PyProxy } = {},
+    options: { globals?: PyProxy; locals?: PyProxy; filename?: string } = {},
   ): Promise<any> {
     if (!options.globals) {
       options.globals = API.globals;
     }
-    return API.pyodide_code.eval_code.callSyncifying(
-      code,
-      options.globals,
-      options.locals,
-    );
+    return API.pyodide_code.eval_code.callSyncifyingKwargs(code, options);
   }
 
   /**

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -168,6 +168,16 @@ class PyodideFuture(Future[T]):
         return result
 
     def syncify(self):
+        """Block until the future is resolved. Only works if JS Promise
+        integration is enabled in the runtime and the current Python call stack
+        was entered via :js:func:`pyodide.runPythonSyncifying` or
+        :js:func:`~PyCallable.callSyncifying`.
+
+        .. admonition:: Experimental
+           :class: warning
+
+           This feature is not yet stable.
+        """
         from .ffi import create_proxy
 
         p = create_proxy(self)


### PR DESCRIPTION
Explains that they are experimental, require JSPI. wip, some xrefs are still broken.
It would still be nice to make `@experimental` tag autorender as an experimental admonition.