### PR TITLE
Added Python Sandbox example

### DIFF
--- a/examples/sandbox/index.html
+++ b/examples/sandbox/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Pyodide Sandbox</title>
+    <script
+      bee-module="./main"
+      src="https://cdn.jsdelivr.net/npm/@kor0p/beepy@0.8.6/dist/beepy.js"
+    ></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/sandbox/main.py
+++ b/examples/sandbox/main.py
@@ -1,0 +1,55 @@
+import io
+from contextlib import redirect_stdout
+
+from beepy import Style, Tag, mount, safe_html, state
+from beepy.tags import button, p, textarea
+from beepy.utils import ensure_sync, js
+
+DEMO_CODE = safe_html(
+    """# Example from python.org
+def fib(n):
+    a, b = 0, 1
+    while a < n:
+        print(a, end=' ')
+        a, b = b, a+b
+    print()
+fib(1000)
+"""
+)
+
+
+class Output(Tag, name="div"):
+    children = [
+        result := state("", model="change"),
+    ]
+
+
+class Main(Tag, name="main"):
+    style = Style(
+        button={"display": "block", "margin": "4px"},
+        textarea={"height": "300px", "width": "400px"},
+    )
+
+    children = [
+        run_btn := button("Run"),
+        reset_btn := button("Reset"),
+        input := textarea(value=DEMO_CODE),
+        p("Output:"),
+        out := Output(),
+    ]
+
+    @run_btn.on("click")
+    async def run_code(self):
+        with redirect_stdout(io.StringIO()) as f:
+            await js.apy(self.input.value)
+        self.out.result = f.getvalue()
+
+    @reset_btn.on("click")
+    def reset_to_demo(self):
+        self.input.value = DEMO_CODE
+
+    def mount(self):
+        ensure_sync(self.run_code())
+
+
+mount(Main(), "#root")


### PR DESCRIPTION
### Description

I want to help with #1498
There was a suggestion to create Python sandbox (like jsFiddle) to show Pyodide example without server
So, that's it :)
Example is deployed with GitHub Pages on https://kor0p.github.io/pyodide/examples/sandbox/

I didn't find "examples" directory, so created new one 😅
As mentioned in #1498, there should be tests for examples, so when idea will be approved, I'll create some tests for it, okay?

### Checklists

- [ ] Add tests

### Notes
An example is created using my little framework [BeePy](https://github.com/kor0p/BeePy), built on Pyodide. It has only main page in documentation and has no tests, but I'm working on it. I started this pet-project in Nov 2021, as a Junior, but I have big plans for it. Thanks for your work on Pyodide ♥️