### PR TITLE
MAINT Improve error message when there is a lockfile version mismatch

### DIFF
--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -259,7 +259,11 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
   );
 
   if (API.lockfile_info.version !== version) {
-    throw new Error("Lock file version doesn't match Pyodide version");
+    throw new Error(
+      "Lock file version doesn't match Pyodide version.\n" +
+        `   lockfile version: ${API.lockfile_info.version}\n` +
+        `   pyodide  version: ${version}`,
+    );
   }
   API.package_loader.init_loaded_packages();
   if (config.fullStdLib) {


### PR DESCRIPTION
This makes it a bit easier to figure out why we get this error message around releases