### PR TITLE
`pyodide_build.buildpkg`: Build in `$PYODIDE_RECIPE_BUILD_DIR ` if set

### DIFF
--- a/.devcontainer/onCreate-conda.sh
+++ b/.devcontainer/onCreate-conda.sh
@@ -18,7 +18,7 @@ echo "conda activate pyodide-env" >> ~/.bashrc
 # https://pyodide.org/en/stable/development/building-from-sources.html#using-docker
 export EMSDK_NUM_CORE=12 EMCC_CORES=12 PYODIDE_JOBS=12
 echo "export EMSDK_NUM_CORE=12 EMCC_CORES=12 PYODIDE_JOBS=12" >> ~/.bashrc
-echo "export PYODIDE_BUILD_TMP=/tmp/pyodide-build" >> ~/.bashrc
+echo "export PYODIDE_RECIPE_BUILD_DIR=/tmp/pyodide-build" >> ~/.bashrc
 
 conda run -n pyodide-env --live-stream pip install -r requirements.txt
 

--- a/.devcontainer/onCreate-docker.sh
+++ b/.devcontainer/onCreate-docker.sh
@@ -6,6 +6,8 @@ set -e
 # https://pyodide.org/en/stable/development/new-packages.html#prerequisites
 pip install -e ./pyodide-build
 
+echo "export PYODIDE_RECIPE_BUILD_DIR=/tmp/pyodide-build" >> ~/.bashrc
+
 # Building emsdk and cpython takes a few minutes to run, so we do not run it here.
 #
 # make -C emsdk

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -5,6 +5,7 @@ Build all of the packages in a given directory.
 """
 
 import dataclasses
+import os
 import shutil
 import subprocess
 import sys
@@ -78,8 +79,14 @@ class BasePackage:
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.name})"
 
+    def build_path(self) -> Path:
+        build_tmp = os.environ.get("PYODIDE_BUILD_TMP")
+        if build_tmp:
+            return Path(build_tmp) / self.name / "build"
+        return self.pkgdir / "build"
+
     def needs_rebuild(self) -> bool:
-        return needs_rebuild(self.pkgdir, self.pkgdir / "build", self.meta.source)
+        return needs_rebuild(self.pkgdir, self.build_path(), self.meta.source)
 
     def build(self, build_args: BuildArgs) -> None:
         raise NotImplementedError()

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -5,7 +5,6 @@ Build all of the packages in a given directory.
 """
 
 import dataclasses
-import os
 import shutil
 import subprocess
 import sys
@@ -477,7 +476,9 @@ def mark_package_needs_build(
         mark_package_needs_build(pkg_map, pkg_map[dep], needs_build)
 
 
-def generate_needs_build_set(pkg_map: dict[str, BasePackage], build_dir: Path) -> set[str]:
+def generate_needs_build_set(
+    pkg_map: dict[str, BasePackage], build_dir: Path
+) -> set[str]:
     """
     Generate the set of packages that need to be rebuilt.
 

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -80,7 +80,7 @@ class BasePackage:
         return f"{type(self).__name__}({self.name})"
 
     def build_path(self) -> Path:
-        build_tmp = os.environ.get("PYODIDE_BUILD_TMP")
+        build_tmp = os.environ.get("PYODIDE_RECIPE_BUILD_DIR")
         if build_tmp:
             return Path(build_tmp) / self.name / "build"
         return self.pkgdir / "build"

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -620,7 +620,9 @@ def needs_rebuild(
     """
     packaged_token = buildpath / ".packaged"
     if not packaged_token.is_file():
-        logger.debug(f"{pkg_root} needs rebuild because {packaged_token} does not exist")
+        logger.debug(
+            f"{pkg_root} needs rebuild because {packaged_token} does not exist"
+        )
         return True
 
     package_time = packaged_token.stat().st_mtime

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -620,6 +620,7 @@ def needs_rebuild(
     """
     packaged_token = buildpath / ".packaged"
     if not packaged_token.is_file():
+        logger.debug(f"{pkg_root} needs rebuild because {packaged_token} does not exist")
         return True
 
     package_time = packaged_token.stat().st_mtime
@@ -757,7 +758,7 @@ def _build_package_inner(
             shutil.rmtree(dist_dir, ignore_errors=True)
             shutil.copytree(src_dist_dir, dist_dir)
 
-        create_packaged_token(build_dir)
+        create_packaged_token(build_path)
 
 
 def _load_package_config(package_dir: Path) -> tuple[Path, MetaConfig]:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -664,7 +664,7 @@ def _build_package_inner(
     build_metadata = pkg.build
     name = pkg.package.name
     version = pkg.package.version
-    build_tmp = os.environ.get("PYODIDE_BUILD_TMP")
+    build_tmp = os.environ.get("PYODIDE_RECIPE_BUILD_DIR")
     if build_tmp:
         build_dir = Path(build_tmp) / name / "build"
         build_dir.mkdir(parents=True, exist_ok=True)

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -664,7 +664,12 @@ def _build_package_inner(
     build_metadata = pkg.build
     name = pkg.package.name
     version = pkg.package.version
-    build_dir = pkg_root / "build"
+    build_tmp = os.environ.get("PYODIDE_BUILD_TMP")
+    if build_tmp:
+        build_dir = Path(build_tmp) / name / "build"
+        build_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        build_dir = pkg_root / "build"
     dist_dir = pkg_root / "dist"
     src_dir_name: str = f"{name}-{version}"
     srcpath = build_dir / src_dir_name
@@ -694,10 +699,6 @@ def _build_package_inner(
             "Cannot find source for rebuild. Expected to find the source "
             f"directory at the path {srcpath}, but that path does not exist."
         )
-
-    import os
-    import subprocess
-    import sys
 
     try:
         stdout_fileno = sys.stdout.fileno()

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -17,6 +17,12 @@ def recipe(
         help="The directory containing the recipe of packages. "
         "If not specified, the default is ``./packages``",
     ),
+    build_dir: str = typer.Option(
+        None,
+        envvar="PYODIDE_RECIPE_BUILD_DIR",
+        help="The directory where build directories for packages are created. "
+        "Default: recipe_dir."
+    ),
     no_deps: bool = typer.Option(
         False, help="If true, do not build dependencies of the specified packages. "
     ),
@@ -80,6 +86,7 @@ def recipe(
 
     root = Path.cwd()
     recipe_dir_ = root / "packages" if not recipe_dir else Path(recipe_dir).resolve()
+    build_dir_ = recipe_dir_ if not build_dir else Path(build_dir).resolve()
     install_dir_ = root / "dist" if not install_dir else Path(install_dir).resolve()
     log_dir_ = None if not log_dir else Path(log_dir).resolve()
     n_jobs = n_jobs or get_num_cores()
@@ -105,7 +112,8 @@ def recipe(
         # TODO: use multiprocessing?
         for package in packages:
             package_path = recipe_dir_ / package
-            buildpkg.build_package(package_path, build_args, force_rebuild, continue_)
+            build_path = build_dir_ / package / "build"
+            buildpkg.build_package(package_path, build_args, build_path, force_rebuild, continue_)
 
     else:
         if len(packages) == 1 and "," in packages[0]:
@@ -116,7 +124,7 @@ def recipe(
             targets = ",".join(packages)
 
         pkg_map = buildall.build_packages(
-            recipe_dir_, targets, build_args, n_jobs, force_rebuild
+            recipe_dir_, targets, build_args, build_dir_, n_jobs, force_rebuild,
         )
 
         if log_dir_:

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -21,7 +21,7 @@ def recipe(
         None,
         envvar="PYODIDE_RECIPE_BUILD_DIR",
         help="The directory where build directories for packages are created. "
-        "Default: recipe_dir."
+        "Default: recipe_dir.",
     ),
     no_deps: bool = typer.Option(
         False, help="If true, do not build dependencies of the specified packages. "
@@ -113,7 +113,9 @@ def recipe(
         for package in packages:
             package_path = recipe_dir_ / package
             build_path = build_dir_ / package / "build"
-            buildpkg.build_package(package_path, build_args, build_path, force_rebuild, continue_)
+            buildpkg.build_package(
+                package_path, build_args, build_path, force_rebuild, continue_
+            )
 
     else:
         if len(packages) == 1 and "," in packages[0]:
@@ -124,7 +126,12 @@ def recipe(
             targets = ",".join(packages)
 
         pkg_map = buildall.build_packages(
-            recipe_dir_, targets, build_args, build_dir_, n_jobs, force_rebuild,
+            recipe_dir_,
+            targets,
+            build_args,
+            build_dir_,
+            n_jobs,
+            force_rebuild,
         )
 
         if log_dir_:

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -112,9 +112,8 @@ def recipe(
         # TODO: use multiprocessing?
         for package in packages:
             package_path = recipe_dir_ / package
-            build_path = build_dir_ / package / "build"
             buildpkg.build_package(
-                package_path, build_args, build_path, force_rebuild, continue_
+                package_path, build_args, build_dir_, force_rebuild, continue_
             )
 
     else:

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -10,7 +10,7 @@ from pyodide_build import buildall
 from pyodide_build.pywasmcross import BuildArgs
 
 RECIPE_DIR = Path(__file__).parent / "_test_recipes"
-
+BUILD_DIR = RECIPE_DIR
 
 def test_generate_dependency_graph():
     # beautifulsoup4 has a circular dependency on soupsieve
@@ -102,14 +102,14 @@ def test_build_dependencies(n_jobs, monkeypatch):
     build_list = []
 
     class MockPackage(buildall.Package):
-        def build(self, args: Any) -> None:
+        def build(self, args: Any, build_dir: Path) -> None:
             build_list.append(self.name)
 
     monkeypatch.setattr(buildall, "Package", MockPackage)
 
     pkg_map = buildall.generate_dependency_graph(RECIPE_DIR, {"pkg_1", "pkg_2"})
 
-    buildall.build_from_graph(pkg_map, BuildArgs(), n_jobs=n_jobs, force_rebuild=True)
+    buildall.build_from_graph(pkg_map, BuildArgs(), BUILD_DIR, n_jobs=n_jobs, force_rebuild=True)
 
     assert set(build_list) == {
         "pkg_1",
@@ -129,7 +129,7 @@ def test_build_error(n_jobs, monkeypatch):
     """Try building all the dependency graph, without the actual build operations"""
 
     class MockPackage(buildall.Package):
-        def build(self, args: Any) -> None:
+        def build(self, args: Any, build_dir: Path) -> None:
             raise ValueError("Failed build")
 
     monkeypatch.setattr(buildall, "Package", MockPackage)
@@ -138,7 +138,7 @@ def test_build_error(n_jobs, monkeypatch):
 
     with pytest.raises(ValueError, match="Failed build"):
         buildall.build_from_graph(
-            pkg_map, BuildArgs(), n_jobs=n_jobs, force_rebuild=True
+            pkg_map, BuildArgs(), BUILD_DIR, n_jobs=n_jobs, force_rebuild=True
         )
 
 

--- a/pyodide-build/pyodide_build/tests/test_buildall.py
+++ b/pyodide-build/pyodide_build/tests/test_buildall.py
@@ -12,6 +12,7 @@ from pyodide_build.pywasmcross import BuildArgs
 RECIPE_DIR = Path(__file__).parent / "_test_recipes"
 BUILD_DIR = RECIPE_DIR
 
+
 def test_generate_dependency_graph():
     # beautifulsoup4 has a circular dependency on soupsieve
     pkg_map = buildall.generate_dependency_graph(RECIPE_DIR, {"beautifulsoup4"})
@@ -109,7 +110,9 @@ def test_build_dependencies(n_jobs, monkeypatch):
 
     pkg_map = buildall.generate_dependency_graph(RECIPE_DIR, {"pkg_1", "pkg_2"})
 
-    buildall.build_from_graph(pkg_map, BuildArgs(), BUILD_DIR, n_jobs=n_jobs, force_rebuild=True)
+    buildall.build_from_graph(
+        pkg_map, BuildArgs(), BUILD_DIR, n_jobs=n_jobs, force_rebuild=True
+    )
 
     assert set(build_list) == {
         "pkg_1",

--- a/pyodide-build/pyodide_build/tests/test_buildpkg.py
+++ b/pyodide-build/pyodide_build/tests/test_buildpkg.py
@@ -102,8 +102,7 @@ def test_prepare_source(monkeypatch, tmp_path):
 
     for pkg in test_pkgs:
         source_dir_name = pkg.package.name + "-" + pkg.package.version
-        pkg_root = Path(pkg.package.name)
-        buildpath = tmp_path / pkg_root / "build"
+        buildpath = tmp_path / pkg.package.name / "build"
         src_metadata = pkg.source
         srcpath = buildpath / source_dir_name
         buildpkg.prepare_source(buildpath, srcpath, src_metadata)
@@ -153,11 +152,10 @@ def test_unvendor_tests(tmpdir):
 
 
 def test_needs_rebuild(tmpdir):
-    pkg_root = tmpdir
-    pkg_root = Path(pkg_root)
-    builddir = pkg_root / "build"
+    pkg_root = Path(tmpdir)
+    buildpath = pkg_root / "build"
     meta_yaml = pkg_root / "meta.yaml"
-    packaged = builddir / ".packaged"
+    packaged = buildpath / ".packaged"
 
     patch_file = pkg_root / "patch"
     extra_file = pkg_root / "extra"
@@ -179,7 +177,7 @@ def test_needs_rebuild(tmpdir):
         path=str(src_path),
     )
 
-    builddir.mkdir()
+    buildpath.mkdir()
     meta_yaml.touch()
     patch_file.touch()
     extra_file.touch()
@@ -187,39 +185,39 @@ def test_needs_rebuild(tmpdir):
     src_path_file.touch()
 
     # No .packaged file, rebuild
-    assert buildpkg.needs_rebuild(pkg_root, builddir, source_metadata) is True
+    assert buildpkg.needs_rebuild(pkg_root, buildpath, source_metadata) is True
 
     # .packaged file exists, no rebuild
     packaged.touch()
-    assert buildpkg.needs_rebuild(pkg_root, builddir, source_metadata) is False
+    assert buildpkg.needs_rebuild(pkg_root, buildpath, source_metadata) is False
 
     # newer meta.yaml file, rebuild
     packaged.touch()
     time.sleep(0.01)
     meta_yaml.touch()
-    assert buildpkg.needs_rebuild(pkg_root, builddir, source_metadata) is True
+    assert buildpkg.needs_rebuild(pkg_root, buildpath, source_metadata) is True
 
     # newer patch file, rebuild
     packaged.touch()
     time.sleep(0.01)
     patch_file.touch()
-    assert buildpkg.needs_rebuild(pkg_root, builddir, source_metadata) is True
+    assert buildpkg.needs_rebuild(pkg_root, buildpath, source_metadata) is True
 
     # newer extra file, rebuild
     packaged.touch()
     time.sleep(0.01)
     extra_file.touch()
-    assert buildpkg.needs_rebuild(pkg_root, builddir, source_metadata) is True
+    assert buildpkg.needs_rebuild(pkg_root, buildpath, source_metadata) is True
 
     # newer source path, rebuild
     packaged.touch()
     time.sleep(0.01)
     src_path_file.touch()
-    assert buildpkg.needs_rebuild(pkg_root, builddir, source_metadata) is True
+    assert buildpkg.needs_rebuild(pkg_root, buildpath, source_metadata) is True
 
     # newer .packaged file, no rebuild
     packaged.touch()
-    assert buildpkg.needs_rebuild(pkg_root, builddir, source_metadata) is False
+    assert buildpkg.needs_rebuild(pkg_root, buildpath, source_metadata) is False
 
 
 def test_copy_sharedlib(tmp_path):


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->
When the new environment variable `PYODIDE_RECIPE_BUILD_DIR ` is set, put the temporary build directories there instead of in `$PYODIDE_ROOT/packages/PACKAGE/build`. (The same functionality is also available with the new command-line option `--build-dir`.)

This enables users to use a fast file system for the build, for example a tmpfs.

In particular, this helps when using a devcontainer on macOS (config see #4402): Not only is poor performance mitigated, but `export PYODIDE_RECIPE_BUILD_DIR=/tmp/pyodide-build` also fixes  a reproducible build error in `pyodide build-recipes libgmp --install`:
```
make[2]: Entering directory '/workspaces/pyodide/packages/libgmp/build/libgmp-6.3.0'                                                                                                      
/bin/bash ./libtool  --tag=CC   --mode=link /workspaces/pyodide/emsdk/emsdk/upstream/emscripten/emcc  -fPIC   -version-info 15:0:5  -o libgmp.la -rpath                                   
/workspaces/pyodide/packages/.libs/lib assert.lo compat.lo errno.lo extract-dbl.lo invalid.lo memory.lo mp_bpl.lo mp_clz_tab.lo mp_dv_tab.lo mp_minv_tab.lo mp_get_fns.lo mp_set_fns.lo   
version.lo nextprime.lo primesieve.lo tal-reent.lo mpf/init.lo mpf/init2.lo mpf/inits.lo mpf/set.lo mpf/set_ui.lo mpf/set_si.lo mpf/set_str.lo mpf/set_d.lo mpf/set_z.lo mpf/iset.lo      
mpf/iset_ui.lo mpf/iset_si.lo mpf/iset_str.lo mpf/iset_d.lo mpf/clear.lo mpf/clears.lo mpf/get_str.lo mpf/dump.lo mpf/size.lo mpf/eq.lo mpf/reldiff.lo mpf/sqrt.lo mpf/random2.lo         
mpf/inp_str.lo mpf/out_str.lo mpf/add.lo mpf/add_ui.lo mpf/sub.lo mpf/sub_ui.lo mpf/ui_sub.lo mpf/mul.lo mpf/mul_ui.lo mpf/div.lo mpf/div_ui.lo mpf/cmp_z.lo mpf/cmp.lo mpf/cmp_d.lo      
mpf/cmp_ui.lo mpf/cmp_si.lo mpf/mul_2exp.lo mpf/div_2exp.lo mpf/abs.lo mpf/neg.lo mpf/set_q.lo mpf/get_d.lo mpf/get_d_2exp.lo mpf/set_dfl_prec.lo mpf/set_prc.lo mpf/set_prc_raw.lo       
mpf/get_dfl_prec.lo mpf/get_prc.lo mpf/ui_div.lo mpf/sqrt_ui.lo mpf/ceilfloor.lo mpf/trunc.lo mpf/pow_ui.lo mpf/urandomb.lo mpf/swap.lo mpf/fits_sint.lo mpf/fits_slong.lo                
mpf/fits_sshort.lo mpf/fits_uint.lo mpf/fits_ulong.lo mpf/fits_ushort.lo mpf/get_si.lo mpf/get_ui.lo mpf/int_p.lo mpz/abs.lo mpz/add.lo mpz/add_ui.lo mpz/aorsmul.lo mpz/aorsmul_i.lo     
mpz/and.lo mpz/array_init.lo mpz/bin_ui.lo mpz/bin_uiui.lo mpz/cdiv_q.lo mpz/cdiv_q_ui.lo mpz/cdiv_qr.lo mpz/cdiv_qr_ui.lo mpz/cdiv_r.lo mpz/cdiv_r_ui.lo mpz/cdiv_ui.lo                  
mpz/cfdiv_q_2exp.lo mpz/cfdiv_r_2exp.lo mpz/clear.lo mpz/clears.lo mpz/clrbit.lo mpz/cmp.lo mpz/cmp_d.lo mpz/cmp_si.lo mpz/cmp_ui.lo mpz/cmpabs.lo mpz/cmpabs_d.lo mpz/cmpabs_ui.lo       
mpz/com.lo mpz/combit.lo mpz/cong.lo mpz/cong_2exp.lo mpz/cong_ui.lo mpz/divexact.lo mpz/divegcd.lo mpz/dive_ui.lo mpz/divis.lo mpz/divis_ui.lo mpz/divis_2exp.lo mpz/dump.lo             
mpz/export.lo mpz/mfac_uiui.lo mpz/2fac_ui.lo mpz/fac_ui.lo mpz/oddfac_1.lo mpz/prodlimbs.lo mpz/fdiv_q_ui.lo mpz/fdiv_qr.lo mpz/fdiv_qr_ui.lo mpz/fdiv_r.lo mpz/fdiv_r_ui.lo             
mpz/fdiv_q.lo mpz/fdiv_ui.lo mpz/fib_ui.lo mpz/fib2_ui.lo mpz/fits_sint.lo mpz/fits_slong.lo mpz/fits_sshort.lo mpz/fits_uint.lo mpz/fits_ulong.lo mpz/fits_ushort.lo mpz/gcd.lo          
mpz/gcd_ui.lo mpz/gcdext.lo mpz/get_d.lo mpz/get_d_2exp.lo mpz/get_si.lo mpz/get_str.lo mpz/get_ui.lo mpz/getlimbn.lo mpz/hamdist.lo mpz/import.lo mpz/init.lo mpz/init2.lo mpz/inits.lo  
mpz/inp_raw.lo mpz/inp_str.lo mpz/invert.lo mpz/ior.lo mpz/iset.lo mpz/iset_d.lo mpz/iset_si.lo mpz/iset_str.lo mpz/iset_ui.lo mpz/jacobi.lo mpz/kronsz.lo mpz/kronuz.lo mpz/kronzs.lo    
mpz/kronzu.lo mpz/lcm.lo mpz/lcm_ui.lo mpz/limbs_finish.lo mpz/limbs_modify.lo mpz/limbs_read.lo mpz/limbs_write.lo mpz/lucmod.lo mpz/lucnum_ui.lo mpz/lucnum2_ui.lo mpz/millerrabin.lo   
mpz/mod.lo mpz/mul.lo mpz/mul_2exp.lo mpz/mul_si.lo mpz/mul_ui.lo mpz/n_pow_ui.lo mpz/neg.lo mpz/nextprime.lo mpz/out_raw.lo mpz/out_str.lo mpz/perfpow.lo mpz/perfsqr.lo mpz/popcount.lo 
mpz/pow_ui.lo mpz/powm.lo mpz/powm_sec.lo mpz/powm_ui.lo mpz/primorial_ui.lo mpz/pprime_p.lo mpz/random.lo mpz/random2.lo mpz/realloc.lo mpz/realloc2.lo mpz/remove.lo mpz/roinit_n.lo    
mpz/root.lo mpz/rootrem.lo mpz/rrandomb.lo mpz/scan0.lo mpz/scan1.lo mpz/set.lo mpz/set_d.lo mpz/set_f.lo mpz/set_q.lo mpz/set_si.lo mpz/set_str.lo mpz/set_ui.lo mpz/setbit.lo           
mpz/size.lo mpz/sizeinbase.lo mpz/sqrt.lo mpz/sqrtrem.lo mpz/stronglucas.lo mpz/sub.lo mpz/sub_ui.lo mpz/swap.lo mpz/tdiv_ui.lo mpz/tdiv_q.lo mpz/tdiv_q_2exp.lo mpz/tdiv_q_ui.lo         
mpz/tdiv_qr.lo mpz/tdiv_qr_ui.lo mpz/tdiv_r.lo mpz/tdiv_r_2exp.lo mpz/tdiv_r_ui.lo mpz/tstbit.lo mpz/ui_pow_ui.lo mpz/ui_sub.lo mpz/urandomb.lo mpz/urandomm.lo mpz/xor.lo mpq/abs.lo     
mpq/aors.lo mpq/canonicalize.lo mpq/clear.lo mpq/clears.lo mpq/cmp.lo mpq/cmp_si.lo mpq/cmp_ui.lo mpq/div.lo mpq/get_d.lo mpq/get_den.lo mpq/get_num.lo mpq/get_str.lo mpq/init.lo        
mpq/inits.lo mpq/inp_str.lo mpq/inv.lo mpq/md_2exp.lo mpq/mul.lo mpq/neg.lo mpq/out_str.lo mpq/set.lo mpq/set_den.lo mpq/set_num.lo mpq/set_si.lo mpq/set_str.lo mpq/set_ui.lo            
mpq/equal.lo mpq/set_z.lo mpq/set_d.lo mpq/set_f.lo mpq/swap.lo mpn/fib_table.lo mpn/mp_bases.lo  mpn/add.lo mpn/add_1.lo mpn/add_n.lo mpn/sub.lo mpn/sub_1.lo mpn/sub_n.lo               
mpn/cnd_add_n.lo mpn/cnd_sub_n.lo mpn/cnd_swap.lo mpn/neg.lo mpn/com.lo mpn/mul_1.lo mpn/addmul_1.lo mpn/submul_1.lo mpn/add_err1_n.lo mpn/add_err2_n.lo mpn/add_err3_n.lo                
mpn/sub_err1_n.lo mpn/sub_err2_n.lo mpn/sub_err3_n.lo mpn/lshift.lo mpn/rshift.lo mpn/dive_1.lo mpn/diveby3.lo mpn/divis.lo mpn/divrem.lo mpn/divrem_1.lo mpn/divrem_2.lo mpn/fib2_ui.lo  
mpn/fib2m.lo mpn/mod_1.lo mpn/mod_34lsub1.lo mpn/mode1o.lo mpn/pre_divrem_1.lo mpn/pre_mod_1.lo mpn/dump.lo mpn/mod_1_1.lo mpn/mod_1_2.lo mpn/mod_1_3.lo mpn/mod_1_4.lo mpn/lshiftc.lo    
mpn/mul.lo mpn/mul_fft.lo mpn/mul_n.lo mpn/sqr.lo mpn/mul_basecase.lo mpn/sqr_basecase.lo mpn/nussbaumer_mul.lo mpn/mulmid_basecase.lo mpn/toom42_mulmid.lo mpn/mulmid_n.lo mpn/mulmid.lo 
mpn/random.lo mpn/random2.lo mpn/pow_1.lo mpn/rootrem.lo mpn/sqrtrem.lo mpn/sizeinbase.lo mpn/get_str.lo mpn/set_str.lo mpn/compute_powtab.lo mpn/scan0.lo mpn/scan1.lo mpn/popcount.lo   
mpn/hamdist.lo mpn/cmp.lo mpn/zero_p.lo mpn/perfsqr.lo mpn/perfpow.lo mpn/strongfibo.lo mpn/gcd_11.lo mpn/gcd_22.lo mpn/gcd_1.lo mpn/gcd.lo mpn/gcdext_1.lo mpn/gcdext.lo                 
mpn/gcd_subdiv_step.lo mpn/gcdext_lehmer.lo mpn/div_q.lo mpn/tdiv_qr.lo mpn/jacbase.lo mpn/jacobi_2.lo mpn/jacobi.lo mpn/get_d.lo mpn/matrix22_mul.lo mpn/matrix22_mul1_inverse_vector.lo 
mpn/hgcd_matrix.lo mpn/hgcd2.lo mpn/hgcd_step.lo mpn/hgcd_reduce.lo mpn/hgcd.lo mpn/hgcd_appr.lo mpn/hgcd2_jacobi.lo mpn/hgcd_jacobi.lo mpn/mullo_n.lo mpn/mullo_basecase.lo mpn/sqrlo.lo 
mpn/sqrlo_basecase.lo mpn/toom22_mul.lo mpn/toom32_mul.lo mpn/toom42_mul.lo mpn/toom52_mul.lo mpn/toom62_mul.lo mpn/toom33_mul.lo mpn/toom43_mul.lo mpn/toom53_mul.lo mpn/toom54_mul.lo   
mpn/toom63_mul.lo mpn/toom44_mul.lo mpn/toom6h_mul.lo mpn/toom6_sqr.lo mpn/toom8h_mul.lo mpn/toom8_sqr.lo mpn/toom_couple_handling.lo mpn/toom2_sqr.lo mpn/toom3_sqr.lo mpn/toom4_sqr.lo  
mpn/toom_eval_dgr3_pm1.lo mpn/toom_eval_dgr3_pm2.lo mpn/toom_eval_pm1.lo mpn/toom_eval_pm2.lo mpn/toom_eval_pm2exp.lo mpn/toom_eval_pm2rexp.lo mpn/toom_interpolate_5pts.lo               
mpn/toom_interpolate_6pts.lo mpn/toom_interpolate_7pts.lo mpn/toom_interpolate_8pts.lo mpn/toom_interpolate_12pts.lo mpn/toom_interpolate_16pts.lo mpn/invertappr.lo mpn/invert.lo        
mpn/binvert.lo mpn/mulmod_bnm1.lo mpn/sqrmod_bnm1.lo mpn/mulmod_bknp1.lo mpn/div_qr_1.lo mpn/div_qr_1n_pi1.lo mpn/div_qr_2.lo mpn/div_qr_2n_pi1.lo mpn/div_qr_2u_pi1.lo mpn/sbpi1_div_q.lo
mpn/sbpi1_div_qr.lo mpn/sbpi1_divappr_q.lo mpn/dcpi1_div_q.lo mpn/dcpi1_div_qr.lo mpn/dcpi1_divappr_q.lo mpn/mu_div_qr.lo mpn/mu_divappr_q.lo mpn/mu_div_q.lo mpn/bdiv_q_1.lo             
mpn/sbpi1_bdiv_q.lo mpn/sbpi1_bdiv_qr.lo mpn/sbpi1_bdiv_r.lo mpn/dcpi1_bdiv_q.lo mpn/dcpi1_bdiv_qr.lo mpn/mu_bdiv_q.lo mpn/mu_bdiv_qr.lo mpn/bdiv_q.lo mpn/bdiv_qr.lo mpn/broot.lo        
mpn/brootinv.lo mpn/bsqrt.lo mpn/bsqrtinv.lo mpn/divexact.lo mpn/bdiv_dbm1c.lo mpn/redc_1.lo mpn/redc_2.lo mpn/redc_n.lo mpn/powm.lo mpn/powlo.lo mpn/sec_powm.lo mpn/sec_mul.lo          
mpn/sec_sqr.lo mpn/sec_div_qr.lo mpn/sec_div_r.lo mpn/sec_pi1_div_qr.lo mpn/sec_pi1_div_r.lo mpn/sec_add_1.lo mpn/sec_sub_1.lo mpn/sec_invert.lo mpn/trialdiv.lo mpn/remove.lo            
mpn/and_n.lo mpn/andn_n.lo mpn/nand_n.lo mpn/ior_n.lo mpn/iorn_n.lo mpn/nior_n.lo mpn/xor_n.lo mpn/xnor_n.lo mpn/copyi.lo mpn/copyd.lo mpn/zero.lo mpn/sec_tabselect.lo mpn/comb_tables.lo
mpn/add_n_sub_n.lo printf/asprintf.lo printf/asprntffuns.lo printf/doprnt.lo printf/doprntf.lo printf/doprnti.lo printf/fprintf.lo printf/obprintf.lo printf/obvprintf.lo                 
printf/obprntffuns.lo printf/printf.lo printf/printffuns.lo printf/snprintf.lo printf/snprntffuns.lo printf/sprintf.lo printf/sprintffuns.lo printf/vasprintf.lo printf/vfprintf.lo       
printf/vprintf.lo printf/vsnprintf.lo printf/vsprintf.lo printf/repl-vsnprintf.lo  scanf/doscan.lo scanf/fscanf.lo scanf/fscanffuns.lo scanf/scanf.lo scanf/sscanf.lo scanf/sscanffuns.lo 
scanf/vfscanf.lo scanf/vscanf.lo scanf/vsscanf.lo rand/rand.lo rand/randclr.lo rand/randdef.lo rand/randiset.lo rand/randlc2s.lo rand/randlc2x.lo rand/randmt.lo rand/randmts.lo          
rand/rands.lo rand/randsd.lo rand/randsdui.lo rand/randbui.lo rand/randmui.lo                                                                                                             
libtool: link: rm -fr  .libs/libgmp.lax                                                                                                                                                   
copying selected object files to avoid basename conflicts...                                                                                                                              
libtool: link: ln mpz/abs.o .libs/libgmp.lax/lt1-abs.o || cp mpz/abs.o .libs/libgmp.lax/lt1-abs.o                                                                                         
libtool: link: ln mpz/add.o .libs/libgmp.lax/lt2-add.o || cp mpz/add.o .libs/libgmp.lax/lt2-add.o                                                                                         
libtool: link: ln mpz/add_ui.o .libs/libgmp.lax/lt3-add_ui.o || cp mpz/add_ui.o .libs/libgmp.lax/lt3-add_ui.o                                                                             
libtool: link: ln mpz/clear.o .libs/libgmp.lax/lt4-clear.o || cp mpz/clear.o .libs/libgmp.lax/lt4-clear.o                                                                                 
libtool: link: ln mpz/clears.o .libs/libgmp.lax/lt5-clears.o || cp mpz/clears.o .libs/libgmp.lax/lt5-clears.o                                                                             
libtool: link: ln mpz/cmp.o .libs/libgmp.lax/lt6-cmp.o || cp mpz/cmp.o .libs/libgmp.lax/lt6-cmp.o                                                                                         
libtool: link: ln mpz/cmp_d.o .libs/libgmp.lax/lt7-cmp_d.o || cp mpz/cmp_d.o .libs/libgmp.lax/lt7-cmp_d.o                                                                                 
libtool: link: ln mpz/cmp_si.o .libs/libgmp.lax/lt8-cmp_si.o || cp mpz/cmp_si.o .libs/libgmp.lax/lt8-cmp_si.o                                                                             
libtool: link: ln mpz/cmp_ui.o .libs/libgmp.lax/lt9-cmp_ui.o || cp mpz/cmp_ui.o .libs/libgmp.lax/lt9-cmp_ui.o                                                                             
libtool: link: ln mpz/dump.o .libs/libgmp.lax/lt10-dump.o || cp mpz/dump.o .libs/libgmp.lax/lt10-dump.o                                                                                   
libtool: link: ln mpz/fits_sint.o .libs/libgmp.lax/lt11-fits_sint.o || cp mpz/fits_sint.o .libs/libgmp.lax/lt11-fits_sint.o                                                               
libtool: link: ln mpz/fits_slong.o .libs/libgmp.lax/lt12-fits_slong.o || cp mpz/fits_slong.o .libs/libgmp.lax/lt12-fits_slong.o                                                           
libtool: link: ln mpz/fits_sshort.o .libs/libgmp.lax/lt13-fits_sshort.o || cp mpz/fits_sshort.o .libs/libgmp.lax/lt13-fits_sshort.o                                                       
libtool: link: ln mpz/fits_uint.o .libs/libgmp.lax/lt14-fits_uint.o || cp mpz/fits_uint.o .libs/libgmp.lax/lt14-fits_uint.o                                                               
libtool: link: ln mpz/fits_ulong.o .libs/libgmp.lax/lt15-fits_ulong.o || cp mpz/fits_ulong.o .libs/libgmp.lax/lt15-fits_ulong.o                                                           
libtool: link: ln mpz/fits_ushort.o .libs/libgmp.lax/lt16-fits_ushort.o || cp mpz/fits_ushort.o .libs/libgmp.lax/lt16-fits_ushort.o                                                       
libtool: link: ln mpz/get_d.o .libs/libgmp.lax/lt17-get_d.o || cp mpz/get_d.o .libs/libgmp.lax/lt17-get_d.o                                                                               
libtool: link: ln mpz/get_d_2exp.o .libs/libgmp.lax/lt18-get_d_2exp.o || cp mpz/get_d_2exp.o .libs/libgmp.lax/lt18-get_d_2exp.o                                                           
libtool: link: ln mpz/get_si.o .libs/libgmp.lax/lt19-get_si.o || cp mpz/get_si.o .libs/libgmp.lax/lt19-get_si.o                                                                           
libtool: link: ln mpz/get_str.o .libs/libgmp.lax/lt20-get_str.o || cp mpz/get_str.o .libs/libgmp.lax/lt20-get_str.o                                                                       
libtool: link: ln mpz/get_ui.o .libs/libgmp.lax/lt21-get_ui.o || cp mpz/get_ui.o .libs/libgmp.lax/lt21-get_ui.o                                                                           
libtool: link: ln mpz/init.o .libs/libgmp.lax/lt22-init.o || cp mpz/init.o .libs/libgmp.lax/lt22-init.o                                                                                   
libtool: link: ln mpz/init2.o .libs/libgmp.lax/lt23-init2.o || cp mpz/init2.o .libs/libgmp.lax/lt23-init2.o                                                                               
libtool: link: ln mpz/inits.o .libs/libgmp.lax/lt24-inits.o || cp mpz/inits.o .libs/libgmp.lax/lt24-inits.o                                                                               
libtool: link: ln mpz/inp_str.o .libs/libgmp.lax/lt25-inp_str.o || cp mpz/inp_str.o .libs/libgmp.lax/lt25-inp_str.o                                                                       
libtool: link: ln mpz/iset.o .libs/libgmp.lax/lt26-iset.o || cp mpz/iset.o .libs/libgmp.lax/lt26-iset.o                                                                                   
libtool: link: ln mpz/iset_d.o .libs/libgmp.lax/lt27-iset_d.o || cp mpz/iset_d.o .libs/libgmp.lax/lt27-iset_d.o                                                                           
libtool: link: ln mpz/iset_si.o .libs/libgmp.lax/lt28-iset_si.o || cp mpz/iset_si.o .libs/libgmp.lax/lt28-iset_si.o                                                                       
libtool: link: ln mpz/iset_str.o .libs/libgmp.lax/lt29-iset_str.o || cp mpz/iset_str.o .libs/libgmp.lax/lt29-iset_str.o                                                                   
libtool: link: ln mpz/iset_ui.o .libs/libgmp.lax/lt30-iset_ui.o || cp mpz/iset_ui.o .libs/libgmp.lax/lt30-iset_ui.o                                                                       
libtool: link: ln mpz/mul.o .libs/libgmp.lax/lt31-mul.o || cp mpz/mul.o .libs/libgmp.lax/lt31-mul.o                                                                                       
libtool: link: ln mpz/mul_2exp.o .libs/libgmp.lax/lt32-mul_2exp.o || cp mpz/mul_2exp.o .libs/libgmp.lax/lt32-mul_2exp.o                                                                   
libtool: link: ln mpz/mul_ui.o .libs/libgmp.lax/lt33-mul_ui.o || cp mpz/mul_ui.o .libs/libgmp.lax/lt33-mul_ui.o                                                                           
libtool: link: ln mpz/neg.o .libs/libgmp.lax/lt34-neg.o || cp mpz/neg.o .libs/libgmp.lax/lt34-neg.o                                                                                       
libtool: link: ln mpz/nextprime.o .libs/libgmp.lax/lt35-nextprime.o || cp mpz/nextprime.o .libs/libgmp.lax/lt35-nextprime.o                                                               
libtool: link: ln mpz/out_str.o .libs/libgmp.lax/lt36-out_str.o || cp mpz/out_str.o .libs/libgmp.lax/lt36-out_str.o                                                                       
libtool: link: ln mpz/pow_ui.o .libs/libgmp.lax/lt37-pow_ui.o || cp mpz/pow_ui.o .libs/libgmp.lax/lt37-pow_ui.o                                                                           
libtool: link: ln mpz/random2.o .libs/libgmp.lax/lt38-random2.o || cp mpz/random2.o .libs/libgmp.lax/lt38-random2.o                                                                       
libtool: link: ln mpz/set.o .libs/libgmp.lax/lt39-set.o || cp mpz/set.o .libs/libgmp.lax/lt39-set.o                                                                                       
libtool: link: ln mpz/set_d.o .libs/libgmp.lax/lt40-set_d.o || cp mpz/set_d.o .libs/libgmp.lax/lt40-set_d.o                                                                               
libtool: link: ln mpz/set_q.o .libs/libgmp.lax/lt41-set_q.o || cp mpz/set_q.o .libs/libgmp.lax/lt41-set_q.o                                                                               
libtool: link: ln mpz/set_si.o .libs/libgmp.lax/lt42-set_si.o || cp mpz/set_si.o .libs/libgmp.lax/lt42-set_si.o                                                                           
libtool: link: ln mpz/set_str.o .libs/libgmp.lax/lt43-set_str.o || cp mpz/set_str.o .libs/libgmp.lax/lt43-set_str.o                                                                       
libtool: link: ln mpz/set_ui.o .libs/libgmp.lax/lt44-set_ui.o || cp mpz/set_ui.o .libs/libgmp.lax/lt44-set_ui.o                                                                           
libtool: link: ln mpz/size.o .libs/libgmp.lax/lt45-size.o || cp mpz/size.o .libs/libgmp.lax/lt45-size.o                                                                                   
libtool: link: ln mpz/sqrt.o .libs/libgmp.lax/lt46-sqrt.o || cp mpz/sqrt.o .libs/libgmp.lax/lt46-sqrt.o                                                                                   
libtool: link: ln mpz/sub.o .libs/libgmp.lax/lt47-sub.o || cp mpz/sub.o .libs/libgmp.lax/lt47-sub.o                                                                                       
libtool: link: ln mpz/sub_ui.o .libs/libgmp.lax/lt48-sub_ui.o || cp mpz/sub_ui.o .libs/libgmp.lax/lt48-sub_ui.o                                                                           
libtool: link: ln mpz/swap.o .libs/libgmp.lax/lt49-swap.o || cp mpz/swap.o .libs/libgmp.lax/lt49-swap.o                                                                                   
libtool: link: ln mpz/ui_sub.o .libs/libgmp.lax/lt50-ui_sub.o || cp mpz/ui_sub.o .libs/libgmp.lax/lt50-ui_sub.o                                                                           
libtool: link: ln mpz/urandomb.o .libs/libgmp.lax/lt51-urandomb.o || cp mpz/urandomb.o .libs/libgmp.lax/lt51-urandomb.o                                                                   
libtool: link: ln mpq/abs.o .libs/libgmp.lax/lt52-abs.o || cp mpq/abs.o .libs/libgmp.lax/lt52-abs.o                                                                                       
libtool: link: ln mpq/clear.o .libs/libgmp.lax/lt53-clear.o || cp mpq/clear.o .libs/libgmp.lax/lt53-clear.o                                                                               
libtool: link: ln mpq/clears.o .libs/libgmp.lax/lt54-clears.o || cp mpq/clears.o .libs/libgmp.lax/lt54-clears.o                                                                           
libtool: link: ln mpq/cmp.o .libs/libgmp.lax/lt55-cmp.o || cp mpq/cmp.o .libs/libgmp.lax/lt55-cmp.o                                                                                       
libtool: link: ln mpq/cmp_si.o .libs/libgmp.lax/lt56-cmp_si.o || cp mpq/cmp_si.o .libs/libgmp.lax/lt56-cmp_si.o                                                                           
libtool: link: ln mpq/cmp_ui.o .libs/libgmp.lax/lt57-cmp_ui.o || cp mpq/cmp_ui.o .libs/libgmp.lax/lt57-cmp_ui.o                                                                           
libtool: link: ln mpq/div.o .libs/libgmp.lax/lt58-div.o || cp mpq/div.o .libs/libgmp.lax/lt58-div.o                                                                                       
libtool: link: ln mpq/get_d.o .libs/libgmp.lax/lt59-get_d.o || cp mpq/get_d.o .libs/libgmp.lax/lt59-get_d.o                                                                               
libtool: link: ln mpq/get_str.o .libs/libgmp.lax/lt60-get_str.o || cp mpq/get_str.o .libs/libgmp.lax/lt60-get_str.o                                                                       
libtool: link: ln mpq/init.o .libs/libgmp.lax/lt61-init.o || cp mpq/init.o .libs/libgmp.lax/lt61-init.o                                                                                   
libtool: link: ln mpq/inits.o .libs/libgmp.lax/lt62-inits.o || cp mpq/inits.o .libs/libgmp.lax/lt62-inits.o                                                                               
libtool: link: ln mpq/inp_str.o .libs/libgmp.lax/lt63-inp_str.o || cp mpq/inp_str.o .libs/libgmp.lax/lt63-inp_str.o                                                                       
libtool: link: ln mpq/mul.o .libs/libgmp.lax/lt64-mul.o || cp mpq/mul.o .libs/libgmp.lax/lt64-mul.o                                                                                       
libtool: link: ln mpq/neg.o .libs/libgmp.lax/lt65-neg.o || cp mpq/neg.o .libs/libgmp.lax/lt65-neg.o                                                                                       
libtool: link: ln mpq/out_str.o .libs/libgmp.lax/lt66-out_str.o || cp mpq/out_str.o .libs/libgmp.lax/lt66-out_str.o                                                                       
libtool: link: ln mpq/set.o .libs/libgmp.lax/lt67-set.o || cp mpq/set.o .libs/libgmp.lax/lt67-set.o                                                                                       
libtool: link: ln mpq/set_si.o .libs/libgmp.lax/lt68-set_si.o || cp mpq/set_si.o .libs/libgmp.lax/lt68-set_si.o                                                                           
libtool: link: ln mpq/set_str.o .libs/libgmp.lax/lt69-set_str.o || cp mpq/set_str.o .libs/libgmp.lax/lt69-set_str.o                                                                       
libtool: link: ln mpq/set_ui.o .libs/libgmp.lax/lt70-set_ui.o || cp mpq/set_ui.o .libs/libgmp.lax/lt70-set_ui.o                                                                           
libtool: link: ln mpq/set_z.o .libs/libgmp.lax/lt71-set_z.o || cp mpq/set_z.o .libs/libgmp.lax/lt71-set_z.o                                                                               
libtool: link: ln mpq/set_d.o .libs/libgmp.lax/lt72-set_d.o || cp mpq/set_d.o .libs/libgmp.lax/lt72-set_d.o                                                                               
libtool: link: ln mpq/set_f.o .libs/libgmp.lax/lt73-set_f.o || cp mpq/set_f.o .libs/libgmp.lax/lt73-set_f.o                                                                               
libtool: link: ln mpq/swap.o .libs/libgmp.lax/lt74-swap.o || cp mpq/swap.o .libs/libgmp.lax/lt74-swap.o                                                                                   
libtool: link: ln mpn/add.o .libs/libgmp.lax/lt75-add.o || cp mpn/add.o .libs/libgmp.lax/lt75-add.o                                                                                       
libtool: link: ln mpn/sub.o .libs/libgmp.lax/lt76-sub.o || cp mpn/sub.o .libs/libgmp.lax/lt76-sub.o                                                                                       
libtool: link: ln mpn/neg.o .libs/libgmp.lax/lt77-neg.o || cp mpn/neg.o .libs/libgmp.lax/lt77-neg.o                                                                                       
libtool: link: ln mpn/com.o .libs/libgmp.lax/lt78-com.o || cp mpn/com.o .libs/libgmp.lax/lt78-com.o                                                                                       
libtool: link: ln mpn/divis.o .libs/libgmp.lax/lt79-divis.o || cp mpn/divis.o .libs/libgmp.lax/lt79-divis.o                                                                               
libtool: link: ln mpn/fib2_ui.o .libs/libgmp.lax/lt80-fib2_ui.o || cp mpn/fib2_ui.o .libs/libgmp.lax/lt80-fib2_ui.o                                                                       
libtool: link: ln mpn/dump.o .libs/libgmp.lax/lt81-dump.o || cp mpn/dump.o .libs/libgmp.lax/lt81-dump.o                                                                                   
libtool: link: ln mpn/mul.o .libs/libgmp.lax/lt82-mul.o || cp mpn/mul.o .libs/libgmp.lax/lt82-mul.o                                                                                       
libtool: link: ln mpn/random.o .libs/libgmp.lax/lt83-random.o || cp mpn/random.o .libs/libgmp.lax/lt83-random.o                                                                           
libtool: link: ln mpn/random2.o .libs/libgmp.lax/lt84-random2.o || cp mpn/random2.o .libs/libgmp.lax/lt84-random2.o                                                                       
libtool: link: ln mpn/rootrem.o .libs/libgmp.lax/lt85-rootrem.o || cp mpn/rootrem.o .libs/libgmp.lax/lt85-rootrem.o                                                                       
libtool: link: ln mpn/sqrtrem.o .libs/libgmp.lax/lt86-sqrtrem.o || cp mpn/sqrtrem.o .libs/libgmp.lax/lt86-sqrtrem.o                                                                       
libtool: link: ln mpn/sizeinbase.o .libs/libgmp.lax/lt87-sizeinbase.o || cp mpn/sizeinbase.o .libs/libgmp.lax/lt87-sizeinbase.o                                                           
libtool: link: ln mpn/get_str.o .libs/libgmp.lax/lt88-get_str.o || cp mpn/get_str.o .libs/libgmp.lax/lt88-get_str.o                                                                       
libtool: link: ln mpn/set_str.o .libs/libgmp.lax/lt89-set_str.o || cp mpn/set_str.o .libs/libgmp.lax/lt89-set_str.o                                                                       
libtool: link: ln mpn/scan0.o .libs/libgmp.lax/lt90-scan0.o || cp mpn/scan0.o .libs/libgmp.lax/lt90-scan0.o                                                                               
libtool: link: ln mpn/scan1.o .libs/libgmp.lax/lt91-scan1.o || cp mpn/scan1.o .libs/libgmp.lax/lt91-scan1.o                                                                               
libtool: link: ln mpn/popcount.o .libs/libgmp.lax/lt92-popcount.o || cp mpn/popcount.o .libs/libgmp.lax/lt92-popcount.o                                                                   
libtool: link: ln mpn/hamdist.o .libs/libgmp.lax/lt93-hamdist.o || cp mpn/hamdist.o .libs/libgmp.lax/lt93-hamdist.o                                                                       
libtool: link: ln mpn/cmp.o .libs/libgmp.lax/lt94-cmp.o || cp mpn/cmp.o .libs/libgmp.lax/lt94-cmp.o                                                                                       
libtool: link: ln mpn/perfsqr.o .libs/libgmp.lax/lt95-perfsqr.o || cp mpn/perfsqr.o .libs/libgmp.lax/lt95-perfsqr.o                                                                       
libtool: link: ln mpn/perfpow.o .libs/libgmp.lax/lt96-perfpow.o || cp mpn/perfpow.o .libs/libgmp.lax/lt96-perfpow.o                                                                       
libtool: link: ln mpn/gcd.o .libs/libgmp.lax/lt97-gcd.o || cp mpn/gcd.o .libs/libgmp.lax/lt97-gcd.o                                                                                       
libtool: link: ln mpn/gcdext.o .libs/libgmp.lax/lt98-gcdext.o || cp mpn/gcdext.o .libs/libgmp.lax/lt98-gcdext.o                                                                           
libtool: link: ln mpn/tdiv_qr.o .libs/libgmp.lax/lt99-tdiv_qr.o || cp mpn/tdiv_qr.o .libs/libgmp.lax/lt99-tdiv_qr.o                                                                       
libtool: link: ln mpn/jacobi.o .libs/libgmp.lax/lt100-jacobi.o || cp mpn/jacobi.o .libs/libgmp.lax/lt100-jacobi.o                                                                         
libtool: link: ln mpn/get_d.o .libs/libgmp.lax/lt101-get_d.o || cp mpn/get_d.o .libs/libgmp.lax/lt101-get_d.o                                                                             
libtool: link: ln mpn/invert.o .libs/libgmp.lax/lt102-invert.o || cp mpn/invert.o .libs/libgmp.lax/lt102-invert.o                                                                         
libtool: link: ln mpn/divexact.o .libs/libgmp.lax/lt103-divexact.o || cp mpn/divexact.o .libs/libgmp.lax/lt103-divexact.o                                                                 
libtool: link: ln mpn/powm.o .libs/libgmp.lax/lt104-powm.o || cp mpn/powm.o .libs/libgmp.lax/lt104-powm.o                                                                                 
libtool: link: ln mpn/remove.o .libs/libgmp.lax/lt105-remove.o || cp mpn/remove.o .libs/libgmp.lax/lt105-remove.o                                                                         
libtool: link: /workspaces/pyodide/emsdk/emsdk/upstream/emscripten/emar cq .libs/libgmp.a assert.o compat.o errno.o extract-dbl.o invalid.o memory.o mp_bpl.o mp_clz_tab.o mp_dv_tab.o    
mp_minv_tab.o mp_get_fns.o mp_set_fns.o version.o nextprime.o primesieve.o tal-reent.o mpf/init.o mpf/init2.o mpf/inits.o mpf/set.o mpf/set_ui.o mpf/set_si.o mpf/set_str.o mpf/set_d.o   
mpf/set_z.o mpf/iset.o mpf/iset_ui.o mpf/iset_si.o mpf/iset_str.o mpf/iset_d.o mpf/clear.o mpf/clears.o mpf/get_str.o mpf/dump.o mpf/size.o mpf/eq.o mpf/reldiff.o mpf/sqrt.o             
mpf/random2.o mpf/inp_str.o mpf/out_str.o mpf/add.o mpf/add_ui.o mpf/sub.o mpf/sub_ui.o mpf/ui_sub.o mpf/mul.o mpf/mul_ui.o mpf/div.o mpf/div_ui.o mpf/cmp_z.o mpf/cmp.o mpf/cmp_d.o      
mpf/cmp_ui.o mpf/cmp_si.o mpf/mul_2exp.o mpf/div_2exp.o mpf/abs.o mpf/neg.o mpf/set_q.o mpf/get_d.o mpf/get_d_2exp.o mpf/set_dfl_prec.o mpf/set_prc.o mpf/set_prc_raw.o mpf/get_dfl_prec.o
mpf/get_prc.o mpf/ui_div.o mpf/sqrt_ui.o mpf/ceilfloor.o mpf/trunc.o mpf/pow_ui.o mpf/urandomb.o mpf/swap.o mpf/fits_sint.o mpf/fits_slong.o mpf/fits_sshort.o mpf/fits_uint.o            
mpf/fits_ulong.o mpf/fits_ushort.o mpf/get_si.o mpf/get_ui.o mpf/int_p.o .libs/libgmp.lax/lt1-abs.o .libs/libgmp.lax/lt2-add.o .libs/libgmp.lax/lt3-add_ui.o mpz/aorsmul.o mpz/aorsmul_i.o
mpz/and.o mpz/array_init.o mpz/bin_ui.o mpz/bin_uiui.o mpz/cdiv_q.o mpz/cdiv_q_ui.o mpz/cdiv_qr.o mpz/cdiv_qr_ui.o mpz/cdiv_r.o mpz/cdiv_r_ui.o mpz/cdiv_ui.o mpz/cfdiv_q_2exp.o          
mpz/cfdiv_r_2exp.o .libs/libgmp.lax/lt4-clear.o .libs/libgmp.lax/lt5-clears.o mpz/clrbit.o .libs/libgmp.lax/lt6-cmp.o .libs/libgmp.lax/lt7-cmp_d.o .libs/libgmp.lax/lt8-cmp_si.o          
.libs/libgmp.lax/lt9-cmp_ui.o mpz/cmpabs.o mpz/cmpabs_d.o mpz/cmpabs_ui.o mpz/com.o mpz/combit.o mpz/cong.o mpz/cong_2exp.o mpz/cong_ui.o mpz/divexact.o mpz/divegcd.o mpz/dive_ui.o      
mpz/divis.o mpz/divis_ui.o mpz/divis_2exp.o .libs/libgmp.lax/lt10-dump.o mpz/export.o mpz/mfac_uiui.o mpz/2fac_ui.o mpz/fac_ui.o mpz/oddfac_1.o mpz/prodlimbs.o mpz/fdiv_q_ui.o           
mpz/fdiv_qr.o mpz/fdiv_qr_ui.o mpz/fdiv_r.o mpz/fdiv_r_ui.o mpz/fdiv_q.o mpz/fdiv_ui.o mpz/fib_ui.o mpz/fib2_ui.o .libs/libgmp.lax/lt11-fits_sint.o .libs/libgmp.lax/lt12-fits_slong.o    
.libs/libgmp.lax/lt13-fits_sshort.o .libs/libgmp.lax/lt14-fits_uint.o .libs/libgmp.lax/lt15-fits_ulong.o .libs/libgmp.lax/lt16-fits_ushort.o mpz/gcd.o mpz/gcd_ui.o mpz/gcdext.o          
.libs/libgmp.lax/lt17-get_d.o .libs/libgmp.lax/lt18-get_d_2exp.o .libs/libgmp.lax/lt19-get_si.o .libs/libgmp.lax/lt20-get_str.o .libs/libgmp.lax/lt21-get_ui.o mpz/getlimbn.o             
mpz/hamdist.o mpz/import.o .libs/libgmp.lax/lt22-init.o .libs/libgmp.lax/lt23-init2.o .libs/libgmp.lax/lt24-inits.o mpz/inp_raw.o .libs/libgmp.lax/lt25-inp_str.o mpz/invert.o mpz/ior.o  
.libs/libgmp.lax/lt26-iset.o .libs/libgmp.lax/lt27-iset_d.o .libs/libgmp.lax/lt28-iset_si.o .libs/libgmp.lax/lt29-iset_str.o .libs/libgmp.lax/lt30-iset_ui.o mpz/jacobi.o mpz/kronsz.o    
mpz/kronuz.o mpz/kronzs.o mpz/kronzu.o mpz/lcm.o mpz/lcm_ui.o mpz/limbs_finish.o mpz/limbs_modify.o mpz/limbs_read.o mpz/limbs_write.o mpz/lucmod.o mpz/lucnum_ui.o mpz/lucnum2_ui.o      
mpz/millerrabin.o mpz/mod.o .libs/libgmp.lax/lt31-mul.o .libs/libgmp.lax/lt32-mul_2exp.o mpz/mul_si.o .libs/libgmp.lax/lt33-mul_ui.o mpz/n_pow_ui.o .libs/libgmp.lax/lt34-neg.o           
.libs/libgmp.lax/lt35-nextprime.o mpz/out_raw.o .libs/libgmp.lax/lt36-out_str.o mpz/perfpow.o mpz/perfsqr.o mpz/popcount.o .libs/libgmp.lax/lt37-pow_ui.o mpz/powm.o mpz/powm_sec.o       
mpz/powm_ui.o mpz/primorial_ui.o mpz/pprime_p.o mpz/random.o .libs/libgmp.lax/lt38-random2.o mpz/realloc.o mpz/realloc2.o mpz/remove.o mpz/roinit_n.o mpz/root.o mpz/rootrem.o            
mpz/rrandomb.o mpz/scan0.o mpz/scan1.o .libs/libgmp.lax/lt39-set.o .libs/libgmp.lax/lt40-set_d.o mpz/set_f.o .libs/libgmp.lax/lt41-set_q.o .libs/libgmp.lax/lt42-set_si.o                 
.libs/libgmp.lax/lt43-set_str.o .libs/libgmp.lax/lt44-set_ui.o mpz/setbit.o .libs/libgmp.lax/lt45-size.o mpz/sizeinbase.o .libs/libgmp.lax/lt46-sqrt.o mpz/sqrtrem.o mpz/stronglucas.o    
.libs/libgmp.lax/lt47-sub.o .libs/libgmp.lax/lt48-sub_ui.o .libs/libgmp.lax/lt49-swap.o mpz/tdiv_ui.o mpz/tdiv_q.o mpz/tdiv_q_2exp.o mpz/tdiv_q_ui.o mpz/tdiv_qr.o mpz/tdiv_qr_ui.o       
mpz/tdiv_r.o mpz/tdiv_r_2exp.o mpz/tdiv_r_ui.o mpz/tstbit.o mpz/ui_pow_ui.o .libs/libgmp.lax/lt50-ui_sub.o .libs/libgmp.lax/lt51-urandomb.o mpz/urandomm.o mpz/xor.o                      
.libs/libgmp.lax/lt52-abs.o mpq/aors.o mpq/canonicalize.o .libs/libgmp.lax/lt53-clear.o .libs/libgmp.lax/lt54-clears.o .libs/libgmp.lax/lt55-cmp.o .libs/libgmp.lax/lt56-cmp_si.o         
.libs/libgmp.lax/lt57-cmp_ui.o .libs/libgmp.lax/lt58-div.o .libs/libgmp.lax/lt59-get_d.o mpq/get_den.o mpq/get_num.o .libs/libgmp.lax/lt60-get_str.o .libs/libgmp.lax/lt61-init.o         
.libs/libgmp.lax/lt62-inits.o .libs/libgmp.lax/lt63-inp_str.o mpq/inv.o mpq/md_2exp.o .libs/libgmp.lax/lt64-mul.o .libs/libgmp.lax/lt65-neg.o .libs/libgmp.lax/lt66-out_str.o             
.libs/libgmp.lax/lt67-set.o mpq/set_den.o mpq/set_num.o .libs/libgmp.lax/lt68-set_si.o .libs/libgmp.lax/lt69-set_str.o .libs/libgmp.lax/lt70-set_ui.o mpq/equal.o                         
.libs/libgmp.lax/lt71-set_z.o .libs/libgmp.lax/lt72-set_d.o .libs/libgmp.lax/lt73-set_f.o .libs/libgmp.lax/lt74-swap.o mpn/fib_table.o mpn/mp_bases.o .libs/libgmp.lax/lt75-add.o         
mpn/add_1.o mpn/add_n.o .libs/libgmp.lax/lt76-sub.o mpn/sub_1.o mpn/sub_n.o mpn/cnd_add_n.o mpn/cnd_sub_n.o mpn/cnd_swap.o .libs/libgmp.lax/lt77-neg.o .libs/libgmp.lax/lt78-com.o        
mpn/mul_1.o mpn/addmul_1.o mpn/submul_1.o mpn/add_err1_n.o mpn/add_err2_n.o mpn/add_err3_n.o mpn/sub_err1_n.o mpn/sub_err2_n.o mpn/sub_err3_n.o mpn/lshift.o mpn/rshift.o mpn/dive_1.o    
mpn/diveby3.o .libs/libgmp.lax/lt79-divis.o mpn/divrem.o mpn/divrem_1.o mpn/divrem_2.o .libs/libgmp.lax/lt80-fib2_ui.o mpn/fib2m.o mpn/mod_1.o mpn/mod_34lsub1.o mpn/mode1o.o             
mpn/pre_divrem_1.o mpn/pre_mod_1.o .libs/libgmp.lax/lt81-dump.o mpn/mod_1_1.o mpn/mod_1_2.o mpn/mod_1_3.o mpn/mod_1_4.o mpn/lshiftc.o .libs/libgmp.lax/lt82-mul.o mpn/mul_fft.o           
mpn/mul_n.o mpn/sqr.o mpn/mul_basecase.o mpn/sqr_basecase.o mpn/nussbaumer_mul.o mpn/mulmid_basecase.o mpn/toom42_mulmid.o mpn/mulmid_n.o mpn/mulmid.o .libs/libgmp.lax/lt83-random.o     
.libs/libgmp.lax/lt84-random2.o mpn/pow_1.o .libs/libgmp.lax/lt85-rootrem.o .libs/libgmp.lax/lt86-sqrtrem.o .libs/libgmp.lax/lt87-sizeinbase.o .libs/libgmp.lax/lt88-get_str.o            
.libs/libgmp.lax/lt89-set_str.o mpn/compute_powtab.o .libs/libgmp.lax/lt90-scan0.o .libs/libgmp.lax/lt91-scan1.o .libs/libgmp.lax/lt92-popcount.o .libs/libgmp.lax/lt93-hamdist.o         
.libs/libgmp.lax/lt94-cmp.o mpn/zero_p.o .libs/libgmp.lax/lt95-perfsqr.o .libs/libgmp.lax/lt96-perfpow.o mpn/strongfibo.o mpn/gcd_11.o mpn/gcd_22.o mpn/gcd_1.o                           
.libs/libgmp.lax/lt97-gcd.o mpn/gcdext_1.o .libs/libgmp.lax/lt98-gcdext.o mpn/gcd_subdiv_step.o mpn/gcdext_lehmer.o mpn/div_q.o .libs/libgmp.lax/lt99-tdiv_qr.o mpn/jacbase.o             
mpn/jacobi_2.o .libs/libgmp.lax/lt100-jacobi.o .libs/libgmp.lax/lt101-get_d.o mpn/matrix22_mul.o mpn/matrix22_mul1_inverse_vector.o mpn/hgcd_matrix.o mpn/hgcd2.o mpn/hgcd_step.o         
mpn/hgcd_reduce.o mpn/hgcd.o mpn/hgcd_appr.o mpn/hgcd2_jacobi.o mpn/hgcd_jacobi.o mpn/mullo_n.o mpn/mullo_basecase.o mpn/sqrlo.o mpn/sqrlo_basecase.o mpn/toom22_mul.o mpn/toom32_mul.o   
mpn/toom42_mul.o mpn/toom52_mul.o mpn/toom62_mul.o mpn/toom33_mul.o mpn/toom43_mul.o mpn/toom53_mul.o mpn/toom54_mul.o mpn/toom63_mul.o mpn/toom44_mul.o mpn/toom6h_mul.o mpn/toom6_sqr.o 
mpn/toom8h_mul.o mpn/toom8_sqr.o mpn/toom_couple_handling.o mpn/toom2_sqr.o mpn/toom3_sqr.o mpn/toom4_sqr.o mpn/toom_eval_dgr3_pm1.o mpn/toom_eval_dgr3_pm2.o mpn/toom_eval_pm1.o         
mpn/toom_eval_pm2.o mpn/toom_eval_pm2exp.o mpn/toom_eval_pm2rexp.o mpn/toom_interpolate_5pts.o mpn/toom_interpolate_6pts.o mpn/toom_interpolate_7pts.o mpn/toom_interpolate_8pts.o        
mpn/toom_interpolate_12pts.o mpn/toom_interpolate_16pts.o mpn/invertappr.o .libs/libgmp.lax/lt102-invert.o mpn/binvert.o mpn/mulmod_bnm1.o mpn/sqrmod_bnm1.o mpn/mulmod_bknp1.o           
mpn/div_qr_1.o mpn/div_qr_1n_pi1.o mpn/div_qr_2.o mpn/div_qr_2n_pi1.o mpn/div_qr_2u_pi1.o mpn/sbpi1_div_q.o mpn/sbpi1_div_qr.o mpn/sbpi1_divappr_q.o mpn/dcpi1_div_q.o mpn/dcpi1_div_qr.o 
mpn/dcpi1_divappr_q.o mpn/mu_div_qr.o mpn/mu_divappr_q.o mpn/mu_div_q.o mpn/bdiv_q_1.o mpn/sbpi1_bdiv_q.o mpn/sbpi1_bdiv_qr.o mpn/sbpi1_bdiv_r.o mpn/dcpi1_bdiv_q.o mpn/dcpi1_bdiv_qr.o   
mpn/mu_bdiv_q.o mpn/mu_bdiv_qr.o mpn/bdiv_q.o mpn/bdiv_qr.o mpn/broot.o mpn/brootinv.o mpn/bsqrt.o mpn/bsqrtinv.o .libs/libgmp.lax/lt103-divexact.o mpn/bdiv_dbm1c.o mpn/redc_1.o         
mpn/redc_2.o mpn/redc_n.o .libs/libgmp.lax/lt104-powm.o mpn/powlo.o mpn/sec_powm.o mpn/sec_mul.o mpn/sec_sqr.o mpn/sec_div_qr.o mpn/sec_div_r.o mpn/sec_pi1_div_qr.o mpn/sec_pi1_div_r.o  
mpn/sec_add_1.o mpn/sec_sub_1.o mpn/sec_invert.o mpn/trialdiv.o .libs/libgmp.lax/lt105-remove.o mpn/and_n.o mpn/andn_n.o mpn/nand_n.o mpn/ior_n.o mpn/iorn_n.o mpn/nior_n.o mpn/xor_n.o   
mpn/xnor_n.o mpn/copyi.o mpn/copyd.o mpn/zero.o mpn/sec_tabselect.o mpn/comb_tables.o mpn/add_n_sub_n.o printf/asprintf.o printf/asprntffuns.o printf/doprnt.o printf/doprntf.o           
printf/doprnti.o printf/fprintf.o printf/obprintf.o printf/obvprintf.o printf/obprntffuns.o printf/printf.o printf/printffuns.o printf/snprintf.o printf/snprntffuns.o printf/sprintf.o   
printf/sprintffuns.o printf/vasprintf.o printf/vfprintf.o printf/vprintf.o printf/vsnprintf.o printf/vsprintf.o printf/repl-vsnprintf.o scanf/doscan.o scanf/fscanf.o scanf/fscanffuns.o  
scanf/scanf.o scanf/sscanf.o scanf/sscanffuns.o scanf/vfscanf.o scanf/vscanf.o scanf/vsscanf.o rand/rand.o rand/randclr.o rand/randdef.o rand/randiset.o rand/randlc2s.o rand/randlc2x.o  
rand/randmt.o rand/randmts.o rand/rands.o rand/randsd.o rand/randsdui.o rand/randbui.o rand/randmui.o                                                                                     
/workspaces/pyodide/emsdk/emsdk/upstream/bin/llvm-ar: error: .libs/libgmp.lax/lt91-scan1.o: No such file or directory                                                                     
make[2]: *** [Makefile:883: libgmp.la] Error 1                                                                                                                                            
make[2]: Leaving directory '/workspaces/pyodide/packages/libgmp/build/libgmp-6.3.0'                                                                                                       
make[1]: *** [Makefile:998: all-recursive] Error 1                                                                                                                                        
make[1]: Leaving directory '/workspaces/pyodide/packages/libgmp/build/libgmp-6.3.0'                                                                                                       
make: *** [Makefile:788: all] Error 2                                                                                                                                                     
```

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
