### PR TITLE
`pyodide_build.logger`: Do not use escape sequences when running under pytest

### DIFF
--- a/pyodide-build/pyodide_build/logger.py
+++ b/pyodide-build/pyodide_build/logger.py
@@ -9,6 +9,7 @@ from rich.logging import RichHandler
 from rich.theme import Theme
 
 IN_CI = "CI" in os.environ
+IN_PYTEST = "IN_PYTEST" in os.environ
 
 COLOR_THEME = Theme(
     {
@@ -30,7 +31,7 @@ class CIAwareConsole(Console):
     @property
     def is_terminal(self) -> bool:
         """Check if the console is writing to a terminal."""
-        return not IN_CI and super().is_terminal
+        return not IN_CI and not IN_PYTEST and super().is_terminal
 
 
 class StdoutFilter(logging.Filter):


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Running in the Conda devcontainer, I was getting:
```
$ pytest pyodide_build/tests/test_buildpkg.py 
============================================================== test session starts ==============================================================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspaces/pyodide
configfile: pyproject.toml
plugins: hypothesis-6.96.2, cov-4.1.0, pyodide-0.56.2, httpserver-1.0.8, benchmark-4.0.0, asyncio-0.23.3
asyncio: mode=Mode.STRICT
collected 7 items                                                                                                                               

pyodide_build/tests/test_buildpkg.py ..F....                                                                                              [100%]

=================================================================== FAILURES ====================================================================
____________________________________________________ test_subprocess_with_shared_env_logging ____________________________________________________
pyodide_build/tests/test_buildpkg.py:81: in test_subprocess_with_shared_env_logging
    assert [l.strip() for l in cap.err.splitlines()] == [
E   AssertionError: assert ['\x1b[1;31mE...xit 7\x1b[0m'] == ['ERROR: test...ed', 'exit 7']
E     At index 0 diff: '\x1b[1;31mERROR: test2 script failed\x1b[0m' != 'ERROR: test2 script failed'
E     Use -v to get more diff
```

(This is output from the process itself, not the subprocess being tested.) We fix it by handling the environment variable `IN_PYTEST` (set by `conftest.py`) the same way as `IN_CI` is already handled.
