### PR TITLE
Fix `pytest test_run_docker.py` when invoked from a subdirectory

### DIFF
--- a/pyodide-build/pyodide_build/tests/test_run_docker.py
+++ b/pyodide-build/pyodide_build/tests/test_run_docker.py
@@ -2,7 +2,12 @@ import os
 import subprocess
 from pathlib import Path
 
-PYODIDE_ROOT = Path(os.environ.get("PYODIDE_ROOT", os.getcwd()))
+PYODIDE_ROOT = os.environ.get("PYODIDE_ROOT")
+if PYODIDE_ROOT:
+    PYODIDE_ROOT = Path(PYODIDE_ROOT)
+else:
+    from pyodide_build import build_env
+    PYODIDE_ROOT = build_env.search_pyodide_root(os.getcwd())
 
 
 def test_run_docker_script():

--- a/pyodide-build/pyodide_build/tests/test_run_docker.py
+++ b/pyodide-build/pyodide_build/tests/test_run_docker.py
@@ -7,6 +7,7 @@ if PYODIDE_ROOT:
     PYODIDE_ROOT = Path(PYODIDE_ROOT)
 else:
     from pyodide_build import build_env
+
     PYODIDE_ROOT = build_env.search_pyodide_root(os.getcwd())
 
 

--- a/pyodide-build/pyodide_build/tests/test_run_docker.py
+++ b/pyodide-build/pyodide_build/tests/test_run_docker.py
@@ -2,13 +2,12 @@ import os
 import subprocess
 from pathlib import Path
 
-PYODIDE_ROOT = os.environ.get("PYODIDE_ROOT")
-if PYODIDE_ROOT:
-    PYODIDE_ROOT = Path(PYODIDE_ROOT)
+if "PYODIDE_ROOT" in os.environ:
+    PYODIDE_ROOT = Path(os.environ["PYODIDE_ROOT"])
 else:
     from pyodide_build import build_env
 
-    PYODIDE_ROOT = build_env.search_pyodide_root(os.getcwd())
+    PYODIDE_ROOT = build_env.search_pyodide_root(Path.cwd())
 
 
 def test_run_docker_script():


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->
```
$ cd pyodide-build
$ pytest
____________________________________________________________ test_run_docker_script _____________________________________________________________
pyodide_build/tests/test_run_docker.py:15: in test_run_docker_script
    assert "Usage: run_docker" in res.stdout.decode("utf-8")
E   AssertionError: assert 'Usage: run_docker' in ''
E    +  where '' = <built-in method decode of bytes object at 0x562ea20a9bc8>('utf-8')
E    +    where <built-in method decode of bytes object at 0x562ea20a9bc8> = b''.decode
E    +      where b'' = CompletedProcess(args=['bash', '/workspaces/pyodide/pyodide-build/run_docker', '--help'], returncode=127, stdout=b'', stderr=b'bash: /workspaces/pyodide/pyodide-build/run_docker: No such file or directory\n').stdout
```

Here we improve how `PYODIDE_ROOT`, the location of the `run_docker` script, is determined.

