### PR TITLE
`tools/dependency-check.sh`: Avoid issuing confusing error message

### DIFF
--- a/tools/dependency-check.sh
+++ b/tools/dependency-check.sh
@@ -6,12 +6,21 @@ failure_exit() {
 }
 
 check_python_version() {
+  if [ -z "$PYMAJOR$PYMINOR" ]; then
+    echo >&2 "$0: This script expects that environment variables PYMAJOR and PYMINOR are set; skipping check_python_version"
+    return
+  fi
   if ! command -v python"$PYMAJOR"."$PYMINOR" &> /dev/null; then
     echo >&2 "Must compile with python $PYMAJOR.$PYMINOR."
     exit 1
   fi
 }
+
 check_python_headers() {
+  if [ -z "$PYMAJOR$PYMINOR" ]; then
+    echo >&2 "$0: This script expects that environment variables PYMAJOR and PYMINOR are set; skipping check_python_headers"
+    return
+  fi
   local python_headers_present
   python_headers_present=$(pkg-config --libs python-"$PYMAJOR"."$PYMINOR")
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->
```
$ ./tools/dependency-check.sh 
Must compile with python ..
```

The trivial improvement of this PR is to change this to:
```
$ ./tools/dependency-check.sh 
./tools/dependency-check.sh: This script expects that environment variables PYMAJOR and PYMINOR are set; skipping check_python_version
```
