### PR TITLE
dev containers: Create a convenience symlink to the package build directory

### DIFF
--- a/.devcontainer/onCreate-conda.sh
+++ b/.devcontainer/onCreate-conda.sh
@@ -18,7 +18,11 @@ echo "conda activate pyodide-env" >> ~/.bashrc
 # https://pyodide.org/en/stable/development/building-from-sources.html#using-docker
 export EMSDK_NUM_CORE=12 EMCC_CORES=12 PYODIDE_JOBS=12
 echo "export EMSDK_NUM_CORE=12 EMCC_CORES=12 PYODIDE_JOBS=12" >> ~/.bashrc
-echo "export PYODIDE_RECIPE_BUILD_DIR=/tmp/pyodide-build" >> ~/.bashrc
+
+export PYODIDE_RECIPE_BUILD_DIR=/tmp/pyodide-build
+mkdir -p "$PYODIDE_RECIPE_BUILD_DIR"
+echo "export PYODIDE_RECIPE_BUILD_DIR=$PYODIDE_RECIPE_BUILD_DIR" >> ~/.bashrc
+ln -sf "$PYODIDE_RECIPE_BUILD_DIR" packages/.build || echo "Note: Could not create convenience symlink packages/.build"
 
 conda run -n pyodide-env --live-stream pip install -r requirements.txt
 

--- a/.devcontainer/onCreate-docker.sh
+++ b/.devcontainer/onCreate-docker.sh
@@ -6,7 +6,10 @@ set -e
 # https://pyodide.org/en/stable/development/new-packages.html#prerequisites
 pip install -e ./pyodide-build
 
-echo "export PYODIDE_RECIPE_BUILD_DIR=/tmp/pyodide-build" >> ~/.bashrc
+export PYODIDE_RECIPE_BUILD_DIR=/tmp/pyodide-build
+mkdir -p "$PYODIDE_RECIPE_BUILD_DIR"
+echo "export PYODIDE_RECIPE_BUILD_DIR=$PYODIDE_RECIPE_BUILD_DIR" >> ~/.bashrc
+ln -sf "$PYODIDE_RECIPE_BUILD_DIR" packages/.build || echo "Note: Could not create convenience symlink packages/.build"
 
 # Building emsdk and cpython takes a few minutes to run, so we do not run it here.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ emsdk/emsdk
 geckodriver.log
 node_modules
 packages/.artifacts
+packages/.build
 packages/.libs
 packages/*/build.log*
 packages/build-logs


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Creating a symlink `packages/.build` to the `$PYODIDE_RECIPE_BUILD_DIR`, located in `/tmp`.
This gives convenient access to the build directories in VS Code.

<img width="520" alt="Screenshot 2024-01-26 at 1 29 20 PM" src="https://github.com/pyodide/pyodide/assets/8345221/3964a7de-4cbe-414c-b62d-55fb21e8b310">

