### PR TITLE
Update docker image to bookworm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     # Note: when updating the docker image version,
     #       make sure there are no extra old versions lying around.
     #       (e.g. `rg -F --hidden <old_tag>`)
-    - image: pyodide/pyodide-env:20230506-chrome112-firefox112-py311
+    - image: pyodide/pyodide-env:20240127-chrome114-firefox122-py311
   environment:
     - EMSDK_NUM_CORES: 3
       EMCC_CORES: 3

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Docker",
   // keep in sync with "run_docker"
-  "image": "pyodide/pyodide-env:20230506-chrome112-firefox112-py311",
+  "image": "pyodide/pyodide-env:20240127-chrome114-firefox122-py311",
   "remoteUser": "root",
   "onCreateCommand": ".devcontainer/onCreate-docker.sh"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:20.1.0-buster-slim AS node-image
-FROM python:3.11.3-slim-buster
+FROM node:20.11-bookworm-slim AS node-image
+FROM python:3.11.7-slim-bookworm
 
 # Requirements for building packages
 RUN apt-get update \
@@ -7,7 +7,7 @@ RUN apt-get update \
         bzip2 ccache f2c g++ gfortran git make \
         patch pkg-config swig unzip wget xz-utils \
         autoconf autotools-dev automake texinfo dejagnu \
-        build-essential prelink autoconf libtool libltdl-dev \
+        build-essential libtool libltdl-dev \
         gnupg2 libdbus-glib-1-2 sudo sqlite3 \
         ninja-build jq xxd \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Buster isn't available for anymore for Python 312 so we have to update.

Bookworm doesn't seem to have the prelink package unfortunately
