### PR TITLE
FIX on buildall fail, print info after exiting rich context

### DIFF
--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -19,6 +19,7 @@ from threading import Lock, Thread
 from time import perf_counter, sleep
 from typing import Any
 
+from packaging.utils import canonicalize_name
 from pyodide_lock import PyodideLockSpec
 from pyodide_lock.spec import PackageSpec as PackageLockSpec
 from pyodide_lock.utils import update_package_sha256
@@ -26,8 +27,6 @@ from rich.live import Live
 from rich.progress import BarColumn, Progress, TimeElapsedColumn
 from rich.spinner import Spinner
 from rich.table import Table
-
-from packaging.utils import canonicalize_name
 
 from . import build_env, recipe
 from .buildpkg import needs_rebuild

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -559,7 +559,7 @@ def build_from_graph(
         if len(pkg.unbuilt_host_dependencies) == 0:
             build_queue.put((job_priority(pkg), pkg))
 
-    built_queue: Queue[BasePackage | Exception] = Queue()
+    built_queue: Queue[BasePackage | BaseException] = Queue()
     thread_lock = Lock()
     queue_idx = 1
     building_rust_pkg = False
@@ -627,10 +627,8 @@ def build_from_graph(
                 match built_queue.get():
                     case BaseException() as err:
                         raise err
-                    case a_package:
-                        # MyPy should understand that this is a BasePackage
-                        assert not isinstance(a_package, Exception)
-                        pkg = a_package
+                    case BasePackage() as pkg:
+                        pass
 
                 num_built += 1
 


### PR DESCRIPTION
Otherwise the rich Live context will sometimes overwrite part of the failure message.
