### PR TITLE
Split build-recipes and build-recipes-no-deps into separate commands

### DIFF
--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -1,14 +1,54 @@
 from pathlib import Path
+import dataclasses
 
 import typer
 
-from .. import build_env, buildall, buildpkg, pywasmcross
+from ..pywasmcross import BuildArgs
+from .. import build_env, buildall, buildpkg
 from ..build_env import init_environment
 from ..common import get_num_cores
 from ..logger import logger
 
 
-def recipe(
+@dataclasses.dataclass(eq=False, order=False, kw_only=True)
+class Args:
+    recipe_dir: Path
+    build_dir: Path
+    install_dir: Path
+    build_args: BuildArgs
+    force_rebuild: bool
+    n_jobs: int
+
+    def __init__(
+        self,
+        *,
+        recipe_dir: Path | str | None,
+        build_dir: Path | str | None,
+        install_dir: Path | str | None = None,
+        build_args: BuildArgs,
+        force_rebuild: bool,
+        n_jobs: int | None = None
+    ):
+        root = Path.cwd()
+        self.recipe_dir = (
+            root / "packages" if not recipe_dir else Path(recipe_dir).resolve()
+        )
+        self.build_dir = self.recipe_dir if not build_dir else Path(build_dir).resolve()
+        self.install_dir = root / "dist" if not install_dir else Path(install_dir).resolve()
+        self.build_args = build_args
+        self.force_rebuild = force_rebuild
+        self.n_jobs = n_jobs or get_num_cores()
+        if not self.recipe_dir.is_dir():
+            raise FileNotFoundError(f"Recipe directory {self.recipe_dir} not found")
+
+
+@dataclasses.dataclass(eq=False, order=False, kw_only=True)
+class InstallOptions:
+    compression_level: int
+    metadata: bool
+
+
+def build_recipes_no_deps(
     packages: list[str] = typer.Argument(
         ..., help="Packages to build, or ``*`` for all packages in recipe directory"
     ),
@@ -23,8 +63,80 @@ def recipe(
         help="The directory where build directories for packages are created. "
         "Default: recipe_dir.",
     ),
-    no_deps: bool = typer.Option(
-        False, help="If true, do not build dependencies of the specified packages. "
+    cflags: str = typer.Option(
+        None, help="Extra compiling flags. Default: SIDE_MODULE_CFLAGS"
+    ),
+    cxxflags: str = typer.Option(
+        None, help="Extra compiling flags. Default: SIDE_MODULE_CXXFLAGS"
+    ),
+    ldflags: str = typer.Option(
+        None, help="Extra linking flags. Default: SIDE_MODULE_LDFLAGS"
+    ),
+    target_install_dir: str = typer.Option(
+        None,
+        help="The path to the target Python installation. Default: TARGETINSTALLDIR",
+    ),
+    host_install_dir: str = typer.Option(
+        None,
+        help="Directory for installing built host packages. Default: HOSTINSTALLDIR",
+    ),
+    force_rebuild: bool = typer.Option(
+        False,
+        help="Force rebuild of all packages regardless of whether they appear to have been updated",
+    ),
+    continue_: bool = typer.Option(
+        False,
+        "--continue",
+        help="Continue a build from the middle. For debugging. Implies '--force-rebuild'",
+    ),
+) -> None:
+    """Build packages using yaml recipes and create pyodide-lock.json"""
+    init_environment()
+
+    if build_env.in_xbuildenv():
+        build_env.check_emscripten_version()
+
+    build_args = BuildArgs(
+        cflags=cflags,
+        cxxflags=cxxflags,
+        ldflags=ldflags,
+        target_install_dir=target_install_dir,
+        host_install_dir=host_install_dir,
+    )
+    build_args = buildall.set_default_build_args(build_args)
+    args = Args(
+        build_args=build_args,
+        build_dir=build_dir,
+        recipe_dir=recipe_dir,
+        force_rebuild=force_rebuild
+    )
+
+    return build_recipes_no_deps_impl(packages, args, continue_)
+
+
+def build_recipes_no_deps_impl(packages: list[str], args: Args, continue_: bool) -> None:
+    # TODO: use multiprocessing?
+    for package in packages:
+        package_path = args.recipe_dir / package
+        buildpkg.build_package(
+            package_path, args.build_args, args.build_dir, args.force_rebuild, continue_
+        )
+
+
+def build_recipes(
+    packages: list[str] = typer.Argument(
+        ..., help="Packages to build, or ``*`` for all packages in recipe directory"
+    ),
+    recipe_dir: str = typer.Option(
+        None,
+        help="The directory containing the recipe of packages. "
+        "If not specified, the default is ``./packages``",
+    ),
+    build_dir: str = typer.Option(
+        None,
+        envvar="PYODIDE_RECIPE_BUILD_DIR",
+        help="The directory where build directories for packages are created. "
+        "Default: recipe_dir.",
     ),
     install: bool = typer.Option(
         False,
@@ -64,11 +176,6 @@ def recipe(
         False,
         help="Force rebuild of all packages regardless of whether they appear to have been updated",
     ),
-    continue_: bool = typer.Option(
-        False,
-        "--continue",
-        help="Continue a build from the middle. For debugging. Implies '--force-rebuild'",
-    ),
     n_jobs: int = typer.Option(
         None,
         help="Number of packages to build in parallel  (default: # of cores in the system)",
@@ -78,23 +185,21 @@ def recipe(
         help="Level of zip compression to apply when installing. 0 means no compression.",
     ),
 ) -> None:
-    """Build packages using yaml recipes and create pyodide-lock.json"""
+    if metadata_files and not install:
+        logger.warning(
+            "WARNING: when --install is not set, the --metadata-files parameter is ignored",
+        )
+
+    install_options: InstallOptions | None = None
+    if install:
+        install_options = InstallOptions(metadata=metadata_files, compression_level=compression_level)
+
     init_environment()
 
     if build_env.in_xbuildenv():
         build_env.check_emscripten_version()
 
-    root = Path.cwd()
-    recipe_dir_ = root / "packages" if not recipe_dir else Path(recipe_dir).resolve()
-    build_dir_ = recipe_dir_ if not build_dir else Path(build_dir).resolve()
-    install_dir_ = root / "dist" if not install_dir else Path(install_dir).resolve()
-    log_dir_ = None if not log_dir else Path(log_dir).resolve()
-    n_jobs = n_jobs or get_num_cores()
-
-    if not recipe_dir_.is_dir():
-        raise FileNotFoundError(f"Recipe directory {recipe_dir_} not found")
-
-    build_args = pywasmcross.BuildArgs(
+    build_args = BuildArgs(
         cflags=cflags,
         cxxflags=cxxflags,
         ldflags=ldflags,
@@ -102,48 +207,42 @@ def recipe(
         host_install_dir=host_install_dir,
     )
     build_args = buildall.set_default_build_args(build_args)
+    args = Args(
+        build_args=build_args,
+        build_dir=build_dir,
+        install_dir=install_dir,
+        recipe_dir=recipe_dir,
+        force_rebuild=force_rebuild,
+        n_jobs=n_jobs
+    )
+    log_dir_ = Path(log_dir).resolve() if log_dir else None
+    build_recipes_impl(packages, args, log_dir_, install_options)
 
-    if no_deps:
-        if install or log_dir_ or metadata_files:
-            logger.warning(
-                "WARNING: when --no-deps is set, the --install, --log-dir, and --metadata-files parameters are ignored",
-            )
 
-        # TODO: use multiprocessing?
-        for package in packages:
-            package_path = recipe_dir_ / package
-            buildpkg.build_package(
-                package_path, build_args, build_dir_, force_rebuild, continue_
-            )
-
+def build_recipes_impl(packages: list[str], args: Args, *, log_dir: str | None, install_options: InstallOptions | None) -> None:
+    if len(packages) == 1 and "," in packages[0]:
+        # Handle packages passed with old comma separated syntax.
+        # This is to support `PYODIDE_PACKAGES="pkg1,pkg2,..." make` syntax.
+        targets = packages[0].replace(" ", "")
     else:
-        if len(packages) == 1 and "," in packages[0]:
-            # Handle packages passed with old comma separated syntax.
-            # This is to support `PYODIDE_PACKAGES="pkg1,pkg2,..." make` syntax.
-            targets = packages[0].replace(" ", "")
-        else:
-            targets = ",".join(packages)
+        targets = ",".join(packages)
 
-        pkg_map = buildall.build_packages(
-            recipe_dir_,
-            targets,
-            build_args,
-            build_dir_,
-            n_jobs,
-            force_rebuild,
+    pkg_map = buildall.build_packages(
+        args.recipe_dir,
+        targets=targets,
+        build_args=args.build_args,
+        build_dir=args.build_dir,
+        n_jobs=args.n_jobs,
+        force_rebuild=args.force_rebuild,
+    )
+
+    if log_dir:
+        buildall.copy_logs(pkg_map, log_dir)
+
+    if install_options:
+        buildall.install_packages(
+            pkg_map,
+            args.install_dir,
+            compression_level=install_options.compression_level,
+            metadata_files=install_options.metadata_files,
         )
-
-        if log_dir_:
-            buildall.copy_logs(pkg_map, log_dir_)
-
-        if install:
-            buildall.install_packages(
-                pkg_map,
-                install_dir_,
-                compression_level=compression_level,
-                metadata_files=metadata_files,
-            )
-        elif metadata_files:
-            logger.warning(
-                "WARNING: when --install is not set, the --metadata-files parameter is ignored",
-            )

--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -48,7 +48,8 @@ Documentation = "https://pyodide.org/en/stable/"
 
 [project.entry-points."pyodide.cli"]
 build = "pyodide_build.cli.build:main"
-build-recipes = "pyodide_build.cli.build_recipes:recipe"
+build-recipes = "pyodide_build.cli.build_recipes:build_recipes"
+build-recipes-no-deps = "pyodide_build.cli.build_recipes:build_recipes_no_deps"
 venv = "pyodide_build.cli.venv:main"
 skeleton = "pyodide_build.cli.skeleton:app"
 py-compile = "pyodide_build.cli.py_compile:main"


### PR DESCRIPTION
There are a lot of options that are only implemented for one or the other of these. We warn about some combinations of options that are ignored but skip a lot of them. Seems best to turn them into separate commands so that the two commands each only accept arguments that change their behavior.