### PR TITLE
build-recipes: Call search_pyodide_root to determine root

### DIFF
--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -121,7 +121,7 @@ def get_pyodide_root() -> Path:
     return Path(os.environ["PYODIDE_ROOT"])
 
 
-def search_pyodide_root(curdir: str | Path, *, max_depth: int = 5) -> Path:
+def search_pyodide_root(curdir: str | Path, *, max_depth: int = 10) -> Path:
     """
     Recursively search for the root of the Pyodide repository,
     by looking for the pyproject.toml file in the parent directories

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -31,6 +31,10 @@ class Args:
         n_jobs: int | None = None,
     ):
         root = Path.cwd()
+        try:
+            root = build_env.search_pyodide_root(root)
+        except FileNotFoundError:
+            pass
         self.recipe_dir = (
             root / "packages" if not recipe_dir else Path(recipe_dir).resolve()
         )


### PR DESCRIPTION
This makes it work all over the source tree. I also increased the default depth for search_pyodide_root to 10 because I think 5 is too small.
