### PR TITLE
pyodide_build.buildpkg: Do not copy dist/*.whl files from source trees

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -322,7 +322,16 @@ def prepare_source(
     if not srcdir.is_dir():
         raise ValueError(f"path={srcdir} must point to a directory that exists")
 
-    shutil.copytree(srcdir, srcpath)
+    def ignore(path, names):
+        ignored = []
+        if fnmatch.fnmatch(path, f'*/dist'):
+            # Do not copy dist/*.whl files from a dirty source tree;
+            # this can lead to "Exception: Unexpected number of wheels" later.
+            ignored.extend(name for name in names
+                           if name.endswith(".whl"))
+        return ignored
+
+    shutil.copytree(srcdir, srcpath, ignore=ignore)
 
 
 def patch(pkg_root: Path, srcpath: Path, src_metadata: _SourceSpec) -> None:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -324,11 +324,10 @@ def prepare_source(
 
     def ignore(path, names):
         ignored = []
-        if fnmatch.fnmatch(path, f'*/dist'):
+        if fnmatch.fnmatch(path, "*/dist"):
             # Do not copy dist/*.whl files from a dirty source tree;
             # this can lead to "Exception: Unexpected number of wheels" later.
-            ignored.extend(name for name in names
-                           if name.endswith(".whl"))
+            ignored.extend(name for name in names if name.endswith(".whl"))
         return ignored
 
     shutil.copytree(srcdir, srcpath, ignore=ignore)


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

When a meta.yaml uses `source/path` to build from some source tree, `pyodide build-recipes` copies the source tree to the build directory before building. When the source directory has some `dist/*.whl` files, they are copied as well, which later causes "Exception: Unexpected number of wheels".
Here we filter them out.
