### PR TITLE
TST Move run_docker test outside of pyodide-build

### DIFF
--- a/tools/tests/test_run_docker.py
+++ b/tools/tests/test_run_docker.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 

--- a/tools/tests/test_run_docker.py
+++ b/tools/tests/test_run_docker.py
@@ -2,12 +2,7 @@ import os
 import subprocess
 from pathlib import Path
 
-if "PYODIDE_ROOT" in os.environ:
-    PYODIDE_ROOT = Path(os.environ["PYODIDE_ROOT"])
-else:
-    from pyodide_build import build_env
-
-    PYODIDE_ROOT = build_env.search_pyodide_root(Path.cwd())
+PYODIDE_ROOT = Path(__file__).parent.parent.parent
 
 
 def test_run_docker_script():


### PR DESCRIPTION
It is weird that `test_run_docker` is inside pyodide-build. This PR moves the run_docker test file to `tools` directory. Maybe it is not the best place to put this test file, but it is at least better than pyodide-build.