### PR TITLE
Update the `boost-cpp` package to build common libraries

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -53,6 +53,11 @@ myst:
 - Upgraded `libproj` to 9.3.1, `pyproj` to 3.6.1, `h5py` to 3.10.0 {pr}`4426`,
   `packaging` to 23.2, `typing-extensions` to 4.9 {pr}`4428`
 
+- Updated `boost-cpp` config to build Boost.Atomic, Boost.Cobalt, Boost.Exception,
+  Boost.Graph, Boost.GraphParallel, Boost.Headers, Boost.IOStreams, Boost.Locale,
+  Boost.Log, Boost.Math, Boost.NoWide, Boost.Python, Boost.Test, Boost.Timer,
+  and Boost.Url. {pr}`4465`
+
 ## Version 0.25.0
 
 _January 18, 2023_

--- a/packages/boost-cpp/meta.yaml
+++ b/packages/boost-cpp/meta.yaml
@@ -18,15 +18,46 @@ build:
     # I don't understand why... the jam file used by boost is quite hard to understand.
     printf "using clang : emscripten : emcc : <archiver>emar <ranlib>emranlib <linker>emlink ;" | tee -a ./project-config.jam
 
+    # Boost Container (header-only possible) does not compile possibly due to pthread dependency.
+    # Boost Context (and thus Boost Coroutine, Boost Fiber) only supports certain architectures.
+    # Boost Contract requires Boost Thread.
+    # Boost JSON (header-only possible) uses Boost Container.
+    # Boost MPI actually builds successfully, but I doubt whether it makes any sense.
+    # Boost Type Erasure (header-only possible) / Boost Wave does not compile,
+    #   yielding a "Name clash for '<...>libboost_chrono.a'" error.
     ./b2 variant=release toolset=clang-emscripten link=static threading=single \
-      --with-date_time --with-filesystem \
-      --with-system --with-regex --with-chrono --with-random --with-program_options --disable-icu \
-      cxxflags="$SIDE_MODULE_CXXFLAGS -fexceptions -DBOOST_SP_DISABLE_THREADS=1" \
-      cflags="$SIDE_MODULE_CFLAGS -fexceptions -DBOOST_SP_DISABLE_THREADS=1" \
+      --with-atomic \
+      --with-chrono \
+      --with-cobalt \
+      --with-date_time \
+      --with-exception \
+      --with-filesystem \
+      --with-graph \
+      --with-graph_parallel \
+      --with-headers \
+      --with-iostreams \
+      --with-locale \
+      --with-log \
+      --with-math \
+      --with-nowide \
+      --with-program_options \
+      --with-python \
+      --with-random \
+      --with-regex \
+      --with-serialization \
+      --with-stacktrace \
+      --with-system \
+      --with-test \
+      --with-timer \
+      --with-url \
+      --disable-icu \
+      cxxflags="$SIDE_MODULE_CXXFLAGS -fexceptions -DBOOST_SP_DISABLE_THREADS=1 -DBOOST_LOG_WITHOUT_SYSLOG=1" \
+      cflags="$SIDE_MODULE_CFLAGS -fexceptions -DBOOST_SP_DISABLE_THREADS=1 -DBOOST_LOG_WITHOUT_SYSLOG=1" \
       linkflags="-fpic $SIDE_MODULE_LDFLAGS" \
       --layout=system -j"${PYODIDE_JOBS:-3}" --prefix=${INSTALL_DIR} \
       install
 
 about:
   home: https://www.boost.org/
+  license: BSL-1.0
   summary: Free peer-reviewed portable C++ source libraries.


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

The `boost-cpp` package was originally introduced as a dependency of the Robot Raconteur package, and it has only built `date_time, filesystem, system, regex, chrono, random, program_options` out of a ton of other libraries offered by Boost.

This PR adds options to the build commands in the `meta.yaml` file of `boost-cpp` to build more Boost libraries. The list is extracted by running `./b2 --show-libraries` with certain unsupported libraries excluded (see the comments in `meta.yaml`).

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [X] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [not necessary] Add / update tests
- [not necessary] Add new / update outdated documentation
