### PR TITLE
MAINT sysconfigdata updates split from #4435

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -24,12 +24,20 @@ endif
 
 all: $(INSTALL)/lib/$(LIB) $(INSTALL)/lib/libffi.a $(INSTALL)/lib/libhiwire.a
 
-
-$(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB)
+.PHONY=sysconfigdata
+sysconfigdata:
 	# Generate sysconfigdata. It outputs into a subfolder of build/, and
 	# the subfolder is written to pybuilddir.txt.
 	cd $(BUILD) && _PYTHON_SYSCONFIGDATA_NAME=$(SYSCONFIG_NAME) _PYTHON_PROJECT_BASE=$(BUILD) $(HOSTPYTHON) -m sysconfig --generate-posix-vars
+	$(eval PYBUILDDIR=$(BUILD)/`cat $(BUILD)/pybuilddir.txt`)
+	PYTHONPATH=$(PYBUILDDIR) python$(PYMAJOR).$(PYMINOR) adjust_sysconfig.py
+	mkdir -p $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
+	mkdir -p $(SYSCONFIGDATA_DIR)
+	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
+	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(SYSCONFIGDATA_DIR)
 
+
+$(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) sysconfigdata
 	( \
 		cd $(BUILD); \
 		sed -i -e 's/libinstall:.*/libinstall:/' Makefile; \
@@ -39,15 +47,9 @@ $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB)
 		cp $(LIB) $(INSTALL)/lib/ \
 	)
 
-	$(eval PYBUILDDIR=$(BUILD)/`cat $(BUILD)/pybuilddir.txt`)
-	PYTHONPATH=$(PYBUILDDIR) python$(PYMAJOR).$(PYMINOR) adjust_sysconfig.py
-	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
-	mkdir -p $(SYSCONFIGDATA_DIR)
-	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(SYSCONFIGDATA_DIR)
-
 
 .PHONY=rebuild
-rebuild:
+rebuild: sysconfigdata
 	emmake make -C $(BUILD) PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(LIB) -j $${PYODIDE_JOBS:-3}
 	cp $(BUILD)/$(LIB) $(INSTALL)/lib/
 

--- a/cpython/adjust_sysconfig.py
+++ b/cpython/adjust_sysconfig.py
@@ -1,5 +1,6 @@
 import os
 import pprint
+from textwrap import dedent
 
 
 def load_sysconfig(sysconfig_name: str):
@@ -10,11 +11,27 @@ def load_sysconfig(sysconfig_name: str):
 
 def write_sysconfig(destfile: str, config_vars: dict[str, str]):
     with open(destfile, "w", encoding="utf8") as f:
-        f.write(
-            "# system configuration generated and used by" " the sysconfig module\n"
-        )
+        f.write("# system configuration generated and used by the sysconfig module\n")
         f.write("build_time_vars = ")
         pprint.pprint(config_vars, stream=f)
+        # at build time, packages that are looking for the Python includes and
+        # libraries can get deceived by the values of platbase and
+        # installed_base (and possibly others, but we haven't run into trouble
+        # with them yet).
+        #
+        # At run time, the default behavior is correct. We look for the
+        # "PYODIDE" environment variable which is defined at build time but not
+        # at run time.
+        f.write(
+            dedent(
+                """
+                import os
+                if os.environ.get("PYODIDE", None) == "1":
+                    build_time_vars["installed_base"] = build_time_vars["prefix"]
+                    build_time_vars["platbase"] = build_time_vars["prefix"]
+                """
+            )
+        )
 
 
 def adjust_sysconfig(config_vars: dict[str, str]):


### PR DESCRIPTION
Generate sysconfig data as a separate .PHONY build step (it's fast and useful to be able to retrigger so why not). Update sysconfigdata to give better values at build time.