### PR TITLE
Fix linking of libhacl and tidy up cpython makefile

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -149,7 +149,6 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-lwebsocket.js \
 	-leventloop.js \
 	-lhiwire \
-	-lHacl_Hash_SHA2 \
 	\
 	-lGL \
 	-legl.js \
@@ -221,7 +220,6 @@ ifeq ($(DISABLE_DYLINK), 1)
 		-lhiwire \
 		-lidbfs.js \
 		-lnodefs.js \
-		-lHacl_Hash_SHA2 \
 
 endif
 

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -70,7 +70,7 @@ clean-all: clean
 $(PYTARBALL):
 	[ -d $(ROOT)/downloads ] || mkdir $(ROOT)/downloads
 	wget -q -O $@ $(PYTHON_ARCHIVE_URL)
-	@GOT_SHASUM=`shasum --algorithm 256 $(TARBALL) | cut -f1 -d' '` \
+	@GOT_SHASUM=`shasum --algorithm 256 $(PYTARBALL) | cut -f1 -d' '` \
 		&& (echo $$GOT_SHASUM | grep -q $(PYTHON_ARCHIVE_SHA256)) \
 		|| (\
 			   echo "Got unexpected shasum $$GOT_SHASUM" \

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -5,10 +5,10 @@ ROOT=$(abspath .)
 
 PYTHON_CFLAGS=$(CFLAGS_BASE) -DPY_CALL_TRAMPOLINE
 
-BUILD=$(CPYTHONROOT)/build/Python-$(PYVERSION)
-INSTALL=$(CPYTHONINSTALL)
-TARBALL=$(ROOT)/downloads/Python-$(PYVERSION).tgz
-LIB=libpython$(PYMAJOR).$(PYMINOR)$(CPYTHON_ABI_FLAGS).a
+PYBUILD=$(CPYTHONROOT)/build/Python-$(PYVERSION)
+PYINSTALL=$(CPYTHONINSTALL)
+PYTARBALL=$(ROOT)/downloads/Python-$(PYVERSION).tgz
+PYLIB=libpython$(PYMAJOR).$(PYMINOR)$(CPYTHON_ABI_FLAGS).a
 
 FFIBUILD=$(ROOT)/build/libffi
 LIBFFIREPO=https://github.com/libffi/libffi
@@ -22,38 +22,41 @@ ifdef CPYTHON_DEBUG
 	MAYBE_WITH_PYDEBUG=--with-pydebug
 endif
 
-all: $(INSTALL)/lib/$(LIB) $(INSTALL)/lib/libffi.a $(INSTALL)/lib/libhiwire.a
+all: $(PYINSTALL)/lib/$(PYLIB) $(PYINSTALL)/lib/libffi.a $(PYINSTALL)/lib/libhiwire.a
 
 .PHONY=sysconfigdata
 sysconfigdata:
 	# Generate sysconfigdata. It outputs into a subfolder of build/, and
 	# the subfolder is written to pybuilddir.txt.
-	cd $(BUILD) && _PYTHON_SYSCONFIGDATA_NAME=$(SYSCONFIG_NAME) _PYTHON_PROJECT_BASE=$(BUILD) $(HOSTPYTHON) -m sysconfig --generate-posix-vars
-	$(eval PYBUILDDIR=$(BUILD)/`cat $(BUILD)/pybuilddir.txt`)
+	cd $(PYBUILD) && _PYTHON_SYSCONFIGDATA_NAME=$(SYSCONFIG_NAME) _PYTHON_PROJECT_BASE=$(PYBUILD) $(HOSTPYTHON) -m sysconfig --generate-posix-vars
+	$(eval PYBUILDDIR=$(PYBUILD)/`cat $(PYBUILD)/pybuilddir.txt`)
 	PYTHONPATH=$(PYBUILDDIR) python$(PYMAJOR).$(PYMINOR) adjust_sysconfig.py
-	mkdir -p $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
+	mkdir -p $(PYINSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
 	mkdir -p $(SYSCONFIGDATA_DIR)
-	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(INSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
+	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(PYINSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
 	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(SYSCONFIGDATA_DIR)
 
+LIBPYTHON_EXTRA_OBJECTS=$$(LIBMPDEC_OBJS) $$(LIBEXPAT_OBJS) $$(LIBHACL_SHA2_OBJS)
 
-$(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) sysconfigdata
-	( \
-		cd $(BUILD); \
-		sed -i -e 's/libinstall:.*/libinstall:/' Makefile; \
-		sed -i '/MODOBJS=/s/$$/ $$(LIBMPDEC_OBJS) $$(LIBEXPAT_OBJS) /' Makefile; \
-		touch $(BUILD)/$(LIB) ; \
-		emmake make PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(LIB) -j $${PYODIDE_JOBS:-3} && \
-		cp $(LIB) $(INSTALL)/lib/ \
-	)
+$(PYBUILD)/.patched_makefile:
+	# Clear out libinstall deps (we build what we want explicitly first)
+	cd $(PYBUILD) && sed -i -e 's/libinstall:.*/libinstall:/' Makefile;
+	# Inject extra objects into libpython3.12.a so we don't have to link them
+	# separately
+	cd $(PYBUILD) && sed -i '/MODOBJS=/s/$$/ $(LIBPYTHON_EXTRA_OBJECTS)/' Makefile
+	touch $(PYBUILD)/.patched_makefile
 
-	cp $(BUILD)/Modules/_hacl/libHacl_Hash_SHA2.a $(INSTALL)/lib/
+$(PYINSTALL)/lib/$(PYLIB): $(PYBUILD)/$(PYLIB) sysconfigdata $(PYBUILD)/.patched_makefile
+	# touch libpython3.12.a so we don't remake it due to modified Makefile(??)
+	touch $(PYBUILD)/$(PYLIB)
+	emmake make -C $(PYBUILD) PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(PYLIB) -j $${PYODIDE_JOBS:-3}
+	cp $(PYBUILD)/$(PYLIB) $(PYINSTALL)/lib/
 
 
 .PHONY=rebuild
 rebuild: sysconfigdata
-	emmake make -C $(BUILD) PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(LIB) -j $${PYODIDE_JOBS:-3}
-	cp $(BUILD)/$(LIB) $(INSTALL)/lib/
+	emmake make -C $(PYBUILD) PYTHON_FOR_BUILD=$(HOSTPYTHON) CROSS_COMPILE=yes inclinstall libinstall $(PYLIB) -j $${PYODIDE_JOBS:-3}
+	cp $(PYBUILD)/$(PYLIB) $(PYINSTALL)/lib/
 
 
 clean:
@@ -64,7 +67,7 @@ clean-all: clean
 	-rm -fr $(ROOT)/downloads
 
 
-$(TARBALL):
+$(PYTARBALL):
 	[ -d $(ROOT)/downloads ] || mkdir $(ROOT)/downloads
 	wget -q -O $@ $(PYTHON_ARCHIVE_URL)
 	@GOT_SHASUM=`shasum --algorithm 256 $(TARBALL) | cut -f1 -d' '` \
@@ -77,12 +80,14 @@ $(TARBALL):
 
 
 
-$(BUILD)/.patched: $(TARBALL)
-	[ -d $(BUILD) ] || (mkdir -p $(dir $(BUILD)); tar -C $(dir $(BUILD)) -xf $(TARBALL))
-	cat patches/*.patch | (cd $(BUILD) ; patch -p1)
+prepare-source: $(PYBUILD)/.patched
+
+$(PYBUILD)/.patched: $(PYTARBALL)
+	[ -d $(PYBUILD) ] || (mkdir -p $(dir $(PYBUILD)); tar -C $(dir $(PYBUILD)) -xf $(PYTARBALL))
+	cat patches/*.patch | (cd $(PYBUILD) ; patch -p1)
 	touch $@
 
-$(INSTALL)/lib/libffi.a :
+$(PYINSTALL)/lib/libffi.a :
 	rm -rf $(FFIBUILD)
 	mkdir $(FFIBUILD)
 	(\
@@ -94,11 +99,11 @@ $(INSTALL)/lib/libffi.a :
 		&& ./testsuite/emscripten/build.sh --wasm-bigint \
 		&& make install \
 	)
-	cp $(FFIBUILD)/target/include/*.h $(BUILD)/Include/
-	mkdir -p $(INSTALL)/lib
-	cp $(FFIBUILD)/target/lib/libffi.a $(INSTALL)/lib/
+	cp $(FFIBUILD)/target/include/*.h $(PYBUILD)/Include/
+	mkdir -p $(PYINSTALL)/lib
+	cp $(FFIBUILD)/target/lib/libffi.a $(PYINSTALL)/lib/
 
-$(INSTALL)/lib/libhiwire.a :
+$(PYINSTALL)/lib/libhiwire.a :
 	rm -rf $(HIWIREBUILD)
 	mkdir $(HIWIREBUILD)
 	(\
@@ -109,10 +114,12 @@ $(INSTALL)/lib/libhiwire.a :
 		&& . $(PYODIDE_ROOT)/emsdk/emsdk/emsdk_env.sh \
 		&& CC=emcc EMSCRIPTEN_DEDUPLICATE=1 EXTERN_FAIL=1 make \
 	)
-	cp -r $(HIWIREBUILD)/dist/lib $(INSTALL)/
-	cp -r $(HIWIREBUILD)/dist/include $(INSTALL)/include/hiwire
+	cp -r $(HIWIREBUILD)/dist/lib $(PYINSTALL)/
+	cp -r $(HIWIREBUILD)/dist/include $(PYINSTALL)/include/hiwire
 
-$(BUILD)/Makefile: $(BUILD)/.patched
+python-makefile: $(PYBUILD)/Makefile
+
+$(PYBUILD)/Makefile: $(PYBUILD)/.patched
 	# --enable-big-digits=30 :
 	#   Python integers have "digits" of size 15 by default on systems with 32
 	#   bit pointers and size 30 on systems with 16 bit pointers. Python uses
@@ -121,7 +128,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched
 	#   will default to the size 15 digits but WASM has native 64 bit arithmetic
 	#   so it is more efficient to use 30 bit digits.
 	( \
-		cd $(BUILD); \
+		cd $(PYBUILD); \
 		CONFIG_SITE=./Tools/wasm/config.site-wasm32-emscripten READELF=true emconfigure \
 		  ./configure \
 			  CFLAGS="${PYTHON_CFLAGS}" \
@@ -133,21 +140,21 @@ $(BUILD)/Makefile: $(BUILD)/.patched
 			  --enable-big-digits=30 \
 			  --enable-optimizations \
 			  --host=wasm32-unknown-emscripten\
-			  --build=$(shell $(BUILD)/config.guess) \
-			  --prefix=$(INSTALL)  \
+			  --build=$(shell $(PYBUILD)/config.guess) \
+			  --prefix=$(PYINSTALL)  \
 			  --with-build-python=$$(which python$(PYMAJOR).$(PYMINOR)) \
 			  $(MAYBE_WITH_PYDEBUG) \
 	)
 
 
-$(BUILD)/Modules/Setup.local: Setup.local
-	cp Setup.local $(BUILD)/Modules/
+$(PYBUILD)/Modules/Setup.local: Setup.local
+	cp Setup.local $(PYBUILD)/Modules/
 
-$(BUILD)/$(LIB): $(BUILD)/Makefile $(BUILD)/pyconfig.h $(BUILD)/Modules/Setup.local $(INSTALL)/lib/libffi.a
-	cp Setup.local $(BUILD)/Modules/
+$(PYBUILD)/$(PYLIB): $(PYBUILD)/Makefile $(PYBUILD)/pyconfig.h $(PYBUILD)/Modules/Setup.local $(PYINSTALL)/lib/libffi.a
+	cp Setup.local $(PYBUILD)/Modules/
 	( \
-		cd $(BUILD); \
+		cd $(PYBUILD); \
 		make regen-frozen; \
-		emmake make CROSS_COMPILE=yes $(LIB) -j $${PYODIDE_JOBS:-3} \
+		emmake make CROSS_COMPILE=yes $(PYLIB) -j $${PYODIDE_JOBS:-3} \
 	)
-	touch $(BUILD)/$(LIB)
+	touch $(PYBUILD)/$(PYLIB)


### PR DESCRIPTION
I also added a `PY` prefix to the Python build variables to make it a bit clearer.