### PR TITLE
fix 0.25.0 release year in changelog.md

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -55,7 +55,7 @@ myst:
 
 ## Version 0.25.0
 
-_January 18, 2023_
+_January 18, 2024_
 
 ### General
 


### PR DESCRIPTION
This is a tiny single-character change, fixing the year typo (January 2023 -> 2024) for the release of Pyodide 0.25.0 in the changelog (see https://pyodide.org/en/stable/project/changelog.html#version-0-25-0)
