### PR TITLE
Remove lgtm.yml [skip ci]

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,8 +1,0 @@
-queries:
-  - exclude: py/import-and-import-from
-
-extraction:
-  cpp:
-    prepare:
-      packages:
-        - python3-yaml


### PR DESCRIPTION
I don't remember correctly, but I think we stopped using lgtm.com at some point.