### PR TITLE
Add recipe-maintainers section in meta.yaml

### DIFF
--- a/packages/astropy/meta.yaml
+++ b/packages/astropy/meta.yaml
@@ -49,3 +49,5 @@ about:
   PyPI: https://pypi.org/project/astropy
   summary: Astronomy and astrophysics core library
   license: BSD 3-Clause License
+recipe-maintainers:
+  - jobovy

--- a/packages/astropy/meta.yaml
+++ b/packages/astropy/meta.yaml
@@ -49,5 +49,6 @@ about:
   PyPI: https://pypi.org/project/astropy
   summary: Astronomy and astrophysics core library
   license: BSD 3-Clause License
-recipe-maintainers:
-  - jobovy
+extra:
+  recipe-maintainers:
+    - jobovy

--- a/packages/awkward-cpp/meta.yaml
+++ b/packages/awkward-cpp/meta.yaml
@@ -25,5 +25,6 @@ about:
   home: https://pypi.org/project/awkward-cpp/
   summary: CPU kernels and compiled extensions for Awkward Array
   license: BSD-3-Clause
-recipe-maintainers:
-  - agoose77
+extra:
+  recipe-maintainers:
+    - agoose77

--- a/packages/awkward-cpp/meta.yaml
+++ b/packages/awkward-cpp/meta.yaml
@@ -25,3 +25,5 @@ about:
   home: https://pypi.org/project/awkward-cpp/
   summary: CPU kernels and compiled extensions for Awkward Array
   license: BSD-3-Clause
+recipe-maintainers:
+  - agoose77

--- a/packages/b2d/meta.yaml
+++ b/packages/b2d/meta.yaml
@@ -18,3 +18,5 @@ test:
   imports:
     - b2d
     - b2d.testbed
+recipe-maintainers:
+  - DerThorsten

--- a/packages/b2d/meta.yaml
+++ b/packages/b2d/meta.yaml
@@ -18,5 +18,6 @@ test:
   imports:
     - b2d
     - b2d.testbed
-recipe-maintainers:
-  - DerThorsten
+extra:
+  recipe-maintainers:
+    - DerThorsten

--- a/packages/bokeh/meta.yaml
+++ b/packages/bokeh/meta.yaml
@@ -22,5 +22,6 @@ about:
   PyPI: https://pypi.org/project/bokeh
   summary: Interactive plots and applications in the browser from Python
   license: BSD-3-Clause
-recipe-maintainers:
-  - ianthomas23
+extra:
+  recipe-maintainers:
+    - ianthomas23

--- a/packages/bokeh/meta.yaml
+++ b/packages/bokeh/meta.yaml
@@ -22,3 +22,5 @@ about:
   PyPI: https://pypi.org/project/bokeh
   summary: Interactive plots and applications in the browser from Python
   license: BSD-3-Clause
+recipe-maintainers:
+  - ianthomas23

--- a/packages/boost-cpp/meta.yaml
+++ b/packages/boost-cpp/meta.yaml
@@ -30,3 +30,5 @@ build:
 about:
   home: https://www.boost.org/
   summary: Free peer-reviewed portable C++ source libraries.
+recipe-maintainers:
+  - johnwason

--- a/packages/boost-cpp/meta.yaml
+++ b/packages/boost-cpp/meta.yaml
@@ -30,5 +30,6 @@ build:
 about:
   home: https://www.boost.org/
   summary: Free peer-reviewed portable C++ source libraries.
-recipe-maintainers:
-  - johnwason
+extra:
+  recipe-maintainers:
+    - johnwason

--- a/packages/boost-histogram/meta.yaml
+++ b/packages/boost-histogram/meta.yaml
@@ -17,3 +17,5 @@ about:
   PyPI: https://pypi.org/project/boost-histogram
   summary: The Boost::Histogram Python wrapper.
   license: BSD-3-Clause
+recipe-maintainers:
+  - henryiii

--- a/packages/boost-histogram/meta.yaml
+++ b/packages/boost-histogram/meta.yaml
@@ -17,5 +17,6 @@ about:
   PyPI: https://pypi.org/project/boost-histogram
   summary: The Boost::Histogram Python wrapper.
   license: BSD-3-Clause
-recipe-maintainers:
-  - henryiii
+extra:
+  recipe-maintainers:
+    - henryiii

--- a/packages/contourpy/meta.yaml
+++ b/packages/contourpy/meta.yaml
@@ -20,5 +20,6 @@ about:
   PyPI: https://pypi.org/project/contourpy
   summary: Python library for calculating contours of 2D quadrilateral grids
   license: BSD-3-Clause
-recipe-maintainers:
-  - ianthomas23
+extra:
+  recipe-maintainers:
+    - ianthomas23

--- a/packages/contourpy/meta.yaml
+++ b/packages/contourpy/meta.yaml
@@ -20,3 +20,5 @@ about:
   PyPI: https://pypi.org/project/contourpy
   summary: Python library for calculating contours of 2D quadrilateral grids
   license: BSD-3-Clause
+recipe-maintainers:
+  - ianthomas23

--- a/packages/cramjam/meta.yaml
+++ b/packages/cramjam/meta.yaml
@@ -22,5 +22,6 @@ requirements:
 test:
   imports:
     - cramjam
-recipe-maintainers:
-  - joemarshall
+extra:
+  recipe-maintainers:
+    - joemarshall

--- a/packages/cramjam/meta.yaml
+++ b/packages/cramjam/meta.yaml
@@ -22,3 +22,5 @@ requirements:
 test:
   imports:
     - cramjam
+recipe-maintainers:
+  - joemarshall

--- a/packages/cysignals/meta.yaml
+++ b/packages/cysignals/meta.yaml
@@ -14,3 +14,5 @@ about:
   PyPI: https://pypi.org/project/cysignals
   summary: Interrupt and signal handling for Cython
   license: LGPL v3
+recipe-maintainers:
+  - mkoeppe

--- a/packages/cysignals/meta.yaml
+++ b/packages/cysignals/meta.yaml
@@ -14,5 +14,6 @@ about:
   PyPI: https://pypi.org/project/cysignals
   summary: Interrupt and signal handling for Cython
   license: LGPL v3
-recipe-maintainers:
-  - mkoeppe
+extra:
+  recipe-maintainers:
+    - mkoeppe

--- a/packages/fastparquet/meta.yaml
+++ b/packages/fastparquet/meta.yaml
@@ -18,3 +18,5 @@ about:
   PyPI: https://pypi.org/project/fastparquet
   summary: Python support for Parquet file format
   license: Apache License 2.0
+recipe-maintainers:
+  - joemarshall

--- a/packages/fastparquet/meta.yaml
+++ b/packages/fastparquet/meta.yaml
@@ -18,5 +18,6 @@ about:
   PyPI: https://pypi.org/project/fastparquet
   summary: Python support for Parquet file format
   license: Apache License 2.0
-recipe-maintainers:
-  - joemarshall
+extra:
+  recipe-maintainers:
+    - joemarshall

--- a/packages/fsspec/meta.yaml
+++ b/packages/fsspec/meta.yaml
@@ -11,3 +11,5 @@ about:
   PyPI: https://pypi.org/project/fsspec
   summary: File-system specification
   license: BSD
+recipe-maintainers:
+  - joemarshall

--- a/packages/fsspec/meta.yaml
+++ b/packages/fsspec/meta.yaml
@@ -11,5 +11,6 @@ about:
   PyPI: https://pypi.org/project/fsspec
   summary: File-system specification
   license: BSD
-recipe-maintainers:
-  - joemarshall
+extra:
+  recipe-maintainers:
+    - joemarshall

--- a/packages/galpy/meta.yaml
+++ b/packages/galpy/meta.yaml
@@ -40,3 +40,6 @@ about:
   PyPI: https://pypi.org/project/galpy
   summary: Galactic Dynamics in python
   license: New BSD
+extra:
+  recipe-maintainers:
+    - jobovy

--- a/packages/gdal/meta.yaml
+++ b/packages/gdal/meta.yaml
@@ -108,3 +108,5 @@ build:
     cp ${WASM_LIBRARY_DIR}/lib/libgdal.so ${DISTDIR}
 
 # Note: this package needs to be manually upgraded to the next version
+recipe-maintainers:
+  - jobovy

--- a/packages/gdal/meta.yaml
+++ b/packages/gdal/meta.yaml
@@ -108,5 +108,6 @@ build:
     cp ${WASM_LIBRARY_DIR}/lib/libgdal.so ${DISTDIR}
 
 # Note: this package needs to be manually upgraded to the next version
-recipe-maintainers:
-  - jobovy
+extra:
+  recipe-maintainers:
+    - jobovy

--- a/packages/igraph/meta.yaml
+++ b/packages/igraph/meta.yaml
@@ -25,5 +25,6 @@ about:
   PyPI: https://pypi.org/project/igraph
   summary: High performance graph data structures and algorithms
   license: GNU General Public License (GPL)
-recipe-maintainers:
-  - ntamas
+extra:
+  recipe-maintainers:
+    - ntamas

--- a/packages/igraph/meta.yaml
+++ b/packages/igraph/meta.yaml
@@ -25,3 +25,5 @@ about:
   PyPI: https://pypi.org/project/igraph
   summary: High performance graph data structures and algorithms
   license: GNU General Public License (GPL)
+recipe-maintainers:
+  - ntamas

--- a/packages/memory-allocator/meta.yaml
+++ b/packages/memory-allocator/meta.yaml
@@ -11,5 +11,6 @@ about:
   PyPI: https://pypi.org/project/memory_allocator
   summary: An extension class to allocate memory easily with cython
   license: GPLv3
-recipe-maintainers:
-  - mkoeppe
+extra:
+  recipe-maintainers:
+    - mkoeppe

--- a/packages/memory-allocator/meta.yaml
+++ b/packages/memory-allocator/meta.yaml
@@ -11,3 +11,5 @@ about:
   PyPI: https://pypi.org/project/memory_allocator
   summary: An extension class to allocate memory easily with cython
   license: GPLv3
+recipe-maintainers:
+  - mkoeppe

--- a/packages/msgspec/meta.yaml
+++ b/packages/msgspec/meta.yaml
@@ -11,5 +11,6 @@ about:
   PyPI: https://pypi.org/project/msgspec
   summary: A fast serialization and validation library, with builtin support for JSON, MessagePack, YAML, and TOML.
   license: BSD-3-Clause
-recipe-maintainers:
-  - bollwyvl
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/packages/msgspec/meta.yaml
+++ b/packages/msgspec/meta.yaml
@@ -11,3 +11,5 @@ about:
   PyPI: https://pypi.org/project/msgspec
   summary: A fast serialization and validation library, with builtin support for JSON, MessagePack, YAML, and TOML.
   license: BSD-3-Clause
+recipe-maintainers:
+  - bollwyvl

--- a/packages/orjson/meta.yaml
+++ b/packages/orjson/meta.yaml
@@ -18,5 +18,6 @@ about:
     Fast, correct Python JSON library supporting dataclasses, datetimes, and
     numpy
   license: Apache-2.0 OR MIT
-recipe-maintainers:
-  - spicy-sauce
+extra:
+  recipe-maintainers:
+    - spicy-sauce

--- a/packages/orjson/meta.yaml
+++ b/packages/orjson/meta.yaml
@@ -18,3 +18,5 @@ about:
     Fast, correct Python JSON library supporting dataclasses, datetimes, and
     numpy
   license: Apache-2.0 OR MIT
+recipe-maintainers:
+  - spicy-sauce

--- a/packages/ppl/meta.yaml
+++ b/packages/ppl/meta.yaml
@@ -29,5 +29,6 @@ build:
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-recipe-maintainers:
-  - mkoeppe
+extra:
+  recipe-maintainers:
+    - mkoeppe

--- a/packages/ppl/meta.yaml
+++ b/packages/ppl/meta.yaml
@@ -29,3 +29,5 @@ build:
         --prefix=${WASM_LIBRARY_DIR}
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
+recipe-maintainers:
+  - mkoeppe

--- a/packages/pplpy/meta.yaml
+++ b/packages/pplpy/meta.yaml
@@ -25,3 +25,5 @@ about:
   PyPI: https://pypi.org/project/pplpy
   summary: Python PPL wrapper
   license: GPL v3
+recipe-maintainers:
+  - mkoeppe

--- a/packages/pplpy/meta.yaml
+++ b/packages/pplpy/meta.yaml
@@ -25,5 +25,6 @@ about:
   PyPI: https://pypi.org/project/pplpy
   summary: Python PPL wrapper
   license: GPL v3
-recipe-maintainers:
-  - mkoeppe
+extra:
+  recipe-maintainers:
+    - mkoeppe

--- a/packages/primecount/meta.yaml
+++ b/packages/primecount/meta.yaml
@@ -25,5 +25,6 @@ build:
           .
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-recipe-maintainers:
-  - mkoeppe
+extra:
+  recipe-maintainers:
+    - mkoeppe

--- a/packages/primecount/meta.yaml
+++ b/packages/primecount/meta.yaml
@@ -25,3 +25,5 @@ build:
           .
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
+recipe-maintainers:
+  - mkoeppe

--- a/packages/primecountpy/meta.yaml
+++ b/packages/primecountpy/meta.yaml
@@ -23,3 +23,5 @@ build:
     -I$(WASM_LIBRARY_DIR)/include
   ldflags: |
     -L$(WASM_LIBRARY_DIR)/lib
+recipe-maintainers:
+  - mkoeppe

--- a/packages/primecountpy/meta.yaml
+++ b/packages/primecountpy/meta.yaml
@@ -23,5 +23,6 @@ build:
     -I$(WASM_LIBRARY_DIR)/include
   ldflags: |
     -L$(WASM_LIBRARY_DIR)/lib
-recipe-maintainers:
-  - mkoeppe
+extra:
+  recipe-maintainers:
+    - mkoeppe

--- a/packages/primesieve/meta.yaml
+++ b/packages/primesieve/meta.yaml
@@ -24,5 +24,6 @@ build:
           .
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
-recipe-maintainers:
-  - mkoeppe
+extra:
+  recipe-maintainers:
+    - mkoeppe

--- a/packages/primesieve/meta.yaml
+++ b/packages/primesieve/meta.yaml
@@ -24,3 +24,5 @@ build:
           .
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
+recipe-maintainers:
+  - mkoeppe

--- a/packages/protobuf/meta.yaml
+++ b/packages/protobuf/meta.yaml
@@ -13,5 +13,6 @@ about:
   PyPI: https://pypi.org/project/protobuf
   summary: Protocol Buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data
   license: Custom
-recipe-maintainers:
-  - bartbroere
+extra:
+  recipe-maintainers:
+    - bartbroere

--- a/packages/protobuf/meta.yaml
+++ b/packages/protobuf/meta.yaml
@@ -13,3 +13,5 @@ about:
   PyPI: https://pypi.org/project/protobuf
   summary: Protocol Buffers are a language-neutral, platform-neutral extensible mechanism for serializing structured data
   license: Custom
+recipe-maintainers:
+  - bartbroere

--- a/packages/pysam/meta.yaml
+++ b/packages/pysam/meta.yaml
@@ -26,5 +26,6 @@ about:
   PyPI: https://pypi.org/project/pysam
   summary: Package for reading, manipulating, and writing genomic data
   license: MIT License
-recipe-maintainers:
-  - stevenweaver
+extra:
+  recipe-maintainers:
+    - stevenweaver

--- a/packages/pysam/meta.yaml
+++ b/packages/pysam/meta.yaml
@@ -26,3 +26,5 @@ about:
   PyPI: https://pypi.org/project/pysam
   summary: Package for reading, manipulating, and writing genomic data
   license: MIT License
+recipe-maintainers:
+  - stevenweaver

--- a/packages/python-flint/meta.yaml
+++ b/packages/python-flint/meta.yaml
@@ -22,3 +22,5 @@ about:
   PyPI: https://pypi.org/project/python-flint
   summary: Bindings for FLINT and Arb
   license: MIT
+recipe-maintainers:
+  - mkoeppe

--- a/packages/python-flint/meta.yaml
+++ b/packages/python-flint/meta.yaml
@@ -22,5 +22,6 @@ about:
   PyPI: https://pypi.org/project/python-flint
   summary: Bindings for FLINT and Arb
   license: MIT
-recipe-maintainers:
-  - mkoeppe
+extra:
+  recipe-maintainers:
+    - mkoeppe

--- a/packages/python-sat/meta.yaml
+++ b/packages/python-sat/meta.yaml
@@ -20,5 +20,6 @@ about:
   PyPI: https://pypi.org/project/python-sat
   summary: A Python library for prototyping with SAT oracles
   license: MIT
-recipe-maintainers:
-  - alexeyignatiev
+extra:
+  recipe-maintainers:
+    - alexeyignatiev

--- a/packages/python-sat/meta.yaml
+++ b/packages/python-sat/meta.yaml
@@ -20,3 +20,5 @@ about:
   PyPI: https://pypi.org/project/python-sat
   summary: A Python library for prototyping with SAT oracles
   license: MIT
+recipe-maintainers:
+  - alexeyignatiev

--- a/packages/rebound/meta.yaml
+++ b/packages/rebound/meta.yaml
@@ -25,3 +25,5 @@ about:
   PyPI: https://pypi.org/project/rebound
   summary: An open-source multi-purpose N-body code
   license: GPL
+recipe-maintainers:
+  - hannorein

--- a/packages/rebound/meta.yaml
+++ b/packages/rebound/meta.yaml
@@ -25,5 +25,6 @@ about:
   PyPI: https://pypi.org/project/rebound
   summary: An open-source multi-purpose N-body code
   license: GPL
-recipe-maintainers:
-  - hannorein
+extra:
+  recipe-maintainers:
+    - hannorein

--- a/packages/reboundx/meta.yaml
+++ b/packages/reboundx/meta.yaml
@@ -23,5 +23,6 @@ about:
   PyPI: https://pypi.org/project/reboundx
   summary: A library for including additional forces in REBOUND
   license: GPL
-recipe-maintainers:
-  - hannorein
+extra:
+  recipe-maintainers:
+    - hannorein

--- a/packages/reboundx/meta.yaml
+++ b/packages/reboundx/meta.yaml
@@ -23,3 +23,5 @@ about:
   PyPI: https://pypi.org/project/reboundx
   summary: A library for including additional forces in REBOUND
   license: GPL
+recipe-maintainers:
+  - hannorein

--- a/packages/river/meta.yaml
+++ b/packages/river/meta.yaml
@@ -29,3 +29,5 @@ test:
   imports:
     - river
     - river.api
+recipe-maintainers:
+  - MaxHalford

--- a/packages/river/meta.yaml
+++ b/packages/river/meta.yaml
@@ -29,5 +29,6 @@ test:
   imports:
     - river
     - river.api
-recipe-maintainers:
-  - MaxHalford
+extra:
+  recipe-maintainers:
+    - MaxHalford

--- a/packages/scikit-learn/meta.yaml
+++ b/packages/scikit-learn/meta.yaml
@@ -65,5 +65,6 @@ about:
   PyPI: https://pypi.org/project/scikit-learn
   summary: A set of python modules for machine learning and data mining
   license: new BSD
-recipe-maintainers:
-  - lesteve
+extra:
+  recipe-maintainers:
+    - lesteve

--- a/packages/scikit-learn/meta.yaml
+++ b/packages/scikit-learn/meta.yaml
@@ -65,3 +65,5 @@ about:
   PyPI: https://pypi.org/project/scikit-learn
   summary: A set of python modules for machine learning and data mining
   license: new BSD
+recipe-maintainers:
+  - lesteve

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -150,6 +150,7 @@ about:
   PyPI: https://pypi.org/project/scipy
   summary: "SciPy: Scientific Library for Python"
   license: BSD
-recipe-maintainers:
-  - lesteve
-  - steppi
+extra:
+  recipe-maintainers:
+    - lesteve
+    - steppi

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -150,3 +150,6 @@ about:
   PyPI: https://pypi.org/project/scipy
   summary: "SciPy: Scientific Library for Python"
   license: BSD
+recipe-maintainers:
+  - lesteve
+  - steppi

--- a/packages/zengl/meta.yaml
+++ b/packages/zengl/meta.yaml
@@ -15,5 +15,6 @@ about:
   PyPI: https://pypi.org/project/zengl
   summary: Self-Contained OpenGL Rendering Pipelines for Python
   license: MIT
-recipe-maintainers:
-  - szabolcsdombi
+extra:
+  recipe-maintainers:
+    - szabolcsdombi

--- a/packages/zengl/meta.yaml
+++ b/packages/zengl/meta.yaml
@@ -15,3 +15,5 @@ about:
   PyPI: https://pypi.org/project/zengl
   summary: Self-Contained OpenGL Rendering Pipelines for Python
   license: MIT
+recipe-maintainers:
+  - szabolcsdombi

--- a/pyodide-build/pyodide_build/io.py
+++ b/pyodide-build/pyodide_build/io.py
@@ -151,6 +151,10 @@ class _AboutSpec(BaseModel):
         extra = pydantic.Extra.forbid
 
 
+class _ExtraSpec(BaseModel):
+    recipe_maintainers: list[str] = Field([], alias="recipe-maintainers")
+
+
 class MetaConfig(BaseModel):
     package: _PackageSpec
     source: _SourceSpec = _SourceSpec()
@@ -158,6 +162,7 @@ class MetaConfig(BaseModel):
     requirements: _RequirementsSpec = _RequirementsSpec()
     test: _TestSpec = _TestSpec()
     about: _AboutSpec = _AboutSpec()
+    extra: _ExtraSpec = _ExtraSpec()
 
     class Config:
         extra = pydantic.Extra.forbid

--- a/pyodide-build/pyodide_build/mkpkg.py
+++ b/pyodide-build/pyodide_build/mkpkg.py
@@ -193,6 +193,7 @@ def make_package(
             "summary": summary,
             "license": license,
         },
+        "extra": {"recipe-maintainers": ["PUT_YOUR_GITHUB_USERNAME_HERE"]},
     }
 
     package_dir = packages_dir / package


### PR DESCRIPTION
### Description

This adds `recipe-maintainers` section in meta.yaml, inspired by conda-forge ([example](https://github.com/conda-forge/pkg-config-feedstock/blob/c7a98e5797cd5147bc72e45bf7bba3a31f0262af/recipe/meta.yaml#L45-L51)).

There is no usage for this section yet, but at least we can notify maintainers that something is wrong with a package.
In the future, we may make a tool that automatically notifies recipe maintainers, just like conda-forge.
