### PR TITLE
Update numpy to 1.26.4 and don't set MESON env variable

### DIFF
--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: numpy
-  version: 1.26.1
+  version: 1.26.4
   tag:
     - min-scipy-stack
   top-level:
     - numpy
 source:
-  url: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz
-  sha256: c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe
+  url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz
+  sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
 
 build:
   # numpy uses vendored meson, so we need to pass the cross file manually

--- a/pyodide-build/pyodide_build/pypabuild.py
+++ b/pyodide-build/pyodide_build/pypabuild.py
@@ -40,6 +40,19 @@ AVOIDED_REQUIREMENTS = [
     "patchelf",
 ]
 
+# corresponding env variables for symlinks
+SYMLINK_ENV_VARS = {
+    "cc": "CC",
+    "c++": "CXX",
+    "ld": "LD",
+    "lld": "LLD",
+    "ar": "AR",
+    "gcc": "GCC",
+    "ranlib": "RANLIB",
+    "strip": "STRIP",
+    "gfortran": "FC",  # https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables
+}
+
 
 def _gen_runner(
     cross_build_env: Mapping[str, str],
@@ -207,13 +220,8 @@ def make_command_wrapper_symlinks(symlink_dir: Path) -> dict[str, str]:
             symlink_path.unlink()
 
         symlink_path.symlink_to(pywasmcross_exe)
-        if symlink == "c++":
-            var = "CXX"
-        elif symlink == "gfortran":
-            var = "FC"  # https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables
-        else:
-            var = symlink.upper()
-        env[var] = str(symlink_path)
+        if symlink in SYMLINK_ENV_VARS:
+            env[SYMLINK_ENV_VARS[symlink]] = str(symlink_path)
 
     return env
 

--- a/pyodide-build/pyodide_build/tests/test_pypabuild.py
+++ b/pyodide-build/pyodide_build/tests/test_pypabuild.py
@@ -41,12 +41,13 @@ def test_make_command_wrapper_symlinks(tmp_path):
     assert not wrapper.is_symlink()
     assert wrapper.stat().st_mode & 0o755 == 0o755
 
-    for _, path in env.items():
+    for key, path in env.items():
         symlink_path = symlink_dir / path
 
         assert symlink_path.exists()
         assert symlink_path.is_symlink()
         assert symlink_path.name in pywasmcross.SYMLINKS
+        assert key in pypabuild.SYMLINK_ENV_VARS.values()
 
 
 def test_get_build_env(tmp_path):


### PR DESCRIPTION
### Description

Resolve #4498 

From `meson-python` 0.15, `$MESON` env variable is used to overwrite the meson binary path. We don't want that behavior.

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
