### PR TITLE
Add numpy as host requirement for several packages

### DIFF
--- a/packages/gsw/meta.yaml
+++ b/packages/gsw/meta.yaml
@@ -12,6 +12,8 @@ source:
 requirements:
   run:
     - numpy
+  host:
+    - numpy
 
 about:
   home: https://github.com/TEOS-10/GSW-python

--- a/packages/msprime/meta.yaml
+++ b/packages/msprime/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - demes
   host:
     - libgsl
+    - numpy
 about:
   home: https://tskit.dev/msprime
   PyPI: https://pypi.org/project/msprime

--- a/packages/tskit/meta.yaml
+++ b/packages/tskit/meta.yaml
@@ -11,6 +11,8 @@ requirements:
     - numpy
     - svgwrite
     - jsonschema
+  host:
+    - numpy
 about:
   home: https://tskit.dev/tskit
   PyPI: https://pypi.org/project/tskit


### PR DESCRIPTION
I ran the build commands in the Docker container found in the Circle CI configuration, but the `gsw` package seems to be needing `numpy` installed in the host when building.

Update: same for the `tskit` package it seems

Update: `msprime` as well. More might follow.
