### PR TITLE
Reduce the amount of stuff that the makefile always redoes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: check \
 	dist/webworker.js \
 	dist/webworker_dev.js \
 	dist/module_webworker_dev.js
-	echo -e "\nSUCCESS!"
+	@echo -e "\nSUCCESS!"
 
 src/core/pyodide_pre.o: src/js/generated/_pyodide.out.js src/core/pre.js src/core/stack_switching/stack_switching.out.js
 # Our goal here is to inject src/js/generated/_pyodide.out.js into an archive
@@ -99,7 +99,7 @@ dist/pyodide.asm.js: \
 	$(wildcard src/py/lib/*.py) \
 	$(CPYTHONLIB) \
 	dist/libpyodide.a
-	date +"[%F %T] Building pyodide.asm.js..."
+	@date +"[%F %T] Building pyodide.asm.js..."
 	[ -d dist ] || mkdir dist
    # TODO(ryanking13): Link libgl to a side module not to the main module.
    # For unknown reason, a side module cannot see symbols when libGL is linked to it.
@@ -122,7 +122,7 @@ dist/pyodide.asm.js: \
 	# Sed nonsense from https://stackoverflow.com/a/13383331
 	sed -i -n -e :a -e '1,4!{P;N;D;};N;ba' dist/pyodide.asm.js
 	echo "globalThis._createPyodideModule = _createPyodideModule;" >> dist/pyodide.asm.js
-	date +"[%F %T] done building pyodide.asm.js."
+	@date +"[%F %T] done building pyodide.asm.js."
 
 
 env:
@@ -181,12 +181,9 @@ src/js/generated/pyproxy.ts : src/core/pyproxy.* src/core/*.h
 		>> $@
 
 pyodide_build:
-	python -c '0;\
-		from importlib.util import find_spec; \
-		import sys; \
-		sys.exit(not find_spec("pyodide_build"))\
-	' || $(HOSTPYTHON) -m pip install -e ./pyodide-build
-	which pyodide >/dev/null
+	@echo "Ensuring editable pyodide-build is installed"
+	./tools/check_editable_pyodide_build.py || $(HOSTPYTHON) -m pip install -e ./pyodide-build
+	@which pyodide >/dev/null
 
 dist/python_stdlib.zip: $(wildcard src/py/**/*) $(CPYTHONLIB)
 	make pyodide_build
@@ -250,22 +247,22 @@ src/core/jslib_asm.o: src/core/jslib_asm.s
 
 
 $(CPYTHONLIB): emsdk/emsdk/.complete
-	date +"[%F %T] Building cpython..."
+	@date +"[%F %T] Building cpython..."
 	make -C $(CPYTHONROOT)
-	date +"[%F %T] done building cpython..."
+	@date +"[%F %T] done building cpython..."
 
 
 dist/pyodide-lock.json: FORCE
 	make pyodide_build
-	date +"[%F %T] Building packages..."
+	@date +"[%F %T] Building packages..."
 	make -C packages
-	date +"[%F %T] done building packages..."
+	@date +"[%F %T] done building packages..."
 
 
 emsdk/emsdk/.complete:
-	date +"[%F %T] Building emsdk..."
+	@date +"[%F %T] Building emsdk..."
 	make -C emsdk
-	date +"[%F %T] done building emsdk."
+	@date +"[%F %T] done building emsdk."
 
 
 rust:
@@ -278,11 +275,11 @@ FORCE:
 
 
 check:
-	./tools/dependency-check.sh
+	@./tools/dependency-check.sh
 
 
 check-emcc: emsdk/emsdk/.complete
-	python3 tools/check_ccache.py
+	@python3 tools/check_ccache.py
 
 
 debug :

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ dist/pyodide.asm.js: \
 	dist/libpyodide.a
 	date +"[%F %T] Building pyodide.asm.js..."
 	[ -d dist ] || mkdir dist
-    # TODO(ryanking13): Link libgl to a side module not to the main module.
-    # For unknown reason, a side module cannot see symbols when libGL is linked to it.
+   # TODO(ryanking13): Link libgl to a side module not to the main module.
+   # For unknown reason, a side module cannot see symbols when libGL is linked to it.
 	embuilder build libgl
 	$(CXX) -o dist/pyodide.asm.js dist/libpyodide.a src/core/main.o $(MAIN_MODULE_LDFLAGS)
 

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -5,15 +5,12 @@ include ../Makefile.envs
 
 all:
 	mkdir -p $(HOSTINSTALLDIR) $(WASM_LIBRARY_DIR)
-	PYODIDE_ROOT=$(PYODIDE_ROOT) pyodide build-recipes \
-	"$(PYODIDE_PACKAGES)" \
-	--recipe-dir=./ \
-	--install \
-	--install-dir=../dist \
-	--metadata-files \
-	--n-jobs $${PYODIDE_JOBS:-4} \
-	--log-dir=./build-logs \
-	--compression-level "$(PYODIDE_ZIP_COMPRESSION_LEVEL)"
+	pyodide build-recipes "$(PYODIDE_PACKAGES)" \
+		--install \
+		--metadata-files \
+		--n-jobs $${PYODIDE_JOBS:-4} \
+		--log-dir=./build-logs \
+		--compression-level "$(PYODIDE_ZIP_COMPRESSION_LEVEL)"
 
 update-all:
 	for pkg in $$(find . -maxdepth 1 ! -name ".*" -type d -exec basename {} \; | tail -n +2); do \

--- a/tools/check_editable_pyodide_build.py
+++ b/tools/check_editable_pyodide_build.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-from pathlib import Path
 import sys
+from pathlib import Path
 
-try: 
+try:
     import pyodide_build
 except ImportError:
     sys.exit(1)
@@ -11,4 +11,3 @@ install_path = Path(pyodide_build.__path__[0])
 editable_install_path = Path(__file__).parents[1] / "pyodide-build/pyodide_build"
 
 sys.exit(install_path != editable_install_path)
-

--- a/tools/check_editable_pyodide_build.py
+++ b/tools/check_editable_pyodide_build.py
@@ -2,12 +2,17 @@
 import sys
 from pathlib import Path
 
-try:
-    import pyodide_build
-except ImportError:
-    sys.exit(1)
+def main():
+    try:
+        import pyodide_build
+    except ImportError:
+        sys.exit(1)
 
-install_path = Path(pyodide_build.__path__[0])
-editable_install_path = Path(__file__).parents[1] / "pyodide-build/pyodide_build"
+    install_path = Path(pyodide_build.__path__[0])
+    editable_install_path = Path(__file__).parents[1] / "pyodide-build/pyodide_build"
 
-sys.exit(install_path != editable_install_path)
+    sys.exit(install_path != editable_install_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_editable_pyodide_build.py
+++ b/tools/check_editable_pyodide_build.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+try: 
+    import pyodide_build
+except ImportError:
+    sys.exit(1)
+
+install_path = Path(pyodide_build.__path__[0])
+editable_install_path = Path(__file__).parents[1] / "pyodide-build/pyodide_build"
+
+sys.exit(install_path != editable_install_path)
+

--- a/tools/check_editable_pyodide_build.py
+++ b/tools/check_editable_pyodide_build.py
@@ -2,6 +2,7 @@
 import sys
 from pathlib import Path
 
+
 def main():
     try:
         import pyodide_build


### PR DESCRIPTION
libgl is marked .PHONY and is a dependency for the link step which forces us to always redo the link step even though it's completely not necessary. I moved `embuilder build libgl` into the link step since that's the only place where it's needed.

`dist/python_stdlib.zip` and `dist/pyodide-lock.json` both declare a dependency on `pyodide_build` but there is never a file of that name so they always have to run. Instead, run `make pyodide_build` so that they can reuse the logic but they don't always run if their other deps are satisfied.

Now that `dist/python_stdlib.zip` doesn't always run it needs to rely on all files in `src/py`.

Make `pyodide_build` only invoke `pip install` if `pyodide_build` is not already installed. Pip generates a lot of noise and takes a while so skipping it when we don't need it helps a lot.

Make `dist/webworker.js` and friends not phony since they stopped needing to be when `PYODIDE_BASE_URL` was removed from them.