### PR TITLE
xfail failing firefox package tests

### DIFF
--- a/packages/bokeh/test_bokeh.py
+++ b/packages/bokeh/test_bokeh.py
@@ -1,6 +1,8 @@
+import pytest
 from pytest_pyodide.decorator import run_in_pyodide
 
 
+@pytest.mark.xfail_browsers(firefox="times out")
 @run_in_pyodide(packages=["bokeh"])
 def test_bokeh(selenium):
     """

--- a/packages/sisl/test_sisl.py
+++ b/packages/sisl/test_sisl.py
@@ -2,6 +2,7 @@ import pytest
 from pytest_pyodide import run_in_pyodide
 
 
+@pytest.mark.xfail_browsers(firefox="Too slow")
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_load_sisl(selenium):
     """Loading sisl takes a really long time so this separates it out to reduce
@@ -18,6 +19,7 @@ def test_nodes(selenium):
     pytest.main(["--pyargs", "sisl.nodes"])
 
 
+@pytest.mark.xfail_browsers(firefox="Too slow")
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_geom(selenium):
     import pytest
@@ -25,6 +27,7 @@ def test_geom(selenium):
     pytest.main(["--pyargs", "sisl.geom"])
 
 
+@pytest.mark.xfail_browsers(firefox="Too slow")
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_linalg(selenium):
     import pytest
@@ -32,6 +35,7 @@ def test_linalg(selenium):
     pytest.main(["--pyargs", "sisl.linalg"])
 
 
+@pytest.mark.xfail_browsers(firefox="Too slow")
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_sparse(selenium):
     import pytest
@@ -39,6 +43,7 @@ def test_sparse(selenium):
     pytest.main(["--pyargs", "sisl.tests.test_sparse"])
 
 
+@pytest.mark.xfail_browsers(firefox="Too slow")
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_physics_sparse(selenium):
     import pytest

--- a/packages/sisl/test_sisl.py
+++ b/packages/sisl/test_sisl.py
@@ -1,6 +1,16 @@
+import pytest
 from pytest_pyodide import run_in_pyodide
 
 
+@run_in_pyodide(packages=["sisl-tests", "pytest"])
+def test_load_sisl(selenium):
+    """Loading sisl takes a really long time so this separates it out to reduce
+    the chance that test_nodes times out.
+    """
+    pass
+
+
+@pytest.mark.xfail_browsers(firefox="Too slow")
 @run_in_pyodide(packages=["sisl-tests", "pytest"])
 def test_nodes(selenium):
     import pytest


### PR DESCRIPTION
xfail sisl and bokeh tests on firefox since they time out.
make a separate test that loads sisl and does nothing else to separate the loading time from the testing time.