### PR TITLE
MAINT Make search_pyodide_root return None instead of raising

### DIFF
--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -99,9 +99,8 @@ def init_environment(*, quiet: bool = False) -> None:
     if "PYODIDE_ROOT" in os.environ:
         return
 
-    try:
-        root = search_pyodide_root(Path.cwd())
-    except FileNotFoundError:  # Not in Pyodide tree
+    root = search_pyodide_root(Path.cwd())
+    if not root:  # Not in Pyodide tree
         root = _init_xbuild_env(quiet=quiet)
 
     os.environ["PYODIDE_ROOT"] = str(root)
@@ -137,7 +136,7 @@ def get_pyodide_root() -> Path:
     return Path(os.environ["PYODIDE_ROOT"])
 
 
-def search_pyodide_root(curdir: str | Path, *, max_depth: int = 10) -> Path:
+def search_pyodide_root(curdir: str | Path, *, max_depth: int = 10) -> Path | None:
     """
     Recursively search for the root of the Pyodide repository,
     by looking for the pyproject.toml file in the parent directories
@@ -162,9 +161,7 @@ def search_pyodide_root(curdir: str | Path, *, max_depth: int = 10) -> Path:
         if "tool" in configs and "pyodide" in configs["tool"]:
             return base
 
-    raise FileNotFoundError(
-        "Could not find Pyodide root directory. If you are not in the Pyodide directory, set `PYODIDE_ROOT=<pyodide-root-directory>`."
-    )
+    return None
 
 
 def in_xbuildenv() -> bool:

--- a/pyodide-build/pyodide_build/cli/build_recipes.py
+++ b/pyodide-build/pyodide_build/cli/build_recipes.py
@@ -29,11 +29,8 @@ class Args:
         force_rebuild: bool,
         n_jobs: int | None = None,
     ):
-        root = Path.cwd()
-        try:
-            root = build_env.search_pyodide_root(root)
-        except FileNotFoundError:
-            pass
+        cwd = Path.cwd()
+        root = build_env.search_pyodide_root(cwd) or cwd
         self.recipe_dir = (
             root / "packages" if not recipe_dir else Path(recipe_dir).resolve()
         )

--- a/pyodide-build/pyodide_build/cli/skeleton.py
+++ b/pyodide-build/pyodide_build/cli/skeleton.py
@@ -56,13 +56,10 @@ def new_recipe_pypi(
     else:
         cwd = Path.cwd()
 
-        try:
-            root = build_env.search_pyodide_root(cwd)
-        except FileNotFoundError:
-            root = cwd
-
         if build_env.in_xbuildenv():
             root = cwd
+        else:
+            root = build_env.search_pyodide_root(cwd) or cwd
 
         recipe_dir_ = root / "packages"
 

--- a/pyodide-build/pyodide_build/tests/test_build_env.py
+++ b/pyodide-build/pyodide_build/tests/test_build_env.py
@@ -52,8 +52,7 @@ class TestInTree:
         assert build_env.search_pyodide_root(tmp_path / "subdir" / "subdir") == tmp_path
 
         pyproject_file.unlink()
-        with pytest.raises(FileNotFoundError):
-            build_env.search_pyodide_root(tmp_path)
+        assert build_env.search_pyodide_root(tmp_path) is None
 
     def test_in_xbuildenv(self, reset_env_vars, reset_cache):
         assert not build_env.in_xbuildenv()


### PR DESCRIPTION
Every spot that we call it we have a try block to catch this exception, so returning None makes the code more succinct