### PR TITLE
Unpin playwright version in GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,8 +178,6 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -e ./pyodide-build
-          # FIXME: pytest-pyodide hangs in playwright==1.40, chromium
-          pip install "playwright<1.40"
           python -m playwright install
 
       - name: run core tests


### PR DESCRIPTION
Hopefully fix the timeout in GHA that started to happen after we updated Python version to 3.12