### PR TITLE
CI Disable webworker tests in gha

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,6 +190,7 @@ jobs:
           ls -lh dist/
           tools/pytest_wrapper.py src packages/micropip/ \
             -v \
+            -k "not webworker" \
             --runtime="${BROWSER}-no-host" \
             --runner "${RUNNER}" \
             --durations 50 \


### PR DESCRIPTION
GHA still hangs, and sadly, #4525 didn't work.

Looking at the log, the test always seems to hang at webworker tests. So maybe we need to investigate this in `pytest-pyodide` side. This PR disables webworker tests in GHA until we find a fix.