### PR TITLE
Remove pyodide.runPythonSyncifying

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -55,6 +55,10 @@ only_node = pytest.mark.xfail_browsers(
     chrome="node only", firefox="node only", safari="node only"
 )
 
+requires_jspi = pytest.mark.xfail_browsers(
+    firefox="requires jspi", safari="requires jspi"
+)
+
 
 def pytest_addoption(parser):
     group = parser.getgroup("general")

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,6 +16,9 @@ myst:
 
 ## Unreleased
 
+- {{ Enhancement }} Improved support for stack switching.
+  {pr}`4532`, {pr}`4547`
+
 - Upgraded Python to v3.12.1
   {pr}`4431` {pr}`4435`
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -286,41 +286,6 @@ export class PyodideAPI {
   }
 
   /**
-   * Runs a Python code string like :js:func:`pyodide.runPython` but with stack
-   * switching enabled. Code executed in this way can use
-   * :py:meth:`PyodideFuture.syncify() <pyodide.webloop.PyodideFuture.syncify>`
-   * to block until a :py:class:`~asyncio.Future` or :js:class:`Promise` is
-   * resolved. Only works in runtimes with JS Promise Integration enabled.
-   *
-   * .. admonition:: Experimental
-   *    :class: warning
-   *
-   *    This feature is not yet stable.
-   *
-   * @experimental
-   * @param code The Python code to run
-   * @param options
-   * @param options.globals An optional Python dictionary to use as the globals.
-   * Defaults to :js:attr:`pyodide.globals`.
-   * @param options.locals An optional Python dictionary to use as the locals.
-   *        Defaults to the same as ``globals``.
-   * @param options.filename An optional string to use as the file name.
-   *        Defaults to ``"<exec>"``. If a custom file name is given, the
-   *        traceback for any exception that is thrown will show source lines
-   *        (unless the given file name starts with ``<`` and ends with ``>``).
-   * @returns The result of the Python code translated to JavaScript.
-   */
-  static async runPythonSyncifying(
-    code: string,
-    options: { globals?: PyProxy; locals?: PyProxy; filename?: string } = {},
-  ): Promise<any> {
-    if (!options.globals) {
-      options.globals = API.globals;
-    }
-    return API.pyodide_code.eval_code.callSyncifyingKwargs(code, options);
-  }
-
-  /**
    * Registers the JavaScript object ``module`` as a JavaScript module named
    * ``name``. This module can then be imported from Python using the standard
    * Python import system. If another module by the same name has already been

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -170,8 +170,9 @@ class PyodideFuture(Future[T]):
     def syncify(self):
         """Block until the future is resolved. Only works if JS Promise
         integration is enabled in the runtime and the current Python call stack
-        was entered via :js:func:`pyodide.runPythonSyncifying` or
-        :js:func:`~PyCallable.callSyncifying`.
+        was entered via :js:func:`pyodide.runPythonAsync`, by calling an async
+        Python function, or via :js:func:`~PyCallable.callSyncifying`.
+
 
         .. admonition:: Experimental
            :class: warning

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -188,7 +188,7 @@ def test_syncify_getset(selenium):
 
 @requires_jspi
 @pytest.mark.requires_dynamic_linking
-@pytest.mark.xfail(reason="Will fix in a followup")
+@pytest.mark.skip(reason="Will fix in a followup")
 @run_in_pyodide
 def test_syncify_ctypes(selenium):
     from pyodide.code import run_js

--- a/src/tests/test_syncify.py
+++ b/src/tests/test_syncify.py
@@ -26,7 +26,7 @@ def test_syncify_not_supported1(selenium_standalone_noload):
         delete WebAssembly.Suspender;
         let pyodide = await loadPyodide({});
         await assertThrowsAsync(
-          async () => await pyodide.runPythonAsync("1+1"),
+          async () => await pyodide._api.pyodide_code.eval_code.callSyncifying("1+1"),
           "Error",
           "WebAssembly stack switching not supported in this JavaScript runtime"
         );
@@ -51,7 +51,7 @@ def test_syncify_not_supported2(selenium_standalone_noload):
         WebAssembly.Module = new Proxy(WebAssembly.Module, {construct(){throw new Error("NOPE!");}});
         let pyodide = await loadPyodide({});
         await assertThrowsAsync(
-          async () => await pyodide.runPythonAsync("1+1"),
+          async () => await pyodide._api.pyodide_code.eval_code.callSyncifying("1+1"),
           "Error",
           "WebAssembly stack switching not supported in this JavaScript runtime"
         );

--- a/src/tests/test_syncify.py
+++ b/src/tests/test_syncify.py
@@ -190,7 +190,7 @@ def test_syncify_getset(selenium):
 @pytest.mark.requires_dynamic_linking
 @pytest.mark.xfail(reason="Will fix in a followup")
 @run_in_pyodide
-def test_syncify_ctypes():
+def test_syncify_ctypes(selenium):
     from pyodide.code import run_js
 
     test = run_js(

--- a/src/tests/test_syncify.py
+++ b/src/tests/test_syncify.py
@@ -1,8 +1,10 @@
 import pytest
 from pytest_pyodide import run_in_pyodide
 
+from conftest import requires_jspi
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+
+@requires_jspi
 @run_in_pyodide
 def test_syncify_create_task(selenium):
     import asyncio
@@ -24,7 +26,7 @@ def test_syncify_not_supported1(selenium_standalone_noload):
         delete WebAssembly.Suspender;
         let pyodide = await loadPyodide({});
         await assertThrowsAsync(
-          async () => await pyodide.runPythonSyncifying("1+1"),
+          async () => await pyodide.runPythonAsync("1+1"),
           "Error",
           "WebAssembly stack switching not supported in this JavaScript runtime"
         );
@@ -49,7 +51,7 @@ def test_syncify_not_supported2(selenium_standalone_noload):
         WebAssembly.Module = new Proxy(WebAssembly.Module, {construct(){throw new Error("NOPE!");}});
         let pyodide = await loadPyodide({});
         await assertThrowsAsync(
-          async () => await pyodide.runPythonSyncifying("1+1"),
+          async () => await pyodide.runPythonAsync("1+1"),
           "Error",
           "WebAssembly stack switching not supported in this JavaScript runtime"
         );
@@ -62,7 +64,7 @@ def test_syncify_not_supported2(selenium_standalone_noload):
     )
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 @run_in_pyodide
 def test_syncify1(selenium):
     from pyodide.code import run_js
@@ -78,7 +80,7 @@ def test_syncify1(selenium):
     assert test().syncify() == 7
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 @run_in_pyodide(packages=["pytest"])
 def test_syncify2(selenium):
     import importlib.metadata
@@ -95,7 +97,7 @@ def test_syncify2(selenium):
     assert importlib.metadata.version("micropip")
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 @run_in_pyodide(packages=["pytest"])
 def test_syncify_error(selenium):
     import pytest
@@ -115,7 +117,7 @@ def test_syncify_error(selenium):
         asyncThrow().syncify()
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 @run_in_pyodide
 def test_syncify_null(selenium):
     from pyodide.code import run_js
@@ -131,12 +133,12 @@ def test_syncify_null(selenium):
     assert asyncNull().syncify() is None
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 def test_syncify_no_suspender(selenium):
     selenium.run_js(
         """
         await pyodide.loadPackage("pytest");
-        await pyodide.runPython(`
+        pyodide.runPython(`
             from pyodide.code import run_js
             import pytest
 
@@ -157,7 +159,7 @@ def test_syncify_no_suspender(selenium):
 
 
 @pytest.mark.requires_dynamic_linking
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 @run_in_pyodide(packages=["fpcast-test"])
 def test_syncify_getset(selenium):
     from pyodide.code import run_js
@@ -184,36 +186,34 @@ def test_syncify_getset(selenium):
     assert x == [7, 7]
 
 
+@requires_jspi
 @pytest.mark.requires_dynamic_linking
 @pytest.mark.xfail(reason="Will fix in a followup")
+@run_in_pyodide
 def test_syncify_ctypes():
-    selenium.run_js(  # type: ignore[name-defined] # noqa: F821
+    from pyodide.code import run_js
+
+    test = run_js(
         """
-        await pyodide.runPythonSyncifying(`
-            from pyodide.code import run_js
-
-            test = run_js(
-                '''
-                (async function test() {
-                    await sleep(1000);
-                    return 7;
-                })
-                '''
-            )
-
-            def wrapper():
-                return test().syncify()
-            from ctypes import pythonapi, py_object
-            pythonapi.PyObject_CallNoArgs.argtypes = [py_object]
-            pythonapi.PyObject_CallNoArgs.restype = py_object
-            assert pythonapi.PyObject_CallNoArgs(wrapper) == 7
-        `);
+        (async function test() {
+            await sleep(1000);
+            return 7;
+        })
         """
     )
 
+    def wrapper():
+        return test().syncify()
 
+    from ctypes import py_object, pythonapi
+
+    pythonapi.PyObject_CallNoArgs.argtypes = [py_object]
+    pythonapi.PyObject_CallNoArgs.restype = py_object
+    assert pythonapi.PyObject_CallNoArgs(wrapper) == 7
+
+
+@requires_jspi
 @pytest.mark.requires_dynamic_linking
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
 def test_cpp_exceptions_and_syncify(selenium):
     assert (
         selenium.run_js(
@@ -256,7 +256,7 @@ def test_cpp_exceptions_and_syncify(selenium):
     )
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 def test_two_way_transfer(selenium):
     res = selenium.run_js(
         """
@@ -291,7 +291,7 @@ def test_two_way_transfer(selenium):
     ]
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 def test_sync_async_mix(selenium):
     res = selenium.run_js(
         """
@@ -336,7 +336,7 @@ def test_sync_async_mix(selenium):
     ]
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 def test_nested_syncify(selenium):
     res = selenium.run_js(
         """
@@ -376,7 +376,7 @@ def test_nested_syncify(selenium):
         const g2 = pyodide.globals.get("g2");
         const p = [];
         p.push(g.callSyncifying().then((res) => l.append(res)));
-        p.push(pyodide.runPythonSyncifying(`
+        p.push(pyodide.runPythonAsync(`
             from js import sleep
             for i in range(20):
                 sleep(9).syncify()
@@ -395,7 +395,7 @@ def test_nested_syncify(selenium):
     assert res == list(range(20))
 
 
-@pytest.mark.xfail_browsers(safari="No JSPI on Safari", firefox="No JSPI on firefox")
+@requires_jspi
 @run_in_pyodide
 async def test_promise_methods(selenium):
     from asyncio import ensure_future, sleep


### PR DESCRIPTION
It is now a worse version of `pyodide.runPythonAsync` since you can stack switch from
there but also you can use top level await.
