### PR TITLE
Replace `pkgconfig` with `pkg-config` for Meson configuration file

### DIFF
--- a/pyodide-build/pyodide_build/tools/emscripten.meson.cross
+++ b/pyodide-build/pyodide_build/tools/emscripten.meson.cross
@@ -1,7 +1,7 @@
 # compiler paths are omitted intentionally so we can override the compiler using environment variables
 [binaries]
 exe_wrapper = 'node'
-pkgconfig = 'pkg-config'
+pkg-config = 'pkg-config'
 
 [properties]
 needs_exe_wrapper = true


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This PR is a small fix to silence a Meson deprecation warning, where the `pkgconfig` entry in the Meson cross-configuration file has to be replaced by the term `pkg-config`. This is referenced in the following lines:

https://github.com/mesonbuild/meson/blob/39e1bf19fb653ac4f040e48b9a33aaa59dea1196/mesonbuild/envconfig.py#L399-L404

Closes #4540 

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
