### PR TITLE
Add mountNodeFS

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -61,6 +61,10 @@ myst:
   it fails.
   {pr}`4559`
 
+- {{ Enhancement }} Added a new API `pyodide.mountNodeFS` which mounts a host
+  directory into the Pyodide file system when running in node.
+  {pr}`2987`
+
 ### Packages
 
 - New Packages: `cysignals`, `ppl`, `pplpy` {pr}`4407`, `flint`, `python-flint` {pr}`4410`,

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -63,7 +63,7 @@ myst:
 
 - {{ Enhancement }} Added a new API `pyodide.mountNodeFS` which mounts a host
   directory into the Pyodide file system when running in node.
-  {pr}`2987`
+  {pr}`4561`
 
 ### Packages
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -5,7 +5,7 @@ import { CanvasInterface, canvas } from "./canvas";
 
 import { PackageData, loadPackage, loadedPackages } from "./load-package";
 import { type PyProxy, type PyDict } from "generated/pyproxy";
-import { loadBinaryFile } from "./compat";
+import { loadBinaryFile, nodeFSMod } from "./compat";
 import { version } from "./version";
 import { setStdin, setStdout, setStderr } from "./streams";
 import { TypedArray } from "./types";
@@ -49,6 +49,23 @@ API.saveState = () => API.pyodide_py._state.save_state();
 
 /** @private */
 API.restoreState = (state: any) => API.pyodide_py._state.restore_state(state);
+
+function ensureMountPathExists(path: string): void {
+  Module.FS.mkdirTree(path);
+  const { node } = Module.FS.lookupPath(path, {
+    follow_mount: false,
+  });
+
+  if (FS.isMountpoint(node)) {
+    throw new Error(`path '${path}' is already a file system mount point`);
+  }
+  if (!FS.isDir(node.mode)) {
+    throw new Error(`path '${path}' points to a file not a directory`);
+  }
+  for (const _ in node.contents) {
+    throw new Error(`directory '${path}' is not empty`);
+  }
+}
 
 /**
  * Why is this a class rather than an object?
@@ -482,12 +499,15 @@ export class PyodideAPI {
 
   /**
    * Mounts a :js:class:`FileSystemDirectoryHandle` into the target directory.
+   * Currently it's only possible to acquire a
+   * :js:class:`FileSystemDirectoryHandle` in Chrome.
    *
    * @param path The absolute path in the Emscripten file system to mount the
-   * native directory. If the directory does not exist, it will be created. If it
-   * does exist, it must be empty.
-   * @param fileSystemHandle A handle returned by :js:func:`navigator.storage.getDirectory() <getDirectory>`
-   * or :js:func:`window.showDirectoryPicker() <showDirectoryPicker>`.
+   * native directory. If the directory does not exist, it will be created. If
+   * it does exist, it must be empty.
+   * @param fileSystemHandle A handle returned by
+   * :js:func:`navigator.storage.getDirectory() <getDirectory>` or
+   * :js:func:`window.showDirectoryPicker() <showDirectoryPicker>`.
    */
   static async mountNativeFS(
     path: string,
@@ -500,25 +520,11 @@ export class PyodideAPI {
         `Expected argument 'fileSystemHandle' to be a FileSystemDirectoryHandle`,
       );
     }
-
-    Module.FS.mkdirTree(path);
-    const { node } = Module.FS.lookupPath(path, {
-      follow_mount: false,
-    });
-
-    if (FS.isMountpoint(node)) {
-      throw new Error(`path '${path}' is already a file system mount point`);
-    }
-    if (!FS.isDir(node.mode)) {
-      throw new Error(`path '${path}' points to a file not a directory`);
-    }
-    for (const _ in node.contents) {
-      throw new Error(`directory '${path}' is not empty`);
-    }
+    ensureMountPathExists(path);
 
     Module.FS.mount(
       Module.FS.filesystems.NATIVEFS_ASYNC,
-      { fileSystemHandle: fileSystemHandle },
+      { fileSystemHandle },
       path,
     );
 
@@ -530,6 +536,33 @@ export class PyodideAPI {
       syncfs: async () =>
         new Promise((resolve, _) => Module.FS.syncfs(false, resolve)),
     };
+  }
+
+  /**
+   * Mounts a host directory into Pyodide file system. Only works in node.
+   *
+   * @param emscriptenPath The absolute path in the Emscripten file system to
+   * mount the native directory. If the directory does not exist, it will be
+   * created. If it does exist, it must be empty.
+   * @param hostPath The host path to mount. It must be a directory that exists.
+   */
+  static mountNodeFS(emscriptenPath: string, hostPath: string): void {
+    ensureMountPathExists(emscriptenPath);
+    let stat;
+    try {
+      stat = nodeFSMod.lstatSync(hostPath);
+    } catch (e) {
+      throw new Error(`hostPath '${hostPath}' does not exist`);
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`hostPath '${hostPath}' is not a directory`);
+    }
+
+    Module.FS.mount(
+      Module.FS.filesystems.NODEFS,
+      { root: hostPath },
+      emscriptenPath,
+    );
   }
 
   /**

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -9,6 +9,7 @@ import { loadBinaryFile, nodeFSMod } from "./compat";
 import { version } from "./version";
 import { setStdin, setStdout, setStderr } from "./streams";
 import { TypedArray } from "./types";
+import { IN_NODE } from "./environments";
 
 // Exported for micropip
 API.loadBinaryFile = loadBinaryFile;
@@ -547,6 +548,9 @@ export class PyodideAPI {
    * @param hostPath The host path to mount. It must be a directory that exists.
    */
   static mountNodeFS(emscriptenPath: string, hostPath: string): void {
+    if (!IN_NODE) {
+      throw new Error("mountNodeFS only works in Node");
+    }
     ensureMountPathExists(emscriptenPath);
     let stat;
     try {


### PR DESCRIPTION
This is a helper function for mounting native directories in node, analogous to `mountNativeFS`.


- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
