### PR TITLE
Cleanup: Remove importlib.invalidate_caches calls

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,7 +38,6 @@ pytest_pyodide.runner.NODE_FLAGS.extend(["--experimental-wasm-stack-switching"])
 pytest_pyodide.runner.INITIALIZE_SCRIPT = """
     pyodide.globals.get;
     pyodide.runPython("import pyodide_js._api; del pyodide_js");
-    pyodide._api.importlib.invalidate_caches;
     pyodide._api.package_loader.unpack_buffer;
     pyodide._api.package_loader.get_dynlibs;
     pyodide._api.pyodide_code.eval_code;

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -384,37 +384,6 @@ to change which packages {js:func}`pyodide.loadPackagesFromImports` loads, you
 can monkey patch {py:func}`pyodide.code.find_imports` which takes `code` as an
 argument and returns a list of packages imported.
 
-## Why can't I import a file I just wrote to the file system?
-
-For example:
-
-```py
-from pathlib import Path
-Path("mymodule.py").write_text("""\
-def hello():
-  print("hello world!")
-"""
-)
-from mymodule import hello # may raise "ModuleNotFoundError: No module named 'mymodule'"
-hello()
-```
-
-If you see this error, call {py:func}`importlib.invalidate_caches` before
-importing the module:
-
-```py
-import importlib
-from pathlib import Path
-Path("mymodule.py").write_text("""\
-def hello():
-  print("hello world!")
-"""
-)
-importlib.invalidate_caches() # Make sure Python notices the new .py file
-from mymodule import hello
-hello()
-```
-
 ## Why changes made to IndexedDB don't persist?
 
 Unlike other filesystems, IndexedDB (pyodide.FS.filesystem.IDBFS) is an asynchronous filesystem.

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -675,24 +675,23 @@ API.finalizeBootstrap = function (): PyodideInterface {
   // runPythonInternal uses a separate namespace, so we don't pollute the main
   // environment with variables from our setup.
   API.runPythonInternal_dict = API._pyodide._base.eval_code("{}") as PyProxy;
-  API.importlib = API.runPythonInternal("import importlib; importlib");
-  let import_module = API.importlib.import_module;
+  const import_module = API._pyodide._base.pyimport_impl;
 
   API.sys = import_module("sys");
   API.sys.path.insert(0, API.config.env.HOME);
   API.os = import_module("os");
 
   // Set up globals
-  let globals = API.runPythonInternal(
+  const globals = API.runPythonInternal(
     "import __main__; __main__.__dict__",
   ) as PyDict;
-  let builtins = API.runPythonInternal(
+  const builtins = API.runPythonInternal(
     "import builtins; builtins.__dict__",
   ) as PyDict;
   API.globals = wrapPythonGlobals(globals, builtins);
 
   // Set up key Javascript modules.
-  let importhook = API._pyodide._importhook;
+  const importhook = API._pyodide._importhook;
   function jsFinderHook(o: object) {
     if ("__all__" in o) {
       return;

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -534,10 +534,6 @@ export async function loadPackage(
         errorCallback(err.message);
       }
     }
-
-    // We have to invalidate Python's import caches, or it won't
-    // see the new files.
-    API.importlib.invalidate_caches();
     return Array.from(loadedPackageData, filterPackageData);
   } finally {
     releaseLock();

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -323,7 +323,6 @@ export interface API {
   restoreState: (state: any) => void;
 
   package_loader: any;
-  importlib: any;
   _import_name_to_package_name: Map<string, string>;
   lockFilePromise: Promise<Lockfile>;
   lockfile_unvendored_stdlibs: string[];

--- a/src/tests/test_filesystem.py
+++ b/src/tests/test_filesystem.py
@@ -36,8 +36,6 @@ def test_idbfs_persist_code(selenium_standalone):
             p = pathlib.Path('{mount_dir}/test_idbfs/__init__.py')
             p.parent.mkdir(exist_ok=True, parents=True)
             p.write_text("def test(): return 7")
-            from importlib import invalidate_caches
-            invalidate_caches()
             import sys
             sys.path.append('{mount_dir}')
             from test_idbfs import test
@@ -65,9 +63,7 @@ def test_idbfs_persist_code(selenium_standalone):
     selenium.run_js(
         f"""
         pyodide.runPython(`
-            from importlib import invalidate_caches
             import sys
-            invalidate_caches()
             err_type = None
             try:
                 sys.path.append('{mount_dir}')
@@ -98,8 +94,6 @@ def test_idbfs_persist_code(selenium_standalone):
     selenium.run_js(
         f"""
         pyodide.runPython(`
-            from importlib import invalidate_caches
-            invalidate_caches()
             import sys
             sys.path.append('{mount_dir}')
             from test_idbfs import test


### PR DESCRIPTION
It hasn't been needed since we brought in the patch that fixed the time functions on Emscripten:
https://github.com/emscripten-core/emscripten/pull/18301
