### PR TITLE
MAINT Update error handling code to use new Python 3.12 APIs

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -150,6 +150,10 @@ wrap_exception()
   PyErr_SetRaisedException(Py_NewRef(exc));
   // print standard traceback to standard error, clear the error flag, and set
   // sys.last_exc, sys.last_type, etc
+  //
+  // Calls sys.excepthook. We set the excepthook to call
+  // traceback.print_exception, see `set_excepthook()` in
+  // `_pyodide/__init__.py`.
   PyErr_Print();
   JsVal formatted_exception = restore_stderr();
 

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -68,8 +68,8 @@ new_error,
 // clang-format on
 
 /**
- * Restore sys.last_exception as the current exception if sys.last_value matches
- * the argument value. Used for reentrant errors.
+ * Restore sys.last_exception as the current exception if sys.last_exc matches
+ * the argument `exc`. Used for reentrant errors.
  * Returns true if it restored the error indicator, false otherwise.
  *
  * If we throw a JavaScript PythonError and it bubbles out to the enclosing
@@ -124,7 +124,7 @@ EM_JS(JsVal, restore_stderr, (void), {
  *
  * We are cautious about leaking the Python stack frame, so we don't increment
  * the reference count on the exception object, we just store a pointer to it.
- * Later we can check if this pointer is equal to sys.last_value and if so
+ * Later we can check if this pointer is equal to sys.last_exc and if so
  * restore the exception (see restore_sys_last_exception).
  *
  * WARNING: dereferencing the error pointer stored on the PythonError is a

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -13,7 +13,6 @@ static PyObject* tbmod = NULL;
 static PyObject* _pyodide_importhook = NULL;
 
 _Py_IDENTIFIER(__qualname__);
-_Py_IDENTIFIER(format_exception);
 _Py_IDENTIFIER(add_note_to_module_not_found_error);
 
 void
@@ -62,50 +61,11 @@ set_error(PyObject* err)
 EM_JS(
 JsVal,
 new_error,
-(const char* type, const char* msg, PyObject* err),
+(const char* type, JsVal msg, PyObject* err),
 {
-  return new API.PythonError(UTF8ToString(type), UTF8ToString(msg), err);
+  return new API.PythonError(UTF8ToString(type), msg, err);
 });
 // clang-format on
-
-/**
- * Fetch the exception, normalize it, and ensure that traceback is not NULL.
- *
- * Always succeeds, always results in type, value, traceback not NULL.
- */
-static void
-fetch_and_normalize_exception(PyObject** type,
-                              PyObject** value,
-                              PyObject** traceback)
-{
-  PyErr_Fetch(type, value, traceback);
-  PyErr_NormalizeException(type, value, traceback);
-  if (*type == NULL || Py_IsNone(*type) || *value == NULL ||
-      Py_IsNone(*value)) {
-    Py_CLEAR(*type);
-    Py_CLEAR(*value);
-    Py_CLEAR(*traceback);
-    fail_test();
-    PyErr_SetString(PyExc_TypeError,
-                    "Pyodide internal error: no exception type or value");
-    PyErr_Fetch(type, value, traceback);
-    PyErr_NormalizeException(type, value, traceback);
-  }
-
-  if (*traceback == NULL) {
-    *traceback = Py_None;
-    Py_INCREF(*traceback);
-  }
-  PyException_SetTraceback(*value, *traceback);
-}
-
-static void
-store_sys_last_exception(PyObject* type, PyObject* value, PyObject* traceback)
-{
-  PySys_SetObject("last_type", type);
-  PySys_SetObject("last_value", value);
-  PySys_SetObject("last_traceback", traceback);
-}
 
 /**
  * Restore sys.last_exception as the current exception if sys.last_value matches
@@ -124,56 +84,37 @@ store_sys_last_exception(PyObject* type, PyObject* value, PyObject* traceback)
  * support for catching errors by type.
  */
 EMSCRIPTEN_KEEPALIVE bool
-restore_sys_last_exception(void* value)
+restore_sys_last_exception(void* exc)
 {
-  bool success = false;
-  FAIL_IF_NULL(value);
-  PyObject* last_type = PySys_GetObject("last_type");
-  FAIL_IF_NULL(last_type);
-  PyObject* last_value = PySys_GetObject("last_value");
-  FAIL_IF_NULL(last_value);
-  PyObject* last_traceback = PySys_GetObject("last_traceback");
-  FAIL_IF_NULL(last_traceback);
-  if (value != last_value) {
-    return 0;
+  if (exc == NULL) {
+    return false;
   }
-  // PyErr_Restore steals a reference to each of its arguments so need to incref
-  // them first.
-  Py_INCREF(last_type);
-  Py_INCREF(last_value);
-  Py_INCREF(last_traceback);
-  PyErr_Restore(last_type, last_value, last_traceback);
-  success = true;
-finally:
-  return success;
+  // PySys_GetObject returns a borrowed reference and will return NULL without
+  // setting an exception if it fails.
+  PyObject* last_exc = PySys_GetObject("last_exc");
+  if (last_exc != exc) {
+    return false;
+  }
+  // PyErr_SetRaisedException steals a reference to its argument and
+  // PySys_GetObject returns a borrow so need to incref last_xxc first.
+  Py_INCREF(last_exc);
+  PyErr_SetRaisedException(last_exc);
+  return true;
 }
 
-EM_JS(void, fail_test, (), { API.fail_test = true; })
+// clang-format off
+EM_JS(void, fail_test, (), {
+  API.fail_test = true;
+})
 
-/**
- * Calls traceback.format_exception(type, value, traceback) and joins the
- * resulting list of strings together.
- */
-static PyObject*
-format_exception_traceback(PyObject* type, PyObject* value, PyObject* traceback)
-{
-  PyObject* pylines = NULL;
-  PyObject* empty = NULL;
-  PyObject* result = NULL;
+EM_JS(void, capture_stderr, (void), {
+  API.capture_stderr();
+});
 
-  pylines = _PyObject_CallMethodIdObjArgs(
-    tbmod, &PyId_format_exception, type, value, traceback, NULL);
-  FAIL_IF_NULL(pylines);
-  empty = PyUnicode_New(0, 0);
-  FAIL_IF_NULL(empty);
-  result = PyUnicode_Join(empty, pylines);
-  FAIL_IF_NULL(result);
-
-finally:
-  Py_CLEAR(pylines);
-  Py_CLEAR(empty);
-  return result;
-}
+EM_JS(JsVal, restore_stderr, (void), {
+  return API.restore_stderr();
+});
+// clang-format on
 
 /**
  * Wrap the exception in a JavaScript PythonError object.
@@ -193,29 +134,31 @@ EMSCRIPTEN_KEEPALIVE JsVal
 wrap_exception()
 {
   bool success = false;
-  PyObject* type = NULL;
-  PyObject* value = NULL;
-  PyObject* traceback = NULL;
+  PyObject* exc = NULL;
   PyObject* typestr = NULL;
-  PyObject* pystr = NULL;
-  fetch_and_normalize_exception(&type, &value, &traceback);
-  store_sys_last_exception(type, value, traceback);
-  if (type == PyExc_ModuleNotFoundError) {
+
+  exc = PyErr_GetRaisedException();
+
+  if (PyErr_GivenExceptionMatches(exc, PyExc_ModuleNotFoundError)) {
     PyObject* res = _PyObject_CallMethodIdOneArg(
-      _pyodide_importhook, &PyId_add_note_to_module_not_found_error, value);
+      _pyodide_importhook, &PyId_add_note_to_module_not_found_error, exc);
     FAIL_IF_NULL(res);
     Py_CLEAR(res);
   }
 
-  typestr = _PyObject_GetAttrId(type, &PyId___qualname__);
+  capture_stderr();
+  PyErr_SetRaisedException(Py_NewRef(exc));
+  // print standard traceback to standard error, clear the error flag, and set
+  // sys.last_exc, sys.last_type, etc
+  PyErr_Print();
+  JsVal formatted_exception = restore_stderr();
+
+  typestr = _PyObject_GetAttrId((PyObject*)Py_TYPE(exc), &PyId___qualname__);
   FAIL_IF_NULL(typestr);
   const char* typestr_utf8 = PyUnicode_AsUTF8(typestr);
   FAIL_IF_NULL(typestr_utf8);
-  pystr = format_exception_traceback(type, value, traceback);
-  FAIL_IF_NULL(pystr);
-  const char* pystr_utf8 = PyUnicode_AsUTF8(pystr);
-  FAIL_IF_NULL(pystr_utf8);
-  JsVal jserror = new_error(typestr_utf8, pystr_utf8, value);
+
+  JsVal jserror = new_error(typestr_utf8, formatted_exception, exc);
   FAIL_IF_JS_NULL(jserror);
 
   success = true;
@@ -225,17 +168,15 @@ finally:
     PySys_WriteStderr(
       "Pyodide: Internal error occurred while formatting traceback:\n");
     PyErr_Print();
-    if (type != NULL) {
+    if (exc != NULL) {
       PySys_WriteStderr("\nOriginal exception was:\n");
-      PyErr_Display(type, value, traceback);
+      PyErr_DisplayException(exc);
     }
-    jserror = new_error(
-      "PyodideInternalError", "Error occurred while formatting traceback", 0);
+    Js_static_string(msg, "Error occurred while formatting traceback");
+    jserror = new_error("PyodideInternalError", JsvString_FromId(&msg), 0);
   }
-  Py_CLEAR(type);
-  Py_CLEAR(value);
-  Py_CLEAR(traceback);
-  Py_CLEAR(pystr);
+  Py_CLEAR(exc);
+  Py_CLEAR(typestr);
   return jserror;
 }
 

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -297,7 +297,7 @@ Module.handle_js_error = function (e: any) {
  * In order to reduce the risk of large memory leaks, the :js:class:`PythonError`
  * contains no reference to the Python exception that caused it. You can find
  * the actual Python exception that caused this error as
- * :py:data:`sys.last_value`.
+ * :py:data:`sys.last_exc`.
  *
  * See :ref:`type translations of errors <type-translations-errors>` for more
  * information.
@@ -306,7 +306,7 @@ Module.handle_js_error = function (e: any) {
  *    :class: warning
  *
  *    If you make a :js:class:`~pyodide.ffi.PyProxy` of
- *    :py:data:`sys.last_value`, you should be especially careful to
+ *    :py:data:`sys.last_exc`, you should be especially careful to
  *    :js:meth:`~pyodide.ffi.PyProxy.destroy` it when you are done. You may leak a large
  *    amount of memory including the local variables of all the stack frames in
  *    the traceback if you don't. The easiest way is to only handle the
@@ -317,7 +317,7 @@ Module.handle_js_error = function (e: any) {
 export class PythonError extends Error {
   /**
    * The address of the error we are wrapping. We may later compare this
-   * against sys.last_value.
+   * against sys.last_exc.
    * WARNING: we don't own a reference to this pointer, dereferencing it
    * may be a use-after-free error!
    * @private

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -252,7 +252,8 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
   }
   await API.packageIndexReady;
 
-  let importhook = API._pyodide._importhook;
+  API._pyodide.set_excepthook();
+  const importhook = API._pyodide._importhook;
   importhook.register_module_not_found_hook(
     API._import_name_to_package_name,
     API.lockfile_unvendored_stdlibs_and_test,

--- a/src/py/_pyodide/__init__.py
+++ b/src/py/_pyodide/__init__.py
@@ -10,3 +10,21 @@
 from . import _base, _importhook
 
 __all__ = ["_base", "_importhook"]
+
+
+def set_excepthook():
+    import sys
+    import traceback
+
+    # We call sys.excepthook via PyErr_Print() in wrap_exception().
+    # traceback.print_exception in most ways behaves the same as the default
+    # sys.excepthook **except** traceback.print_exception uses the linecache
+    # whereas sys.excepthook only uses the file system. If the user calls
+    # `runPython` with a `file` argument, then we put this into the linecache
+    # but not into the filesystem. This means that the default excepthook won't
+    # print the lines, but `traceback.print_exception` will. I think this is the
+    # only difference in their behavior.
+    #
+    # Python 3.13 seems to have switched to using `traceback.print_exception` as
+    # the default excepthook.
+    sys.excepthook = traceback.print_exception

--- a/src/py/pyodide/_state.py
+++ b/src/py/pyodide/_state.py
@@ -40,6 +40,7 @@ def restore_state(state: dict[str, Any]) -> int:
             del sys.modules[key]
     sys.modules.update(loaded_js_modules)
 
+    sys.last_exc = None  # type:ignore[attr-defined]
     sys.last_type = None
     sys.last_value = None
     sys.last_traceback = None

--- a/src/py/pyodide/console.py
+++ b/src/py/pyodide/console.py
@@ -398,6 +398,7 @@ class Console:
         This doesn't include a stack trace because there isn't one. The actual
         error object is stored into :py:data:`sys.last_value`.
         """
+        sys.last_exc = e  # type:ignore[attr-defined]
         sys.last_type = type(e)
         sys.last_value = e
         sys.last_traceback = None
@@ -419,6 +420,7 @@ class Console:
 
         The actual error object is stored into :py:data:`sys.last_value`.
         """
+        sys.last_exc = e  # type:ignore[attr-defined]
         sys.last_type = type(e)
         sys.last_value = e
         sys.last_traceback = e.__traceback__

--- a/src/tests/test_core_python.py
+++ b/src/tests/test_core_python.py
@@ -54,6 +54,8 @@ def test_cpython_core(main_test, selenium, request):
                 res = None
                 import platform
                 from test.libregrtest.main import main
+                import sys
+                sys.excepthook = sys.__excepthook__
 
                 platform.platform(aliased=True)
                 import _testcapi

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -531,6 +531,7 @@ def test_run_python_last_exc(selenium):
         } catch(e){}
         pyodide.runPython(`
             import sys
+            assert sys.last_exc is x
             assert sys.last_value is x
             assert sys.last_type is type(x)
             assert sys.last_traceback is x.__traceback__
@@ -1273,10 +1274,11 @@ def test_restore_error(selenium):
                 f()
             except Exception as e:
                 assert err == e
+                assert e == sys.last_exc
                 assert e == sys.last_value
             finally:
                 del err
-            assert sys.getrefcount(sys.last_value) == 2
+            assert sys.getrefcount(sys.last_exc) == 2
         `);
         """
     )

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1278,7 +1278,7 @@ def test_restore_error(selenium):
                 assert e == sys.last_value
             finally:
                 del err
-            assert sys.getrefcount(sys.last_exc) == 2
+            assert sys.getrefcount(sys.last_exc) == 3
         `);
         """
     )


### PR DESCRIPTION
The only behavior change here should be that we are setting `sys.last_exc` (added in Python3.12). Since we haven't released with Python 3.12 yet, this doesn't need a changelog.

Python 3.12 added a bunch of modern APIs that handle a single exception object rather than the (type, val, tb) triples. They also 
repaired various quirks of the old error handling APIs. They are much easier to work with. Also, now that we have `capture_stderr` and `restore_stderr` we can use `PyErr_Print()` to format the traceback. This allows us to cut out a fair amount of code in error_handling.c.

This now uses `sys.excepthook` to format exceptions. We set `sys.excepthook` to `traceback.print_exception` because the default excepthook does not respect the linecache which we use to implement `pyodide.runPython("...", {file: "some_file.py"});`