### PR TITLE
Make sysconfigdata relocatable

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -30,7 +30,7 @@ sysconfigdata:
 	# the subfolder is written to pybuilddir.txt.
 	cd $(PYBUILD) && _PYTHON_SYSCONFIGDATA_NAME=$(SYSCONFIG_NAME) _PYTHON_PROJECT_BASE=$(PYBUILD) $(HOSTPYTHON) -m sysconfig --generate-posix-vars
 	$(eval PYBUILDDIR=$(PYBUILD)/`cat $(PYBUILD)/pybuilddir.txt`)
-	PYTHONPATH=$(PYBUILDDIR) python$(PYMAJOR).$(PYMINOR) adjust_sysconfig.py
+	PYODIDE_ROOT=$(PYODIDE_ROOT) PYTHONPATH=$(PYBUILDDIR) python$(PYMAJOR).$(PYMINOR) adjust_sysconfig.py
 	mkdir -p $(PYINSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
 	mkdir -p $(SYSCONFIGDATA_DIR)
 	cp $(PYBUILDDIR)/$(SYSCONFIG_NAME).py $(PYINSTALL)/lib/python$(PYMAJOR).$(PYMINOR)/
@@ -73,11 +73,11 @@ $(PYTARBALL):
 	@GOT_SHASUM=`shasum --algorithm 256 $(PYTARBALL) | cut -f1 -d' '` \
 		&& (echo $$GOT_SHASUM | grep -q $(PYTHON_ARCHIVE_SHA256)) \
 		|| (\
-			   echo "Got unexpected shasum $$GOT_SHASUM" \
+			   rm $@ \
+			&& echo "Got unexpected shasum $$GOT_SHASUM" \
 			&& echo "If you are updating the Python version, set PYTHON_ARCHIVE_SHA256 in Makefile.envs to this." \
 			&& exit 1 \
 		)
-
 
 
 prepare-source: $(PYBUILD)/.patched

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -23,6 +23,7 @@ from .build_env import (
     RUST_BUILD_PRELUDE,
     BuildArgs,
     get_build_environment_vars,
+    get_pyodide_root,
     pyodide_tags,
     replace_so_abi_tags,
 )
@@ -95,7 +96,7 @@ class RecipeBuilder:
             Path(build_dir).resolve() if build_dir else self.pkg_root / "build"
         )
 
-        self.library_install_prefix = self.build_dir.parent.parent / ".libs"
+        self.library_install_prefix = get_pyodide_root() / "packages/.libs"
 
         self.src_extract_dir = (
             self.build_dir / self.fullname

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -23,7 +23,6 @@ from .build_env import (
     RUST_BUILD_PRELUDE,
     BuildArgs,
     get_build_environment_vars,
-    get_pyodide_root,
     pyodide_tags,
     replace_so_abi_tags,
 )
@@ -96,7 +95,7 @@ class RecipeBuilder:
             Path(build_dir).resolve() if build_dir else self.pkg_root / "build"
         )
 
-        self.library_install_prefix = get_pyodide_root() / "packages/.libs"
+        self.library_install_prefix = self.build_dir.parent.parent / ".libs"
 
         self.src_extract_dir = (
             self.build_dir / self.fullname


### PR DESCRIPTION
This replaces PYODIDE_ROOT with a variable in all places in the sysconfigdata. It makes it possible to build numpy out of tree.

