### PR TITLE
Don't throw when calling str on a proxy without a toString method

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,6 +16,13 @@ myst:
 
 ## Unreleased
 
+- {{ Enhancement }} `str(jsproxy)` has been adjusted to not raise an error if
+  `jsproxy.toString` is undefined. Instead, it will use
+  `Object.prototype.toString` in this case. If `jsproxy.toString` is defined and
+  throws or is not defined but `jsproxy[Symbol.toStringTag]` is defined and
+  throws, then `str` will still raise.
+  {pr}`4574`
+
 - {{ Enhancement }} Improved support for stack switching.
   {pr}`4532`, {pr}`4547`
 

--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -279,7 +279,7 @@ EM_JS_VAL(JsVal, JsvObject_Values, (JsVal obj), {
 
 EM_JS_VAL(JsVal,
 JsvObject_toString, (JsVal obj), {
-  if (typeof obj.toString === "function") {
+  if (hasMethod(obj, "toString")) {
     return obj.toString();
   }
   return Object.prototype.toString.call(obj);

--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -279,7 +279,10 @@ EM_JS_VAL(JsVal, JsvObject_Values, (JsVal obj), {
 
 EM_JS_VAL(JsVal,
 JsvObject_toString, (JsVal obj), {
-  return obj.toString();
+  if (typeof obj.toString === "function") {
+    return obj.toString();
+  }
+  return Object.prototype.toString.call(obj);
 });
 
 

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -268,9 +268,6 @@ JsProxy_Repr(PyObject* self)
 {
   JsVal repr = JsvObject_toString(JsProxy_VAL(self));
   if (JsvNull_Check(repr)) {
-    PyErr_Format(PyExc_TypeError,
-                 "Pyodide cannot generate a repr for this Javascript object "
-                 "because it has no 'toString' method");
     return NULL;
   }
   return js2python(repr);

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -2559,12 +2559,13 @@ def test_js_proxy_attribute(selenium):
 @run_in_pyodide
 async def test_js_proxy_str(selenium):
     import pytest
+    import re
 
     from js import Array
     from pyodide.code import run_js
     from pyodide.ffi import JsException
 
-    assert str(Array) == "function Array() { [native code] }"
+    assert re.sub(r"\s+", " ", str(Array).replace("\n", " ")) == "function Array() { [native code] }"
     assert str(run_js("[1,2,3]")) == "1,2,3"
     assert str(run_js("Object.create(null)")) == "[object Object]"
     mod = await run_js("import('data:text/javascript,')")

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -2558,14 +2558,18 @@ def test_js_proxy_attribute(selenium):
 
 @run_in_pyodide
 async def test_js_proxy_str(selenium):
-    import pytest
     import re
+
+    import pytest
 
     from js import Array
     from pyodide.code import run_js
     from pyodide.ffi import JsException
 
-    assert re.sub(r"\s+", " ", str(Array).replace("\n", " ")) == "function Array() { [native code] }"
+    assert (
+        re.sub(r"\s+", " ", str(Array).replace("\n", " "))
+        == "function Array() { [native code] }"
+    )
     assert str(run_js("[1,2,3]")) == "1,2,3"
     assert str(run_js("Object.create(null)")) == "[object Object]"
     mod = await run_js("import('data:text/javascript,')")

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -2557,3 +2557,20 @@ def test_js_proxy_attribute(selenium):
     assert x.c is None
     with pytest.raises(AttributeError):
         x.d  # noqa: B018
+
+
+@run_in_pyodide
+async def test_js_proxy_str(selenium):
+    from js import Array
+    from pyodide.ffi import JsException
+    from pyodide.code import run_js
+    import pytest
+
+    assert str(Array) == "function Array() { [native code] }"
+    assert str(run_js("[1,2,3]")) == "1,2,3"
+    assert str(run_js("Object.create(null)")) == "[object Object]"
+    mod = await run_js("import('data:text/javascript,')")
+    assert str(mod) == "[object Module]"
+    px = run_js("(p = Proxy.revocable({}, {})); p.revoke(); p.proxy")
+    with pytest.raises(JsException):
+        str(px)

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1286,13 +1286,10 @@ def test_js_id(selenium):
 
 @run_in_pyodide
 def test_object_with_null_constructor(selenium):
-    from unittest import TestCase
-
     from pyodide.code import run_js
 
     o = run_js("Object.create(null)")
-    with TestCase().assertRaises(TypeError):
-        repr(o)
+    assert repr(o) == "[object Object]"
 
 
 @pytest.mark.parametrize("n", [1 << 31, 1 << 32, 1 << 33, 1 << 63, 1 << 64, 1 << 65])

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -2618,6 +2618,6 @@ async def test_js_proxy_str(selenium):
     px = run_js("(p = Proxy.revocable({}, {})); p.revoke(); p.proxy")
     with pytest.raises(
         JsException,
-        match="Cannot perform 'Object.prototype.toString' on a proxy that has been revoked",
+        match="revoked",
     ):
         str(px)


### PR DESCRIPTION
Resolves #4569. It still doesn't make sure `str(jsproxy)` never throws. It will throw if:
1. accessing `obj.toString` succeeds and returns a function, but calling the function throws
2. accessing `obj.toString` fails or returns not a function, and `Object.prototype.toString.call` fails.

See added tests. Sound reasonable @ryanking13? cc @CNSeniorious000.



- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests

