### PR TITLE
Add docs for usage with Vite

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -161,7 +161,7 @@ export default defineConfig({ optimizeDeps: { exclude: ["pyodide"] } });
 You can test your setup with this `index.html` file:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <script type="module" src="/src/main.js"></script>

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -143,7 +143,7 @@ The following instructions have been tested with Vite 5.1.4.
 ```
 
 If you have installed Pyodide via npm as described above, you can use it in Vite
-dev mode as follows. First, install the [`isomorphic-fetch`][] package:
+as follows. First, install the [`isomorphic-fetch`][] package:
 
 ```
 $ npm install --save isomorphic-fetch@^3

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -135,3 +135,76 @@ undefined
    webworker.md
    service-worker.md
 ```
+
+## Vite
+
+```{note}
+The following instructions have been tested with Vite 5.1.4.
+```
+
+If you have installed Pyodide via npm as described above, you can use it in Vite
+dev mode as follows. First, install the [`isomorphic-fetch`][] package:
+
+```
+$ npm install --save isomorphic-fetch@^3
+```
+
+Then, exclude Pyodide from [Vite's dependency pre-bundling][optimizedeps] by
+setting `optimizeDeps.exclude` in your `vite.config.js` file:
+
+```js
+import { defineConfig } from "vite";
+
+export default defineConfig({ optimizeDeps: { exclude: ["pyodide"] } });
+```
+
+You can test your setup with this `index.html` file:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module" src="/src/main.js"></script>
+  </head>
+</html>
+```
+
+And this `src/main.js` file:
+
+```js
+import { loadPyodide } from "pyodide";
+
+async function hello_python() {
+  let pyodide = await loadPyodide();
+  return pyodide.runPythonAsync("1+1");
+}
+
+hello_python().then((result) => {
+  console.log("Python says that 1+1 =", result);
+});
+```
+
+This should be sufficient for Vite dev mode:
+
+```
+$ npx vite
+```
+
+For a production build, you must also manually make sure that all Pyodide files
+will be available in `dist/assets`, by first copying them to `public/assets`
+before building:
+
+```
+$ mkdir -p public/assets/
+$ cp node_modules/pyodide/* public/assets/
+$ npx vite build
+```
+
+Then you can view this production build to verify that it works:
+
+```
+$ npx vite preview
+```
+
+[`isomorphic-fetch`]: https://www.npmjs.com/package/isomorphic-fetch
+[optimizedeps]: https://vitejs.dev/guide/dep-pre-bundling.html

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -129,82 +129,10 @@ undefined
 .. toctree::
    :hidden:
 
+   working-with-bundlers.md
    loading-custom-python-code.md
    file-system.md
    accessing-files.md
    webworker.md
    service-worker.md
 ```
-
-## Vite
-
-```{note}
-The following instructions have been tested with Vite 5.1.4.
-```
-
-If you have installed Pyodide via npm as described above, you can use it in Vite
-as follows. First, install the [`isomorphic-fetch`][] package:
-
-```
-$ npm install --save isomorphic-fetch@^3
-```
-
-Then, exclude Pyodide from [Vite's dependency pre-bundling][optimizedeps] by
-setting `optimizeDeps.exclude` in your `vite.config.js` file:
-
-```js
-import { defineConfig } from "vite";
-
-export default defineConfig({ optimizeDeps: { exclude: ["pyodide"] } });
-```
-
-You can test your setup with this `index.html` file:
-
-```html
-<!doctype html>
-<html>
-  <head>
-    <script type="module" src="/src/main.js"></script>
-  </head>
-</html>
-```
-
-And this `src/main.js` file:
-
-```js
-import { loadPyodide } from "pyodide";
-
-async function hello_python() {
-  let pyodide = await loadPyodide();
-  return pyodide.runPythonAsync("1+1");
-}
-
-hello_python().then((result) => {
-  console.log("Python says that 1+1 =", result);
-});
-```
-
-This should be sufficient for Vite dev mode:
-
-```
-$ npx vite
-```
-
-For a production build, you must also manually make sure that all Pyodide files
-will be available in `dist/assets`, by first copying them to `public/assets`
-before building:
-
-```
-$ mkdir -p public/assets/
-$ cp node_modules/pyodide/* public/assets/
-$ npx vite build
-```
-
-Then you can view this production build to verify that it works:
-
-```
-$ npx vite preview
-```
-
-[`isomorphic-fetch`]: https://www.npmjs.com/package/isomorphic-fetch
-[optimizedeps]: https://vitejs.dev/guide/dep-pre-bundling.html

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -129,10 +129,10 @@ undefined
 .. toctree::
    :hidden:
 
-   working-with-bundlers.md
    loading-custom-python-code.md
    file-system.md
    accessing-files.md
    webworker.md
    service-worker.md
+   working-with-bundlers.md
 ```

--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -1,0 +1,82 @@
+(working-with-bundlers)=
+
+# Working with Bundlers
+
+## Webpack
+
+There is a [Pyodide Webpack Plugin][] to load Pyodide from a CDN in a Webpack
+project.
+
+## Vite
+
+```{note}
+The following instructions have been tested with Pyodide 0.25.0 and Vite 5.1.4.
+```
+
+If you have installed Pyodide via npm, you can use it in Vite as follows. First,
+install the [`isomorphic-fetch`][] package:
+
+```
+$ npm install --save isomorphic-fetch@^3
+```
+
+Then, exclude Pyodide from [Vite's dependency pre-bundling][optimizedeps] by
+setting `optimizeDeps.exclude` in your `vite.config.js` file:
+
+```js
+import { defineConfig } from "vite";
+
+export default defineConfig({ optimizeDeps: { exclude: ["pyodide"] } });
+```
+
+You can test your setup with this `index.html` file:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module" src="/src/main.js"></script>
+  </head>
+</html>
+```
+
+And this `src/main.js` file:
+
+```js
+import { loadPyodide } from "pyodide";
+
+async function hello_python() {
+  let pyodide = await loadPyodide();
+  return pyodide.runPythonAsync("1+1");
+}
+
+hello_python().then((result) => {
+  console.log("Python says that 1+1 =", result);
+});
+```
+
+This should be sufficient for Vite dev mode:
+
+```
+$ npx vite
+```
+
+For a production build, you must also manually make sure that all Pyodide files
+will be available in `dist/assets`, by first copying them to `public/assets`
+before building:
+
+```
+$ mkdir -p public/assets/
+$ cp node_modules/pyodide/* public/assets/
+$ npx vite build
+```
+
+Then you can view this production build to verify that it works:
+
+```
+$ npx vite preview
+```
+
+[`isomorphic-fetch`]: https://www.npmjs.com/package/isomorphic-fetch
+[optimizedeps]: https://vitejs.dev/guide/dep-pre-bundling.html
+[pyodide webpack plugin]: https://github.com/pyodide/pyodide-webpack-plugin

--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -35,7 +35,7 @@ export default defineConfig({ optimizeDeps: { exclude: ["pyodide"] } });
 You can test your setup with this `index.html` file:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <script type="module" src="/src/main.js"></script>

--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -32,7 +32,7 @@ export default defineConfig({ optimizeDeps: { exclude: ["pyodide"] } });
 You can test your setup with this `index.html` file:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <script type="module" src="/src/main.js"></script>

--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -14,7 +14,10 @@ The following instructions have been tested with Pyodide 0.25.0 and Vite 5.1.4.
 ```
 
 If you have installed Pyodide via npm, you can use it in Vite as follows. First,
-install the [`isomorphic-fetch`][] package:
+the Pyodide npm package currently uses [`node-fetch`][] to load some files,
+which does not work in a browser; to resolve this, install the
+[`isomorphic-fetch`][] package so that Pyodide does not try to load `node-fetch`
+in the browser:
 
 ```
 $ npm install --save isomorphic-fetch@^3
@@ -32,7 +35,7 @@ export default defineConfig({ optimizeDeps: { exclude: ["pyodide"] } });
 You can test your setup with this `index.html` file:
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <script type="module" src="/src/main.js"></script>
@@ -78,5 +81,6 @@ $ npx vite preview
 ```
 
 [`isomorphic-fetch`]: https://www.npmjs.com/package/isomorphic-fetch
+[`node-fetch`]: https://www.npmjs.com/package/node-fetch
 [optimizedeps]: https://vitejs.dev/guide/dep-pre-bundling.html
 [pyodide webpack plugin]: https://github.com/pyodide/pyodide-webpack-plugin


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Currently it is fairly difficult to use the Pyodide npm package with a modern web build tool like Vite. For instance, Googling turns up a few GitHub discussion threads with some tips on how to do this, but they all seem to be some combination of incomplete or out of date. As a first step to addressing that difficulty, this PR adds a doc section on how to use Pyodide from npm in Vite.

Ideally, this will be followed up by improvements to the Pyodide npm package itself so that fewer of these hacky steps are needed.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation

I've left the test box unchecked, along with the changelog box because from a quick search I don't see any doc-only changes in the current changelog.