### PR TITLE
Always build tblib

### DIFF
--- a/packages/tblib/meta.yaml
+++ b/packages/tblib/meta.yaml
@@ -4,6 +4,7 @@ package:
   top-level:
     - tblib
   tag:
+    - always
     - core
     - min-scipy-stack
 source:


### PR DESCRIPTION
This automatically makes sure everyone gets good tracebacks with `run_in_pyodide` which should make things easier for occasional contributors.

