### PR TITLE
Fix fatal error when except blocks are interleaved by stack switching

### DIFF
--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -125,6 +125,11 @@ saveExceptionState(PyThreadState* tstate)
   ExceptionState es;
   es.exc_info = tstate->exc_info;
   es.exc_state = tstate->exc_state;
+  // Clear exc_state without decrementing any refcounts (we moved ownership to es)
+  // See test_switch_from_except_block for a test case for this.
+  tstate->exc_state.exc_value = NULL;
+  tstate->exc_state.previous_item = NULL;
+  tstate->exc_info = &tstate->exc_state;
   return es;
 }
 

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -125,8 +125,8 @@ saveExceptionState(PyThreadState* tstate)
   ExceptionState es;
   es.exc_info = tstate->exc_info;
   es.exc_state = tstate->exc_state;
-  // Clear exc_state without decrementing any refcounts (we moved ownership to es)
-  // See test_switch_from_except_block for a test case for this.
+  // Clear exc_state without decrementing any refcounts (we moved ownership to
+  // es) See test_switch_from_except_block for a test case for this.
   tstate->exc_state.exc_value = NULL;
   tstate->exc_state.previous_item = NULL;
   tstate->exc_info = &tstate->exc_state;


### PR DESCRIPTION
Before we moved the exception state into the saved ExceptionState as part of saving the Python state but we didn't clear the exception state. This logic was copied from greenlet; I can't find where they clear the exception state either. However, in our case it is definitely wrong. If we stack switch inside an except block and then enter and stack switch inside a second except block, after exiting from everything we end up witht the exception state set instead of cleared (as if we were still in an except block) and worse the exception state is set to an already freed exception. I'm not actually sure why the bug manifests in this particular way, but this change fixes it.

### Checklist

- [x] Add / update tests
