### PR TITLE
Fix stack switching leaks

### DIFF
--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -759,6 +759,18 @@ finally:
   return result;
 }
 
+void
+set_new_cframe(_PyCFrame* frame);
+
+_PyCFrame*
+get_cframe();
+
+void
+exit_cframe(_PyCFrame* frame);
+
+void
+restore_cframe(_PyCFrame* frame);
+
 /**
  * call _pyproxy_apply but save the error flag into the argument so it can't be
  * observed by unrelated Python callframes. callPyObjectKwargsSuspending will
@@ -773,8 +785,12 @@ _pyproxy_apply_promising(PyObject* callable,
                          size_t numkwargs,
                          PyObject** exc)
 {
+  _PyCFrame* cur = get_cframe();
+  _PyCFrame frame;
+  set_new_cframe(&frame);
   JsVal res =
     _pyproxy_apply(callable, jsargs, numposargs, jskwnames, numkwargs);
+  exit_cframe(cur);
   *exc = PyErr_GetRaisedException();
   return res;
 }

--- a/src/core/stack_switching/suspenders.mjs
+++ b/src/core/stack_switching/suspenders.mjs
@@ -89,8 +89,6 @@ export function promisingApply(...args) {
   Module.stackStop = stackSave();
   // Subtle cframe shenanigans...
   Module.origCframe = _get_cframe();
-  const cframe = stackAlloc(HEAP32[_size_of_cframe / 4]);
-  _set_new_cframe(cframe);
   return promisingApplyHandler(...args);
 }
 

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -578,81 +578,57 @@ def test_switch_from_except_block(selenium):
     ]
 
 
+# Start with just a no-op script
+LEAK_SCRIPT1 = """
+def test(n):
+    pass
+"""
+
+#
+LEAK_SCRIPT2 = """
+from pyodide.ffi import run_sync
+from js import sleep
+
+def test(n):
+    run_sync(sleep(1))
+"""
+
+LEAK_SCRIPT3 = """
+from pyodide.ffi import run_sync
+from asyncio import sleep as py_sleep, ensure_future
+
+async def sleep(x):
+    await py_sleep(x/1000)
+
+def test(n):
+    run_sync(ensure_future(sleep(1)))
+"""
+
+LEAK_SCRIPT4 = """
+from pyodide.ffi import run_sync
+from asyncio import sleep as py_sleep
+
+async def sleep(x):
+    await py_sleep(x/1000)
+
+def test(n):
+    run_sync(sleep(1))
+"""
+
+
 @requires_jspi
-def test_memory_leak1(selenium):
+@pytest.mark.parametrize(
+    "script", [LEAK_SCRIPT1, LEAK_SCRIPT2, LEAK_SCRIPT3, LEAK_SCRIPT4]
+)
+def test_memory_leak(selenium, script):
     length_change = selenium.run_js(
+        f"""
+        pyodide.runPython(`{script}`);
         """
-        t = pyodide.runPython(`
-            def t(n):
-                pass
-
-            t
-        `);
-        for (let i = 0; i < 10; i++) {
-            t.callSyncifying(1)
-        }
-        const startLength = pyodide._module.HEAP32.length;
-        for (let i = 0; i < 200; i++) {
-            t.callSyncifying(1)
-        }
-        t.destroy();
-        return pyodide._module.HEAP32.length - startLength;
         """
-    )
-    assert length_change == 0
-
-
-@requires_jspi
-def test_memory_leak2(selenium):
-    length_change = selenium.run_js(
-        """
-        t = pyodide.runPython(`
-            from pyodide.ffi import run_sync
-            from js import sleep
-
-            def test(n):
-                run_sync(sleep(1))
-
-            test
-        `);
+        const t = pyodide.globals.get("test");
         let p = [];
-        for (let i = 0; i < 200; i++) {
-            p.push(t.callSyncifying(1));
-        }
-        await Promise.all(p);
-        const startLength = pyodide._module.HEAP32.length;
-        for (let i = 0; i < 10; i++) {
-            p = [];
-            for (let i = 0; i < 200; i++) {
-                p.push(t.callSyncifying(1));
-            }
-            await Promise.all(p);
-        }
-        t.destroy();
-        return pyodide._module.HEAP32.length - startLength;
-        """
-    )
-    assert length_change == 0
-
-
-@pytest.mark.xfail(reason="It leaks still")
-@requires_jspi
-def test_memory_leak3(selenium):
-    length_change = selenium.run_js(
-        """
-        t = pyodide.runPython(`
-            from pyodide.ffi import run_sync
-            from asyncio import sleep as py_sleep
-
-            async def sleep(x):
-                await py_sleep(x/1000)
-
-            def test(n):
-                run_sync(sleep(1))
-
-            test
-        `);
-        let p = [];
+        // warm up first to avoid edge problems
         for (let i = 0; i < 200; i++) {
             p.push(t.callSyncifying(1));
         }


### PR DESCRIPTION
Stack switching leaks datastack chunks. It is very confusing, but the leaked chunks are allocated in slabs of size 2^14 so it doesn't take long to leak a substantial amount of memory.

- [x] Add / update tests

