### PR TITLE
Updated python-sat to version 1.8.dev6.

### DIFF
--- a/packages/python-sat/meta.yaml
+++ b/packages/python-sat/meta.yaml
@@ -1,15 +1,16 @@
 package:
   name: python-sat
-  version: 0.1.7.dev26
+  version: 1.8.dev6
   top-level:
     - pysat
 source:
-  sha256: 49679925000a9d6a7718848efa9152db7838026a2b4946f09b1996e587811e40
-  url: https://files.pythonhosted.org/packages/57/b9/a731ed0ec63c8ca13b76c3d65ad0e6b075bac7a8abdacc0b23b98393d703/python-sat-0.1.7.dev26.tar.gz
+  sha256: 2ca77496dcc1996950e6fd1cf6b3892f97423f698ae5e2b9fa32d5aea41bb543
+  url: https://files.pythonhosted.org/packages/9f/98/a8e128da98eff2c01513a0e07b4e8c25afabfd7127d5804d228ba8b63d46/python-sat-1.8.dev6.tar.gz
 
   patches:
     - patches/force_malloc.patch
     - patches/proper_build.patch
+    - patches/dummy_buildhpp.patch
 
 requirements:
   run:

--- a/packages/python-sat/patches/dummy_buildhpp.patch
+++ b/packages/python-sat/patches/dummy_buildhpp.patch
@@ -1,0 +1,20 @@
+diff --git a/solvers/patches/cadical195.patch b/solvers/patches/cadical195.patch
+index 15bb501..c55d9e4 100644
+--- a/solvers/patches/cadical195.patch
++++ b/solvers/patches/cadical195.patch
+@@ -275,6 +275,15 @@ diff -Naur solvers/cadical195/block.hpp solvers/cdc195/block.hpp
+ +} // namespace CaDiCaL195
+  
+  #endif
++diff -Naur solvers/cadical195/build.hpp solvers/cdc195/build.hpp
++--- solvers/cadical195/build.hpp	1970-01-01 10:00:00
+++++ solvers/cdc195/build.hpp	2024-03-27 18:00:13
++@@ -0,0 +1,5 @@
+++#define VERSION "1.9.5"
+++#define IDENTIFIER "c81480f03dd89a18708b63e126b517789c7f1305"
+++#define COMPILER "Apple clang version 15.0.0 (clang-1500.3.9.4)"
+++#define FLAGS "-std=c++11 -fPIC -Wall -Wno-deprecated -fno-strict-aliasing -DQUIET"
+++#define DATE "Wed Mar 27 18:00:13 AEDT 2024 Darwin MU00154850X 23.4.0 arm64"
+ diff -Naur solvers/cadical195/cadical.hpp solvers/cdc195/cadical.hpp
+ --- solvers/cadical195/cadical.hpp	2024-02-29 02:59:11
+ +++ solvers/cdc195/cadical.hpp	2024-03-17 17:49:46

--- a/packages/python-sat/patches/force_malloc.patch
+++ b/packages/python-sat/patches/force_malloc.patch
@@ -26,18 +26,18 @@ index c4d2ead..a0a30db 100644
  
  	if (m == NULL)
 diff --git a/solvers/pysolvers.cc b/solvers/pysolvers.cc
-index a198f43..d45639b 100644
+index c2ef77d..67a3303 100644
 --- a/solvers/pysolvers.cc
 +++ b/solvers/pysolvers.cc
-@@ -15,6 +15,7 @@
+@@ -16,6 +16,7 @@
  #include <setjmp.h>
  #include <signal.h>
  #include <stdio.h>
 +#include <stdlib.h>
  #include <vector>
  
- #ifdef WITH_CADICAL
-@@ -643,8 +644,14 @@ static struct PyModuleDef module_def = {
+ #ifdef WITH_CADICAL103
+@@ -848,8 +849,14 @@ static struct PyModuleDef module_def = {
  	NULL,              /* m_free */
  };
  

--- a/packages/python-sat/patches/proper_build.patch
+++ b/packages/python-sat/patches/proper_build.patch
@@ -4,22 +4,20 @@ difficult to compile. Solving this issue seems possible eventually but it
 requires more effort to put, which might be not worth it at this point.
 
 diff --git a/setup.py b/setup.py
-index 82dac9c..3fe102f 100644
+index e27f0bc..f708d2b 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -69,8 +69,8 @@ Details can be found at `https://pysathq.github.io <https://pysathq.github.io>`_
- # solvers to install
+@@ -70,7 +70,7 @@ Details can be found at `https://pysathq.github.io <https://pysathq.github.io>`_
  #==============================================================================
- to_install = ['cadical', 'gluecard30', 'gluecard41', 'glucose30', 'glucose41',
--        'lingeling', 'maplechrono', 'maplecm', 'maplesat', 'mergesat3',
--        'minicard', 'minisat22', 'minisatgh']
-+        'maplechrono', 'maplecm', 'maplesat', 'mergesat3', 'minicard',
-+        'minisat22', 'minisatgh']
+ to_install = ['cadical103', 'cadical153', 'cadical195', 'gluecard30',
+               'gluecard41', 'glucose30', 'glucose41', 'glucose421',
+-              'lingeling', 'maplechrono', 'maplecm', 'maplesat', 'mergesat3',
++              'maplechrono', 'maplecm', 'maplesat', 'mergesat3',
+               'minicard', 'minisat22', 'minisatgh']
  
- # example scripts to install as standalone executables
- #==============================================================================
-@@ -78,47 +78,9 @@ scripts = ['fm', 'genhard', 'lbx', 'lsu', 'mcsls', 'models', 'musx', 'optux',
-         'rc2']
+ # example and allies scripts to install as standalone executables
+@@ -80,47 +80,9 @@ example_scripts = ['fm', 'genhard', 'lbx', 'lsu', 'mcsls', 'models', 'musx',
+ allies_scripts = ['approxmc', 'unigen']
  
  
 -# we need to redefine the build command to
@@ -67,7 +65,7 @@ index 82dac9c..3fe102f 100644
  if platform.system() == 'Darwin':
      compile_flags += ['--stdlib=libc++']
      cpplib = ['c++']
-@@ -141,23 +103,19 @@ pycard_ext = Extension('pycard',
+@@ -143,23 +105,19 @@ pycard_ext = Extension('pycard',
  
  pysolvers_sources = ['solvers/pysolvers.cc']
  
@@ -102,19 +100,19 @@ index 82dac9c..3fe102f 100644
      extra_compile_args=compile_flags + \
          list(map(lambda x: '-DWITH_{0}'.format(x.upper()), to_install)),
      include_dirs=['solvers'],
-@@ -182,7 +140,6 @@ setup(name='python-sat',
-     url='https://github.com/pysathq/pysat',
+@@ -185,7 +143,6 @@ setup(name='python-sat',
      ext_modules=[pycard_ext, pysolvers_ext],
-     scripts=['examples/{0}.py'.format(s) for s in scripts],
--    cmdclass={'build': build, 'build_ext': build_ext},
+     scripts=['examples/{0}.py'.format(s) for s in example_scripts] + \
+             ['allies/{0}.py'.format(s) for s in allies_scripts],
+-    cmdclass={'build': build},
      install_requires=['six'],
      extras_require = {
          'aiger': ['py-aiger-cnf>=2.0.0'],
 diff --git a/solvers/prepare.py b/solvers/prepare.py
-index a1b5e91..464e1d1 100644
+index f9bd19d..7829083 100644
 --- a/solvers/prepare.py
 +++ b/solvers/prepare.py
-@@ -520,8 +520,6 @@ def do(to_install):
+@@ -840,8 +840,6 @@ def do(to_install):
          adapt_files(solver)
          patch_solver(solver)
  

--- a/packages/python-sat/test_python_sat.py
+++ b/packages/python-sat/test_python_sat.py
@@ -2,7 +2,9 @@ import pytest
 from pytest_pyodide import run_in_pyodide
 
 solvers = [
-    "cadical",
+    "cadical103",
+    "cadical153",
+    "cadical195",
     "gluecard30",
     "gluecard41",
     "glucose30",


### PR DESCRIPTION
This PR updates `python-sat` to the most recent version (`1.8.dev6`). There are a large number of changes and fixes since the last version supported in Pyodide, including additional SAT solvers, arbitrary Boolean formula manipulation and on-the-fly clausification as well as external user-defined engines to be attached to solvers supporting the IPASIR-UP interface.