### PR TITLE
Update docs/usage/file-system.md about IDBFS

### DIFF
--- a/docs/usage/file-system.md
+++ b/docs/usage/file-system.md
@@ -45,7 +45,7 @@ For instance, to store data persistently between page reloads, one could mount
 a folder with the
 [IDBFS file system](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-idbfs)
 
-```js
+```pyodide
 let mountDir = "/mnt";
 pyodide.FS.mkdirTree(mountDir);
 pyodide.FS.mount(pyodide.FS.filesystems.IDBFS, {}, mountDir);

--- a/docs/usage/file-system.md
+++ b/docs/usage/file-system.md
@@ -48,7 +48,7 @@ a folder with the
 ```js
 let mountDir = "/mnt";
 pyodide.FS.mkdirTree(mountDir);
-pyodide.FS.mount(pyodide.FS.filesystems.IDBFS, { root: "." }, mountDir);
+pyodide.FS.mount(pyodide.FS.filesystems.IDBFS, {}, mountDir);
 ```
 
 If you are using Node.js you can access the native file system by mounting `NODEFS`.


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Looks like the `FS.mount()` API doesn't take the `root` option for `IDBFS`.
Unlike `NODEFS`, `IDBFS` doesn't touch the host OS file system, so the `root` value doesn't make sense.
Ref: https://emscripten.org/docs/api_reference/Filesystem-API.html#FS.mount

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add new / update outdated documentation
