### PR TITLE
Add asJsonAdaptor to PyProxy of Sequence or Map

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -81,6 +81,10 @@ myst:
 - {{ Fix }} `toJs` now works as expected on subclasses of `dict`.
   {pr}`4637`
 
+- {{ Enhancement }} Added `PyProxy.asJsonAdaptor` method to adapt between Python
+  JSON (lists and dicts) and JavaScript JSON (Arrays and Objects).
+  {pr}`4666`
+
 ### Packages
 
 - New Packages: `cysignals`, `ppl`, `pplpy` {pr}`4407`, `flint`, `python-flint` {pr}`4410`,

--- a/src/core/pyproxy.h
+++ b/src/core/pyproxy.h
@@ -11,7 +11,11 @@
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
 JsVal
-pyproxy_new_ex(PyObject* obj, bool capture_this, bool roundtrip, bool register);
+pyproxy_new_ex(PyObject* obj,
+               bool capture_this,
+               bool roundtrip,
+               bool register,
+               bool is_json_adaptor);
 
 JsVal
 pyproxy_new(PyObject* obj);

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -497,7 +497,7 @@ finally:
  *
  */
 JsVal
-python2js_inner(PyObject* x, JsVal proxies, bool track_proxies, bool gc_register)
+python2js_inner(PyObject* x, JsVal proxies, bool track_proxies, bool gc_register, bool is_json_adaptor)
 {
   RETURN_IF_HAS_VALUE(_python2js_immutable(x));
   RETURN_IF_HAS_VALUE(_python2js_proxy(x));
@@ -505,7 +505,7 @@ python2js_inner(PyObject* x, JsVal proxies, bool track_proxies, bool gc_register
     PyErr_SetString(conversion_error, "No conversion known for x.");
     FAIL();
   }
-  JsVal proxy = pyproxy_new_ex(x, false, false, gc_register);
+  JsVal proxy = pyproxy_new_ex(x, false, false, gc_register, is_json_adaptor);
   FAIL_IF_JS_NULL(proxy);
   if (track_proxies) {
     JsvArray_Push(proxies, proxy);
@@ -535,7 +535,7 @@ finally:
 JsVal
 python2js_track_proxies(PyObject* x, JsVal proxies, bool gc_register)
 {
-  return python2js_inner(x, proxies, true, gc_register);
+  return python2js_inner(x, proxies, true, gc_register, false);
 }
 
 /**
@@ -545,7 +545,13 @@ python2js_track_proxies(PyObject* x, JsVal proxies, bool gc_register)
 EMSCRIPTEN_KEEPALIVE JsVal
 python2js(PyObject* x)
 {
-  return python2js_inner(x, JS_NULL, false, true);
+  return python2js_inner(x, JS_NULL, false, true, false);
+}
+
+EMSCRIPTEN_KEEPALIVE JsVal
+python2js_json_adaptor(PyObject* x, bool is_json_adaptor)
+{
+  return python2js_inner(x, JS_NULL, false, true, is_json_adaptor);
 }
 
 // taking function pointers to EM_JS functions leads to linker errors.

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -548,12 +548,6 @@ python2js(PyObject* x)
   return python2js_inner(x, JS_NULL, false, true, false);
 }
 
-EMSCRIPTEN_KEEPALIVE JsVal
-python2js_json_adaptor(PyObject* x, bool is_json_adaptor)
-{
-  return python2js_inner(x, JS_NULL, false, true, is_json_adaptor);
-}
-
 // taking function pointers to EM_JS functions leads to linker errors.
 static JsVal
 _JsMap_New(ConversionContext *context)

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -17,7 +17,11 @@ JsVal
 python2js(PyObject* x);
 
 JsVal
-python2js_json_adaptor(PyObject* x, bool is_json_adaptor);
+python2js_inner(PyObject* x,
+                JsVal proxies,
+                bool track_proxies,
+                bool gc_register,
+                bool is_json_adaptor);
 
 /**
  * Like python2js except in the handling of PyProxy creation.

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -16,6 +16,9 @@
 JsVal
 python2js(PyObject* x);
 
+JsVal
+python2js_json_adaptor(PyObject* x, bool is_json_adaptor);
+
 /**
  * Like python2js except in the handling of PyProxy creation.
  *

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -109,6 +109,7 @@ declare global {
   export const __pyproxy_getitem: (
     obj: number,
     key: any,
+    cache: Map<string, any>,
     is_json_adaptor: boolean,
   ) => any;
   export const __pyproxy_setitem: (ptr: number, key: any, value: any) => number;
@@ -119,6 +120,7 @@ declare global {
   export const __pyproxy_aiter_next: (ptr: number) => any;
   export const __pyproxy_iter_next: (
     ptr: number,
+    cache: Map<string, any>,
     is_json_adaptor: boolean,
   ) => any;
   export const __pyproxyGen_Send: (

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -100,17 +100,27 @@ declare global {
         ) => any),
   ) => any;
 
-  export const _pyproxy_getflags: (ptr: number) => number;
+  export const _pyproxy_getflags: (
+    ptr: number,
+    is_json_adaptor: boolean,
+  ) => number;
   export const __pyproxy_type: (ptr: number) => string;
   export const __pyproxy_repr: (ptr: number) => string;
-  export const __pyproxy_getitem: (obj: number, key: any) => any;
+  export const __pyproxy_getitem: (
+    obj: number,
+    key: any,
+    is_json_adaptor: boolean,
+  ) => any;
   export const __pyproxy_setitem: (ptr: number, key: any, value: any) => number;
   export const __pyproxy_delitem: (ptr: number, key: any) => number;
   export const __pyproxy_contains: (ptr: number, key: any) => number;
   export const __pyproxy_GetIter: (ptr: number) => number;
   export const __pyproxy_GetAIter: (ptr: number) => number;
   export const __pyproxy_aiter_next: (ptr: number) => any;
-  export const __pyproxy_iter_next: (ptr: number) => any;
+  export const __pyproxy_iter_next: (
+    ptr: number,
+    is_json_adaptor: boolean,
+  ) => any;
   export const __pyproxyGen_Send: (
     ptr: number,
     arg: any,

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -2455,78 +2455,22 @@ def test_as_json_adaptor_ownkeys(selenium):
     assert set(f(o)) == set(o.keys())
 
 
+@pytest.mark.parametrize(
+    "o",
+    [
+        [7],
+        [[7]],
+        {"c": 7},
+        {"c": [7]},
+        [1, {"c": 2}],
+        [1, 2, {"a": 3, "b": {"c": 4, "d": [1, {"c": 2}]}}],
+    ],
+)
 @run_in_pyodide
-def test_as_json_adaptor_stringify1(selenium):
+def test_as_json_adaptor_stringify(selenium, o):
     from json import loads
 
     from pyodide.code import run_js
 
-    o = [7]
-    f = run_js("(o) => JSON.stringify(o.asJsonAdaptor())")
-    assert loads(f(o)) == o
-
-
-@run_in_pyodide
-def test_as_json_adaptor_stringify2(selenium):
-    from json import loads
-
-    from pyodide.code import run_js
-
-    o = [[7]]
-    f = run_js("(o) => JSON.stringify(o.asJsonAdaptor())")
-    assert loads(f(o)) == o
-
-
-@run_in_pyodide
-def test_as_json_adaptor_stringify3(selenium):
-    from json import loads
-
-    from pyodide.code import run_js
-
-    o = {"c": 7}
-    f = run_js("(o) => JSON.stringify(o.asJsonAdaptor())")
-    assert loads(f(o)) == o
-
-
-@run_in_pyodide
-def test_as_json_adaptor_stringify4(selenium):
-    from json import loads
-
-    from pyodide.code import run_js
-
-    o = {"c": [7]}
-    f = run_js("(o) => JSON.stringify(o.asJsonAdaptor())")
-    assert loads(f(o)) == o
-
-
-@run_in_pyodide
-def test_as_json_adaptor_stringify5(selenium):
-    from json import loads
-
-    from pyodide.code import run_js
-
-    o = [1, {"c": 2}]
-    f = run_js("(o) => JSON.stringify(o.asJsonAdaptor())")
-    assert loads(f(o)) == o
-
-
-@run_in_pyodide
-def test_as_json_adaptor_stringify6(selenium):
-    from json import loads
-
-    from pyodide.code import run_js
-
-    o = {"c": [1]}
-    f = run_js("(o) => JSON.stringify(o.asJsonAdaptor())")
-    assert loads(f(o)) == o
-
-
-@run_in_pyodide
-def test_as_json_adaptor_stringify7(selenium):
-    from json import loads
-
-    from pyodide.code import run_js
-
-    o = [1, 2, {"a": 3, "b": {"c": 4, "d": [1, {"c": 2}]}}]
     f = run_js("(o) => JSON.stringify(o.asJsonAdaptor())")
     assert loads(f(o)) == o

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -427,7 +427,7 @@ def test_pyproxy_mixins1(selenium):
         let result = {};
         for(let [name, x] of Object.entries(name_proxy)){
             let impls = {};
-            for(let [name, key] of [
+            for (let [name, key] of [
                 ["then", "then"],
                 ["catch", "catch"],
                 ["finally_", "finally"],
@@ -436,10 +436,11 @@ def test_pyproxy_mixins1(selenium):
             ]){
                 impls[name] = key in x;
             }
-            for(let name of ["PyAwaitable", "PyIterable", "PyIterator"]){
+            for (let name of ["PyAwaitable", "PyIterable", "PyIterator"]){
                 impls[name] = x instanceof pyodide.ffi[name];
             }
             result[name] = impls;
+            assert(() => !("asJsonAdaptor" in x))
             x.destroy();
         }
         return result;
@@ -500,6 +501,7 @@ def test_pyproxy_mixins2(selenium):
         assert(() => d.$get.type === "builtin_function_or_method");
         assert(() => d.get.type === undefined);
         assert(() => d.set.type === undefined);
+        assert(() => "asJsonAdaptor" in d);
         d.destroy();
         """
     )
@@ -677,6 +679,7 @@ def test_pyproxy_mixins5(selenium):
             assert(() => !("length" in Test));
             assert(() => t.length === 9);
             assert(() => t instanceof pyodide.ffi.PyProxyWithLength);
+            assert(() => !("asJsonAdaptor" in t));
             assertThrows(() => {t.length = 10}, "TypeError", "");
             assert(() => t.length === 9);
 
@@ -707,6 +710,7 @@ def test_pyproxy_mixins6(selenium):
         assert(() => l instanceof pyodide.ffi.PyProxyWithHas);
         assert(() => l instanceof pyodide.ffi.PyProxyWithGet);
         assert(() => l instanceof pyodide.ffi.PyProxyWithSet);
+        assert(() => "asJsonAdaptor" in l);
         l.set(0, 80);
         pyodide.runPython(`
             assert l[0] == 80
@@ -2361,3 +2365,114 @@ def test_automatic_coroutine_scheduling(selenium):
         """
     )
     assert res == [3, 4, 6]
+
+
+@run_in_pyodide
+def test_stringify_sequence(selenium):
+    from json import loads
+
+    from js import JSON
+
+    l = [1, 2, 3]
+
+    assert loads(JSON.stringify(l)) == l  # type:ignore[arg-type]
+    assert loads(JSON.stringify(tuple(l))) == l  # type:ignore[arg-type]
+
+
+@run_in_pyodide
+def test_as_json_adaptor1(selenium):
+    from pyodide.code import run_js
+
+    o = [1, 2, {"a": 3, "b": {"c": 4, "d": [1, {"c": 2}]}}]
+
+    f = run_js(
+        """
+        (o, l) =>  {
+            const o2 = o.asJsonAdaptor();
+            return l.reduce((x, y) => {
+                const res = x?.[y];
+                x !== o2 && x?.destroy?.();
+                return res;
+            }, o2);
+        }
+        """
+    )
+
+    assert f(o, [0]) == 1
+    assert f(o, [1]) == 2
+    assert f(o, [2, "a"]) == 3
+    assert f(o, [2, "b", "c"]) == 4
+    assert f(o, [2, "b", "d", 0]) == 1
+    assert f(o, [2, "b", "d", 1, "c"]) == 2
+
+
+@pytest.mark.skip_pyproxy_check
+@run_in_pyodide
+def test_as_json_adaptor2(selenium):
+    """Stringifying a PyProxy is leaky, but there is no obvious fix."""
+    from json import loads
+
+    from pyodide.code import run_js
+
+    o = [1, 2, {"a": 3, "b": {"c": 4, "d": [1, {"c": 2}]}}]
+
+    f = run_js(
+        """
+        (o) => JSON.stringify(o.asJsonAdaptor())
+        """
+    )
+    assert loads(f(o)) == o
+
+
+@run_in_pyodide
+def test_as_json_adaptor3(selenium):
+    from pyodide.code import run_js
+
+    class T1:
+        a = {"x": 2}
+
+    class T2:
+        a = {"x": 2}
+
+        def __getitem__(self, key):
+            return {"y": 3}
+
+    o = [T1(), T2()]
+
+    f = run_js(
+        """
+        (o) => {
+            const x = o.asJsonAdaptor();
+            const x0 = x[0];
+            const x1 = x[1];
+            const x1a = x1.a;
+            return {
+                x0,
+                x1,
+                xflags: x.$$flags,
+                x0flags: x0.$$flags,
+                x1flags: x1.$$flags,
+                x0a: x0.a,
+                x1a,
+                x1ay: x1a.y,
+            };
+        }
+        """
+    )
+    resjs = f(o)
+    res = resjs.to_py()
+    assert res["xflags"] & (1 << 16) != 0
+    assert res["x0flags"] & (1 << 15) == 0
+    assert res["x1flags"] & (1 << 15) != 0
+    assert res["x0a"] == {"x": 2}
+    assert res["x1a"] == {"y": 3}
+    assert res["x1ay"] == 3
+    run_js(
+        """
+        (obj) => {
+            for (const attr in obj) {
+                obj[attr]?.destroy?.();
+            }
+        }
+        """
+    )(resjs)


### PR DESCRIPTION
Designed to make dictionaries + lists behave like JavaScript JSON so that `JSON.stringify`, `Response.json`, etc work as expected and direct access like `a[0].b.c[1].d` works. I think this is how `as_object_map()` should have behaved all along. As a followup, I'd also like to add a symmetric `as_json_adaptor()` to JsProxy.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
