### PR TITLE
docs: fix typo

### DIFF
--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -740,7 +740,7 @@ pyodide.runPython(`
 console.log(my_js_namespace.y); // 7
 ```
 
-If the JavaScript object's name is a reserved Python keyword, the {py:func}`setattr` function can be used to access the object by name within the js module::
+If the JavaScript object's name is a reserved Python keyword, the {py:func}`getattr` function can be used to access the object by name within the js module::
 
 ```pyodide
 lambda = (x) => {return x + 1};


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Fix a typo in docs/usage/type-conversions.md:743, change `setattr` to `getattr`.

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

