### PR TITLE
Add duckdb to packages

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -85,6 +85,7 @@ myst:
 - Upgraded `bokeh` to 3.4.2 {pr}`4888`
 - Upgraded `pandas` to 2.2.2 {pr}`4893`
 - Upgraded `zengl` to 2.5.0 {pr}`4894`
+- Added `duckdb` 1.0.0 {pr}`4684`
 
 ## Version 0.26.1
 

--- a/packages/duckdb/meta.yaml
+++ b/packages/duckdb/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: duckdb
-  version: 0.10.2
+  version: 1.0.0
   top-level:
     - duckdb
 source:

--- a/packages/duckdb/meta.yaml
+++ b/packages/duckdb/meta.yaml
@@ -4,8 +4,8 @@ package:
   top-level:
     - duckdb
 source:
-  url: https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-0.10.2-cp311-cp311-emscripten_3_1_46_wasm32.whl
-  sha256: 9babd195558647f7a0339558c1218ac0f0ee1004cdfa8ff987642def9f00f6fd
+  url: https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-1.0.0-cp312-cp312-pyodide_2024_0_wasm32.whl
+  sha256: 02ee0ea70f528e8aa6843f74b1fdd93619a8fb8521ccfb67585e2a68b25e3a39
 about:
   home: https://github.com/duckdb/duckdb
   PyPI: https://pypi.org/project/duckdb

--- a/packages/duckdb/meta.yaml
+++ b/packages/duckdb/meta.yaml
@@ -1,0 +1,13 @@
+package:
+  name: duckdb
+  version: 0.10.2
+  top-level:
+    - duckdb
+source:
+  url: https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-0.10.2-cp311-cp311-emscripten_3_1_46_wasm32.whl
+  sha256: 9babd195558647f7a0339558c1218ac0f0ee1004cdfa8ff987642def9f00f6fd
+about:
+  home: https://github.com/duckdb/duckdb
+  PyPI: https://pypi.org/project/duckdb
+  summary: A fast in-process analytical database
+  license: MIT

--- a/packages/duckdb/test_duckdb.py
+++ b/packages/duckdb/test_duckdb.py
@@ -18,7 +18,8 @@ def test_duckdb(selenium):
             con.execute("INSERT INTO t VALUES (42, 'hello'), (43, 'world')")
             query_result = con.execute("SELECT rowid, * FROM t ORDER BY rowid").fetchall()
 
-        assert platform == "wasm_eh_pyodide"
+        assert "pyodide" in platform
+        assert "wasm" in platform
         assert query_result == [(0, 42, "hello"), (1, 43, "world")]
         """
     )

--- a/packages/duckdb/test_duckdb.py
+++ b/packages/duckdb/test_duckdb.py
@@ -1,27 +1,46 @@
+import pytest
+
+from conftest import package_is_built
 from pytest_pyodide import run_in_pyodide
 
 
 @run_in_pyodide(packages=["duckdb"])
 def test_duckdb(selenium):
-    import duckdb
+    if not package_is_built("duckdb"):
+        pytest.skip("duckdb not built")
 
-    with duckdb.connect() as con:
-        (platform,) = con.execute("PRAGMA platform").fetchone()
-        con.execute("CREATE TEMP TABLE t (id INT, content STRING)")
-        con.execute("INSERT INTO t VALUES (42, 'hello'), (43, 'world')")
-        query_result = con.execute("SELECT rowid, * FROM t").fetchall()
+    selenium.load_package(["duckdb"])
+    selenium.run(
+        """
+        import duckdb
 
-    assert platform == "wasm_eh_pyodide"
-    assert query_result == [(0, 42, "hello"), (1, 43, "world")]
+        with duckdb.connect() as con:
+            (platform,) = con.execute("PRAGMA platform").fetchone()
+            con.execute("CREATE TEMP TABLE t (id INT, content STRING)")
+            con.execute("INSERT INTO t VALUES (42, 'hello'), (43, 'world')")
+            query_result = con.execute("SELECT rowid, * FROM t").fetchall()
+
+        assert platform == "wasm_eh_pyodide"
+        assert query_result == [(0, 42, "hello"), (1, 43, "world")]
+        """
+    )
 
 
 @run_in_pyodide(packages=["duckdb", "pandas"])
 def test_duckdb_with_pandas(selenium):
-    import duckdb
-    import pandas as pd
+    if not package_is_built("pandas"):
+        pytest.skip("pandas not built")
 
-    with duckdb.connect() as con:
-        df = con.sql("SELECT UNNEST(RANGE(5)) as x").df()
+    selenium.load_package(["duckdb", "pandas"])
+    selenium.run(
+        """
+        import duckdb
+        import pandas as pd
 
-    expected = pd.DataFrame({"x": range(5)})
-    assert df.equals(expected)
+        with duckdb.connect() as con:
+            df = con.sql("SELECT UNNEST(RANGE(5)) as x").df()
+
+        expected = pd.DataFrame({"x": range(5)})
+        assert df.equals(expected)
+        """
+    )

--- a/packages/duckdb/test_duckdb.py
+++ b/packages/duckdb/test_duckdb.py
@@ -16,7 +16,7 @@ def test_duckdb(selenium):
             (platform,) = con.execute("PRAGMA platform").fetchone()
             con.execute("CREATE TEMP TABLE t (id INT, content STRING)")
             con.execute("INSERT INTO t VALUES (42, 'hello'), (43, 'world')")
-            query_result = con.execute("SELECT rowid, * FROM t").fetchall()
+            query_result = con.execute("SELECT rowid, * FROM t ORDER BY rowid").fetchall()
 
         assert platform == "wasm_eh_pyodide"
         assert query_result == [(0, 42, "hello"), (1, 43, "world")]
@@ -25,17 +25,20 @@ def test_duckdb(selenium):
 
 
 def test_duckdb_with_pandas(selenium):
-    if not package_is_built("pandas"):
-        pytest.skip("pandas not built")
+    packages = ["duckdb", "pandas"]
 
-    selenium.load_package(["duckdb", "pandas"])
+    for package in packages:
+        if not package_is_built(package):
+            pytest.skip(f"{package} not built")
+
+    selenium.load_package(packages)
     selenium.run(
         """
         import duckdb
         import pandas as pd
 
         with duckdb.connect() as con:
-            df = con.sql("SELECT UNNEST(RANGE(5)) as x").df()
+            df = con.sql("SELECT UNNEST(RANGE(5)) as x ORDER BY x").df()
 
         expected = pd.DataFrame({"x": range(5)})
         assert df.equals(expected)

--- a/packages/duckdb/test_duckdb.py
+++ b/packages/duckdb/test_duckdb.py
@@ -1,40 +1,50 @@
 import pytest
+from pytest_pyodide import run_in_pyodide
 
 from conftest import package_is_built
 
 
-def test_duckdb(selenium):
-    if not package_is_built("duckdb"):
-        pytest.skip("duckdb not built")
+def skip_if_not_installed(packages):
+    for package in packages:
+        if not package_is_built(package):
+            pytest.skip(f"{package} not built")
 
-    selenium.load_package(["duckdb"])
-    selenium.run(
-        """
+
+def test_duckdb(selenium):
+    packages = ["duckdb"]
+
+    skip_if_not_installed(packages)
+
+    selenium.load_package(packages)
+
+    @run_in_pyodide
+    def do_test(selenium):
         import duckdb
 
         with duckdb.connect() as con:
             (platform,) = con.execute("PRAGMA platform").fetchone()
             con.execute("CREATE TEMP TABLE t (id INT, content STRING)")
             con.execute("INSERT INTO t VALUES (42, 'hello'), (43, 'world')")
-            query_result = con.execute("SELECT rowid, * FROM t ORDER BY rowid").fetchall()
+            query_result = con.execute(
+                "SELECT rowid, * FROM t ORDER BY rowid"
+            ).fetchall()
 
         assert "pyodide" in platform
         assert "wasm" in platform
         assert query_result == [(0, 42, "hello"), (1, 43, "world")]
-        """
-    )
+
+    do_test(selenium)
 
 
 def test_duckdb_with_pandas(selenium):
     packages = ["duckdb", "pandas"]
 
-    for package in packages:
-        if not package_is_built(package):
-            pytest.skip(f"{package} not built")
+    skip_if_not_installed(packages)
 
     selenium.load_package(packages)
-    selenium.run(
-        """
+
+    @run_in_pyodide
+    def do_test(selenium):
         import duckdb
         import pandas as pd
 
@@ -43,5 +53,5 @@ def test_duckdb_with_pandas(selenium):
 
         expected = pd.DataFrame({"x": range(5)})
         assert df.equals(expected)
-        """
-    )
+
+    do_test(selenium)

--- a/packages/duckdb/test_duckdb.py
+++ b/packages/duckdb/test_duckdb.py
@@ -1,7 +1,7 @@
 import pytest
+from pytest_pyodide import run_in_pyodide
 
 from conftest import package_is_built
-from pytest_pyodide import run_in_pyodide
 
 
 @run_in_pyodide(packages=["duckdb"])

--- a/packages/duckdb/test_duckdb.py
+++ b/packages/duckdb/test_duckdb.py
@@ -1,0 +1,27 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["duckdb"])
+def test_duckdb(selenium):
+    import duckdb
+
+    with duckdb.connect() as con:
+        (platform,) = con.execute("PRAGMA platform").fetchone()
+        con.execute("CREATE TEMP TABLE t (id INT, content STRING)")
+        con.execute("INSERT INTO t VALUES (42, 'hello'), (43, 'world')")
+        query_result = con.execute("SELECT rowid, * FROM t").fetchall()
+
+    assert platform == "wasm_eh_pyodide"
+    assert query_result == [(0, 42, "hello"), (1, 43, "world")]
+
+
+@run_in_pyodide(packages=["duckdb", "pandas"])
+def test_duckdb_with_pandas(selenium):
+    import duckdb
+    import pandas as pd
+
+    with duckdb.connect() as con:
+        df = con.sql("SELECT UNNEST(RANGE(5)) as x").df()
+
+    expected = pd.DataFrame({"x": range(5)})
+    assert df.equals(expected)

--- a/packages/duckdb/test_duckdb.py
+++ b/packages/duckdb/test_duckdb.py
@@ -1,10 +1,8 @@
 import pytest
-from pytest_pyodide import run_in_pyodide
 
 from conftest import package_is_built
 
 
-@run_in_pyodide(packages=["duckdb"])
 def test_duckdb(selenium):
     if not package_is_built("duckdb"):
         pytest.skip("duckdb not built")
@@ -26,7 +24,6 @@ def test_duckdb(selenium):
     )
 
 
-@run_in_pyodide(packages=["duckdb", "pandas"])
 def test_duckdb_with_pandas(selenium):
     if not package_is_built("pandas"):
         pytest.skip("pandas not built")


### PR DESCRIPTION
### Description

Adds `duckdb` to the list of packages shipping with pyodide.

The included patches can be removed after the next duckdb release.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
