### PR TITLE
BLD Prevent redundant xbuildenv installation if there is already a version in use

### DIFF
--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -121,7 +121,9 @@ def _init_xbuild_env(*, quiet: bool = False) -> Path:
     with context:
         manager = CrossBuildEnvManager(xbuildenv_path)
         if manager.current_version is None:
-            return manager.install()
+            manager.install()
+
+        return manager.pyodide_root
 
 
 @functools.cache

--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -120,7 +120,8 @@ def _init_xbuild_env(*, quiet: bool = False) -> Path:
     context = redirect_stdout(StringIO()) if quiet else nullcontext()
     with context:
         manager = CrossBuildEnvManager(xbuildenv_path)
-        return manager.install()
+        if manager.current_version is None:
+            return manager.install()
 
 
 @functools.cache

--- a/pyodide-build/pyodide_build/tests/fixture.py
+++ b/pyodide-build/pyodide_build/tests/fixture.py
@@ -69,8 +69,6 @@ def reset_cache():
 def xbuildenv(selenium, tmp_path, reset_env_vars, reset_cache):
     import subprocess as sp
 
-    from pyodide_build import __version__
-
     assert "PYODIDE_ROOT" not in os.environ
 
     envpath = Path(tmp_path) / xbuildenv_dirname()
@@ -88,7 +86,7 @@ def xbuildenv(selenium, tmp_path, reset_env_vars, reset_cache):
 
     assert result.returncode == 0
 
-    version_dir = envpath / __version__
+    version_dir = envpath / "temp_version"
     version_dir.mkdir()
 
     sp.run(

--- a/pyodide-build/pyodide_build/xbuildenv.py
+++ b/pyodide-build/pyodide_build/xbuildenv.py
@@ -38,6 +38,13 @@ class CrossBuildEnvManager:
         return self.env_dir / "xbuildenv"
 
     @property
+    def pyodide_root(self) -> Path:
+        """
+        Returns the path to the pyodide-root directory inside the xbuildenv directory.
+        """
+        return self.symlink_dir.resolve() / "xbuildenv" / "pyodide-root"
+
+    @property
     def current_version(self) -> str | None:
         """
         Returns the currently used xbuildenv version.


### PR DESCRIPTION
### Description

After #4640, we can install multiple xbuildenvs simultaneously. As a follow up, this PR fixes `init_environment()` to use the currently specified version of xbuildenv instead of always using the xbuildenv that matches the pyodide-build version.

### Checklists

- [x] Add / update tests
