### PR TITLE
fix for exceptions in dynamic linked int64 code

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,6 +16,8 @@ myst:
 
 ## Unreleased
 
+- {{ Fix }} Fix exception handling in dynamic linking of int64 functions {pr}`4698`.
+
 - {{ Enhancement }} `str(jsproxy)` has been adjusted to not raise an error if
   `jsproxy.toString` is undefined. Instead, it will use
   `Object.prototype.toString` in this case. If `jsproxy.toString` is defined and

--- a/emsdk/patches/0001-fix-dylink-exceptions.patch
+++ b/emsdk/patches/0001-fix-dylink-exceptions.patch
@@ -18,7 +18,7 @@ index bfd0d4fcaa83..f380f4be6055 100644
 +        // In theory this if could be done on creating the function, 
 +        // but I just added this to save wasting code space
 +        // and it only happens on an exception
-+        if(sig[0]=="j")return BigInt(0);
++        if (sig[0] == "j") return 0n;
        }
      }
    },

--- a/emsdk/patches/0001-fix-dylink-exceptions.patch
+++ b/emsdk/patches/0001-fix-dylink-exceptions.patch
@@ -1,0 +1,24 @@
+From b20eefb15b19b44c79326f754c80fbb2e2df5844 Mon Sep 17 00:00:00 2001
+From: Joe Marshall <joe.marshall@nottingham.ac.uk>
+Date: Sat, 13 Apr 2024 21:41:11 +0100
+Subject: Upstream PR: https://github.com/emscripten-core/emscripten/pull/21759
+
+---
+ src/library_dylink.js | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/library_dylink.js b/src/library_dylink.js
+index bfd0d4fcaa83..f380f4be6055 100644
+--- a/src/library_dylink.js
++++ b/src/library_dylink.js
+@@ -92,6 +92,10 @@ var LibraryDylink = {
+         if (e !== e+0) throw e;
+ #endif
+         _setThrew(1, 0);
++        // In theory this if could be done on creating the function, 
++        // but I just added this to save wasting code space
++        // and it only happens on an exception
++        if(sig[0]=="j")return BigInt(0);
+       }
+     }
+   },


### PR DESCRIPTION
This is a backport of https://github.com/emscripten-core/emscripten/pull/21759 

It fixes a crash which happens when 
1) An exception is thrown inside a function returning int64
2) The function is in a dynamic library and has been called through dynamic invocation.

I could really do with this getting into the next release of pyodide as it is a blocker for #2933 , so I can't send people wheels to test  yet.
