### PR TITLE
Bumped python-sat from 1.8.dev10 to 1.8.dev12

### DIFF
--- a/packages/python-sat/meta.yaml
+++ b/packages/python-sat/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python-sat
-  version: 1.8.dev10
+  version: 1.8.dev12
   top-level:
     - pysat
 source:
-  sha256: 073a6360181a46e22a10d189e01f212a9c627b9ad125b23ea43d598447543e25
-  url: https://files.pythonhosted.org/packages/ab/d4/66f24e80de03d2dcdc9857374aa1f0e95837d13ef1f575ed435bb8c684e4/python-sat-1.8.dev10.tar.gz
+  sha256: 91d83422ec97e6d68dafcdbf9fb1015dcfc6b8c67f3883eda95beeca52bb8518
+  url: https://files.pythonhosted.org/packages/69/ef/bf96e7e9ebe777ab072a72e69f2dd222ace2b68d10356a2feba3fbccac38/python-sat-1.8.dev12.tar.gz
 
   patches:
     - patches/force_malloc.patch


### PR DESCRIPTION
This brings a few fixes of the issues related to arbitrary formula simplification and on-the-fly clausification. Namely, the same formula can have two sets of clauses associated with it depending on whether it is an outermost formula or a sub-formula. Also, this modifies the way Boolean constants are stored and handled.
