### PR TITLE
FIX Use response file for EXPORTED_FUNCTIONS

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,6 +16,9 @@ myst:
 
 ## Unreleased
 
+- {{ Fix }} pyodide-build now use response file when passing list of exported symbols to `emcc`.
+  This Fixes "Argument list too long" error.
+
 - {{ Fix }} Pass through `-E` (command mode) arguments in CMake wrapper {pr}`4705`.
 
 - {{ Fix }} Fix exception handling in dynamic linking of int64 functions {pr}`4698`.

--- a/packages/awkward-cpp/meta.yaml
+++ b/packages/awkward-cpp/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   script: |
     export CMAKE_ARGS="${CMAKE_ARGS} -DEMSCRIPTEN=1"
-  exports: whole_archive
+  exports: requested
 
 requirements:
   run:

--- a/packages/lightgbm/meta.yaml
+++ b/packages/lightgbm/meta.yaml
@@ -6,7 +6,7 @@ source:
   sha256: 006f5784a9bcee43e5a7e943dc4f02de1ba2ee7a7af1ee5f190d383f3b6c9ebe
 build:
   backend-flags: cmake.define.USE_OPENMP=OFF
-  exports: whole_archive # FIXME: using "requested" fails with SIGKILL, not sure why
+  exports: requested
 requirements:
   run:
     - numpy

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -319,8 +319,6 @@ class RecipeBuilder:
         )
         if "filename" in parameters:
             tarballname = parameters["filename"]
-            # Remove a possible query string
-            tarballname = tarballname.rsplit("?")[0]
         else:
             tarballname = Path(response.geturl()).name
 

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -319,6 +319,8 @@ class RecipeBuilder:
         )
         if "filename" in parameters:
             tarballname = parameters["filename"]
+            # Remove a possible query string
+            tarballname = tarballname.rsplit("?")[0]
         else:
             tarballname = Path(response.geturl()).name
 

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -435,7 +435,8 @@ def get_export_flags(
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         # Use a response file to avoid command line length limits
         f.write(json.dumps(prefixed_exports))
-        yield f"-sEXPORTED_FUNCTIONS=@{f.name}"
+
+    yield f"-sEXPORTED_FUNCTIONS=@{f.name}"
 
 
 def handle_command_generate_args(  # noqa: C901

--- a/pyodide-build/pyodide_build/pywasmcross.py
+++ b/pyodide-build/pyodide_build/pywasmcross.py
@@ -427,8 +427,15 @@ def get_export_flags(
         export_list = calculate_exports(line, exports == "requested")
     else:
         export_list = exports
+
     prefixed_exports = ["_" + x for x in export_list]
-    yield f"-sEXPORTED_FUNCTIONS={prefixed_exports!r}"
+
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        # Use a response file to avoid command line length limits
+        f.write(json.dumps(prefixed_exports))
+        yield f"-sEXPORTED_FUNCTIONS=@{f.name}"
 
 
 def handle_command_generate_args(  # noqa: C901


### PR DESCRIPTION
### Description

Resolve https://github.com/pyodide/pyodide/issues/4674.

Fixes "argument too long" issue when list of exports are too long. It was a fairly easy fix compared to the length of time this issue was left unattended.

Adding tests for this function is a bit tricky since it requires `emcc` to test it, so I didn't add any tests in this PR. For now, we can verify the behavior by checking that the recipes we were having trouble with build fine.

I'll work on improving the test pipeline so that we can test the part of pyodide-build that uses emcc.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
