### PR TITLE
Distinguish between emscripten settings and instantiated emscripten module

### DIFF
--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -1,7 +1,6 @@
 import ErrorStackParser from "../js/node_modules/error-stack-parser/error-stack-parser";
 import "types";
 
-declare var Module: any;
 declare var Tests: any;
 
 function ensureCaughtObjectIsError(e: any): Error {

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -1,4 +1,3 @@
-declare var Module: any;
 import "./module";
 import { ffi } from "./ffi";
 import { CanvasInterface, canvas } from "./canvas";
@@ -606,7 +605,7 @@ export class PyodideAPI {
    * purpose you like.
    */
   static setInterruptBuffer(interrupt_buffer: TypedArray) {
-    Module.HEAP8[Module._Py_EMSCRIPTEN_SIGNAL_HANDLING] = !!interrupt_buffer;
+    Module.HEAP8[Module._Py_EMSCRIPTEN_SIGNAL_HANDLING] = +!!interrupt_buffer;
     Module.Py_EmscriptenSignalBuffer = interrupt_buffer;
   }
 

--- a/src/js/canvas.ts
+++ b/src/js/canvas.ts
@@ -1,5 +1,3 @@
-declare var Module: any;
-
 /**
  * This interface contains the helper functions for using the HTML5 canvas.
  *

--- a/src/js/dynload.ts
+++ b/src/js/dynload.ts
@@ -1,21 +1,17 @@
 /* Handle dynamic library loading. */
 
-declare var Module: any;
 declare var DEBUG: boolean;
 
 import { createLock } from "./lock";
 import { memoize } from "./pyodide-util";
 import { InternalPackageData } from "./load-package";
+import { LoadDynlibFS, ReadFileType } from "./types";
 
-type ReadFileType = (path: string) => Uint8Array;
 
 // File System-like type which can be passed to
 // Module.loadDynamicLibrary or Module.loadWebAssemblyModule
 
-type LoadDynlibFS = {
-  readFile: ReadFileType;
-  findObject: (path: string, dontResolveLastLink: boolean) => any;
-};
+
 
 /**
  * Creates a filesystem-like object to be passed to Module.loadDynamicLibrary or Module.loadWebAssemblyModule

--- a/src/js/dynload.ts
+++ b/src/js/dynload.ts
@@ -7,11 +7,8 @@ import { memoize } from "./pyodide-util";
 import { InternalPackageData } from "./load-package";
 import { LoadDynlibFS, ReadFileType } from "./types";
 
-
 // File System-like type which can be passed to
 // Module.loadDynamicLibrary or Module.loadWebAssemblyModule
-
-
 
 /**
  * Creates a filesystem-like object to be passed to Module.loadDynamicLibrary or Module.loadWebAssemblyModule

--- a/src/js/module.ts
+++ b/src/js/module.ts
@@ -3,24 +3,24 @@
 import { ConfigType } from "./pyodide";
 import { initializeNativeFS } from "./nativefs";
 import { loadBinaryFile, getBinaryResponse } from "./compat";
-import { Module } from "./types";
+import { EmscriptenSettings } from "./types";
 
 /**
  * The Emscripten Module.
  *
  * @private
  */
-export function createModule(): Module {
-  let Module: any = {};
-  Module.noImageDecoding = true;
-  Module.noAudioDecoding = true;
-  Module.noWasmDecoding = false; // we preload wasm using the built in plugin now
-  Module.preRun = [];
-  Module.quit = (status: number, toThrow: Error) => {
-    Module.exited = { status, toThrow };
-    throw toThrow;
+export function createSettings(): EmscriptenSettings {
+  return {
+    noImageDecoding: true,
+    noAudioDecoding: true,
+    noWasmDecoding: false,
+    preRun: [],
+    quit(status: number, toThrow: Error) {
+      this.exited = { status, toThrow };
+      throw toThrow;
+    },
   };
-  return Module as Module;
 }
 
 /**
@@ -31,8 +31,8 @@ export function createModule(): Module {
  * @param path The path to the home directory.
  * @private
  */
-function createHomeDirectory(Module: Module, path: string) {
-  Module.preRun.push(function () {
+function createHomeDirectory(settings: EmscriptenSettings, path: string) {
+  settings.preRun.push(function (Module) {
     const fallbackPath = "/";
     try {
       Module.FS.mkdirTree(path);
@@ -46,8 +46,11 @@ function createHomeDirectory(Module: Module, path: string) {
   });
 }
 
-function setEnvironment(Module: Module, env: { [key: string]: string }) {
-  Module.preRun.push(function () {
+function setEnvironment(
+  settings: EmscriptenSettings,
+  env: { [key: string]: string },
+) {
+  settings.preRun.push(function (Module) {
     Object.assign(Module.ENV, env);
   });
 }
@@ -57,8 +60,8 @@ function setEnvironment(Module: Module, env: { [key: string]: string }) {
  * @param module The Emscripten Module.
  * @param mounts The list of paths to mount.
  */
-function mountLocalDirectories(Module: Module, mounts: string[]) {
-  Module.preRun.push(() => {
+function mountLocalDirectories(settings: EmscriptenSettings, mounts: string[]) {
+  settings.preRun.push((Module) => {
     for (const mount of mounts) {
       Module.FS.mkdirTree(mount);
       Module.FS.mount(Module.FS.filesystems.NODEFS, { root: mount }, mount);
@@ -80,10 +83,10 @@ function mountLocalDirectories(Module: Module, mounts: string[]) {
  * @param Module The Emscripten Module.
  * @param stdlibPromise A promise that resolves to the standard library.
  */
-function installStdlib(Module: Module, stdlibURL: string) {
+function installStdlib(settings: EmscriptenSettings, stdlibURL: string) {
   const stdlibPromise: Promise<Uint8Array> = loadBinaryFile(stdlibURL);
 
-  Module.preRun.push(() => {
+  settings.preRun.push((Module) => {
     /* @ts-ignore */
     const pymajor = Module._py_version_major();
     /* @ts-ignore */
@@ -112,7 +115,10 @@ function installStdlib(Module: Module, stdlibURL: string) {
  * Initialize the virtual file system, before loading Python interpreter.
  * @private
  */
-export function initializeFileSystem(Module: Module, config: ConfigType) {
+export function initializeFileSystem(
+  settings: EmscriptenSettings,
+  config: ConfigType,
+) {
   let stdLibURL;
   if (config.stdLibURL != undefined) {
     stdLibURL = config.stdLibURL;
@@ -120,14 +126,14 @@ export function initializeFileSystem(Module: Module, config: ConfigType) {
     stdLibURL = config.indexURL + "python_stdlib.zip";
   }
 
-  installStdlib(Module, stdLibURL);
-  createHomeDirectory(Module, config.env.HOME);
-  setEnvironment(Module, config.env);
-  mountLocalDirectories(Module, config._node_mounts);
-  Module.preRun.push(() => initializeNativeFS(Module));
+  installStdlib(settings, stdLibURL);
+  createHomeDirectory(settings, config.env.HOME);
+  setEnvironment(settings, config.env);
+  mountLocalDirectories(settings, config._node_mounts);
+  settings.preRun.push((Module) => initializeNativeFS(Module));
 }
 
-export function preloadWasm(Module: Module, indexURL: string) {
+export function preloadWasm(settings: EmscriptenSettings, indexURL: string) {
   if (SOURCEMAP) {
     // According to the docs:
     //
@@ -137,7 +143,7 @@ export function preloadWasm(Module: Module, indexURL: string) {
     return;
   }
   const { binary, response } = getBinaryResponse(indexURL + "pyodide.asm.wasm");
-  Module.instantiateWasm = function (
+  settings.instantiateWasm = function (
     imports: { [key: string]: any },
     successCallback: (
       instance: WebAssembly.Instance,

--- a/src/js/module.ts
+++ b/src/js/module.ts
@@ -11,16 +11,17 @@ import { EmscriptenSettings } from "./types";
  * @private
  */
 export function createSettings(): EmscriptenSettings {
-  return {
+  const settings: EmscriptenSettings = {
     noImageDecoding: true,
     noAudioDecoding: true,
     noWasmDecoding: false,
     preRun: [],
     quit(status: number, toThrow: Error) {
-      this.exited = { status, toThrow };
+      settings.exited = { status, toThrow };
       throw toThrow;
     },
   };
+  return settings;
 }
 
 /**

--- a/src/js/test/unit/module.test.ts
+++ b/src/js/test/unit/module.test.ts
@@ -4,7 +4,7 @@ import * as pyodideModule from "../../module";
 describe("Module", () => {
   describe("noWasmDecoding", () => {
     it("should be false ", () => {
-      const Module = pyodideModule.createModule();
+      const Module = pyodideModule.createSettings();
       chai.assert.equal(Module.noWasmDecoding, false);
     });
   });

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -250,17 +250,30 @@ export interface FS {
   registerDevice<T>(dev: number, ops: FSStreamOpsGen<T>): void;
 }
 
-export interface Module {
-  noImageDecoding: boolean;
-  noAudioDecoding: boolean;
-  noWasmDecoding: boolean;
-  quit: (status: number, toThrow: Error) => void;
-  preRun: { (): void }[];
+export interface EmscriptenSettings {
+  noImageDecoding?: boolean;
+  noAudioDecoding?: boolean;
+  noWasmDecoding?: boolean;
+  preRun: { (Module: Module): void }[];
+  quit?: (status: number, toThrow: Error) => void;
+  exited?: { status: number; toThrow: Error };
   print?: (a: string) => void;
   printErr?: (a: string) => void;
-  arguments: string[];
+  arguments?: string[];
+  instantiateWasm?: (
+    imports: { [key: string]: any },
+    successCallback: (
+      instance: WebAssembly.Instance,
+      module: WebAssembly.Module,
+    ) => void,
+  ) => void;
+  API?: API;
+  postRun?: ((a: Module) => void) | ((a: Module) => void)[];
+  locateFile?: (file: string) => string;
+}
+
+export interface Module {
   API: API;
-  postRun: ((a: Module) => void) | ((a: Module) => void)[];
   locateFile: (file: string) => string;
   exited?: { toThrow: any };
   ENV: { [key: string]: string };
@@ -272,13 +285,6 @@ export interface Module {
   removeRunDependency: (id: string) => void;
   reportUndefinedSymbols: () => void;
   ERRNO_CODES: { [k: string]: number };
-  instantiateWasm?: (
-    imports: { [key: string]: any },
-    successCallback: (
-      instance: WebAssembly.Instance,
-      module: WebAssembly.Module,
-    ) => void,
-  ) => void;
 }
 
 type LockfileInfo = {

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -178,6 +178,7 @@ export type FSNode = {
   timestamp: number;
   rdev: number;
   contents: Uint8Array;
+  mode: number;
 };
 
 export type FSStream = {
@@ -231,7 +232,9 @@ export interface FS {
   readdir: (node: FSNode) => string[];
   isDir: (mode: number) => boolean;
   isMountpoint: (mode: FSNode) => boolean;
-  lookupPath: (path: string) => { node: FSNode };
+  lookupPath: (path: string, options?:{
+    follow_mount?: boolean,
+  }) => { node: FSNode };
   isFile: (mode: number) => boolean;
   writeFile: (path: string, contents: any, o?: { canOwn?: boolean }) => void;
   chmod: (path: string, mode: number) => void;
@@ -248,6 +251,9 @@ export interface FS {
   close: (stream: FSStream) => void;
   ErrnoError: { new (errno: number): Error };
   registerDevice<T>(dev: number, ops: FSStreamOpsGen<T>): void;
+  syncfs(dir: boolean, oncomplete: (val: void) => void): void;
+  findObject(a: string, dontResolveLastLink?: boolean): any;
+  readFile(a: string): Uint8Array;
 }
 
 export interface EmscriptenSettings {
@@ -272,6 +278,21 @@ export interface EmscriptenSettings {
   locateFile?: (file: string) => string;
 }
 
+export type ReadFileType = (path: string) => Uint8Array;
+
+export type LoadDynlibFS = {
+  readFile: ReadFileType;
+  findObject: (path: string, dontResolveLastLink: boolean) => any;
+};
+
+type DSO = any;
+
+export interface LDSO {
+  loadedLibsByName: {
+    [key: string]: DSO;
+  }
+};
+
 export interface Module {
   API: API;
   locateFile: (file: string) => string;
@@ -280,11 +301,41 @@ export interface Module {
   PATH: any;
   TTY: any;
   FS: FS;
+  LDSO: LDSO;
   canvas?: HTMLCanvasElement;
-  addRunDependency: (id: string) => void;
-  removeRunDependency: (id: string) => void;
-  reportUndefinedSymbols: () => void;
+  addRunDependency(id: string): void;
+  removeRunDependency(id: string): void;
+  reportUndefinedSymbols(): void;
+  loadDynamicLibrary(lib: string, options?: {
+    loadAsync?: boolean;
+    nodelete?: boolean;
+    allowUndefined?: boolean;
+    global?: boolean;
+    fs: LoadDynlibFS;
+  }): void;
+  getDylinkMetadata(binary: Uint8Array | WebAssembly.Module): {
+    neededDynlibs: string[];
+  };
+
   ERRNO_CODES: { [k: string]: number };
+  stringToNewUTF8(x: string): number;
+  _compat_to_string_repr: number;
+  js2python_convert: (obj: any, options: {
+    depth?: number;
+    defaultConverter?: (value: any, converter: (value: any) => any, cacheConversion: (input: any, output: any) => void) => any;
+  }) => any;
+  _PropagatePythonError: typeof Error;
+  _Py_EMSCRIPTEN_SIGNAL_HANDLING: number;
+  Py_EmscriptenSignalBuffer: TypedArray;
+  HEAP8: Uint8Array;
+  __hiwire_get(a: number): any;
+  __hiwire_set(a: number, b: any): void;
+  __hiwire_immortal_add(a: any): void;
+  _jslib_init() : number;
+  _init_pyodide_proxy(): number;
+  jsWrapperTag: any; // Should be WebAssembly.Tag
+  getExceptionMessage(e:number): [string, string];
+  handle_js_error(e: any): void;
 }
 
 type LockfileInfo = {

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -232,9 +232,12 @@ export interface FS {
   readdir: (node: FSNode) => string[];
   isDir: (mode: number) => boolean;
   isMountpoint: (mode: FSNode) => boolean;
-  lookupPath: (path: string, options?:{
-    follow_mount?: boolean,
-  }) => { node: FSNode };
+  lookupPath: (
+    path: string,
+    options?: {
+      follow_mount?: boolean;
+    },
+  ) => { node: FSNode };
   isFile: (mode: number) => boolean;
   writeFile: (path: string, contents: any, o?: { canOwn?: boolean }) => void;
   chmod: (path: string, mode: number) => void;
@@ -290,8 +293,8 @@ type DSO = any;
 export interface LDSO {
   loadedLibsByName: {
     [key: string]: DSO;
-  }
-};
+  };
+}
 
 export interface Module {
   API: API;
@@ -306,13 +309,16 @@ export interface Module {
   addRunDependency(id: string): void;
   removeRunDependency(id: string): void;
   reportUndefinedSymbols(): void;
-  loadDynamicLibrary(lib: string, options?: {
-    loadAsync?: boolean;
-    nodelete?: boolean;
-    allowUndefined?: boolean;
-    global?: boolean;
-    fs: LoadDynlibFS;
-  }): void;
+  loadDynamicLibrary(
+    lib: string,
+    options?: {
+      loadAsync?: boolean;
+      nodelete?: boolean;
+      allowUndefined?: boolean;
+      global?: boolean;
+      fs: LoadDynlibFS;
+    },
+  ): void;
   getDylinkMetadata(binary: Uint8Array | WebAssembly.Module): {
     neededDynlibs: string[];
   };
@@ -320,10 +326,17 @@ export interface Module {
   ERRNO_CODES: { [k: string]: number };
   stringToNewUTF8(x: string): number;
   _compat_to_string_repr: number;
-  js2python_convert: (obj: any, options: {
-    depth?: number;
-    defaultConverter?: (value: any, converter: (value: any) => any, cacheConversion: (input: any, output: any) => void) => any;
-  }) => any;
+  js2python_convert: (
+    obj: any,
+    options: {
+      depth?: number;
+      defaultConverter?: (
+        value: any,
+        converter: (value: any) => any,
+        cacheConversion: (input: any, output: any) => void,
+      ) => any;
+    },
+  ) => any;
   _PropagatePythonError: typeof Error;
   _Py_EMSCRIPTEN_SIGNAL_HANDLING: number;
   Py_EmscriptenSignalBuffer: TypedArray;
@@ -331,10 +344,10 @@ export interface Module {
   __hiwire_get(a: number): any;
   __hiwire_set(a: number, b: any): void;
   __hiwire_immortal_add(a: any): void;
-  _jslib_init() : number;
+  _jslib_init(): number;
   _init_pyodide_proxy(): number;
   jsWrapperTag: any; // Should be WebAssembly.Tag
-  getExceptionMessage(e:number): [string, string];
+  getExceptionMessage(e: number): [string, string];
   handle_js_error(e: any): void;
 }
 


### PR DESCRIPTION
In Emscripten v3.1.58, `createPyodideModule` returns a distinct object from its argument so if we confuse `EmscriptenSettings` with the instantiated module, we'll get problems. This fixes these problems.

I also added some more type declarations.

Split from #4715.