### PR TITLE
Fix url filename parsing again

### DIFF
--- a/packages/ppl/meta.yaml
+++ b/packages/ppl/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: ppl
-  version: 1.2
+  version: "1.2"
   tag:
     - library
 source:
-  url: https://www.bugseng.com/products/ppl/download/ftp/releases/1.2/ppl-1.2.tar.xz
-  sha256: 691f0d5a4fb0e206f4e132fc9132c71d6e33cdda168470d40ac3cf62340e9a60
+  url: https://mirrors.mit.edu/sage/spkg/upstream/ppl/ppl-1.2.tar.bz2
+  sha256: 2d470b0c262904f190a19eac57fb5c2387b1bfc3510de25a08f3c958df62fdf1
   patches:
     - patches/clang5-support.patch
 requirements:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -302,11 +302,13 @@ class RecipeBuilder:
         max_retry = 3
         for retry_cnt in range(max_retry):
             response = requests.get(url)
-            if not response.ok:
+            try:
+                response.raise_for_status()
+            except requests.HTTPError as e:
                 if retry_cnt == max_retry - 1:
                     raise RuntimeError(
                         f"Failed to download {url} after {max_retry} trials"
-                    )
+                    ) from e
 
                 continue
 


### PR DESCRIPTION
### Description

Trying to fix #4721 again, using the URL inside meta.yaml instead of using the response URL (which may contain query strings).

Additionally, removes `cgi` module usage, which will be removed in python3.13
