### PR TITLE
Add missing library dependencies to packages

### DIFF
--- a/packages/libnetcdf/meta.yaml
+++ b/packages/libnetcdf/meta.yaml
@@ -19,6 +19,8 @@ build:
   type: shared_library
   script: |
     export PATH=${WASM_LIBRARY_DIR}/bin:${PATH}
+    
+    embuilder build zlib --pic
 
     # dap + byterange: no libcurl
 
@@ -32,8 +34,9 @@ build:
       --disable-examples \
       --disable-utilities \
       --disable-testsets \
-      CFLAGS="-fPIC -I${WASM_LIBRARY_DIR}/include" \
-      CXXFLAGS="-fPIC -I${WASM_LIBRARY_DIR}/include"
+      CFLAGS="-fPIC -I${WASM_LIBRARY_DIR}/include -s USE_ZLIB=1" \
+      CXXFLAGS="-fPIC -I${WASM_LIBRARY_DIR}/include -s USE_ZLIB=1" \
+      LDFLAGS="-fPIC -s USE_ZLIB=1"
 
     emmake make -j ${PYODIDE_JOBS:-3} LDFLAGS="-avoid-version -L${WASM_LIBRARY_DIR}/lib"
     emmake make -j ${PYODIDE_JOBS:-3} install

--- a/packages/libnetcdf/meta.yaml
+++ b/packages/libnetcdf/meta.yaml
@@ -19,7 +19,7 @@ build:
   type: shared_library
   script: |
     export PATH=${WASM_LIBRARY_DIR}/bin:${PATH}
-    
+
     embuilder build zlib --pic
 
     # dap + byterange: no libcurl

--- a/packages/libwebp/meta.yaml
+++ b/packages/libwebp/meta.yaml
@@ -22,6 +22,7 @@ build:
       -DWEBP_BUILD_WEBPINFO=OFF \
       -DWEBP_BUILD_WEBPMUX=OFF \
       -DWEBP_BUILD_EXTRAS=OFF \
+      -DWEBP_BUILD_ANIM_UTILS=OFF \
       ../
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install

--- a/packages/pysam/meta.yaml
+++ b/packages/pysam/meta.yaml
@@ -18,6 +18,8 @@ build:
     -I$(WASM_LIBRARY_DIR)/include
     -fPIC
   script: |
+    embuilder build zlib --pic
+    embuilder build bzip2 --pic
     cd htslib
     emconfigure ./configure CFLAGS="-s USE_ZLIB=1 -s USE_BZIP2=1 -fPIC" --disable-lzma
     export HTSLIB_MODE="separate"


### PR DESCRIPTION
### Description

Minor recipe updates that I had issues with when building these packages out-of-tree. These packages rely on emscripten library ports, but it was not specified explicitly.