### PR TITLE
Update docs to use latest sphinx-js version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ extensions = [
 myst_enable_extensions = ["substitution", "attrs_inline"]
 
 js_language = "typescript"
-jsdoc_config_path = "../src/js/tsconfig.json"
+jsdoc_tsconfig_path = "../src/js/tsconfig.json"
 root_for_relative_js_paths = "../src/"
 issues_github_path = "pyodide/pyodide"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,25 @@ panels_add_bootstrap_css = False
 # -- Project information -----------------------------------------------------
 
 project = "Pyodide"
-copyright = "2019-2022, Pyodide contributors and Mozilla"
+copyright = "2019-2024, Pyodide contributors and Mozilla"
+
+nitpicky = True
+nitpick_ignore = []
+
+
+def ignore_typevars():
+    """These are all intentionally broken. Disable the warnings about it."""
+    PY_TYPEVARS_TO_IGNORE = ["T", "T_co", "T_contra", "V_co", "KT", "VT", "VT_co"]
+    JS_TYPEVARS_TO_IGNORE = ["TResult", "TResult1", "TResult2", "U"]
+
+    for typevar in PY_TYPEVARS_TO_IGNORE:
+        nitpick_ignore.append(("py:obj", f"_pyodide._core_docs.{typevar}"))
+
+    for typevar in JS_TYPEVARS_TO_IGNORE:
+        nitpick_ignore.append(("js:func", typevar))
+
+
+ignore_typevars()
 
 # -- General configuration ---------------------------------------------------
 
@@ -62,7 +80,7 @@ autodoc_default_flags = ["members", "inherited-members"]
 
 micropip_version = micropip.__version__
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.11", None),
+    "python": ("https://docs.python.org/3.12", None),
     "micropip": (f"https://micropip.pyodide.org/en/v{micropip_version}/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Using Pyodide
    usage/downloading-and-deploying.md
    usage/index.md
    usage/loading-packages.md
-   usage/loading-files.md
+   usage/accessing-files.md
    usage/wasm-constraints.md
    usage/type-conversions.md
    usage/keyboard-interrupts.md

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -18,4 +18,4 @@ pydantic
 micropip==0.2.2
 jinja2>=3.0
 ruamel.yaml
-sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@09fa50221e4f5bef176497a46f6df344b2be482f
+sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@90055b1868851e6d88e492e7e526829da964bf82

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -18,4 +18,4 @@ pydantic
 micropip==0.2.2
 jinja2>=3.0
 ruamel.yaml
-sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@a79be6c863c0789e020116dafe629fd77658bf4b
+sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@09fa50221e4f5bef176497a46f6df344b2be482f

--- a/docs/sphinx_pyodide/sphinx_pyodide/__init__.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/__init__.py
@@ -1,7 +1,7 @@
+from pathlib import Path
+
 from .jsdoc import (
     patch_sphinx_js,
-    ts_post_convert,
-    ts_should_destructure_arg,
     ts_xref_formatter,
 )
 from .lexers import HtmlPyodideLexer, PyodideLexer
@@ -55,7 +55,6 @@ def setup(app):
     app.setup_extension("sphinx_js")
     app.add_directive("pyodide-package-list", get_packages_summary_directive(app))
     app.connect("builder-inited", add_mdn_xrefs)
-    app.config.ts_post_convert = ts_post_convert
-    app.config.ts_should_destructure_arg = ts_should_destructure_arg
     app.config.ts_type_xref_formatter = ts_xref_formatter
     app.config.ts_type_bold = True
+    app.config.ts_sphinx_js_config = Path(__file__).parent / "sphinxJsConfig.ts"

--- a/docs/sphinx_pyodide/sphinx_pyodide/mdn_xrefs.py
+++ b/docs/sphinx_pyodide/sphinx_pyodide/mdn_xrefs.py
@@ -38,6 +38,7 @@ DATA = {
         "Error": "$global/",
         "Function": "$global/",
         "Promise": "$global/",
+        "PromiseLike": "$global/Promise#thenables",
         "FileSystemDirectoryHandle": "API/",
     },
     "js:method": {

--- a/docs/sphinx_pyodide/sphinx_pyodide/sphinxJsConfig.ts
+++ b/docs/sphinx_pyodide/sphinx_pyodide/sphinxJsConfig.ts
@@ -1,0 +1,68 @@
+import {
+  Application,
+  DeclarationReflection,
+  ProjectReflection,
+  ReflectionType,
+} from "typedoc";
+import { Attribute, IRFunction, TopLevelIR } from "sphinx_js/ir";
+
+declare module "typedoc" {
+  export interface Application {
+    extraData: {
+      ffiFields: string[];
+      pyproxyMethods: [string, (Attribute | IRFunction)[]][];
+    };
+  }
+}
+
+function shouldDestructureArg(param) {
+  return param.name === "options";
+}
+
+function calculateFfiFields(project: ProjectReflection): string[] {
+  const ffiMod = project.getChildByName("js/ffi");
+  const ffi = ffiMod?.getChildByName("ffi") as DeclarationReflection;
+  const refl = ffi.type as ReflectionType;
+  const result = refl.declaration.children?.map((x) => x.name);
+  if (!result) {
+    throw new Error("Failed to calculate ffi fields");
+  }
+  return result;
+}
+
+function calculatePyProxyMethods(
+  typeDocToIRMap: Map<DeclarationReflection, TopLevelIR>,
+): [string, (Attribute | IRFunction)[]][] {
+  const pyproxyMethods: [string, (Attribute | IRFunction)[]][] = [];
+  for (const [key, value] of typeDocToIRMap.entries()) {
+    value.exported_from = null;
+    if (value.kind === "attribute" || value.kind === "function") {
+      value.is_private = key.flags.isExternal || key.flags.isPrivate;
+    }
+
+    if (value.kind !== "class") {
+      continue;
+    }
+    if (value.modifier_tags.includes("@hideconstructor")) {
+      value.constructor_ = null;
+    }
+    if (value.deppath === "./core/pyproxy" && value.name.endsWith("Methods")) {
+      pyproxyMethods.push([value.name, value.members]);
+    }
+  }
+  return pyproxyMethods;
+}
+
+function postConvert(
+  app: Application,
+  project: ProjectReflection,
+  typeDocToIRMap: Map<DeclarationReflection, TopLevelIR>,
+) {
+  app.extraData.ffiFields = calculateFfiFields(project);
+  app.extraData.pyproxyMethods = calculatePyProxyMethods(typeDocToIRMap);
+}
+
+export const config = {
+  shouldDestructureArg,
+  postConvert,
+};

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -4,7 +4,7 @@
 
 ## How can I load external files in Pyodide?
 
-See {accessing_files_quickref}`accessing_files_quickref`.
+See {ref}`accessing_files_quickref`.
 
 ## Why can't I load files from the local file system?
 

--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -616,11 +616,11 @@ blocks. At the boundary between Python and JavaScript, errors are caught,
 converted between languages, and rethrown.
 
 JavaScript errors are wrapped in a {py:class}`~pyodide.ffi.JsException`.
-Python exceptions are converted to a {js:class}`~pyodide.PythonError`.
+Python exceptions are converted to a {js:class}`~pyodide.ffi.PythonError`.
 At present if an exception crosses between Python and JavaScript several times,
 the resulting error message won't be as useful as one might hope.
 
-In order to reduce memory leaks, the {js:class}`~pyodide.PythonError` has a
+In order to reduce memory leaks, the {js:class}`~pyodide.ffi.PythonError` has a
 formatted traceback, but no reference to the original Python exception. The
 original exception has references to the stack frame and leaking it will leak
 all the local variables from that stack frame. The actual Python exception will

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -344,7 +344,7 @@ API.PythonError = PythonError;
  * C keeping the current Python error flag. This signals to the EM_JS wrappers
  * that the Python error flag is set and to leave it alone and return the
  * appropriate error value (either NULL or -1).
- * @private
+ * @hidden
  */
 export class _PropagatePythonError extends Error {
   constructor() {

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -337,11 +337,15 @@ export class PythonError extends Error {
   }
 }
 API.PythonError = PythonError;
-// A special marker. If we call a CPython API from an EM_JS function and the
-// CPython API sets an error, we might want to return an error status back to
-// C keeping the current Python error flag. This signals to the EM_JS wrappers
-// that the Python error flag is set and to leave it alone and return the
-// appropriate error value (either NULL or -1).
+
+/**
+ * A special marker. If we call a CPython API from an EM_JS function and the
+ * CPython API sets an error, we might want to return an error status back to
+ * C keeping the current Python error flag. This signals to the EM_JS wrappers
+ * that the Python error flag is set and to leave it alone and return the
+ * appropriate error value (either NULL or -1).
+ * @private
+ */
 export class _PropagatePythonError extends Error {
   constructor() {
     super(

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -935,7 +935,7 @@ export class PyGetItemMethods {
    *     adaptor.
    *
    * For instance, ``JSON.stringify(proxy.asJsonAdaptor())`` acts like an
-   * inverse to Python's :meth:`json.loads`.
+   * inverse to Python's :py:func:`json.loads`.
    */
   asJsonAdaptor(): PyProxy & {} {
     // This is just here for the docs. The actual implementation comes from
@@ -1274,7 +1274,7 @@ export class PyIteratorMethods {
    *
    * This will be used implicitly by ``for(let x of proxy){}``.
    *
-   * @param any The value to send to the generator. The value will be assigned
+   * @param arg The value to send to the generator. The value will be assigned
    * as a result of a yield expression.
    * @returns An Object with two properties: ``done`` and ``value``. When the
    * generator yields ``some_value``, ``next`` returns ``{done : false, value :
@@ -1319,7 +1319,7 @@ export class PyGeneratorMethods {
    *
    * See the documentation for :js:meth:`Generator.throw`.
    *
-   * @param exception Error The error to throw into the generator. Must be an
+   * @param exc Error The error to throw into the generator. Must be an
    * instanceof ``Error``.
    * @returns An Object with two properties: ``done`` and ``value``. When the
    * generator yields ``some_value``, ``return`` returns ``{done : false, value
@@ -1351,7 +1351,7 @@ export class PyGeneratorMethods {
    * :py:exc:`GeneratorExit` or :py:exc:`StopIteration`, that error is propagated. See
    * the documentation for :js:meth:`Generator.return`.
    *
-   * @param any The value to return from the generator.
+   * @param v The value to return from the generator.
    * @returns An Object with two properties: ``done`` and ``value``. When the
    * generator yields ``some_value``, ``return`` returns ``{done : false, value
    * : some_value}``. When the generator raises a
@@ -1401,7 +1401,7 @@ export class PyAsyncIteratorMethods {
    *
    * This will be used implicitly by ``for(let x of proxy){}``.
    *
-   * @param any The value to send to a generator. The value will be assigned as
+   * @param arg The value to send to a generator. The value will be assigned as
    * a result of a yield expression.
    * @returns An Object with two properties: ``done`` and ``value``. When the
    * iterator yields ``some_value``, ``next`` returns ``{done : false, value :
@@ -1459,7 +1459,7 @@ export class PyAsyncGeneratorMethods {
    *
    * See the documentation for :js:meth:`AsyncGenerator.throw`.
    *
-   * @param exception Error The error to throw into the generator. Must be an
+   * @param exc Error The error to throw into the generator. Must be an
    * instanceof ``Error``.
    * @returns An Object with two properties: ``done`` and ``value``. When the
    * generator yields ``some_value``, ``return`` returns ``{done : false, value
@@ -1506,7 +1506,7 @@ export class PyAsyncGeneratorMethods {
    * :py:exc:`GeneratorExit` or :py:exc:`StopAsyncIteration`, that error is
    * propagated. See the documentation for :js:meth:`AsyncGenerator.throw`
    *
-   * @param any The value to return from the generator.
+   * @param v The value to return from the generator.
    * @returns An Object with two properties: ``done`` and ``value``. When the
    * generator yields ``some_value``, ``return`` returns ``{done : false, value
    * : some_value}``. When the generator raises a :py:exc:`StopAsyncIteration`
@@ -1656,7 +1656,7 @@ export class PySequenceMethods {
    * See :js:meth:`Array.filter`. Creates a shallow copy of a portion of a given
    * ``Sequence``, filtered down to just the elements from the given array that pass
    * the test implemented by the provided function.
-   * @param callbackfn A function to execute for each element in the array. It
+   * @param predicate A function to execute for each element in the array. It
    * should return a truthy value to keep the element in the resulting array,
    * and a falsy value otherwise.
    * @param thisArg A value to use as ``this`` when executing ``predicate``.
@@ -1670,7 +1670,7 @@ export class PySequenceMethods {
   /**
    * See :js:meth:`Array.some`. Tests whether at least one element in the
    * ``Sequence`` passes the test implemented by the provided function.
-   * @param callbackfn A function to execute for each element in the
+   * @param predicate A function to execute for each element in the
    * ``Sequence``. It should return a truthy value to indicate the element
    * passes the test, and a falsy value otherwise.
    * @param thisArg A value to use as ``this`` when executing ``predicate``.
@@ -1684,7 +1684,7 @@ export class PySequenceMethods {
   /**
    * See :js:meth:`Array.every`. Tests whether every element in the ``Sequence``
    * passes the test implemented by the provided function.
-   * @param callbackfn A function to execute for each element in the
+   * @param predicate A function to execute for each element in the
    * ``Sequence``. It should return a truthy value to indicate the element
    * passes the test, and a falsy value otherwise.
    * @param thisArg A value to use as ``this`` when executing ``predicate``.
@@ -1702,7 +1702,6 @@ export class PySequenceMethods {
    * running the reducer across all elements of the Sequence is a single value.
    * @param callbackfn A function to execute for each element in the ``Sequence``. Its
    * return value is discarded.
-   * @param thisArg A value to use as ``this`` when executing ``callbackfn``.
    */
   reduce(
     callbackfn: (
@@ -1723,7 +1722,6 @@ export class PySequenceMethods {
    * single value.
    * @param callbackfn A function to execute for each element in the Sequence.
    * Its return value is discarded.
-   * @param thisArg A value to use as ``this`` when executing ``callbackFn``.
    */
   reduceRight(
     callbackfn: (
@@ -1843,7 +1841,7 @@ export class PySequenceMethods {
    *     adaptor.
    *
    * For instance, ``JSON.stringify(proxy.asJsonAdaptor())`` acts like an
-   * inverse to Python's :meth:`json.loads`.
+   * inverse to Python's :py:func:`json.loads`.
    */
   asJsonAdaptor(): PyProxy & {} {
     // This is just here for the docs. The actual implementation comes from
@@ -3148,8 +3146,13 @@ export class PyBufferView {
    */
   f_contiguous: boolean;
 
+  /**
+   * @private
+   */
   _released: boolean;
-
+  /**
+   * @private
+   */
   _view_ptr: number;
 
   /** @private */

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -680,7 +680,7 @@ export class PyProxy {
   }
   /**
    * Returns `str(o)` (unless `pyproxyToStringRepr: true` was passed to
-   * :js:func:`loadPyodide` in which case it will return `repr(o)`)
+   * :js:func:`~globalThis.loadPyodide` in which case it will return `repr(o)`)
    */
   toString(): string {
     let ptrobj = _getPtr(this);

--- a/src/js/emscripten-settings.ts
+++ b/src/js/emscripten-settings.ts
@@ -7,6 +7,7 @@ import { API, PreRunFunc } from "./types";
 
 /**
  * @private
+ * @hidden
  */
 export interface EmscriptenSettings {
   readonly noImageDecoding?: boolean;

--- a/src/js/environments.ts
+++ b/src/js/environments.ts
@@ -48,6 +48,7 @@ export const IN_SAFARI =
 /**
  * Detects the current environment and returns a record with the results.
  * This function is useful for debugging and testing purposes.
+ * @private
  */
 export function detectEnvironment(): Record<string, boolean> {
   return {

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -113,6 +113,9 @@ export type PackageLoadMetadata = {
   packageData: InternalPackageData;
 };
 
+/**
+ * @private
+ */
 export type PackageType =
   | "package"
   | "cpython_module"

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -120,6 +120,9 @@ export type PackageType =
   | "static_library";
 
 // Package data inside pyodide-lock.json
+/**
+ * @private
+ */
 export type PackageData = {
   name: string;
   version: string;

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -156,8 +156,8 @@ export async function loadPyodide(
      */
     packages?: string[];
     /**
-     * Opt into the old behavior where :py:meth:`PyProxy.toString` calls :py:func:`repr` and not
-     * :py:func:`str`.
+     * Opt into the old behavior where :js:func:`PyProxy.toString() <pyodide.ffi.PyProxy.toString>`
+     * calls :py:func:`repr` and not :py:class:`str() <str>`.
      * @deprecated
      */
     pyproxyToStringRepr?: boolean;

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -13,7 +13,7 @@ import { createSettings } from "./emscripten-settings";
 import { version } from "./version";
 
 import type { PyodideInterface } from "./api.js";
-import type { TypedArray, API, Module } from "./types";
+import type { TypedArray, Module } from "./types";
 import type { EmscriptenSettings } from "./emscripten-settings";
 import type { PackageData } from "./load-package";
 export type { PyodideInterface, TypedArray };

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -156,8 +156,8 @@ export async function loadPyodide(
      */
     packages?: string[];
     /**
-     * Opt into the old behavior where PyProxy.toString calls `repr` and not
-     * `str`.
+     * Opt into the old behavior where :py:meth:`PyProxy.toString` calls :py:func:`repr` and not
+     * :py:func:`str`.
      * @deprecated
      */
     pyproxyToStringRepr?: boolean;

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -259,6 +259,7 @@ export interface FS {
   readFile(a: string): Uint8Array;
 }
 
+/** @private */
 export type PreRunFunc = (Module: Module) => void;
 
 export type ReadFileType = (path: string) => Uint8Array;

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1186,6 +1186,7 @@ class JsDomElement(JsProxy):
 # from pyproxy.c
 
 
+@docs_argspec("(obj: Callable[..., Any], /) -> JsOnceCallable")
 def create_once_callable(
     obj: Callable[..., Any], /, *, _may_syncify: bool = False
 ) -> JsOnceCallable:


### PR DESCRIPTION
This pulls in the tip of the master branch of sphinx-js and shortens the
jsdoc.py patches by about 60 lines.

I also fixed some broken links and various typedoc and sphinx warnings.
I turned on nitpicky mode and silenced intentionally broken links so in the
future we can catch broken xrefs better. These warnings also help turn up
cases where private fields are accidentally included into the docs.