### PR TITLE
BLD Pass host env variables to bash runner

### DIFF
--- a/pyodide-build/pyodide_build/bash_runner.py
+++ b/pyodide-build/pyodide_build/bash_runner.py
@@ -110,7 +110,7 @@ def get_bash_runner(
     env.update(extra_envs)
 
     with BashRunnerWithSharedEnvironment(env=env) as b:
-        # Working in`-tree, add emscripten toolchain into PATH and set ccache
+        # Working in-tree, add emscripten toolchain into PATH and set ccache
         if Path(pyodide_root, "pyodide_env.sh").exists():
             b.run(
                 f"source {pyodide_root}/pyodide_env.sh",

--- a/pyodide-build/pyodide_build/bash_runner.py
+++ b/pyodide-build/pyodide_build/bash_runner.py
@@ -110,7 +110,7 @@ def get_bash_runner(
     env.update(extra_envs)
 
     with BashRunnerWithSharedEnvironment(env=env) as b:
-        # Working in-tree, add emscripten toolchain into PATH and set ccache
+        # Working in`-tree, add emscripten toolchain into PATH and set ccache
         if Path(pyodide_root, "pyodide_env.sh").exists():
             b.run(
                 f"source {pyodide_root}/pyodide_env.sh",

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -169,7 +169,7 @@ class RecipeBuilder:
 
         with (
             chdir(self.pkg_root),
-            get_bash_runner(self._get_helper_vars()) as bash_runner,
+            get_bash_runner(self._get_helper_vars() | os.environ.copy()) as bash_runner,
         ):
             if self.recipe.is_rust_package():
                 bash_runner.run(


### PR DESCRIPTION
### Description

A tiny PR that allows passing env variables when building recipes.

For example, `EMCC_DEBUG=1 pyodide build-recipes ...` didn't work before this PR, as EMCC_DEBUG=1 was not passed to the bash_runner.
