### PR TITLE
Add required --root` to `./run_docker` build from source documentation

### DIFF
--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -43,6 +43,10 @@ These Docker images are also available from the Github packages at
 3. Run `make` to build.
 
 ```{note}
+If `make` is failing with `Permission denied`, you can run `./run_docker` with root permissions: `./run_docker --root`
+```
+
+```{note}
 You can control the resources allocated to the build by setting the env
 vars `EMSDK_NUM_CORE`, `EMCC_CORES` and `PYODIDE_JOBS` (the default for each is
 4).


### PR DESCRIPTION

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

It seems `--root` option is required when running `make` in the docker container, see #4753

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

- [x] Add new / update outdated documentation
