### PR TITLE
packages: Add lakers-python

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -110,7 +110,8 @@ myst:
   `pyxirr` {pr}`4513`, `ipython`, `asttokens`, `executing`, `prompt_toolkit`,
   `pure_eval`, `stack_data`, `traitlets`, `wcwidth` {pr}`4452`, `altair` {pr}`4580`,
   `cvxpy` {pr}`4587`, `clarabel` {pr}`4587`, `matplotlib-inline` {pr}`4626`,
-  `pygame-ce` {pr}`4602`, `libcst` {pr}`4665`, `mmh3`, `pyiceberg` {pr}`4648`
+  `pygame-ce` {pr}`4602`, `libcst` {pr}`4665`, `mmh3`, `pyiceberg` {pr}`4648`,
+  `lakers-python` {pr}`4763`
 
 - Upgraded `contourpy` to 1.2.1 {pr}`4680`
 - Upgraded `sourmash` to 4.8.8 {pr}`4683`

--- a/packages/lakers-python/meta.yaml
+++ b/packages/lakers-python/meta.yaml
@@ -6,9 +6,6 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/29/93/5d70b035f987a48dd854c1afc21025fb8446aae4d43c685b68691175623c/lakers_python-0.3.0.tar.gz
   sha256: 009fc5e31b5a9a276216ff43ffd097004396a2a9131359a1da35d464e599cd1c
-build:
-  script: |
-    cargo update -p proc-macro2 --precise 1.0.60
 requirements:
   executable:
     - rustup

--- a/packages/lakers-python/meta.yaml
+++ b/packages/lakers-python/meta.yaml
@@ -1,0 +1,19 @@
+package:
+  name: lakers-python
+  version: 0.3.0
+  top-level:
+    - lakers
+source:
+  url: https://files.pythonhosted.org/packages/29/93/5d70b035f987a48dd854c1afc21025fb8446aae4d43c685b68691175623c/lakers_python-0.3.0.tar.gz
+  sha256: 009fc5e31b5a9a276216ff43ffd097004396a2a9131359a1da35d464e599cd1c
+build:
+  script: |
+    cargo update -p proc-macro2 --precise 1.0.60
+requirements:
+  executable:
+    - rustup
+about:
+  home: https://github.com/openwsn-berkeley/lakers/
+  PyPI: https://pypi.org/project/lakers-python/
+  summary: An implementation of EDHOC (RFC 9528)
+  license: BSD-3-Clause

--- a/packages/lakers-python/test_lakers_python.py
+++ b/packages/lakers-python/test_lakers_python.py
@@ -1,0 +1,25 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["lakers-python"])
+def test_lakers_python(selenium_standalone):
+    import lakers
+
+    # Running an exchange needs some keys and credentials; those are from the EDHOC test vectors.
+    R = bytes.fromhex(
+        "72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac"
+    )
+    CRED_R = bytes.fromhex(
+        "A2026008A101A5010202410A2001215820BBC34960526EA4D32E940CAD2A234148DDC21791A12AFBCBAC93622046DD44F02258204519E257236B2A0CE2023F0931F1F386CA7AFDA64FCDE0108C224C51EABF6072"
+    )
+
+    initiator = lakers.EdhocInitiator()
+    responder = lakers.EdhocResponder(R, CRED_R)
+
+    message_1 = initiator.prepare_message_1()
+    responder.process_message_1(message_1)
+    _message_2 = responder.prepare_message_2(
+        lakers.CredentialTransfer.ByReference, None, None
+    )
+
+    # There's a lot more that can be tested, but if this runs through, we've covered the most critical kinds of operations.


### PR DESCRIPTION
### Description

This adds Lakers (`lakers-python` on PyPI), the Python wrappers for the Rust implementation of EDHOC (RFC9528). EDHOC is a compact key exchange protocol, primarily designed for embedded systems.

As a compiled package it can not use the pure Python wheels published through crates.io. It is useful in pyodide because aiocoap has [good support for pyodide and Jupyter](https://aiocoap.readthedocs.io/en/latest/pyodide.html) for end-to-end encryption between a browser console (or application) and an embedded device (connected through untrusted proxies on the Internet or through local Bluetooth connections). I expect to add EDHOC support to aiocoap through lakers.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
  Marked as checked because I don't think that adding a package needs any added documentation outside the change log.
