### PR TITLE
chore: restore pipx run support without —spec

### DIFF
--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -44,6 +44,9 @@ Homepage = "https://github.com/pyodide/pyodide"
 "Bug Tracker" = "https://github.com/pyodide/pyodide/issues"
 Documentation = "https://pyodide.org/en/stable/"
 
+[project.entry-points."pipx.run"]
+pyodide = "pyodide_cli.__main__:main"
+
 [project.entry-points."pyodide.cli"]
 build = "pyodide_build.cli.build:main"
 build-recipes = "pyodide_build.cli.build_recipes:build_recipes"


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This should restore support for `pipx run pyodide-build` instead of `pipx run —-spec pyodide-build pyodide` by teaching pipx about the primary entry point in the package.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
