### PR TITLE
chore: use hatchling instead of setuptools

### DIFF
--- a/pyodide-build/pyproject.toml
+++ b/pyodide-build/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.2"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "pyodide-build"
@@ -71,19 +71,10 @@ deploy = [
     "moto",
 ]
 
-[tool.setuptools]
-package-dir = {"" = "."}
-license-files = ["LICENSE"]
-include-package-data = false
+[tool.hatch]
+version.path = "pyodide_build/__init__.py"
 
-[tool.setuptools.packages.find]
-where = ["."]
-exclude = ["pyodide_build.tests*"]
-namespaces = true
-
-[tool.setuptools.package-data]
-"pyodide_build.tools" = ["*.ini", "*.cross"]
-"pyodide_build.tools.cmake.Modules.Platform" = ["*.cmake"]
-
-[tool.setuptools.dynamic]
-version = {attr = "pyodide_build.__version__"}
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/pyodide_build/tests",
+]


### PR DESCRIPTION
### Description


This swaps out the build backend of pyodide-build for hatchling, which is simpler and faster.

The difference in the SDists:

```diff
diff (tar -tf dist/old/*.tar.gz | sort | psub) (tar -tf dist/*.tar.gz | sort | psub)
1c1
< pyodide_build-0.26.0.dev0/
---
> pyodide_build-0.26.0.dev0/.gitignore
5,12d4
< pyodide_build-0.26.0.dev0/pyodide_build.egg-info/
< pyodide_build-0.26.0.dev0/pyodide_build.egg-info/PKG-INFO
< pyodide_build-0.26.0.dev0/pyodide_build.egg-info/SOURCES.txt
< pyodide_build-0.26.0.dev0/pyodide_build.egg-info/dependency_links.txt
< pyodide_build-0.26.0.dev0/pyodide_build.egg-info/entry_points.txt
< pyodide_build-0.26.0.dev0/pyodide_build.egg-info/requires.txt
< pyodide_build-0.26.0.dev0/pyodide_build.egg-info/top_level.txt
< pyodide_build-0.26.0.dev0/pyodide_build/
20d11
< pyodide_build-0.26.0.dev0/pyodide_build/cli/
37d27
< pyodide_build-0.26.0.dev0/pyodide_build/out_of_tree/
46,49d35
< pyodide_build-0.26.0.dev0/pyodide_build/tools/
< pyodide_build-0.26.0.dev0/pyodide_build/tools/cmake/
< pyodide_build-0.26.0.dev0/pyodide_build/tools/cmake/Modules/
< pyodide_build-0.26.0.dev0/pyodide_build/tools/cmake/Modules/Platform/
53d38
< pyodide_build-0.26.0.dev0/pyodide_build/vendor/
58d42
< pyodide_build-0.26.0.dev0/setup.cfg
```

This removes the zip directories entries, setup.cfg, and `.egg-info` directory and contents. It includes the `.gitignore`, since hatchling uses that to decide what to include by default.


The difference in the wheel built from the SDist:

```diff
diff (unzip -Z1 dist/old/*.whl | sort | psub) (unzip -Z1 dist/*.whl | sort | psub)
1d0
< pyodide_build-0.26.0.dev0.dist-info/LICENSE
6c5
< pyodide_build-0.26.0.dev0.dist-info/top_level.txt
---
> pyodide_build-0.26.0.dev0.dist-info/licenses/LICENSE
```

The useless `top_level.txt` is gone and the license is in the licenses directory.

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- Add / update tests
- Add new / update outdated documentation

No changelog since a user shouldn't care.
