### PR TITLE
Fix out of tree build after #4777

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -24,7 +24,7 @@ _Date here_
   {pr}`4431` {pr}`4435`
 
 - {{ Update }} The wheel tag for Pyodide wheels has changed to pyodide_2024_0_wasm32.
-  {pr}`4777`
+  {pr}`4777`, {pr}`4780`
 
 - {{ Enhancement }} ABI Break: Updated Emscripten to version 3.1.58
   {pr}`4399` {pr}`4715`

--- a/pyodide-build/pyodide_build/common.py
+++ b/pyodide-build/pyodide_build/common.py
@@ -349,7 +349,7 @@ def retag_wheel(wheel_path: Path, platform: str) -> Path:
     if result.returncode != 0:
         logger.error(f"ERROR: Retagging wheel {wheel_path} to {platform} failed")
         exit_with_stdio(result)
-    return wheel_path.parent / result.stdout.strip()
+    return wheel_path.parent / result.stdout.splitlines()[-1].strip()
 
 
 def extract_wheel_metadata_file(wheel_path: Path, output_path: Path) -> None:

--- a/pyodide-build/pyodide_build/out_of_tree/build.py
+++ b/pyodide-build/pyodide_build/out_of_tree/build.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from build import ConfigSettingsType
 
 from .. import build_env, common, pypabuild
-from ..build_env import get_pyodide_root
+from ..build_env import get_pyodide_root, wheel_platform
 from ..io import _BuildSpecExports
 
 
@@ -41,6 +41,7 @@ def run(
         built_wheel = pypabuild.build(srcdir, outdir, env, config_settings)
 
     wheel_path = Path(built_wheel)
+    wheel_path = common.retag_wheel(wheel_path, wheel_platform())
     with common.modify_wheel(wheel_path) as wheel_dir:
         build_env.replace_so_abi_tags(wheel_dir)
 


### PR DESCRIPTION
I updated the platform when we build with build-recipes but not with `pyodide build`. This also updates the platform tag for wheels produced with `pyodide build`.