### PR TITLE
BLD Clean up unused Makefile sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,12 +134,6 @@ dist/pyodide.asm.js: \
 		cd dist && npx prettier -w pyodide.asm.js ; \
 	fi
 
-   # Strip out C++ symbols which all start __Z.
-   # There are 4821 of these and they have VERY VERY long names.
-   # To show some stats on the symbols you can use the following:
-   # cat dist/pyodide.asm.js | grep -ohE 'var _{0,5}.' | sort | uniq -c | sort -nr | head -n 20
-	sed -i -E 's/var __Z[^;]*;//g' dist/pyodide.asm.js
-	sed -i '1i "use strict";' dist/pyodide.asm.js
 	# Remove last 4 lines of pyodide.asm.js, see issue #2282
 	# Hopefully we will remove this after emscripten fixes it, upstream issue
 	# emscripten-core/emscripten#16518


### PR DESCRIPTION
This stuff is no longer needed since the update to Emscripten 3.1.58.