### PR TITLE
Add `zstandard`

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -129,7 +129,7 @@ _Date here_
   `pure_eval`, `stack_data`, `traitlets`, `wcwidth` {pr}`4452`, `altair` {pr}`4580`,
   `cvxpy` {pr}`4587`, `clarabel` {pr}`4587`, `matplotlib-inline` {pr}`4626`,
   `pygame-ce` {pr}`4602`, `libcst` {pr}`4665`, `mmh3`, `pyiceberg` {pr}`4648`,
-  `lakers-python` {pr}`4763`, `crc32c` {pr}`4789`
+  `lakers-python` {pr}`4763`, `crc32c` {pr}`4789`, `zstandard` {pr}`4792`
 
 - Upgraded `contourpy` to 1.2.1 {pr}`4680`
 - Upgraded `sourmash` to 4.8.8 {pr}`4683`

--- a/packages/zstandard/meta.yaml
+++ b/packages/zstandard/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: zstandard
+  version: 0.22.0
+  top-level:
+    - zstandard
+source:
+  url: https://files.pythonhosted.org/packages/5d/91/2162ab4239b3bd6743e8e407bc2442fca0d326e2d77b3f4a88d90ad5a1fa/zstandard-0.22.0.tar.gz
+  sha256: 8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70
+requirements:
+  host:
+    - cffi
+    - setuptools
+  run:
+    - cffi
+about:
+  home: https://github.com/indygreg/python-zstandard
+  PyPI: https://pypi.org/project/zstandard
+  summary: Zstandard bindings for Python
+  license: BSD
+extra:
+  recipe-maintainers:
+    - agriyakhetarpal

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -7,9 +7,9 @@ from pytest_pyodide import run_in_pyodide
 def env(selenium):
     selenium.run_python(
         """
-      import os
-      os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = "default"
-      """
+        import os
+        os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = "default"
+        """
     )
     yield
 

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -46,7 +46,7 @@ def test_compress_empty(selenium):
     params = zstd.get_frame_parameters(result)
     assert params.window_size == 1024
     assert params.dict_id == 0
-    assert params.has_checksum != 0
+    assert params.has_checksum is False
 
     cctx = zstd.ZstdCompressor()
     result = cctx.compress(b"")
@@ -73,10 +73,10 @@ def test_compress_large(selenium):
     # This matches the test for read_to_iter() below.
     cctx = zstd.ZstdCompressor(level=1, write_content_size=False)
     result = cctx.compress(b"f" * zstd.COMPRESSION_RECOMMENDED_INPUT_SIZE + b"o")
-    assert result == (
-        b"\x28\xb5\x2f\xfd\x00\x40\x54\x00\x00"
+    assert (
+        result == b"\x28\xb5\x2f\xfd\x00\x40\x54\x00\x00"
         b"\x10\x66\x66\x01\x00\xfb\xff\x39\xc0"
-        b"\x02\x09\x00\x00\x6f",
+        b"\x02\x09\x00\x00\x6f"
     )
 
 

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -11,7 +11,7 @@ def set_zstd_backend(selenium, zstd_backend):
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.mark.fixture(params=["cext", "cffi"], autouse=True)
+@pytest.fixture(params=["cext", "cffi"], autouse=True)
 def zstd_backend(selenium, request):
     set_zstd_backend(selenium, request.param)
 

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -1,9 +1,18 @@
-import os
+import pytest
+from pytest_pyodide import run_in_pyodide
+
 
 # Ensure C extension is used, and then CFFI as fallback, error if neither
-os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = "default"
+@pytest.fixture(autouse=True)
+def env(selenium):
+    selenium.run_python(
+        """
+      import os
+      os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = "default"
+      """
+    )
+    yield
 
-from pytest_pyodide import run_in_pyodide
 
 # ------- Some compression tests ----------------------------------------------
 

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -1,0 +1,116 @@
+import os
+
+# Ensure C extension is used, and then CFFI as fallback, error if neither
+os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = "default"
+
+import zstandard as zstd
+from pytest_pyodide import run_in_pyodide
+
+# ------- Some compression tests ----------------------------------------------
+
+
+@run_in_pyodide(packages=["zstandard"])
+def test_zstandard_compression_and_decompression(selenium):
+    data = b"foo"
+    compress = zstd.ZstdCompressor(
+        write_checksum=True, write_content_size=True
+    ).compress
+    decompress = zstd.ZstdDecompressor().decompress
+
+    assert decompress(compress(data)) == data
+
+
+@run_in_pyodide(packages=["zstandard"])
+def test_zstandard_compression_and_decompression_with_level(selenium):
+    data = b"foo"
+    compress = zstd.ZstdCompressor(
+        level=1, write_checksum=True, write_content_size=True
+    ).compress
+    decompress = zstd.ZstdDecompressor().decompress
+
+    assert decompress(compress(data)) == data
+
+
+@run_in_pyodide(packages=["zstandard"])
+def test_compress_empty(selenium):
+    cctx = zstd.ZstdCompressor(level=1, write_content_size=False)
+
+    result = cctx.compress(b"")
+    assert result == b"\x28\xb5\x2f\xfd\x00\x00\x01\x00\x00"
+
+    params = zstd.get_frame_parameters(result)
+    assert params.window_size == 1024
+    assert params.dict_id == 0
+    assert params.has_checksum != 0
+
+    cctx = zstd.ZstdCompressor()
+    result = cctx.compress(b"")
+    assert result == b"\x28\xb5\x2f\xfd\x20\x00\x01\x00\x00"
+    params = zstd.get_frame_parameters(result)
+    assert params.content_size == 0
+
+
+@run_in_pyodide(packages=["zstandard"])
+def test_compress_large(selenium):
+    import struct
+
+    chunks = []
+    for i in range(255):
+        chunks.append(struct.Struct(">B").pack(i) * 16384)
+
+    cctx = zstd.ZstdCompressor(level=3, write_content_size=False)
+    result = cctx.compress(b"".join(chunks))
+    assert len(result) == 999
+    assert result[0:4] == b"\x28\xb5\x2f\xfd"
+
+    # This matches the test for read_to_iter() below.
+    cctx = zstd.ZstdCompressor(level=1, write_content_size=False)
+    result = cctx.compress(b"f" * zstd.COMPRESSION_RECOMMENDED_INPUT_SIZE + b"o")
+    assert result == (
+        b"\x28\xb5\x2f\xfd\x00\x40\x54\x00\x00"
+        b"\x10\x66\x66\x01\x00\xfb\xff\x39\xc0"
+        b"\x02\x09\x00\x00\x6f",
+    )
+
+
+# ------- Some decompression tests --------------------------------------------
+
+
+@run_in_pyodide(packages=["zstandard"])
+def test_empty(selenium):
+    cctx = zstd.ZstdCompressor()
+    frame = cctx.compress(b"")
+
+    assert zstd.frame_content_size(frame) == 0
+
+
+@run_in_pyodide(packages=["zstandard"])
+def test_basic(selenium):
+    cctx = zstd.ZstdCompressor()
+    frame = cctx.compress(b"foobar")
+
+    assert zstd.frame_content_size(frame) == 6
+
+
+@run_in_pyodide(packages=["zstandard"])
+def test_dictionary(selenium):
+    samples = []
+    for _ in range(128):
+        samples.append(b"foo" * 64)
+        samples.append(b"bar" * 64)
+        samples.append(b"foobar" * 64)
+        samples.append(b"qwert" * 64)
+        samples.append(b"yuiop" * 64)
+        samples.append(b"asdfg" * 64)
+        samples.append(b"hijkl" * 64)
+
+    d = zstd.train_dictionary(8192, samples)
+
+    orig = b"foobar" * 16384
+    cctx = zstd.ZstdCompressor(level=1, dict_data=d)
+    compressed = cctx.compress(orig)
+
+    dctx = zstd.ZstdDecompressor(dict_data=d)
+    decompressed = dctx.decompress(compressed)
+
+    assert decompressed == orig

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -2,22 +2,24 @@ import pytest
 from pytest_pyodide import run_in_pyodide
 
 
-# Ensure C extension is used, and then CFFI as fallback, error if neither
+# Ensure that tests are executed with both the C extension and the CFFI backend
+@run_in_pyodide(packages=["zstandard"])
+def pytest_generate_tests(selenium, metafunc):
+    if "zstd_backend" in metafunc.fixturenames:
+        metafunc.parametrize("zstd_backend", ["cext", "cffi"])
+
+
+@run_in_pyodide(packages=["zstandard"])
 @pytest.fixture(autouse=True)
-def env(selenium):
-    selenium.run_python(
-        """
-        import os
-        os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = "default"
-        """
-    )
-    yield
+def set_zstd_backend(selenium, monkeypatch, zstd_backend):
+    monkeypatch.setenv("PYTHON_ZSTANDARD_IMPORT_POLICY", zstd_backend)
 
 
 # ------- Some compression tests ----------------------------------------------
 
 
 @run_in_pyodide(packages=["zstandard"])
+@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_zstandard_compression_and_decompression(selenium):
     import zstandard as zstd
 
@@ -31,6 +33,7 @@ def test_zstandard_compression_and_decompression(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
+@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_zstandard_compression_and_decompression_with_level(selenium):
     import zstandard as zstd
 
@@ -44,6 +47,7 @@ def test_zstandard_compression_and_decompression_with_level(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
+@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_compress_empty(selenium):
     import zstandard as zstd
 
@@ -65,6 +69,7 @@ def test_compress_empty(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
+@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_compress_large(selenium):
     import struct
 
@@ -79,7 +84,6 @@ def test_compress_large(selenium):
     assert len(result) == 999
     assert result[0:4] == b"\x28\xb5\x2f\xfd"
 
-    # This matches the test for read_to_iter() below.
     cctx = zstd.ZstdCompressor(level=1, write_content_size=False)
     result = cctx.compress(b"f" * zstd.COMPRESSION_RECOMMENDED_INPUT_SIZE + b"o")
     assert (
@@ -93,6 +97,7 @@ def test_compress_large(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
+@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_empty(selenium):
     import zstandard as zstd
 
@@ -103,6 +108,7 @@ def test_empty(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
+@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_basic(selenium):
     import zstandard as zstd
 
@@ -113,6 +119,7 @@ def test_basic(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
+@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_dictionary(selenium):
     import zstandard as zstd
 

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -4,16 +4,11 @@ from pytest_pyodide import run_in_pyodide
 
 # Ensure that tests are executed with both the C extension and the CFFI backend
 @run_in_pyodide(packages=["zstandard"])
-def set_zstd_backend(selenium, zstd_backend):
-    import os
+@pytest.fixture(params=["cffi", "cext"], autouse=True)
+def use_backend(selenium, request):
+    import zstandard as zstd
 
-    os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = zstd_backend
-
-
-@run_in_pyodide(packages=["zstandard"])
-@pytest.fixture(params=["cext", "cffi"], autouse=True)
-def zstd_backend(selenium, request):
-    set_zstd_backend(selenium, request.param)
+    zstd.backend = request.param
 
 
 # ------- Some compression tests ----------------------------------------------

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -1,22 +1,15 @@
 import pytest
 from pytest_pyodide import run_in_pyodide
 
-
-# Ensure that tests are executed with both the C extension and the CFFI backend
-@run_in_pyodide(packages=["zstandard"])
-@pytest.fixture(params=["cffi", "cext"], autouse=True)
-def use_backend(selenium, request):
-    import zstandard as zstd
-
-    zstd.backend = request.param
-
-
 # ------- Some compression tests ----------------------------------------------
 
 
 @run_in_pyodide(packages=["zstandard"])
-def test_zstandard_compression_and_decompression(selenium):
+@pytest.mark.parametrize("backend", ["cffi", "cext"])
+def test_zstandard_compression_and_decompression(selenium, backend):
     import zstandard as zstd
+
+    zstd.backend = backend
 
     data = b"foo"
     compress = zstd.ZstdCompressor(
@@ -28,8 +21,11 @@ def test_zstandard_compression_and_decompression(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-def test_zstandard_compression_and_decompression_with_level(selenium):
+@pytest.mark.parametrize("backend", ["cffi", "cext"])
+def test_zstandard_compression_and_decompression_with_level(selenium, backend):
     import zstandard as zstd
+
+    zstd.backend = backend
 
     data = b"foo"
     compress = zstd.ZstdCompressor(
@@ -41,8 +37,11 @@ def test_zstandard_compression_and_decompression_with_level(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-def test_compress_empty(selenium):
+@pytest.mark.parametrize("backend", ["cffi", "cext"])
+def test_compress_empty(selenium, backend):
     import zstandard as zstd
+
+    zstd.backend = backend
 
     cctx = zstd.ZstdCompressor(level=1, write_content_size=False)
 
@@ -62,10 +61,13 @@ def test_compress_empty(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-def test_compress_large(selenium):
+@pytest.mark.parametrize("backend", ["cffi", "cext"])
+def test_compress_large(selenium, backend):
     import struct
 
     import zstandard as zstd
+
+    zstd.backend = backend
 
     chunks = []
     for i in range(255):
@@ -89,8 +91,11 @@ def test_compress_large(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-def test_empty(selenium):
+@pytest.mark.parametrize("backend", ["cffi", "cext"])
+def test_empty(selenium, backend):
     import zstandard as zstd
+
+    zstd.backend = backend
 
     cctx = zstd.ZstdCompressor()
     frame = cctx.compress(b"")
@@ -99,8 +104,11 @@ def test_empty(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-def test_basic(selenium):
+@pytest.mark.parametrize("backend", ["cffi", "cext"])
+def test_basic(selenium, backend):
     import zstandard as zstd
+
+    zstd.backend = backend
 
     cctx = zstd.ZstdCompressor()
     frame = cctx.compress(b"foobar")
@@ -109,8 +117,11 @@ def test_basic(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-def test_dictionary(selenium):
+@pytest.mark.parametrize("backend", ["cffi", "cext"])
+def test_dictionary(selenium, backend):
     import zstandard as zstd
+
+    zstd.backend = backend
 
     samples = []
     for _ in range(128):

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -4,22 +4,22 @@ from pytest_pyodide import run_in_pyodide
 
 # Ensure that tests are executed with both the C extension and the CFFI backend
 @run_in_pyodide(packages=["zstandard"])
-def pytest_generate_tests(selenium, metafunc):
-    if "zstd_backend" in metafunc.fixturenames:
-        metafunc.parametrize("zstd_backend", ["cext", "cffi"])
+def set_zstd_backend(selenium, zstd_backend):
+    import os
+
+    os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = zstd_backend
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.fixture(autouse=True)
-def set_zstd_backend(selenium, monkeypatch, zstd_backend):
-    monkeypatch.setenv("PYTHON_ZSTANDARD_IMPORT_POLICY", zstd_backend)
+@pytest.mark.fixture(params=["cext", "cffi"], autouse=True)
+def zstd_backend(selenium, request):
+    set_zstd_backend(selenium, request.param)
 
 
 # ------- Some compression tests ----------------------------------------------
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_zstandard_compression_and_decompression(selenium):
     import zstandard as zstd
 
@@ -33,7 +33,6 @@ def test_zstandard_compression_and_decompression(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_zstandard_compression_and_decompression_with_level(selenium):
     import zstandard as zstd
 
@@ -47,7 +46,6 @@ def test_zstandard_compression_and_decompression_with_level(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_compress_empty(selenium):
     import zstandard as zstd
 
@@ -69,7 +67,6 @@ def test_compress_empty(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_compress_large(selenium):
     import struct
 
@@ -97,7 +94,6 @@ def test_compress_large(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_empty(selenium):
     import zstandard as zstd
 
@@ -108,7 +104,6 @@ def test_empty(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_basic(selenium):
     import zstandard as zstd
 
@@ -119,7 +114,6 @@ def test_basic(selenium):
 
 
 @run_in_pyodide(packages=["zstandard"])
-@pytest.mark.paramtrize("zstd_backend", ["cext", "cffi"])
 def test_dictionary(selenium):
     import zstandard as zstd
 

--- a/packages/zstandard/test_zstandard.py
+++ b/packages/zstandard/test_zstandard.py
@@ -3,7 +3,6 @@ import os
 # Ensure C extension is used, and then CFFI as fallback, error if neither
 os.environ["PYTHON_ZSTANDARD_IMPORT_POLICY"] = "default"
 
-import zstandard as zstd
 from pytest_pyodide import run_in_pyodide
 
 # ------- Some compression tests ----------------------------------------------
@@ -11,6 +10,8 @@ from pytest_pyodide import run_in_pyodide
 
 @run_in_pyodide(packages=["zstandard"])
 def test_zstandard_compression_and_decompression(selenium):
+    import zstandard as zstd
+
     data = b"foo"
     compress = zstd.ZstdCompressor(
         write_checksum=True, write_content_size=True
@@ -22,6 +23,8 @@ def test_zstandard_compression_and_decompression(selenium):
 
 @run_in_pyodide(packages=["zstandard"])
 def test_zstandard_compression_and_decompression_with_level(selenium):
+    import zstandard as zstd
+
     data = b"foo"
     compress = zstd.ZstdCompressor(
         level=1, write_checksum=True, write_content_size=True
@@ -33,6 +36,8 @@ def test_zstandard_compression_and_decompression_with_level(selenium):
 
 @run_in_pyodide(packages=["zstandard"])
 def test_compress_empty(selenium):
+    import zstandard as zstd
+
     cctx = zstd.ZstdCompressor(level=1, write_content_size=False)
 
     result = cctx.compress(b"")
@@ -53,6 +58,8 @@ def test_compress_empty(selenium):
 @run_in_pyodide(packages=["zstandard"])
 def test_compress_large(selenium):
     import struct
+
+    import zstandard as zstd
 
     chunks = []
     for i in range(255):
@@ -78,6 +85,8 @@ def test_compress_large(selenium):
 
 @run_in_pyodide(packages=["zstandard"])
 def test_empty(selenium):
+    import zstandard as zstd
+
     cctx = zstd.ZstdCompressor()
     frame = cctx.compress(b"")
 
@@ -86,6 +95,8 @@ def test_empty(selenium):
 
 @run_in_pyodide(packages=["zstandard"])
 def test_basic(selenium):
+    import zstandard as zstd
+
     cctx = zstd.ZstdCompressor()
     frame = cctx.compress(b"foobar")
 
@@ -94,6 +105,8 @@ def test_basic(selenium):
 
 @run_in_pyodide(packages=["zstandard"])
 def test_dictionary(selenium):
+    import zstandard as zstd
+
     samples = []
     for _ in range(128):
         samples.append(b"foo" * 64)


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This PR adds the [`zstandard`](https://pypi.org/project/zstandard/) Python package with the C and CFFI backends (the Rust backend is not compiled as of now, but can be a future improvement). `zstandard` is a required dependency in the upcoming version 3 release for Zarr. 

Closes #4788

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation

### Additional context

xref: https://github.com/zarr-developers/zarr-python/pull/1903
