### PR TITLE
Retry on HTTPException when downloading packages

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -5,6 +5,7 @@ Builds a Pyodide package.
 """
 
 import fnmatch
+import http.client
 import os
 import re
 import shutil
@@ -306,7 +307,7 @@ class RecipeBuilder:
             try:
                 response = requests.get(url)
                 response.raise_for_status()
-            except requests.HTTPError as e:
+            except (requests.HTTPError, http.client.HTTPException) as e:
                 if retry_cnt == max_retry - 1:
                     raise RuntimeError(
                         f"Failed to download {url} after {max_retry} trials"


### PR DESCRIPTION
### Description

This fix is mainly to handle the `IncompleteRead` error that occasionally happens when downloading packages. 
