### PR TITLE
Fix deprecated warnings in pyodide-build

### DIFF
--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -4,8 +4,8 @@
 Build all of the packages in a given directory.
 """
 
-import datetime
 import dataclasses
+import datetime
 import shutil
 import subprocess
 import sys

--- a/pyodide-build/pyodide_build/buildall.py
+++ b/pyodide-build/pyodide_build/buildall.py
@@ -4,6 +4,7 @@
 Build all of the packages in a given directory.
 """
 
+import datetime
 import dataclasses
 import shutil
 import subprocess
@@ -11,7 +12,6 @@ import sys
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
-from datetime import datetime
 from functools import total_ordering
 from graphlib import TopologicalSorter
 from pathlib import Path
@@ -188,7 +188,7 @@ class PackageStatus:
         self.finished = False
 
     def finish(self, success: bool, elapsed_time: float) -> None:
-        time = datetime.utcfromtimestamp(elapsed_time)
+        time = datetime.datetime.fromtimestamp(elapsed_time, tz=datetime.UTC)
         if time.minute == 0:
             minutes = ""
         else:

--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -344,7 +344,7 @@ class RecipeBuilder:
             shutil.copy(tarballpath, self.src_dist_dir)
             return
 
-        shutil.unpack_archive(tarballpath, self.build_dir)
+        shutil.unpack_archive(tarballpath, self.build_dir, filter="data")
 
         extract_dir_name = self.source_metadata.extract_dir
         if extract_dir_name is None:

--- a/pyodide-build/pyodide_build/out_of_tree/pypi.py
+++ b/pyodide-build/pyodide_build/out_of_tree/pypi.py
@@ -88,7 +88,7 @@ def _get_built_wheel_internal(url):
         data = requests.get(url).content
         f.write(data)
         f.close()
-        shutil.unpack_archive(f.name, build_path)
+        shutil.unpack_archive(f.name, build_path, filter="data")
         os.unlink(f.name)
         files = list(build_path.iterdir())
         if len(files) == 1 and files[0].is_dir():

--- a/pyodide-build/pyodide_build/xbuildenv.py
+++ b/pyodide-build/pyodide_build/xbuildenv.py
@@ -222,7 +222,7 @@ class CrossBuildEnvManager:
         with NamedTemporaryFile(suffix=".tar") as f:
             f_path = Path(f.name)
             f_path.write_bytes(r.content)
-            shutil.unpack_archive(str(f_path), path)
+            shutil.unpack_archive(str(f_path), path, filter="data")
 
     def _install_cross_build_packages(
         self, xbuildenv_root: Path, xbuildenv_pyodide_root: Path

--- a/pyodide-build/pyodide_build/xbuildenv_releases.py
+++ b/pyodide-build/pyodide_build/xbuildenv_releases.py
@@ -1,4 +1,3 @@
-import pydantic
 from packaging.version import Version
 from pydantic import BaseModel, ConfigDict
 
@@ -17,9 +16,7 @@ class CrossBuildEnvReleaseSpec(BaseModel):
     # Minimum and maximum pyodide-build versions that is compatible with this release
     min_pyodide_build_version: str | None = None
     max_pyodide_build_version: str | None = None
-    model_config = ConfigDict(
-        extra="forbid", title="CrossBuildEnvReleasesSpec"
-    )
+    model_config = ConfigDict(extra="forbid", title="CrossBuildEnvReleasesSpec")
 
     @property
     def python_version_tuple(self) -> tuple[int, int, int]:

--- a/pyodide-build/pyodide_build/xbuildenv_releases.py
+++ b/pyodide-build/pyodide_build/xbuildenv_releases.py
@@ -18,7 +18,7 @@ class CrossBuildEnvReleaseSpec(BaseModel):
     min_pyodide_build_version: str | None = None
     max_pyodide_build_version: str | None = None
     model_config = ConfigDict(
-        extra=pydantic.Extra.forbid, title="CrossBuildEnvReleasesSpec"
+        extra="forbid", title="CrossBuildEnvReleasesSpec"
     )
 
     @property
@@ -89,7 +89,7 @@ class CrossBuildEnvMetaSpec(BaseModel):
 
     releases: dict[str, CrossBuildEnvReleaseSpec]
     model_config = ConfigDict(
-        extra=pydantic.Extra.forbid,
+        extra="forbid",
         title="CrossBuildEnvMetaSpec",
     )
 


### PR DESCRIPTION
This fixes several warnings that are shown when running pyodide-build tests:

```
pyodide-build/pyodide_build/xbuildenv_releases.py:21
  /home/runner/work/pyodide/pyodide/pyodide-build/pyodide_build/xbuildenv_releases.py:21: PydanticDeprecatedSince20: `pydantic.config.Extra` is deprecated, use literal values instead (e.g. `extra='allow'`). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/
    extra=pydantic.Extra.forbid, title="CrossBuildEnvReleasesSpec"

pyodide-build/pyodide_build/tests/test_xbuildenv.py: 5 warnings
  /opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/tarfile.py:2220: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    warnings.warn(

  /home/runner/work/pyodide/pyodide/pyodide-build/pyodide_build/buildall.py:191: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    time = datetime.utcfromtimestamp(elapsed_time)
```