### PR TITLE
ENH Add option to make `run_until_complete` stack switch

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,7 +37,7 @@ pytest_pyodide.runner.NODE_FLAGS.extend(["--experimental-wasm-stack-switching"])
 # We need to go through and touch them all once to keep everything okay.
 pytest_pyodide.runner.INITIALIZE_SCRIPT = """
     pyodide.globals.get;
-    pyodide.runPython("import pyodide_js._api; del pyodide_js");
+    pyodide.runPython("import pyodide_js._api.config; del pyodide_js");
     pyodide._api.importlib.invalidate_caches;
     pyodide._api.package_loader.unpack_buffer;
     pyodide._api.package_loader.get_dynlibs;
@@ -308,7 +308,12 @@ def patched_load_pyodide(self):
         const {readFileSync} = require("fs");
         let snap = readFileSync("snapshot.bin");
         snap = new Uint8Array(snap.buffer);
-        let pyodide = await loadPyodide({ fullStdLib: false, jsglobals : self, _loadSnapshot: snap });
+        let pyodide = await loadPyodide({
+            fullStdLib: false,
+            jsglobals: self,
+            _loadSnapshot: snap,
+            enableRunUntilComplete: true,
+        });
         self.pyodide = pyodide;
         globalThis.pyodide = pyodide;
         pyodide._api.inTestHoist = true; // improve some error messages for tests

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,6 +14,13 @@ myst:
 
 # Change Log
 
+## Unreleased
+
+- {{ Enhancement }} Added the `enableRunUntilComplete` option to `loadPyodide`
+  which makes `run_until_complete` block using stack switching, or crash if
+  stack switching is disabled.
+  {pr}`4817`
+
 ## Version 0.26.0
 
 _May 27, 2024_

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -44,6 +44,7 @@ export type ConfigType = {
   env: { [key: string]: string };
   packages: string[];
   _makeSnapshot: boolean;
+  enableRunUntilComplete: boolean;
 };
 
 /**
@@ -164,6 +165,10 @@ export async function loadPyodide(
      */
     pyproxyToStringRepr?: boolean;
     /**
+     * Make loop.run_until_complete() function correctly using stack switching
+     */
+    enableRunUntilComplete?: boolean;
+    /**
      * @ignore
      */
     _node_mounts?: string[];
@@ -198,6 +203,7 @@ export async function loadPyodide(
     env: {},
     packageCacheDir: indexURL,
     packages: [],
+    enableRunUntilComplete: false,
   };
   const config = Object.assign(default_config, options) as ConfigType;
   if (!config.env.HOME) {

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -8,7 +8,7 @@ from asyncio import Future, Task
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar, overload
 
-from .ffi import IN_BROWSER, create_once_callable
+from .ffi import IN_BROWSER, create_once_callable, run_sync
 
 if IN_BROWSER:
     from pyodide_js._api import scheduleCallback
@@ -259,6 +259,10 @@ class WebLoop(asyncio.AbstractEventLoop):
             do_something_with_result(result)
         ```
         """
+        from pyodide_js._api import config
+
+        if config.enableRunUntilComplete:
+            return run_sync(future)
         return asyncio.ensure_future(future)
 
     #

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest_pyodide import run_in_pyodide
 
-from conftest import only_node, requires_jspi
+from conftest import requires_jspi
 
 
 @requires_jspi
@@ -648,7 +648,7 @@ def test_memory_leak(selenium, script):
     assert length_change == 0
 
 
-@only_node
+@requires_jspi
 @run_in_pyodide
 def test_run_until_complete(selenium):
     from asyncio import create_task, gather, get_event_loop, sleep


### PR DESCRIPTION
After we have this, we can make async tests work correctly. 

cc @agriyakhetarpal After we merge this you can add pytest-asyncio and then we can release 0.27.0a1 and this should unblock https://github.com/zarr-developers/zarr-python/pull/1903.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
