### PR TITLE
NFC Scipy: Add a non-temporary build directory

### DIFF
--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -43,6 +43,7 @@ build:
     -L$(NUMPY_LIB)/core/lib/
     -L$(NUMPY_LIB)/random/lib/
     -fexceptions
+  backend-flags: build-dir=build
   # IMPORTANT: Other locations important in scipy build process:
   # There are two files built in the "capture" pass that need patching:
   #    _blas_subroutines.h, and _cython


### PR DESCRIPTION
Cherry picked from #4719.