### PR TITLE
Retry on network error when downloading packages (take 2)

### DIFF
--- a/pyodide-build/pyodide_build/buildpkg.py
+++ b/pyodide-build/pyodide_build/buildpkg.py
@@ -307,7 +307,10 @@ class RecipeBuilder:
             try:
                 response = requests.get(url)
                 response.raise_for_status()
-            except (requests.exceptions.RequestException, http.client.HTTPException) as e:
+            except (
+                requests.exceptions.RequestException,
+                http.client.HTTPException,
+            ) as e:
                 if retry_cnt == max_retry - 1:
                     raise RuntimeError(
                         f"Failed to download {url} after {max_retry} trials"


### PR DESCRIPTION
### Description

#4794 doesn't seem to be working correctly.

While the inner exception is `urllib3.exceptions.IncompleteRead` which is a subclass of `http.client.HTTPException`, requests wraps it with `requests.exceptions.ChunkedEncodingError`, so catching `http.client.HTTPException` was not handling the error correctly.

```python
>>> import requests, urllib3, http.client
>>> issubclass(requests.exceptions.ChunkedEncodingError, requests.exceptions.RequestException)
True
>>> issubclass(requests.exceptions.ChunkedEncodingError, http.client.HTTPException)
False
>>> issubclass(urllib3.exceptions.IncompleteRead, http.client.HTTPException)
True
>>> issubclass(requests.HTTPError, requests.exceptions.RequestException)
True
```
