### PR TITLE
Backfill missing releases to pyodide-cross-build-environments.json

### DIFF
--- a/pyodide-cross-build-environments.json
+++ b/pyodide-cross-build-environments.json
@@ -1,5 +1,31 @@
 {
   "releases": {
+    "0.26.0": {
+      "version": "0.26.0",
+      "url": "https://github.com/pyodide/pyodide/releases/download/0.26.0/xbuildenv-0.26.0.tar.bz2",
+      "sha256": "0b3f52155fdf54e1802aaed0496aab05e012c3a8347ed2f913620d6c251059a0",
+      "python_version": "3.12.1",
+      "emscripten_version": "3.1.58",
+      "min_pyodide_build_version": "0.26.0"
+    },
+    "0.26.0a6": {
+      "version": "0.26.0a6",
+      "url": "https://github.com/pyodide/pyodide/releases/download/0.26.0a6/xbuildenv-0.26.0a6.tar.bz2",
+      "sha256": "f214f5d1373e9a018afe8516178a16d37f7ac617326d29636f482bcda925f575",
+      "python_version": "3.12.1",
+      "emscripten_version": "3.1.58",
+      "min_pyodide_build_version": "0.26.0a6",
+      "max_pyodide_build_version": "0.26.0a6"
+    },
+    "0.26.0a5": {
+      "version": "0.26.0a5",
+      "url": "https://github.com/pyodide/pyodide/releases/download/0.26.0a5/xbuildenv-0.26.0a5.tar.bz2",
+      "sha256": "3c6dd142f1b7ac6801a7562e1697befde087aa768c393de3f4d06450aafae32f",
+      "python_version": "3.12.1",
+      "emscripten_version": "3.1.58",
+      "min_pyodide_build_version": "0.26.0a5",
+      "max_pyodide_build_version": "0.26.0a5"
+    },
     "0.26.0a4": {
       "version": "0.26.0a4",
       "url": "https://github.com/pyodide/pyodide/releases/download/0.26.0a4/xbuildenv-0.26.0a4.tar.bz2",
@@ -36,17 +62,9 @@
       "min_pyodide_build_version": "0.26.0a1",
       "max_pyodide_build_version": "0.26.0a1"
     },
-    "0.26.0": {
-      "version": "0.26.0",
-      "url": "https://github.com/pyodide/pyodide/releases/download/0.26.0/xbuildenv-0.26.0.tar.bz2",
-      "sha256": "0b3f52155fdf54e1802aaed0496aab05e012c3a8347ed2f913620d6c251059a0",
-      "python_version": "3.21.1",
-      "emscripten_version": "3.1.58",
-      "min_pyodide_build_version": "0.26.0"
-    },
     "0.25.1": {
       "version": "0.25.1",
-      "url": "https://github.com/pyodide/pyodide/releases/download/0.25.0/xbuildenv-0.25.0.tar.bz2",
+      "url": "https://github.com/pyodide/pyodide/releases/download/0.25.0/xbuildenv-0.25.1.tar.bz2",
       "sha256": "7cf639a2063174f00b47064971b0864d05d4bafce89dc12e5df9a497ff871c2d",
       "python_version": "3.11.3",
       "emscripten_version": "3.1.46",

--- a/tools/tests/test_update_cross_build_releases.py
+++ b/tools/tests/test_update_cross_build_releases.py
@@ -73,3 +73,22 @@ def test_add_version():
     assert list(new_metadata.releases.keys())[0] == "0.17.0"
     assert list(new_metadata.releases.keys())[1] == "0.16.1"
     assert list(new_metadata.releases.keys())[2] == "0.16.0"
+
+    new_metadata_raw = add_version(
+        metadata.json(),
+        "0.17.0a1",
+        "https://example.com/xbuildenv-0.17.0a1.tar.bz2",
+        "abcdef1234567890",
+    )
+
+    new_metadata = CrossBuildEnvMetaSpec.parse_raw(new_metadata_raw)
+    assert new_metadata.releases["0.17.0a1"].version == "0.17.0a1"
+    assert (
+        new_metadata.releases["0.17.0a1"].url
+        == "https://example.com/xbuildenv-0.17.0a1.tar.bz2"
+    )
+    assert new_metadata.releases["0.17.0a1"].sha256 == "abcdef1234567890"
+
+    assert list(new_metadata.releases.keys())[0] == "0.17.0"
+    assert list(new_metadata.releases.keys())[1] == "0.17.0a1"
+    assert list(new_metadata.releases.keys())[2] == "0.16.0"

--- a/tools/update_cross_build_releases.py
+++ b/tools/update_cross_build_releases.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import requests
+from packaging.version import Version
 
 from pyodide_build.xbuildenv_releases import (
     CrossBuildEnvMetaSpec,
@@ -44,8 +45,9 @@ def add_version(raw_metadata: str, version: str, url: str, digest: str) -> str:
     metadata.releases[version] = new_release
 
     # Sort releases in reverse order
-    metadata.releases = dict(sorted(metadata.releases.items(), reverse=True))
-
+    metadata.releases = dict(
+        sorted(metadata.releases.items(), reverse=True, key=lambda x: Version(x[0]))
+    )
     dictionary = metadata.dict()
     return json.dumps(dictionary, indent=2)
 
@@ -62,7 +64,7 @@ def main():
     metadata = METADATA_FILE.read_text()
     new_metadata = add_version(metadata, version, full_url, digest)
 
-    METADATA_FILE.write_text(new_metadata)
+    METADATA_FILE.write_text(new_metadata + "\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Backfill missing releases to `pyodide-cross-build-environments.json`, which was not added becuase of the CI failure.

Also, update the script so that the JSON is properly sorted by version.