### PR TITLE
Read build settings from configuration file

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -24,6 +24,9 @@ myst:
 - {{ Fix }} Resolved an issue where string keys in `PyProxyJsonAdaptor` were unexpectedly cast to numbers.
   {pr}`4825`
 
+- {{ Enhancement }} Added implementation to read build settings from `pyproject.toml`.
+  {pr}`4831`
+
 ### Packages
 
 - Upgraded `scikit-learn` to 1.5 {pr}`4823`

--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 from contextlib import nullcontext, redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 
 from packaging.tags import Tag, compatible_tags, cpython_tags
 
@@ -94,7 +94,7 @@ def get_pyodide_root() -> Path:
 
 def search_pyproject_toml(
     curdir: str | Path, max_depth: int = 10
-) -> Tuple[Path, dict[str | Any]] | Tuple[None, None]:
+) -> tuple[Path, dict[str | Any]] | tuple[None, None]:
     """
     Recursively search for the pyproject.toml file in the parent directories.
     """

--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -94,7 +94,7 @@ def get_pyodide_root() -> Path:
 
 def search_pyproject_toml(
     curdir: str | Path, max_depth: int = 10
-) -> tuple[Path, dict[str | Any]] | tuple[None, None]:
+) -> tuple[Path, dict[str, Any]] | tuple[None, None]:
     """
     Recursively search for the pyproject.toml file in the parent directories.
     """
@@ -126,7 +126,7 @@ def search_pyodide_root(curdir: str | Path, *, max_depth: int = 10) -> Path | No
     """
     pyproject_path, pyproject_file = search_pyproject_toml(curdir, max_depth)
 
-    if pyproject_path is None:
+    if pyproject_path is None or pyproject_file is None:
         return None
 
     if "tool" in pyproject_file and "_pyodide" in pyproject_file["tool"]:

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -173,7 +173,7 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
 
 BUILD_VAR_TO_KEY = {v: k for k, v in BUILD_KEY_TO_VAR.items()}
 
-# Configuration keys that can be overriden by the user.
+# Configuration keys that can be overridden by the user.
 # TODO: distinguish between variables that are overridable by the user and those that are not.
 OVERRIDABLE_BUILD_KEYS = {
     "side_module_cflags",

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -94,23 +94,12 @@ class ConfigManager:
         self, curdir: Path, env: Mapping[str, str]
     ) -> Mapping[str, str]:
         # avoid circular import
-        from pyodide_build.build_env import search_pyodide_root
+        from pyodide_build.build_env import search_pyproject_toml
 
-        pyproject_dir = search_pyodide_root(curdir)
+        pyproject_path, configs = search_pyproject_toml(curdir)
 
-        if pyproject_dir is None:
+        if pyproject_path is None:
             return {}
-
-        pyproject_file = pyproject_dir / "pyproject.toml"
-
-        if not pyproject_file.is_file():
-            return {}
-
-        try:
-            with pyproject_file.open("rb") as f:
-                configs = tomllib.load(f)
-        except tomllib.TOMLDecodeError as e:
-            raise ValueError(f"Could not parse {pyproject_file}.") from e
 
         if (
             "tool" in configs

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import tomllib
 from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -28,7 +28,7 @@ class ConfigManager:
         self._config = {
             **self._load_default_config(),
             **self._load_makefile_envs(),
-            **self._load_config_file(pyodide_root / "pyproject.toml", os.environ),
+            **self._load_config_file(Path.cwd(), os.environ),
             **self._load_config_from_env(os.environ),
         }
 
@@ -91,8 +91,18 @@ class ConfigManager:
         }
 
     def _load_config_file(
-        self, pyproject_file: Path, env: Mapping[str, str]
+        self, curdir: Path, env: Mapping[str, str]
     ) -> Mapping[str, str]:
+        # avoid circular import
+        from pyodide_build.build_env import search_pyodide_root
+
+        pyproject_dir = search_pyodide_root(curdir)
+
+        if pyproject_dir is None:
+            return {}
+
+        pyproject_file = pyproject_dir / "pyproject.toml"
+
         if not pyproject_file.is_file():
             return {}
 

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -191,8 +191,9 @@ BUILD_VAR_TO_KEY = {v: k for k, v in BUILD_KEY_TO_VAR.items()}
 # Configuration keys that can be overridden by the user.
 # TODO: distinguish between variables that are overridable by the user and those that are not.
 OVERRIDABLE_BUILD_KEYS = {
-    "side_module_cflags",
-    "side_module_ldflags",
+    "cflags",
+    "cxxflags",
+    "ldflags",
     "rust_toolchain",
     "meson_cross_file",
 }

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -1,8 +1,8 @@
 import os
 import subprocess
+import tomllib
 from collections.abc import Mapping
 from pathlib import Path
-import tomllib
 from types import MappingProxyType
 
 from .common import _environment_substitute_str, exit_with_stdio
@@ -90,7 +90,9 @@ class ConfigManager:
             BUILD_VAR_TO_KEY[key]: env[key] for key in env if key in BUILD_VAR_TO_KEY
         }
 
-    def _load_config_file(self, pyproject_file: Path, env: Mapping[str,str]) -> Mapping[str, str]:
+    def _load_config_file(
+        self, pyproject_file: Path, env: Mapping[str, str]
+    ) -> Mapping[str, str]:
         if not pyproject_file.is_file():
             return {}
 
@@ -100,10 +102,15 @@ class ConfigManager:
         except tomllib.TOMLDecodeError as e:
             raise ValueError(f"Could not parse {pyproject_file}.") from e
 
-        if "tool" in configs and "pyodide" in configs["tool"] and "build" in configs["tool"]["pyodide"]:
+        if (
+            "tool" in configs
+            and "pyodide" in configs["tool"]
+            and "build" in configs["tool"]["pyodide"]
+        ):
             return {
                 key: _environment_substitute_str(v, env)
-                for key, v in configs["tool"]["pyodide"]["build"].items() if key in OVERRIDABLE_BUILD_KEYS
+                for key, v in configs["tool"]["pyodide"]["build"].items()
+                if key in OVERRIDABLE_BUILD_KEYS
             }
         else:
             return {}

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -97,7 +97,7 @@ class ConfigManager:
 
         pyproject_path, configs = search_pyproject_toml(curdir)
 
-        if pyproject_path is None:
+        if pyproject_path is None or configs is None:
             return {}
 
         if (

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -117,11 +117,16 @@ class ConfigManager:
             and "pyodide" in configs["tool"]
             and "build" in configs["tool"]["pyodide"]
         ):
-            return {
-                key: _environment_substitute_str(v, env)
-                for key, v in configs["tool"]["pyodide"]["build"].items()
-                if key in OVERRIDABLE_BUILD_KEYS
-            }
+            build_config = {}
+            for key, v in configs["tool"]["pyodide"]["build"].items():
+                if key not in OVERRIDABLE_BUILD_KEYS:
+                    logger.warning(
+                        f"WARNING: The provided build key {key} is either invalid or not overridable, hence ignored."
+                    )
+                    continue
+                build_config[key] = _environment_substitute_str(v, env)
+
+            return build_config
         else:
             return {}
 

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 
-from .common import _environment_substitute_str, exit_with_stdio
+from .common import _environment_substitute_str, exit_with_stdio, search_pyproject_toml
 from .logger import logger
 
 
@@ -92,9 +92,6 @@ class ConfigManager:
     def _load_config_file(
         self, curdir: Path, env: Mapping[str, str]
     ) -> Mapping[str, str]:
-        # avoid circular import
-        from pyodide_build.build_env import search_pyproject_toml
-
         pyproject_path, configs = search_pyproject_toml(curdir)
 
         if pyproject_path is None or configs is None:
@@ -156,9 +153,9 @@ BUILD_KEY_TO_VAR: dict[str, str] = {
     "cpythoninstall": "CPYTHONINSTALL",
     "rustflags": "RUSTFLAGS",
     "rust_toolchain": "RUST_TOOLCHAIN",
-    "side_module_cflags": "SIDE_MODULE_CFLAGS",
-    "side_module_cxxflags": "SIDE_MODULE_CXXFLAGS",
-    "side_module_ldflags": "SIDE_MODULE_LDFLAGS",
+    "cflags": "SIDE_MODULE_CFLAGS",
+    "cxxflags": "SIDE_MODULE_CXXFLAGS",
+    "ldflags": "SIDE_MODULE_LDFLAGS",
     "stdlib_module_cflags": "STDLIB_MODULE_CFLAGS",
     "sysconfigdata_dir": "SYSCONFIGDATA_DIR",
     "sysconfig_name": "SYSCONFIG_NAME",
@@ -206,9 +203,9 @@ DEFAULT_CONFIG: dict[str, str] = {
 # TODO: Remove dependency on Makefile.envs
 DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     # Compiler flags
-    "side_module_cflags": "$(CFLAGS_BASE) -I$(PYTHONINCLUDE)",
-    "side_module_cxxflags": "$(CXXFLAGS_BASE)",
-    "side_module_ldflags": "$(LDFLAGS_BASE) -s SIDE_MODULE=1",
+    "cflags": "$(CFLAGS_BASE) -I$(PYTHONINCLUDE)",
+    "cxxflags": "$(CXXFLAGS_BASE)",
+    "ldflags": "$(LDFLAGS_BASE) -s SIDE_MODULE=1",
     # Rust-specific configuration
     "pyo3_cross_lib_dir": "$(CPYTHONINSTALL)/lib",
     "pyo3_cross_include_dir": "$(PYTHONINCLUDE)",

--- a/pyodide-build/pyodide_build/tests/test_config.py
+++ b/pyodide-build/pyodide_build/tests/test_config.py
@@ -72,8 +72,8 @@ class TestConfigManager_InTree:
 
         pyproject_file.write_text("""[tool.pyodide.build]
                                   invalid_flags = "this_should_not_be_parsed"
-                                  side_module_cflags = "$(CFLAGS_BASE) -I/path/to/include"
-                                  side_module_ldflags = "-L/path/to/lib"
+                                  cflags = "$(CFLAGS_BASE) -I/path/to/include"
+                                  ldflags = "-L/path/to/lib"
                                   rust_toolchain = "nightly"
                                   meson_cross_file = "$(MESON_CROSS_FILE)"
                                   """)
@@ -83,8 +83,8 @@ class TestConfigManager_InTree:
         config = config_manager._load_config_file(pyproject_file, env)
 
         assert "invalid_flags" not in config
-        assert config["side_module_cflags"] == "-O2 -I/path/to/include"
-        assert config["side_module_ldflags"] == "-L/path/to/lib"
+        assert config["cflags"] == "-O2 -I/path/to/include"
+        assert config["ldflags"] == "-L/path/to/lib"
         assert config["rust_toolchain"] == "nightly"
         assert config["meson_cross_file"] == "/path/to/crossfile"
 

--- a/pyodide-build/pyodide_build/tests/test_config.py
+++ b/pyodide-build/pyodide_build/tests/test_config.py
@@ -62,9 +62,31 @@ class TestConfigManager_InTree:
         assert config["cmake_toolchain_file"] == "/path/to/toolchain"
         assert config["meson_cross_file"] == "/path/to/crossfile"
 
-    def test_load_config_from_file(self):
-        # TODO: Implement this
-        assert True
+    def test_load_config_from_file(self, tmp_path, reset_env_vars, reset_cache):
+        pyproject_file = tmp_path / "pyproject.toml"
+
+        env = {
+            "MESON_CROSS_FILE": "/path/to/crossfile",
+            "CFLAGS_BASE": "-O2",
+        }
+
+        pyproject_file.write_text("""[tool.pyodide.build]
+                                  invalid_flags = "this_should_not_be_parsed"
+                                  side_module_cflags = "$(CFLAGS_BASE) -I/path/to/include"
+                                  side_module_ldflags = "-L/path/to/lib"
+                                  rust_toolchain = "nightly"
+                                  meson_cross_file = "$(MESON_CROSS_FILE)"
+                                  """)
+
+        config_manager = ConfigManager(pyodide_root=ROOT_PATH)
+
+        config = config_manager._load_config_file(pyproject_file, env)
+
+        assert "invalid_flags" not in config
+        assert config["side_module_cflags"] == "-O2 -I/path/to/include"
+        assert config["side_module_ldflags"] == "-L/path/to/lib"
+        assert config["rust_toolchain"] == "nightly"
+        assert config["meson_cross_file"] == "/path/to/crossfile"
 
     def test_config_all(self):
         config_manager = ConfigManager(pyodide_root=ROOT_PATH)


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Added implementation to read user-defined build settings from `$(PYODIDE_ROOT)/pyproject.toml`. As there is no clear distinction yet regarding which configuration keys should be overridable by the user, I have added a list of sample keys as suggested in #4799 .

It will read the configuration under the following entry:
```toml
[tool.pyodide.build]
rust_toolchain = "nightly"
# ...
```

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation
