### PR TITLE
Add generic typing for `create_proxy`, `create_once_callable` and `JsDoubleProxy`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         exclude: ^(benchmark/benchmarks/pystone_benchmarks/pystone\.py|src/js/package-lock\.json)$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.9.0"
+    rev: "v1.10.0"
     hooks:
       - id: mypy
         files: ^(packages/.*/src|src|pyodide-build/pyodide_build)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pre-commit
 build~=1.2.0
 sphinx-click
 hypothesis
+mypy>=1.10,<2
 # (FIXME: 2024/01/28) The latest pytest-asyncio 0.23.3 is not compatible with pytest 8.0.0
 pytest<8.0.0
 pytest-asyncio

--- a/src/py/pyodide/_state.py
+++ b/src/py/pyodide/_state.py
@@ -40,7 +40,7 @@ def restore_state(state: dict[str, Any]) -> int:
             del sys.modules[key]
     sys.modules.update(loaded_js_modules)
 
-    sys.last_exc = None  # type:ignore[attr-defined]
+    sys.last_exc = None  # type:ignore[assignment]
     sys.last_type = None
     sys.last_value = None
     sys.last_traceback = None

--- a/src/py/pyodide/console.py
+++ b/src/py/pyodide/console.py
@@ -398,7 +398,7 @@ class Console:
         This doesn't include a stack trace because there isn't one. The actual
         error object is stored into :py:data:`sys.last_value`.
         """
-        sys.last_exc = e  # type:ignore[attr-defined]
+        sys.last_exc = e
         sys.last_type = type(e)
         sys.last_value = e
         sys.last_traceback = None
@@ -420,7 +420,7 @@ class Console:
 
         The actual error object is stored into :py:data:`sys.last_value`.
         """
-        sys.last_exc = e  # type:ignore[attr-defined]
+        sys.last_exc = e
         sys.last_type = type(e)
         sys.last_value = e
         sys.last_traceback = e.__traceback__

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1780,7 +1780,7 @@ def test_jsarray_remove(selenium):
         a.remove(78)
     assert a.to_py() == l
     l.append([])  # type:ignore[arg-type]
-    p = create_proxy([], roundtrip=False)
+    p = create_proxy([], roundtrip=False)  # type:ignore[var-annotated]
     a.append(p)
     assert a.to_py() == l
     l.remove([])  # type:ignore[arg-type]

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -836,7 +836,7 @@ def test_create_proxy(selenium):
     assert sys.getrefcount(f) == 2
     proxy = create_proxy(f)
     assert sys.getrefcount(f) == 3
-    assert proxy() == 7  # type:ignore[operator]
+    assert proxy() == 7
     testAddListener(proxy)
     assert sys.getrefcount(f) == 3
     assert testCallListener() == 7
@@ -890,7 +890,7 @@ def test_return_destroyed_value(selenium):
     from pyodide.ffi import JsException, create_proxy
 
     f = run_js("(function(x){ return x; })")
-    p = create_proxy([])
+    p = create_proxy([])  # type: ignore[var-annotated]
     p.destroy()
     with pytest.raises(JsException, match="Object has already been destroyed"):
         f(p)

--- a/src/tests/test_static_typing.py
+++ b/src/tests/test_static_typing.py
@@ -1,0 +1,74 @@
+from inspect import getsource
+from textwrap import dedent
+from typing import TypeVar, assert_type
+
+from mypy.api import run
+from pytest import raises
+
+
+def _mypy_check(source: str) -> tuple[str, str, int]:
+    stdout, stderr, exit_status = run(["-c", source, "--check-untyped-defs"])
+    return stdout, stderr, exit_status
+
+
+def assert_no_error(source: str) -> None:
+    stdout, _, exit_status = _mypy_check(f"from typing import *\n\n{dedent(source)}")
+    assert exit_status == 0, stdout
+
+
+def test_self():
+    with raises(AssertionError):
+        assert_no_error("a: str = 123")
+
+
+def test_create_proxy():
+    def _():
+        from pyodide.ffi import create_proxy
+
+        a: int = 2
+        assert_type(create_proxy(a).unwrap(), int)
+
+    assert_no_error(getsource(_))
+
+
+def test_generic():
+    def _():
+        from pyodide.ffi import JsDoubleProxy, JsPromise
+
+        def _(a: JsPromise[int]) -> None:
+            assert_type(a.then(str), JsPromise[str])
+
+        def _(b: JsDoubleProxy[str]) -> None:
+            assert_type(b.unwrap(), str)
+
+    assert_no_error(getsource(_))
+
+
+def test_callable_generic():
+    def _():
+        from pyodide.ffi import create_once_callable, create_proxy
+
+        T = TypeVar("T", int, float, str)
+
+        def f(x: T) -> T:
+            return x * 2
+
+        assert_type(create_once_callable(f)(2), int)
+        assert_type(create_proxy(f)(""), str)
+
+    assert_no_error(getsource(_))
+
+
+def test_decorator_usage():
+    def _():
+        from pyodide.ffi import create_once_callable
+
+        T = TypeVar("T")
+
+        @create_once_callable
+        def f(x: T) -> list[T]:
+            return [x]
+
+        assert_type(f((int(input()), str(input()))), list[tuple[int, str]])
+
+    assert_no_error(getsource(_))

--- a/src/tests/test_static_typing.py
+++ b/src/tests/test_static_typing.py
@@ -1,4 +1,5 @@
 from inspect import getsource
+from pathlib import Path
 from textwrap import dedent
 from typing import TypeVar, assert_type
 
@@ -7,7 +8,8 @@ from pytest import raises
 
 
 def _mypy_check(source: str) -> tuple[str, str, int]:
-    stdout, stderr, exit_status = run(["-c", source, "--check-untyped-defs"])
+    path = str(Path(__file__).parent.parent.parent / "pyproject.toml")
+    stdout, stderr, exit_status = run(["-c", source, "--config-file", path])
     return stdout, stderr, exit_status
 
 


### PR DESCRIPTION
### Description

Fix #4832 

Source:

```py
from typing import TypeVar, reveal_type

from pyodide.ffi import create_once_callable, create_proxy

T = TypeVar("T", int, float, str, list)


@create_once_callable
def f(x: T) -> T:
    return x * 2


reveal_type(f)
reveal_type(f(0.2))
reveal_type(f(""))
reveal_type(f([]))


@create_proxy
def g(x: T) -> T:
    return x * 2


reveal_type(g)
reveal_type(g(0.2))
reveal_type(g(""))
reveal_type(g([]))

reveal_type(g.unwrap())
```

<details><summary>Before this PR:</summary>
<p>

```sh
> mypy test.py
test.py:13: note: Revealed type is "_pyodide._core_docs.JsOnceCallable"
test.py:14: error: Too many arguments for "__call__"  [call-arg]
test.py:14: note: Revealed type is "Any"
test.py:15: error: Too many arguments for "__call__"  [call-arg]
test.py:15: note: Revealed type is "Any"
test.py:16: error: Too many arguments for "__call__"  [call-arg]
test.py:16: note: Revealed type is "Any"
test.py:24: note: Revealed type is "_pyodide._core_docs.JsDoubleProxy"
test.py:25: error: "JsDoubleProxy" not callable  [operator]
test.py:25: note: Revealed type is "Any"
test.py:26: error: "JsDoubleProxy" not callable  [operator]
test.py:26: note: Revealed type is "Any"
test.py:27: error: "JsDoubleProxy" not callable  [operator]
test.py:27: note: Revealed type is "Any"
test.py:29: note: Revealed type is "Any"
Found 6 errors in 1 file (checked 1 source file)
```

```sh
> pyright test.py
test.py:13:13 - information: Type of "f" is "JsOnceCallable"
test.py:14:13 - information: Type of "f(0.2)" is "Unknown"
test.py:14:15 - error: Expected 0 positional arguments (reportCallIssue)
test.py:15:13 - information: Type of "f("")" is "Unknown"
test.py:15:15 - error: Expected 0 positional arguments (reportCallIssue)
test.py:16:13 - information: Type of "f([])" is "Unknown"
test.py:16:15 - error: Expected 0 positional arguments (reportCallIssue)
test.py:24:13 - information: Type of "g" is "JsDoubleProxy"
test.py:25:13 - error: Object of type "JsDoubleProxy" is not callable
    Attribute "__call__" is unknown (reportCallIssue)
test.py:25:13 - information: Type of "g(0.2)" is "Unknown"
test.py:26:13 - error: Object of type "JsDoubleProxy" is not callable
    Attribute "__call__" is unknown (reportCallIssue)
test.py:26:13 - information: Type of "g("")" is "Unknown"
test.py:27:13 - error: Object of type "JsDoubleProxy" is not callable
    Attribute "__call__" is unknown (reportCallIssue)
test.py:27:13 - information: Type of "g([])" is "Unknown"
test.py:29:13 - information: Type of "g.unwrap()" is "Any"
6 errors, 0 warnings, 9 informations
```

</p>
</details>

<details open><summary>After this PR:</summary>
<p>

```sh
> mypy test.py
test.py:13: note: Revealed type is "_pyodide._core_docs.JsOnceCallable[[x: T`55], T`55]"
test.py:14: note: Revealed type is "builtins.float"
test.py:15: note: Revealed type is "builtins.str"
test.py:16: note: Revealed type is "builtins.list[Any]"
test.py:24: note: Revealed type is "_pyodide._core_docs.JsCallableDoubleProxy[[x: T`62], T`62]"
test.py:25: note: Revealed type is "builtins.float"
test.py:26: note: Revealed type is "builtins.str"
test.py:27: note: Revealed type is "builtins.list[Any]"
test.py:29: note: Revealed type is "def [T in (builtins.int, builtins.float, builtins.str, builtins.list[Any])] (x: T`69) -> T`69"
```

```sh
> pyright test.py
test.py:13:13 - information: Type of "f" is "JsOnceCallable[(x: T@f), T@f]"
test.py:14:13 - information: Type of "f(0.2)" is "float"
test.py:15:13 - information: Type of "f("")" is "str"
test.py:16:13 - information: Type of "f([])" is "list[Unknown]"
test.py:24:13 - information: Type of "g" is "JsCallableDoubleProxy[(x: T@g), T@g]"
test.py:25:13 - information: Type of "g(0.2)" is "float"
test.py:26:13 - information: Type of "g("")" is "str"
test.py:27:13 - information: Type of "g([])" is "list[Unknown]"
test.py:29:13 - information: Type of "g.unwrap()" is "(x: T@g) -> T@g"
0 errors, 0 warnings, 9 informations
```

</p>
</details>

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
