### PR TITLE
Update subtable name for checking in-tree build

### DIFF
--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -113,7 +113,7 @@ def search_pyodide_root(curdir: str | Path, *, max_depth: int = 10) -> Path | No
         except tomllib.TOMLDecodeError as e:
             raise ValueError(f"Could not parse {pyproject_file}.") from e
 
-        if "tool" in configs and "pyodide" in configs["tool"]:
+        if "tool" in configs and "_pyodide" in configs["tool"]:
             return base
 
     return None

--- a/pyodide-build/pyodide_build/tests/test_build_env.py
+++ b/pyodide-build/pyodide_build/tests/test_build_env.py
@@ -48,7 +48,7 @@ class TestInTree:
 
     def test_search_pyodide_root(self, tmp_path, reset_env_vars, reset_cache):
         pyproject_file = tmp_path / "pyproject.toml"
-        pyproject_file.write_text("[tool.pyodide]")
+        pyproject_file.write_text("[tool._pyodide]")
         assert build_env.search_pyodide_root(tmp_path) == tmp_path
         assert build_env.search_pyodide_root(tmp_path / "subdir") == tmp_path
         assert build_env.search_pyodide_root(tmp_path / "subdir" / "subdir") == tmp_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,4 +124,4 @@ markers = [
     "requires_dynamic_linking",
 ]
 
-[tool.pyodide]
+[tool._pyodide]


### PR DESCRIPTION
### Description

This updates the subtable name from `[tool.pyodide]` to `[tool._pyodide]`, so we can use `[tool.pyodide.build]` in out-of-tree builds (related: #4831). This is an internal change so I think it does not need a changelog.