### PR TITLE
Set platlibdir in venv pip

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -32,6 +32,10 @@ myst:
   `InvalidStateError`.
   {pr}`4837`
 
+- {{ Fix }} Pyodide virtual environments now work correctly in Fedora and other
+  platforms with platlibdir not equal to "lib".
+  {pr}`4844`
+
 ### Packages
 
 - New Packages: `pytest-asyncio` {pr}`4819`

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -141,6 +141,7 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         os.name = os_name
         orig_platform = sys.platform
         sys.platform = sys_platform
+        sys.platlibdir = "lib"
         sys.implementation._multiarch = multiarch
         platform.system = lambda: sys_platform
         platform.machine = lambda: "wasm32"
@@ -148,7 +149,7 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         os.environ["_PYTHON_SYSCONFIGDATA_NAME"] = f'_sysconfigdata_{{sys.abiflags}}_{{sys.platform}}_{{sys.implementation._multiarch}}'
         sys.path.append("{sysconfigdata_dir}")
         import sysconfig
-        sysconfig.get_config_vars()
+        sysconfig._init_config_vars()
         del os.environ["_PYTHON_SYSCONFIGDATA_NAME"]
         sys.platform = orig_platform
         """


### PR DESCRIPTION
Previously we'd read it from the host environment, which could cause trouble in environments like Fedora where it would have an unusual value. Resolves https://github.com/pypa/cibuildwheel/issues/1853

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
