### PR TITLE
Backports for 0.26.1

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -21,6 +21,9 @@ myst:
   stack switching is disabled.
   {pr}`4817`
 
+- {{ Fix }} Resolved an issue where string keys in `PyProxyJsonAdaptor` were unexpectedly cast to numbers.
+  {pr}`4825`
+
 ## Version 0.26.0
 
 _May 27, 2024_

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,6 +16,9 @@ myst:
 
 ## Unreleased
 
+- {{ Fix }} Fix `pyodide config` command being printing unnecessary outputs.
+  {pr}`4814`
+
 - {{ Enhancement }} Added the `enableRunUntilComplete` option to `loadPyodide`
   which makes `run_until_complete` block using stack switching, or crash if
   stack switching is disabled.

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,6 +14,13 @@ myst:
 
 # Change Log
 
+## Unreleased
+
+- {{ Enhancement }} Added the `enableRunUntilComplete` option to `loadPyodide`
+  which makes `run_until_complete` block using stack switching, or crash if
+  stack switching is disabled.
+  {pr}`4817`
+
 ## Version 0.26.0
 
 _May 27, 2024_

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,7 +18,7 @@ myst:
 
 _June 7, 2024_
 
-### Build system
+### Package build system
 
 - {{ Fix }} Fix `pyodide config` command printing extra output.
   {pr}`4814`
@@ -33,6 +33,10 @@ _June 7, 2024_
 - {{ Fix }} Resolution of JavaScript symbols in dynamic libraries doesn't fail
   anymore in the command line runner.
   {pr}`4836`
+
+- {{ Fix }} Pyodide virtual environments now work correctly in Fedora and other
+  platforms with platlibdir not equal to "lib".
+  {pr}`4844`
 
 
 ### Runtime / FFI

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -38,7 +38,6 @@ _June 7, 2024_
   platforms with platlibdir not equal to "lib".
   {pr}`4844`
 
-
 ### Runtime / FFI
 
 - {{ Enhancement }} Added the `enableRunUntilComplete` option to `loadPyodide`
@@ -53,7 +52,6 @@ _June 7, 2024_
 - {{ Fix }} When a `Future` connected to a `Promise` is cancelled, don't raise
   `InvalidStateError`.
   {pr}`4837`
-
 
 ### Packages
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -28,6 +28,9 @@ myst:
   unexpectedly cast to numbers.
   {pr}`4825`
 
+- {{ Enhancement }} Added implementation to read build settings from `pyproject.toml`.
+  {pr}`4831`
+
 - {{ Fix }} When a `Future` connected to a `Promise` is cancelled, don't raise
   `InvalidStateError`.
   {pr}`4837`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -24,8 +24,13 @@ myst:
   stack switching is disabled.
   {pr}`4817`
 
-- {{ Fix }} Resolved an issue where string keys in `PyProxyJsonAdaptor` were unexpectedly cast to numbers.
+- {{ Fix }} Resolved an issue where string keys in `PyProxyJsonAdaptor` were
+  unexpectedly cast to numbers.
   {pr}`4825`
+
+- {{ Fix }} When a `Future` connected to a `Promise` is cancelled, don't raise
+  `InvalidStateError`.
+  {pr}`4837`
 
 ## Version 0.26.0
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -14,10 +14,28 @@ myst:
 
 # Change Log
 
-## Unreleased
+## Version 0.26.1
+
+_June 7, 2024_
+
+### Build system
 
 - {{ Fix }} Fix `pyodide config` command printing extra output.
   {pr}`4814`
+
+- {{ Enhancement }} Added implementation to read build settings from `pyproject.toml`.
+  {pr}`4831`
+
+- {{ Fix }} In the Pyodide virtual environment, pip sees `platform.system()` as
+  "Emscripten" and not as "emscripten".
+  {pr}`4812`
+
+- {{ Fix }} Resolution of JavaScript symbols in dynamic libraries doesn't fail
+  anymore in the command line runner.
+  {pr}`4836`
+
+
+### Runtime / FFI
 
 - {{ Enhancement }} Added the `enableRunUntilComplete` option to `loadPyodide`
   which makes `run_until_complete` block using stack switching, or crash if
@@ -28,20 +46,10 @@ myst:
   unexpectedly cast to numbers.
   {pr}`4825`
 
-- {{ Enhancement }} Added implementation to read build settings from `pyproject.toml`.
-  {pr}`4831`
-
 - {{ Fix }} When a `Future` connected to a `Promise` is cancelled, don't raise
   `InvalidStateError`.
   {pr}`4837`
 
-- {{ Fix }} In the Pyodide virtual environment, pip sees `platform.system()` as
-  "Emscripten" and not as "emscripten".
-  {pr}`4812`
-
-- {{ Fix }} Resolution of JavaScript symbols in dynamic libraries doesn't fail
-  anymore.
-  {pr}`4836`
 
 ### Packages
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -32,6 +32,10 @@ myst:
   `InvalidStateError`.
   {pr}`4837`
 
+- {{ Fix }} In the Pyodide virtual environment, pip sees `platform.system()` as
+  "Emscripten" and not as "emscripten".
+  {pr}`4812`
+
 ### Packages
 
 - New Packages: `pytest-asyncio` {pr}`4819`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -39,6 +39,10 @@ myst:
   "Emscripten" and not as "emscripten".
   {pr}`4812`
 
+- {{ Fix }} Resolution of JavaScript symbols in dynamic libraries doesn't fail
+  anymore.
+  {pr}`4836`
+
 ### Packages
 
 - New Packages: `pytest-asyncio` {pr}`4819`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,7 +16,7 @@ myst:
 
 ## Unreleased
 
-- {{ Fix }} Fix `pyodide config` command being printing unnecessary outputs.
+- {{ Fix }} Fix `pyodide config` command printing extra output.
   {pr}`4814`
 
 - {{ Enhancement }} Added the `enableRunUntilComplete` option to `loadPyodide`
@@ -31,6 +31,10 @@ myst:
 - {{ Fix }} When a `Future` connected to a `Promise` is cancelled, don't raise
   `InvalidStateError`.
   {pr}`4837`
+
+### Packages
+
+- New Packages: `pytest-asyncio` {pr}`4819`
 
 ## Version 0.26.0
 

--- a/packages/cpp-exceptions-test2/meta.yaml
+++ b/packages/cpp-exceptions-test2/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: cpp-exceptions-test2
+  version: "1.0"
+  tag:
+    - core
+    - pyodide.test
+source:
+  path: src
+build:
+  cxxflags: -fexceptions
+  ldflags: -fexceptions

--- a/packages/cpp-exceptions-test2/src/cpp_exceptions_test2.cpp
+++ b/packages/cpp-exceptions-test2/src/cpp_exceptions_test2.cpp
@@ -1,0 +1,13 @@
+#include "Python.h"
+#include <stdexcept>
+
+extern "C" __attribute__((visibility("default"))) PyObject*
+PyInit_cpp_exceptions_test2()
+{
+  try {
+    throw std::runtime_error("something bad?");
+  } catch (const std::exception& e) {
+    PyErr_SetString(PyExc_ImportError, "oops");
+  }
+  return nullptr;
+}

--- a/packages/cpp-exceptions-test2/src/setup.py
+++ b/packages/cpp-exceptions-test2/src/setup.py
@@ -1,0 +1,16 @@
+from setuptools import Extension, setup
+
+setup(
+    name="cpp-exceptions-test2",
+    version="1.0",
+    ext_modules=[
+        Extension(
+            name="cpp_exceptions_test2",  # as it would be imported
+            # may include packages/namespaces separated by `.`
+            language="c++",
+            sources=[
+                "cpp_exceptions_test2.cpp"
+            ],  # all sources are compiled into a single binary file
+        ),
+    ],
+)

--- a/packages/pytest-asyncio/inner_test_pytest_asyncio.py
+++ b/packages/pytest-asyncio/inner_test_pytest_asyncio.py
@@ -1,0 +1,55 @@
+# mypy: disable-error-code="no-untyped-def"
+
+"""Taken from test_simple.py in pytest-asyncio"""
+
+import asyncio
+from textwrap import dedent
+
+import pytest
+from pytest import Pytester
+
+pytest_plugins = "pytester"
+
+
+async def async_coro():
+    await asyncio.sleep(0)
+    return "ok"
+
+
+def test_event_loop_fixture(event_loop):
+    """Test the injection of the event_loop fixture."""
+    assert event_loop
+    ret = event_loop.run_until_complete(async_coro())
+    assert ret == "ok"
+
+
+@pytest.mark.asyncio
+async def test_asyncio_marker():
+    """Test the asyncio pytest marker."""
+    await asyncio.sleep(0)
+
+
+def test_asyncio_marker_compatibility_with_xfail(pytester: Pytester):
+    pytester.makepyfile(
+        dedent(
+            """\
+                import pytest
+
+                pytest_plugins = "pytest_asyncio"
+
+
+                @pytest.mark.xfail(reason="need a failure", strict=True)
+                @pytest.mark.asyncio
+                async def test_asyncio_marker_fail():
+                    raise AssertionError
+            """
+        )
+    )
+    result = pytester.runpytest("--asyncio-mode=strict")
+    result.assert_outcomes(xfailed=1)
+
+
+@pytest.mark.asyncio
+async def test_asyncio_marker_with_default_param(a_param=None):
+    """Test the asyncio pytest marker."""
+    await asyncio.sleep(0)

--- a/packages/pytest-asyncio/meta.yaml
+++ b/packages/pytest-asyncio/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: pytest-asyncio
+  version: 0.23.7
+  tag:
+    - core
+    - min-scipy-stack
+  top-level:
+    - pytest_asyncio
+source:
+  url: https://files.pythonhosted.org/packages/e5/98/947690b1a79af83e584143cb904497caff05bb6016614b38326a81076357/pytest_asyncio-0.23.7-py3-none-any.whl
+  sha256: 009b48127fbe44518a547bddd25611551b0e43ccdbf1e67d12479f569832c20b
+requirements:
+  run:
+    - pytest
+about:
+  home: https://github.com/pytest-dev/pytest-asyncio
+  PyPI: https://pypi.org/project/pytest-asyncio
+  summary: Pytest support for asyncio
+  license: Apache 2.0
+extra:
+  recipe-maintainers:
+    - agriyakhetarpal

--- a/packages/pytest-asyncio/test_pytest_asyncio.py
+++ b/packages/pytest-asyncio/test_pytest_asyncio.py
@@ -1,0 +1,21 @@
+from pytest_pyodide import run_in_pyodide
+
+from conftest import requires_jspi
+
+
+@run_in_pyodide(packages=["pytest-asyncio"])
+def do_test(selenium, contents):
+    from pathlib import Path
+
+    Path("test_pytest_asyncio.py").write_text(contents)
+    import pytest
+
+    assert pytest.main(["test_pytest_asyncio.py"]) == 0
+
+
+@requires_jspi
+def test_pytest_asyncio(selenium):
+    from pathlib import Path
+
+    contents = (Path(__file__).parent / "inner_test_pytest_asyncio.py").read_text()
+    do_test(selenium, contents)

--- a/pyodide-build/pyodide_build/build_env.py
+++ b/pyodide-build/pyodide_build/build_env.py
@@ -113,7 +113,7 @@ def search_pyodide_root(curdir: str | Path, *, max_depth: int = 10) -> Path | No
         except tomllib.TOMLDecodeError as e:
             raise ValueError(f"Could not parse {pyproject_file}.") from e
 
-        if "tool" in configs and "pyodide" in configs["tool"]:
+        if "tool" in configs and "_pyodide" in configs["tool"]:
             return base
 
     return None

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -86,6 +86,7 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
                 print([
                     os.name,
                     sys.platform,
+                    platform.system(),
                     sys.implementation._multiarch,
                     sysconfig.get_platform()
                 ])
@@ -129,7 +130,7 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
             yield from tags._generic_platforms()
 
         def platform_tags():
-            if platform.system() == "emscripten":
+            if platform.system() == "Emscripten":
                 yield from _emscripten_platforms()
                 return
             return orig_platform_tags()
@@ -137,12 +138,12 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         tags.platform_tags = platform_tags
         """
         f"""
-        os_name, sys_platform, multiarch, host_platform = {platform_data}
+        os_name, sys_platform, platform_system, multiarch, host_platform = {platform_data}
         os.name = os_name
         orig_platform = sys.platform
         sys.platform = sys_platform
         sys.implementation._multiarch = multiarch
-        platform.system = lambda: sys_platform
+        platform.system = lambda: platform_system
         platform.machine = lambda: "wasm32"
         os.environ["_PYTHON_HOST_PLATFORM"] = host_platform
         os.environ["_PYTHON_SYSCONFIGDATA_NAME"] = f'_sysconfigdata_{{sys.abiflags}}_{{sys.platform}}_{{sys.implementation._multiarch}}'

--- a/pyodide-build/pyodide_build/out_of_tree/venv.py
+++ b/pyodide-build/pyodide_build/out_of_tree/venv.py
@@ -142,6 +142,7 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         os.name = os_name
         orig_platform = sys.platform
         sys.platform = sys_platform
+        sys.platlibdir = "lib"
         sys.implementation._multiarch = multiarch
         platform.system = lambda: platform_system
         platform.machine = lambda: "wasm32"
@@ -149,7 +150,7 @@ def get_pip_monkeypatch(venv_bin: Path) -> str:
         os.environ["_PYTHON_SYSCONFIGDATA_NAME"] = f'_sysconfigdata_{{sys.abiflags}}_{{sys.platform}}_{{sys.implementation._multiarch}}'
         sys.path.append("{sysconfigdata_dir}")
         import sysconfig
-        sysconfig.get_config_vars()
+        sysconfig._init_config_vars()
         del os.environ["_PYTHON_SYSCONFIGDATA_NAME"]
         sys.platform = orig_platform
         """

--- a/pyodide-build/pyodide_build/tests/test_build_env.py
+++ b/pyodide-build/pyodide_build/tests/test_build_env.py
@@ -48,7 +48,7 @@ class TestInTree:
 
     def test_search_pyodide_root(self, tmp_path, reset_env_vars, reset_cache):
         pyproject_file = tmp_path / "pyproject.toml"
-        pyproject_file.write_text("[tool.pyodide]")
+        pyproject_file.write_text("[tool._pyodide]")
         assert build_env.search_pyodide_root(tmp_path) == tmp_path
         assert build_env.search_pyodide_root(tmp_path / "subdir") == tmp_path
         assert build_env.search_pyodide_root(tmp_path / "subdir" / "subdir") == tmp_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,4 +124,4 @@ markers = [
     "requires_dynamic_linking",
 ]
 
-[tool.pyodide]
+[tool._pyodide]

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -119,13 +119,13 @@ EM_JS(JsVal, restore_stderr, (void), {
 /**
  * Wrap the exception in a JavaScript PythonError object.
  *
- * The return value of this function is always a valid hiwire ID to an error
- * object. It never returns NULL.
+ * The return value of this function is always a JavaScript error object. It
+ * never returns null.
  *
  * We are cautious about leaking the Python stack frame, so we don't increment
  * the reference count on the exception object, we just store a pointer to it.
- * Later we can check if this pointer is equal to sys.last_exc and if so
- * restore the exception (see restore_sys_last_exception).
+ * Later we can check if this pointer is equal to sys.last_exc and if so restore
+ * the exception (see restore_sys_last_exception).
  *
  * WARNING: dereferencing the error pointer stored on the PythonError is a
  * use-after-free bug.

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -2267,7 +2267,7 @@ const PyProxySequenceHandlers = {
     return true;
   },
   has(jsobj: PyProxy, jskey: any): boolean {
-    if (typeof jskey === "string" && /^[0-9]*$/.test(jskey)) {
+    if (typeof jskey === "string" && /^[0-9]+$/.test(jskey)) {
       return Number(jskey) < jsobj.length;
     }
     return PyProxyHandlers.has(jsobj, jskey);
@@ -2276,7 +2276,7 @@ const PyProxySequenceHandlers = {
     if (jskey === "length") {
       return jsobj.length;
     }
-    if (typeof jskey === "string" && /^[0-9]*$/.test(jskey)) {
+    if (typeof jskey === "string" && /^[0-9]+$/.test(jskey)) {
       try {
         return PyGetItemMethods.prototype.get.call(jsobj, Number(jskey));
       } catch (e) {
@@ -2289,7 +2289,7 @@ const PyProxySequenceHandlers = {
     return PyProxyHandlers.get(jsobj, jskey);
   },
   set(jsobj: PyProxy, jskey: any, jsval: any): boolean {
-    if (typeof jskey === "string" && /^[0-9]*$/.test(jskey)) {
+    if (typeof jskey === "string" && /^[0-9]+$/.test(jskey)) {
       try {
         PySetItemMethods.prototype.set.call(jsobj, Number(jskey), jsval);
         return true;
@@ -2303,7 +2303,7 @@ const PyProxySequenceHandlers = {
     return PyProxyHandlers.set(jsobj, jskey, jsval);
   },
   deleteProperty(jsobj: PyProxy, jskey: any): boolean {
-    if (typeof jskey === "string" && /^[0-9]*$/.test(jskey)) {
+    if (typeof jskey === "string" && /^[0-9]+$/.test(jskey)) {
       try {
         PySetItemMethods.prototype.delete.call(jsobj, Number(jskey));
         return true;
@@ -2334,7 +2334,7 @@ const PyProxyJsonAdaptorDictHandlers = {
     if (PyContainsMethods.prototype.has.call(jsobj, jskey)) {
       return true;
     }
-    if (typeof jskey === "string" && /^[0-9]*$/.test(jskey)) {
+    if (typeof jskey === "string" && /^[0-9]+$/.test(jskey)) {
       jskey = Number(jskey);
     }
     if (PyContainsMethods.prototype.has.call(jsobj, jskey)) {
@@ -2360,7 +2360,7 @@ const PyProxyJsonAdaptorDictHandlers = {
     if (result) {
       return result;
     }
-    if (typeof jskey === "string" && /^[0-9]*$/.test(jskey)) {
+    if (typeof jskey === "string" && /^[0-9]+$/.test(jskey)) {
       jskey = Number(jskey);
       result = PyGetItemMethods.prototype.get.call(jsobj, jskey);
     }
@@ -2372,8 +2372,11 @@ const PyProxyJsonAdaptorDictHandlers = {
   },
   set(jsobj: PyProxy, jskey: any, jsval: any): boolean {
     if (typeof jskey === "string") {
+      if (/^[0-9]+$/.test(jskey)) {
+        jskey = Number(jskey);
+      }
       try {
-        PySetItemMethods.prototype.set.call(jsobj, Number(jskey), jsval);
+        PySetItemMethods.prototype.set.call(jsobj, jskey, jsval);
         return true;
       } catch (e) {
         if (isPythonError(e)) {
@@ -2385,7 +2388,7 @@ const PyProxyJsonAdaptorDictHandlers = {
     return false;
   },
   deleteProperty(jsobj: PyProxy, jskey: any): boolean {
-    if (typeof jskey === "string" && /^[0-9]*$/.test(jskey)) {
+    if (typeof jskey === "string" && /^[0-9]+$/.test(jskey)) {
       try {
         PySetItemMethods.prototype.delete.call(jsobj, Number(jskey));
         return true;

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -555,6 +555,10 @@ export async function loadPackage(
       Array.from(toLoad.values()).map(({ installPromise }) => installPromise),
     );
 
+    // Warning: this sounds like it might not do anything important, but it
+    // fills in the GOT. There can be segfaults if we leave it out.
+    // See https://github.com/emscripten-core/emscripten/issues/22052
+    // TODO: Fix Emscripten so this isn't needed
     Module.reportUndefinedSymbols();
     if (loadedPackageData.size > 0) {
       const successNames = Array.from(loadedPackageData, (pkg) => pkg.name)

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -44,6 +44,7 @@ export type ConfigType = {
   env: { [key: string]: string };
   packages: string[];
   _makeSnapshot: boolean;
+  enableRunUntilComplete: boolean;
 };
 
 /**
@@ -164,6 +165,10 @@ export async function loadPyodide(
      */
     pyproxyToStringRepr?: boolean;
     /**
+     * Make loop.run_until_complete() function correctly using stack switching
+     */
+    enableRunUntilComplete?: boolean;
+    /**
      * @ignore
      */
     _node_mounts?: string[];
@@ -198,6 +203,7 @@ export async function loadPyodide(
     env: {},
     packageCacheDir: indexURL,
     packages: [],
+    enableRunUntilComplete: false,
   };
   const config = Object.assign(default_config, options) as ConfigType;
   if (!config.env.HOME) {

--- a/src/py/_pyodide/_future_helper.py
+++ b/src/py/_pyodide/_future_helper.py
@@ -1,0 +1,14 @@
+def set_result(fut, val):
+    if fut.done():
+        return
+    fut.set_result(val)
+
+
+def set_exception(fut, val):
+    if fut.done():
+        return
+    fut.set_exception(val)
+
+
+def get_future_resolvers(fut):
+    return (set_result.__get__(fut), set_exception.__get__(fut))

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -8,7 +8,7 @@ from asyncio import Future, Task
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar, overload
 
-from .ffi import IN_BROWSER, create_once_callable
+from .ffi import IN_BROWSER, create_once_callable, run_sync
 
 if IN_BROWSER:
     from pyodide_js._api import scheduleCallback
@@ -259,6 +259,10 @@ class WebLoop(asyncio.AbstractEventLoop):
             do_something_with_result(result)
         ```
         """
+        from pyodide_js._api import config
+
+        if config.enableRunUntilComplete:
+            return run_sync(future)
         return asyncio.ensure_future(future)
 
     #

--- a/src/templates/python
+++ b/src/templates/python
@@ -142,6 +142,11 @@ async function main() {
             console.error(e);
         }
     }
+    // Warning: this sounds like it might not do anything important, but it
+    // fills in the GOT. There can be segfaults if we leave it out.
+    // See https://github.com/emscripten-core/emscripten/issues/22052
+    // TODO: Fix Emscripten so this isn't needed
+    py._module.reportUndefinedSymbols();
 
     py.runPython(
         `
@@ -176,14 +181,10 @@ async function main() {
     try {
         errcode = py._module._run_main();
     } catch (e) {
-        // If someone called exit, just exit with the right return code.
         if(e.constructor.name === "ExitStatus"){
             process.exit(e.status);
         }
-        // Otherwise if there is some sort of error, include the Python
-        // tracebook in addition to the JavaScript traceback
-        py._module._dump_traceback();
-        throw e;
+        py._api.fatal_error(e);
     }
     if (errcode) {
         process.exit(errcode);

--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -502,3 +502,19 @@ def test_sys_exit(selenium, venv):
     assert result.returncode == 12
     assert result.stdout == ""
     assert result.stderr == ""
+
+
+def test_cpp_exceptions(selenium, venv):
+    result = install_pkg(venv, "cpp-exceptions-test2")
+    print(result.stdout)
+    print(result.stderr)
+    assert result.returncode == 0
+    result = subprocess.run(
+        [venv / "bin/python", "-c", "import cpp_exceptions_test2"],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    print(result.stdout)
+    print(result.stderr)
+    assert result.returncode == 1
+    assert "ImportError: oops" in result.stderr

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -646,3 +646,29 @@ def test_memory_leak(selenium, script):
         """
     )
     assert length_change == 0
+
+
+@requires_jspi
+@run_in_pyodide
+def test_run_until_complete(selenium):
+    from asyncio import create_task, gather, get_event_loop, sleep
+
+    from js import sleep as js_sleep
+    from pyodide.code import run_js
+
+    loop = get_event_loop()
+
+    async def test():
+        await sleep(0.1)
+        return 7
+
+    assert loop.run_until_complete(test()) == 7
+    assert loop.run_until_complete(create_task(test())) == 7
+    loop.run_until_complete(sleep(0.1))
+    loop.run_until_complete(js_sleep(100))
+    res = loop.run_until_complete(
+        gather(test(), sleep(0.1), js_sleep(100), js_sleep(100))
+    )
+    assert list(res) == [7, None, None, None]
+    p = run_js("[sleep(100).then(() => 99)]")[0]
+    assert loop.run_until_complete(p) == 99


### PR DESCRIPTION
Merge don't squash!

TODO: add #4836.

Read build settings from configuration file
FIX platform.system should be "Emscripten" not "emscripten"
Add pytest-asyncio
ENH Add option to make run_until_complete stack switch
FIX Check if future is done before trying to set a result on it
Fix pyodide-build verbose log by replacing requests with urllib
Fix keys related behaviors on PyProxyJsonAdaptorDictHandlers
Update subtable name for checking in-tree build
Set platlibdir in venv pip
FIX Prevent segfaults in CLI runner