### PR TITLE
Link libhtml5 to main module and pygame-ce

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -160,6 +160,7 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-lGL \
 	-legl.js \
 	-lwebgl.js \
+	-lhtml5.js \
 	-lhtml5_webgl.js \
 	-lsdl.js \
 	-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,9 @@ myst:
   defined in the global scope.
   {pr}`4866`
 
+- {{ Fix }} Fixed keyboard input handling in SDL-based packages.
+  {pr}`4865`
+
 - {{ Fix }} Don't leak the values in a dictionary when applying `to_js` to it.
   {pr}`4853`
 

--- a/packages/pygame-ce/meta.yaml
+++ b/packages/pygame-ce/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-wasm_unify_pygame_web_pyodide_static_Freetype_init.patch
 build:
   script: |
-    embuilder build sdl2 sdl2_ttf sdl2_image sdl2_mixer sdl2_gfx libjpeg libpng giflib harfbuzz vorbis mpg123 libmodplug freetype --pic
+    embuilder build sdl2 sdl2_ttf sdl2_image sdl2_mixer sdl2_gfx libjpeg libpng giflib harfbuzz vorbis mpg123 libmodplug freetype libhtml5 --pic
     export SDL_CONFIG=$(em-config CACHE)/sysroot/bin/sdl2-config
   cflags: |
     -sRELOCATABLE=1
@@ -80,6 +80,7 @@ build:
       -lmodplug \
       -lmpg123 \
       -logg \
+      -lhtml5 \
       ${STATIC_OBJS} \
       ${SHARED_LIBS} \
       -o pygame_static.so

--- a/packages/pygame-ce/test_pygame.py
+++ b/packages/pygame-ce/test_pygame.py
@@ -26,6 +26,18 @@ def test_init(selenium_sdl):
     pygame.display.init()
 
 
+def test_keyboard_input():
+    """
+    Checks if the wheel is importing "emscripten_compute_dom_pk_code" from the main module.
+    This symbol should not appear in the imports of the wheel, as libhtml5 should be linked to the wheel.
+    This symbol is used by SDL2 to handle keyboard input.
+    See: https://github.com/pyodide/pyodide/issues/4805#issuecomment-2169077347
+    TODO: find a better way to test keyboard input
+    """
+    from auditwheel_emscripten import get_imports
+    get_imports
+
+
 @pytest.mark.driver_timeout(300)
 @run_in_pyodide(packages=["pygame-ce", "pygame-ce-tests", "pytest"])
 def test_run_tests(selenium_sdl):

--- a/packages/pygame-ce/test_pygame.py
+++ b/packages/pygame-ce/test_pygame.py
@@ -35,7 +35,15 @@ def test_keyboard_input():
     TODO: find a better way to test keyboard input
     """
     from auditwheel_emscripten import get_imports
-    get_imports
+    from pathlib import Path
+
+    dist_dir = Path(__file__).parent / "dist"
+    wheel_path = next(dist_dir.glob("pygame_ce-*.whl"))
+    assert wheel_path.exists()
+    all_libs = get_imports(wheel_path)
+    for imports in all_libs.values():
+        all_fields = [imp.field for imp in imports]
+        assert "emscripten_compute_dom_pk_code" not in all_fields
 
 
 @pytest.mark.driver_timeout(300)

--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -1450,12 +1450,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"


### PR DESCRIPTION
### Description

This links libhtml5 to the main module (libhtml5.js) and to the pygame-ce (libhtml5.so). From libSDL 2.26, it uses `emscripten_compute_dom_pk_code` function that comes from [libhtml5](https://github.com/emscripten-core/emscripten/blob/0c504193efb3d0b51d30c07895544b29cbad1950/system/lib/html5/dom_pk_codes.c#L11) when handling keyboard input, so we need to link it.

The size difference before and after this PR is negligible.

Resolves #4805 

before

```
pyodide.asm.js  1203 KB
pyodide.asm.wasm 9854 KB
pygame wheel  11425 KB
```

after

```
pyodide.asm.js  1203 KB
pyodide.asm.wasm 9854 KB
pygame wheel  11441 KB
```

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
