### PR TITLE
 Fix dynamic library loading in cli runner

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,11 @@ myst:
 
 - {{ Fix }} Don't leak the values in a dictionary when applying `to_js` to it.
   {pr}`4853`
+
+- {{ Fix }} Loading of dynamic libraries now works slightly better in the cli
+  runner. Resolved {issue}`3865`.
+  {pr}`4871`
+
 - {{ Enhancement }} Added implementation to abort `pyfetch` and `FetchResponse`
   manually or automatically.
   {pr}`4846`

--- a/emsdk/patches/0001-Add-back-fs.findObject-and-fs.readFile-in-loadLibDat.patch
+++ b/emsdk/patches/0001-Add-back-fs.findObject-and-fs.readFile-in-loadLibDat.patch
@@ -1,7 +1,7 @@
 From 137dae4dbdf9a192551582cdae827b085510956f Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 2 Jun 2023 11:59:32 -0700
-Subject: [PATCH 1/5] Add back fs.findObject and fs.readFile in loadLibData
+Subject: [PATCH 1/6] Add back fs.findObject and fs.readFile in loadLibData
 
 See upstream PR:
 https://github.com/emscripten-core/emscripten/pull/19513

--- a/emsdk/patches/0002-Add-useful-error-when-symbol-resolution-fails.patch
+++ b/emsdk/patches/0002-Add-useful-error-when-symbol-resolution-fails.patch
@@ -1,7 +1,7 @@
 From e0cb884277200310eba263dcce5a7b1c4567bae6 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 19 May 2023 12:19:00 -0700
-Subject: [PATCH 2/5] Add useful error when symbol resolution fails
+Subject: [PATCH 2/6] Add useful error when symbol resolution fails
 
 Currently if symbol resolution fails, we get:
 ```js

--- a/emsdk/patches/0003-Changes-for-JSPI.patch
+++ b/emsdk/patches/0003-Changes-for-JSPI.patch
@@ -1,7 +1,7 @@
 From d4d5d35072b6d28c5f98b77a0d578e01bd25ef7e Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 22 Jun 2023 18:53:22 -0700
-Subject: [PATCH 3/5] Changes for JSPI
+Subject: [PATCH 3/6] Changes for JSPI
 
 ---
  src/library.js        | 2 +-

--- a/emsdk/patches/0004-Upstream-PR-https-github.com-emscripten-core-emscrip.patch
+++ b/emsdk/patches/0004-Upstream-PR-https-github.com-emscripten-core-emscrip.patch
@@ -1,7 +1,7 @@
 From 9352fac9a4618603fbe5ce7ad97a26a3963704bd Mon Sep 17 00:00:00 2001
 From: Joe Marshall <joe.marshall@nottingham.ac.uk>
 Date: Sat, 13 Apr 2024 21:41:11 +0100
-Subject: [PATCH 4/5] Upstream PR:
+Subject: [PATCH 4/6] Upstream PR:
  https://github.com/emscripten-core/emscripten/pull/21759
 
 ---

--- a/emsdk/patches/0005-Raise-when-no-argument-is-given.patch
+++ b/emsdk/patches/0005-Raise-when-no-argument-is-given.patch
@@ -1,7 +1,7 @@
 From 44983793a7f67009c228c5c95899f6fe735fd1c5 Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Sat, 20 Jan 2024 19:02:32 +0900
-Subject: [PATCH 5/5] Raise when no argument is given
+Subject: [PATCH 5/6] Raise when no argument is given
 
 Emscripten 3.1.51 does not raise an error when no argument is given.
 Some build tools (e.g. ffmpeg) relies on this behavior, so we should

--- a/emsdk/patches/0006-Load-dependent-libs-globally.patch
+++ b/emsdk/patches/0006-Load-dependent-libs-globally.patch
@@ -1,0 +1,35 @@
+From 2f3ae3b30cf8ce8cd04d512ebb4c8b2218563085 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Mon, 17 Jun 2024 18:32:07 -0700
+Subject: [PATCH 6/6] Load dependent libs globally
+
+I'm not 100% sure why, but we need all dependent shared libs to be loaded
+globally.
+---
+ src/library_dylink.js | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/library_dylink.js b/src/library_dylink.js
+index e0fa4721c..502bc7b25 100644
+--- a/src/library_dylink.js
++++ b/src/library_dylink.js
+@@ -880,11 +880,15 @@ var LibraryDylink = {
+ 
+     // now load needed libraries and the module itself.
+     if (flags.loadAsync) {
++      const origGlobal = flags.global;
++      flags.global = true;
+       return metadata.neededDynlibs
+         .reduce((chain, dynNeeded) => chain.then(() =>
+           loadDynamicLibrary(dynNeeded, flags)
+         ), Promise.resolve())
+-        .then(loadModule);
++        .then(() => {
++          flags.global = origGlobal;
++        }).then(loadModule);
+     }
+ 
+     metadata.neededDynlibs.forEach((needed) => loadDynamicLibrary(needed, flags, localScope));
+-- 
+2.34.1
+

--- a/packages/scipy/cmdline_test_file.py
+++ b/packages/scipy/cmdline_test_file.py
@@ -1,0 +1,8 @@
+import numpy as np
+from scipy.sparse.linalg import svds
+
+rng = np.random.default_rng(0)
+A = rng.random((10, 10))
+
+res = svds(A, k=3, which="LM", random_state=0)
+print("res", res)

--- a/src/templates/python
+++ b/src/templates/python
@@ -137,7 +137,7 @@ async function main() {
     for (const dynlib of dynlibs) {
         try {
             await py._module.API.loadDynlib(dynlib);
-        } catch(e){
+        } catch(e) {
             console.error("Failed to load lib ", dynlib);
             console.error(e);
         }
@@ -181,7 +181,7 @@ async function main() {
     try {
         errcode = py._module._run_main();
     } catch (e) {
-        if(e.constructor.name === "ExitStatus"){
+        if (e.constructor.name === "ExitStatus") {
             process.exit(e.status);
         }
         py._api.fatal_error(e);


### PR DESCRIPTION
All dependent libs should be loaded as globals. We should try  to use this to simplify some of the logic in dynload.ts. Most likely what needs to happen is we need to inspect the wheel at build time to determine which libraries are "leaves" that are not dependencies of anything else and add this list to the package metadata.

Resolves #3865.

- [x] Update changelog
- [x] Add a test
