### PR TITLE
Fix recipes that do not link to their dependencies correctly

### DIFF
--- a/packages/cryptography/meta.yaml
+++ b/packages/cryptography/meta.yaml
@@ -10,15 +10,9 @@ source:
     - patches/0001-Tell-rust-lang-libc-that-time_t-is-64-bits.patch
 build:
   script: |
-    export OPENSSL_INCLUDE_PATH=$(pkg-config --cflags-only-I --dont-define-prefix openssl)
-    export OPENSSL_LIBRARY_PATH=$(pkg-config --libs-only-L --dont-define-prefix openssl)
     export OPENSSL_DIR=$WASM_LIBRARY_DIR
-  cflags: |
-    -Wno-implicit-function-declaration
-    $(OPENSSL_INCLUDE_PATH)
-  ldflags: |
-    $(OPENSSL_LIBRARY_PATH)
-    -Wl,--no-entry
+    # Allow linking to native libraries, otherwise libssl and libcrypto will be not linked to the final binary
+    export RUSTFLAGS="-Z link-native-libraries=yes"
 requirements:
   run:
     - openssl

--- a/packages/libnetcdf/meta.yaml
+++ b/packages/libnetcdf/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - libxml
 
 build:
-  type: shared_library
+  type: static_library
   script: |
     export PATH=${WASM_LIBRARY_DIR}/bin:${PATH}
 
@@ -25,15 +25,18 @@ build:
     # dap + byterange: no libcurl
 
     emconfigure ./configure \
+      --host=none \
       --prefix=${WASM_LIBRARY_DIR} \
       --disable-doxygen \
       --enable-netcdf-4 \
       --disable-dap \
+      --disable-nczarr \
       --disable-byterange \
       --disable-dap-remote-tests \
       --disable-examples \
       --disable-utilities \
       --disable-testsets \
+      --disable-shared \
       CFLAGS="-fPIC -I${WASM_LIBRARY_DIR}/include -s USE_ZLIB=1" \
       CXXFLAGS="-fPIC -I${WASM_LIBRARY_DIR}/include -s USE_ZLIB=1" \
       LDFLAGS="-fPIC -s USE_ZLIB=1"

--- a/packages/netcdf4/meta.yaml
+++ b/packages/netcdf4/meta.yaml
@@ -25,6 +25,10 @@ build:
     export PATH=${WASM_LIBRARY_DIR}/bin:${PATH}
     export HDF5_DIR=${WASM_LIBRARY_DIR}
     echo ${HDF5_DIR}
+  ldflags: |
+    -L$(WASM_LIBRARY_DIR)/lib
+    -lhdf5
+    -lhdf5_hl
 about:
   home: https://github.com/Unidata/netcdf4-python
   PyPI: https://pypi.org/project/netcdf4

--- a/packages/openssl/meta.yaml
+++ b/packages/openssl/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: openssl
-  version: 1.1.1n
+  version: 1.1.1w
   tag:
     - library
 source:
@@ -25,6 +25,11 @@ build:
     make -j ${PYODIDE_JOBS:-3} libssl.a
     emar -d libcrypto.a liblegacy-lib-bn_asm.o liblegacy-lib-des_enc.o liblegacy-lib-fcrypt_b.o
     emcc ${SIDE_MODULE_LDFLAGS} libcrypto.a -o libcrypto.so
-    emcc ${SIDE_MODULE_LDFLAGS} libssl.a -o libssl.so
+    emcc ${SIDE_MODULE_LDFLAGS} libssl.a libcrypto.so -o libssl.so
+
     make install_sw
+    mkdir -p ${WASM_LIBRARY_DIR}/lib
+    # remove static libraries, we will use shared one
+    rm -f ${WASM_LIBRARY_DIR}/lib/{libcrypto.a,libssl.a}
+    cp libcrypto.so libssl.so ${WASM_LIBRARY_DIR}/lib
     cp libcrypto.so libssl.so ${DISTDIR}

--- a/packages/pyproj/meta.yaml
+++ b/packages/pyproj/meta.yaml
@@ -16,6 +16,8 @@ requirements:
 
 build:
   script: |
+    embuilder build sqlite3 --pic
+
     export PROJ_VERSION=9.3.1
     export PROJ_DIR=${WASM_LIBRARY_DIR}
     export PROJ_INCDIR=${WASM_LIBRARY_DIR}/include
@@ -23,6 +25,11 @@ build:
     export PROJ_WHEEL=1
     mkdir -p pyproj/proj_dir/share
     cp -r ${WASM_LIBRARY_DIR}/share/proj pyproj/proj_dir/share
+  cflags: |
+    -sUSE_SQLITE3
+  ldflags: |
+    -sUSE_SQLITE3
+    -lsqlite3
 test:
   imports:
     - pyproj

--- a/packages/sparseqr/meta.yaml
+++ b/packages/sparseqr/meta.yaml
@@ -25,3 +25,11 @@ build:
     rm -f pyproject.toml
     sed -i "s@include_dirs = \[\]@include_dirs = ['\\${WASM_LIBRARY_DIR}/include']@" sparseqr/sparseqr_gen.py
     sed -i "s@library_dirs = \[\]@library_dirs = ['\\${WASM_LIBRARY_DIR}/lib']@" sparseqr/sparseqr_gen.py
+  ldflags: |
+    -lsuitesparseconfig
+    -lamd
+    -lcamd
+    -lccolamd
+    -lcolamd
+    -lcholmod
+    -lmetis

--- a/packages/ssl/meta.yaml
+++ b/packages/ssl/meta.yaml
@@ -12,11 +12,12 @@ source:
 build:
   type: cpython_module
   script: |
+    # OPENSSL_THREADS declares that OPENSSL is threadsafe. We are single threaded so everything is threadsafe.
     emcc $STDLIB_MODULE_CFLAGS -c Modules/_ssl.c -o Modules/_ssl.o \
       $(pkg-config --cflags --dont-define-prefix openssl) \
-      $(pkg-config --libs --dont-define-prefix openssl) \
-      -DOPENSSL_THREADS # This declares that OPENSSL is threadsafe. We are single threaded so everything is threadsafe.
-    emcc Modules/_ssl.o -o $DISTDIR/_ssl.so $SIDE_MODULE_LDFLAGS $(pkg-config --libs --dont-define-prefix openssl)
+      -DOPENSSL_THREADS
+
+    emcc Modules/_ssl.o $(pkg-config --libs --dont-define-prefix openssl) $SIDE_MODULE_LDFLAGS -o $DISTDIR/_ssl.so
 
     cp Lib/ssl.py $DISTDIR
 


### PR DESCRIPTION
### Description

Splitted off from #4876.

What this PR does is basically fixing incorrect shared library dependencies.

For instance, `cryptography` package depends on `openssl`, so the python extension should link to `libssl.so`.

However, before this PR, it was not linked correctly.

```sh
$  pyodide auditwheel show cryptography-42.0.5-cp312-cp312-pyodide_2024_0_wasm32.whl
{'cryptography\\hazmat\\bindings\\_rust.cpython-312-wasm32-emscripten.so': []}
```

After this PR, it is linked correctly.

```bash
$ pyodide auditwheel show cryptography-42.0.5-cp312-cp312-pyodide_2024_0_wasm32.whl
{
│   'cryptography\\hazmat\\bindings\\_rust.cpython-312-wasm32-emscripten.so': [
│   │   'libssl.so',
│   │   'libcrypto.so'
│   ]
}
```

__Why do we need this change?__

Because it is how shared libraries should work.

__Why was this working before?__

Because we loaded dependencies globally. `openssl` is loaded globally, so its symbols were visible to `cryptography` even if they are not linked. However, #4876 will change all library loading mechanism to local, so all shared libraries should now have correct dependencies to work.
