### PR TITLE
Update lakers-python package

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -47,6 +47,7 @@ myst:
 
 - Upgraded `scikit-learn` to 1.5 {pr}`4823`
 - Upgraded `libcst` to 1.4.0 {pr}`4856`
+- Upgraded `lakers` to 0.3.3 {pr}`4885`
 
 ## Version 0.26.1
 

--- a/packages/lakers-python/meta.yaml
+++ b/packages/lakers-python/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: lakers-python
-  version: 0.3.0
+  version: 0.3.3
   top-level:
     - lakers
 source:
-  url: https://files.pythonhosted.org/packages/29/93/5d70b035f987a48dd854c1afc21025fb8446aae4d43c685b68691175623c/lakers_python-0.3.0.tar.gz
-  sha256: 009fc5e31b5a9a276216ff43ffd097004396a2a9131359a1da35d464e599cd1c
+  url: https://files.pythonhosted.org/packages/0b/53/4c942f81eb87be878f82331b63c04c7bff6268a837403837a07dfe129e7a/lakers_python-0.3.3.tar.gz
+  sha256: c0b3cfbc82478bde7dedcf06db275bdce328656361660bae7f527e6de617550c
 requirements:
   executable:
     - rustup


### PR DESCRIPTION
### Description

Plain update of a package version from 0.3.0 to 0.3.3.

Reason to update now is that the pure-Python aiocoap package (which supports secure embedded networks accessed from the browser) depends on 0.3.3.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry

- [x] Add / update tests

  None needed: fixes way outside of what existing tests should do)

- [x] Add new / update outdated documentation

  None needed: Packages need no specific documentation (they just work ;-) )