### PR TITLE
Update pandas to 2.2.2

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -52,6 +52,7 @@ myst:
 - Upgraded `libcst` to 1.4.0 {pr}`4856`
 - Upgraded `lakers` to 0.3.3 {pr}`4885`
 - Upgraded `bokeh` to 3.4.2 {pr}`4888`
+- Upgraded `pandas` to 2.2.2 {pr}`4893`
 
 ## Version 0.26.1
 

--- a/packages/pandas/meta.yaml
+++ b/packages/pandas/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pandas
-  version: 2.2.0
+  version: 2.2.2
   tag:
     - min-scipy-stack
   top-level:

--- a/packages/pandas/meta.yaml
+++ b/packages/pandas/meta.yaml
@@ -6,7 +6,7 @@ package:
   top-level:
     - pandas
 source:
-  url: https://files.pythonhosted.org/packages/03/d2/6fb05f20ee1b3961c7b283c1f8bafc6de752155d075c5db61c173de0de62/pandas-2.2.2.tar.gz
+  url: https://files.pythonhosted.org/packages/88/d9/ecf715f34c73ccb1d8ceb82fc01cd1028a65a5f6dbc57bfa6ea155119058/pandas-2.2.2.tar.gz
   sha256: 9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54
 build:
   cflags:

--- a/packages/pandas/meta.yaml
+++ b/packages/pandas/meta.yaml
@@ -6,8 +6,8 @@ package:
   top-level:
     - pandas
 source:
-  url: https://files.pythonhosted.org/packages/03/d2/6fb05f20ee1b3961c7b283c1f8bafc6de752155d075c5db61c173de0de62/pandas-2.2.0.tar.gz
-  sha256: 30b83f7c3eb217fb4d1b494a57a2fda5444f17834f5df2de6b2ffff68dc3c8e2
+  url: https://files.pythonhosted.org/packages/03/d2/6fb05f20ee1b3961c7b283c1f8bafc6de752155d075c5db61c173de0de62/pandas-2.2.2.tar.gz
+  sha256: 9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54
 build:
   cflags:
     -Werror=implicit-function-declaration -Werror=mismatched-parameter-types


### PR DESCRIPTION
### Description

Fixes https://github.com/pyodide/pyodide/issues/4840.

Basically there was a warning about future pyarrow dependency that was removed in pandas 2.2.1 https://github.com/pandas-dev/pandas/pull/57556. This would avoid the confusing warning reported in #4840.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [X] Add / update tests
- [X] Add new / update outdated documentation
