### PR TITLE
Ensure `Console` is locked and prevent `formatted_traceback` being unexpectedly truncated

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -50,11 +50,11 @@ myst:
   in `CodeRunner` and `Console`.
   {pr}`4897`
 
-- {{ Fix } Fixed a bug that caused `Console`'s `formatted_traceback` being truncated
+- {{ Fix }} Fixed a bug that caused `Console`'s `formatted_traceback` being truncated
   unexpectedly when `filename` is specified.
   {pr}`4905`
 
-- {{ Fix } Locked `PyodideConsole.runcode` to block `loadPackagesFromImports`.
+- {{ Fix }} Locked `PyodideConsole.runcode` to block `loadPackagesFromImports`.
   {pr}`4905`
 
 ### Packages

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -50,6 +50,13 @@ myst:
   in `CodeRunner` and `Console`.
   {pr}`4897`
 
+- {{ Fix } Fixed a bug that caused `Console`'s `formatted_traceback` being truncated
+  unexpectedly when `filename` is specified.
+  {pr}`4905`
+
+- {{ Fix } Locked `PyodideConsole.runcode` to block `loadPackagesFromImports`.
+  {pr}`4905`
+
 ### Packages
 
 - Upgraded `scikit-learn` to 1.5 {pr}`4823`

--- a/src/py/pyodide/console.py
+++ b/src/py/pyodide/console.py
@@ -405,10 +405,10 @@ class Console:
                 res.set_result(fut.result())
             res = None
 
-        ensure_future(self._runcode_inner(source, code)).add_done_callback(done_cb)
+        ensure_future(self._runcode_with_lock(source, code)).add_done_callback(done_cb)
         return res
 
-    async def _runcode_inner(self, source: str, code: CodeRunner) -> Any:
+    async def _runcode_with_lock(self, source: str, code: CodeRunner) -> Any:
         async with self._lock:
             return await self.runcode(source, code)
 

--- a/src/py/pyodide/console.py
+++ b/src/py/pyodide/console.py
@@ -435,7 +435,7 @@ class Console:
         kept_frames = 0
         # Try to trim out stack frames inside our code
         for frame, _ in traceback.walk_tb(tb):
-            keep_frames = keep_frames or frame.f_code.co_filename == "<console>"
+            keep_frames = keep_frames or frame.f_code.co_filename == self.filename
             keep_frames = keep_frames or frame.f_code.co_filename == "<exec>"
             if keep_frames:
                 kept_frames += 1

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -315,6 +315,17 @@ async def test_console_filename():
 
 @pytest.mark.skip_refcount_check
 @run_in_pyodide
+async def test_pyodide_console_runcode_locked(selenium):
+    from pyodide.console import PyodideConsole
+
+    console = PyodideConsole()
+
+    console.push("import numpy as np")
+    await console.push("np")
+
+
+@pytest.mark.skip_refcount_check
+@run_in_pyodide
 async def test_console_imports(selenium):
     from pyodide.console import PyodideConsole
 

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -288,6 +288,7 @@ def test_nonpersistent_redirection(safe_sys_redirections):
     asyncio.run(test())
 
 
+@pytest.mark.asyncio
 async def test_compile_optimize():
     from pyodide.console import Console
 
@@ -300,6 +301,7 @@ async def test_compile_optimize():
     assert await console.push("f.__doc__") is None
 
 
+@pytest.mark.asyncio
 async def test_console_filename():
     from pyodide.console import Console
 

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -300,6 +300,17 @@ async def test_compile_optimize():
     assert await console.push("f.__doc__") is None
 
 
+async def test_console_filename():
+    from pyodide.console import Console
+
+    for filename in ("<console>", "<exec>", "other"):
+        future = Console(filename=filename).push("assert 0")
+        with pytest.raises(AssertionError):
+            await future
+        assert isinstance(future.formatted_error, str)
+        assert f'File "{filename}", line 1, in <module>' in future.formatted_error
+
+
 @pytest.mark.skip_refcount_check
 @run_in_pyodide
 async def test_console_imports(selenium):

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -320,8 +320,8 @@ async def test_pyodide_console_runcode_locked(selenium):
 
     console = PyodideConsole()
 
-    console.push("import numpy as np")
-    await console.push("np")
+    console.push("import micropip")
+    await console.push("micropip")
 
 
 @pytest.mark.skip_refcount_check


### PR DESCRIPTION
Fixed #4899
Fixed #4901

### Description

Added a `_runcode_inner` function to run `runcode` with lock. `runcode` now can be overwritten while still got locked.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
