### PR TITLE
Update `pyodide py-compile` command to accept list of files to exclude

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
       - run:
           name: Py-compile packages
           command: |
-            pyodide py-compile --compression-level 0 dist/
+            make py-compile
             rm -f dist/snapshot.bin
             make dist/snapshot.bin
 

--- a/Makefile
+++ b/Makefile
@@ -334,3 +334,7 @@ check-emcc: emsdk/emsdk/.complete
 debug :
 	EXTRA_CFLAGS+=" -D DEBUG_F" \
 	make
+
+.PHONY: py-compile
+py-compile:
+	pyodide py-compile --compression-level "$(PYODIDE_ZIP_COMPRESSION_LEVEL)" --exclude "$(PYCOMPILE_EXCLUDE_FILES)" dist/

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -78,6 +78,12 @@ export PYZIP_EXCLUDE_FILES=\
 export PYZIP_JS_STUBS=\
 	webbrowser.py
 
+export PYCOMPILE_EXCLUDE_FILES=\
+	RobotRaconteur- \
+	astropy- \
+	opencv_python- \
+	test-
+
 export DBGFLAGS_NODEBUG=-g0
 export DBGFLAGS_WASMDEBUG=-g2
 export DBGFLAGS_SOURCEMAPDEBUG=-g3

--- a/pyodide-build/pyodide_build/tests/test_cli.py
+++ b/pyodide-build/pyodide_build/tests/test_cli.py
@@ -350,7 +350,11 @@ def test_py_compile(tmp_path, target, compression_level):
         target_path = wheel_path
 
     py_compile.main(
-        path=target_path, silent=False, keep=False, compression_level=compression_level
+        path=target_path,
+        silent=False,
+        keep=False,
+        compression_level=compression_level,
+        exclude="",
     )
     with zipfile.ZipFile(tmp_path / "python.zip", "r") as fh:
         if compression_level > 0:

--- a/pyodide-build/pyodide_build/tests/test_py_compile.py
+++ b/pyodide-build/pyodide_build/tests/test_py_compile.py
@@ -248,3 +248,30 @@ def test_py_compile_archive_dir(tmp_path, with_lockfile):
         "file_name": "some-path.tar",
         "checksum": "123",
     }
+
+
+@pytest.mark.parametrize("with_lockfile", [True, False])
+def test_py_compile_archive_dir_excludes(tmp_path, with_lockfile):
+    wheel_data = {
+        "a.so": "abc",
+        "b.txt": "123",
+        "METADATA": "a",
+        "packageB/a.py": "1+1",
+    }
+
+    _create_tmp_wheel(
+        "packageB", base_dir=tmp_path, data=wheel_data, tag="py3-none-any"
+    )
+
+    excludes = ["packageB-"]
+    mapping = _py_compile_archive_dir(tmp_path, keep=True, excludes=excludes)
+
+    assert mapping == {}
+
+    mapping2 = _py_compile_archive_dir(tmp_path, keep=False)
+
+    ver = sys.version_info
+    cpver = f"cp{ver.major}{ver.minor}"
+    assert mapping2 == {
+        "packageB-0.1.0-py3-none-any.whl": f"packageb-0.1.0-{cpver}-none-any.whl",
+    }


### PR DESCRIPTION
### Description

Some of the package names are hard coded in `pyodide py-compile` command. This PR makes it configurable, to loosen the coupling between pyodide-build and list of recipes in pyodide repository.

I did a same thing to the `pyodide create-zipfile` command before (#4723)

### Checklists

- [x] Add / update tests
