### PR TITLE
`np.NaN` was deprecated in the NumPy 2.0 release. Use `np.nan` instead.

### DIFF
--- a/packages/xgboost/test_xgboost.py
+++ b/packages/xgboost/test_xgboost.py
@@ -231,7 +231,7 @@ def test_pandas_categorical(selenium):
     assert transformed.columns[0].min() == 0
 
     # test missing value
-    X = pd.DataFrame({"f0": ["a", "b", np.NaN]})
+    X = pd.DataFrame({"f0": ["a", "b", np.nan]})
     X["f0"] = X["f0"].astype("category")  # type: ignore[call-overload]
     arr, _, _ = xgb.data._transform_pandas_df(X, enable_categorical=True)
     assert not np.any(arr == -1.0)


### PR DESCRIPTION
Numpy 2.0 deprecated many constants including `np.NaN`

### Description

This error is giving every PR check a red mark 🙄.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
