### PR TITLE
Fix Py_EXIT was not called when iterator is exhausted

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -61,6 +61,10 @@ myst:
   should work.
   {pr}`4913`
 
+- {{ Fix }} Fixed a bug with the JSPI that made it interact incorrectly with
+  JavaScript code that iterates a `PyProxy`.
+  {pr}`4919`
+
 ### Packages
 
 - Upgraded `scikit-learn` to 1.5 {pr}`4823`

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -1064,10 +1064,10 @@ function* iter_helper(
     while (true) {
       Py_ENTER();
       const item = __pyproxy_iter_next(iterptr, proxyCache, is_json_adaptor);
+      Py_EXIT();
       if (item === null) {
         break;
       }
-      Py_EXIT();
       yield item;
       // If it's a json adaptor, we cached the result so we don't need to
       // destroy it (they'll get destroyed when we destroy the root).

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -730,10 +730,15 @@ def test_can_run_sync(selenium):
             await run_js("(f) => f()")(fasync)
         `);
 
+        await pyodide.runPythonAsync(`
+            run_js("(x) => Array.from(x)")([]) 
+            expect(8, True)
+        `);
+
         return results;
         """
     )
-    assert len(results) == 8
+    assert len(results) == 9
     for idx, [i, res, expected] in enumerate(results):
         assert idx == i
         assert res == expected

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -731,7 +731,7 @@ def test_can_run_sync(selenium):
         `);
 
         await pyodide.runPythonAsync(`
-            run_js("(x) => Array.from(x)")([]) 
+            run_js("(x) => Array.from(x)")([])
             expect(8, True)
         `);
 


### PR DESCRIPTION
cc @joemarshall


- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
