### PR TITLE
MAINT cleanup `unpack_buffer()`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -39,6 +39,7 @@ pytest_pyodide.runner.INITIALIZE_SCRIPT = """
     pyodide.globals.get;
     pyodide.runPython("import pyodide_js._api.config; del pyodide_js");
     pyodide._api.importlib.invalidate_caches;
+    pyodide._api.package_loader.get_install_dir;
     pyodide._api.package_loader.unpack_buffer;
     pyodide._api.package_loader.get_dynlibs;
     pyodide._api.pyodide_code.eval_code;

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -364,7 +364,9 @@ async function installPackage(
   }
   const filename = pkg.file_name;
   // This Python helper function unpacks the buffer and lists out any .so files in it.
-  const installDir: string = API.package_loader.get_install_dir(pkg.install_dir);
+  const installDir: string = API.package_loader.get_install_dir(
+    pkg.install_dir,
+  );
   const dynlibs: string[] = API.package_loader.unpack_buffer.callKwargs({
     buffer,
     filename,

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -364,10 +364,11 @@ async function installPackage(
   }
   const filename = pkg.file_name;
   // This Python helper function unpacks the buffer and lists out any .so files in it.
+  const installDir: string = API.package_loader.get_install_dir(pkg.install_dir);
   const dynlibs: string[] = API.package_loader.unpack_buffer.callKwargs({
     buffer,
     filename,
-    target: pkg.install_dir,
+    extract_dir: installDir,
     calculate_dynlibs: true,
     installer: "pyodide.loadPackage",
     source: channel === DEFAULT_CHANNEL ? "pyodide" : channel,

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -1,7 +1,6 @@
 import re
 import shutil
 import sys
-import sysconfig
 from collections.abc import Iterable
 from importlib.machinery import EXTENSION_SUFFIXES
 from pathlib import Path
@@ -140,11 +139,11 @@ def get_format(format: str) -> str:
 def get_install_dir(target: Literal["site", "dynlib"] | None = None) -> str:
     """
     Get the installation directory for a target.
+
+    Normally, Python packages are installed into the site-packages directory.
+    However, shared libraries are installed into the system library directory.
     """
-    if target in TARGETS:
-        return str(TARGETS[target])
-    
-    return str(SITE_PACKAGES)
+    return str(TARGETS.get(target, SITE_PACKAGES))
 
 
 def unpack_buffer(
@@ -203,7 +202,7 @@ def unpack_buffer(
         format = get_format(format)
     if not filename and format is None:
         raise ValueError("At least one of filename and format must be provided")
-    
+
     extract_path = Path(extract_dir or ".")
     filename = filename.rpartition("/")[-1]
 
@@ -211,7 +210,7 @@ def unpack_buffer(
     with NamedTemporaryFile(suffix=filename) as f:
         buffer._into_file(f)
         shutil.unpack_archive(f.name, extract_path, format)
-        
+
         suffix = Path(filename).suffix
         if suffix == ".whl":
             set_wheel_installer(filename, f, extract_path, installer, source)

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -139,9 +139,6 @@ def get_format(format: str) -> str:
 def get_install_dir(target: Literal["site", "dynlib"] | None = None) -> str:
     """
     Get the installation directory for a target.
-
-    Normally, Python packages are installed into the site-packages directory.
-    However, shared libraries are installed into the system library directory.
     """
     return str(TARGETS.get(target, SITE_PACKAGES))
 

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -20,7 +20,6 @@ from .ffi import IN_BROWSER, JsArray, JsBuffer, to_js
 SITE_PACKAGES = Path(getsitepackages()[0])
 if sys.base_prefix == sys.prefix:
     # not in a virtualenv
-    STD_LIB = Path(sysconfig.get_path("stdlib"))
     DSO_DIR = Path("/usr/lib")
 else:
     # in a virtualenv
@@ -29,10 +28,8 @@ else:
     #
     # e.g., SITE_PACKAGES = .venv/lib/python3.10/site_packages
     # and   DSO_DIR       = .venv/lib/
-    STD_LIB = SITE_PACKAGES
     DSO_DIR = SITE_PACKAGES.parents[1]
-TARGETS = {"site": SITE_PACKAGES, "stdlib": STD_LIB, "dynlib": DSO_DIR}
-
+TARGETS = {"site": SITE_PACKAGES, "dynlib": DSO_DIR}
 
 ZIP_TYPES = {".whl", ".zip"}
 TAR_TYPES = {
@@ -140,12 +137,21 @@ def get_format(format: str) -> str:
     raise ValueError(f"Unrecognized format {format}")
 
 
+def get_install_dir(target: Literal["site", "dynlib"] | None = None) -> str:
+    """
+    Get the installation directory for a target.
+    """
+    if target in TARGETS:
+        return str(TARGETS[target])
+    
+    return str(SITE_PACKAGES)
+
+
 def unpack_buffer(
     buffer: JsBuffer,
     *,
     filename: str = "",
     format: str | None = None,
-    target: Literal["site", "lib", "dynlib"] | None = None,
     extract_dir: str | None = None,
     calculate_dynlibs: bool = False,
     installer: str | None = None,
@@ -177,16 +183,9 @@ def unpack_buffer(
         3. If neither is present or the file name has no extension, we throw an
            error.
 
-
     extract_dir
         Controls which directory the file is unpacked into. Default is the
-        working directory. Mutually exclusive with target.
-
-    target
-        Controls which directory the file is unpacked into. Either "site" which
-        unpacked the file into the sitepackages directory or "lib" which
-        unpacked the file into the standard library. Mutually exclusive with
-        extract_dir.
+        working directory.
 
     calculate_dynlibs
         If true, will return a Javascript Array of paths to dynamic libraries
@@ -202,30 +201,26 @@ def unpack_buffer(
     """
     if format:
         format = get_format(format)
-    if target and extract_dir:
-        raise ValueError("Cannot provide both 'target' and 'extract_dir'")
     if not filename and format is None:
         raise ValueError("At least one of filename and format must be provided")
-    if target:
-        extract_path = TARGETS[target]
-    elif extract_dir:
-        extract_path = Path(extract_dir)
-    else:
-        extract_path = Path(".")
+    
+    extract_path = Path(extract_dir or ".")
     filename = filename.rpartition("/")[-1]
 
     extract_path.mkdir(parents=True, exist_ok=True)
     with NamedTemporaryFile(suffix=filename) as f:
         buffer._into_file(f)
         shutil.unpack_archive(f.name, extract_path, format)
+        
         suffix = Path(filename).suffix
         if suffix == ".whl":
             set_wheel_installer(filename, f, extract_path, installer, source)
+
         if calculate_dynlibs:
             suffix = Path(f.name).suffix
             return to_js(get_dynlibs(f, suffix, extract_path))
-        else:
-            return None
+
+    return None
 
 
 def should_load_dynlib(path: str | Path) -> bool:

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -140,6 +140,9 @@ def get_install_dir(target: Literal["site", "dynlib"] | None = None) -> str:
     """
     Get the installation directory for a target.
     """
+    if not target:
+        return str(SITE_PACKAGES)
+
     return str(TARGETS.get(target, SITE_PACKAGES))
 
 


### PR DESCRIPTION
### Description

Cleans up pyodide._package_loader.unpack_buffer a bit, NFC. This is a preparation for #4914.

1. Remove `stdlib` target, which no longer exists (#4902 removed it).
2. Remove the `target` parameter from unpack_buffer and separate it into a separate function `get_install_dir`.
