### PR TITLE
NumPy v2

### DIFF
--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: numpy
-  version: 1.26.4
+  version: 2.0.0
   tag:
     - min-scipy-stack
   top-level:
     - numpy
 source:
-  url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz
-  sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
+  url: https://files.pythonhosted.org/packages/05/35/fb1ada118002df3fe91b5c3b28bc0d90f879b881a5d8f68b1f9b79c44bfe/numpy-2.0.0.tar.gz
+  sha256: cf5d1c9e6837f8af9f92b6bd3e86d513cdc11f60fd62185cc49ec7d1aba34864
 
 build:
   # numpy uses vendored meson, so we need to pass the cross file manually


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This PR bumps the NumPy version in-tree to [version 2.0.0](https://github.com/numpy/numpy/issues/24300), [released on June 16, 2024](https://github.com/numpy/numpy/releases/tag/v2.0.0). A lot of packages here are expected to fail with their builds because there has been an ABI change in NumPy, and many packages are being tracked in https://github.com/numpy/numpy/issues/26191 – let us hope there won't be too many of them here. I would suggest that this goes into v0.27 rather than 0.26.2, not that there is a lot of time in 0.26.2 anyway...  I shall try my best to update as many failing packages as I can in this PR, or open separate PRs for each of them if that would be better. I should be able to get an estimate once the CI runs.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
