### PR TITLE
Fix test_scipy_pytest where scipy tests were not really run

### DIFF
--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -43,13 +43,17 @@ def test_binom_ppf(selenium):
     assert binom.ppf(0.9, 1000, 0.1) == 112
 
 
+@pytest.mark.skip_pyproxy_check
 @pytest.mark.driver_timeout(40)
-@run_in_pyodide(packages=["pytest", "scipy-tests"])
-def test_scipy_pytest(selenium):
+@run_in_pyodide(packages=["pytest", "scipy-tests", "micropip"])
+async def test_scipy_pytest(selenium):
     import pytest
+    import micropip
+
+    await micropip.install('hypothesis')
 
     def runtest(module, filter):
-        pytest.main(
+        result = pytest.main(
             [
                 "--pyargs",
                 f"scipy.{module}",
@@ -59,6 +63,7 @@ def test_scipy_pytest(selenium):
                 filter,
             ]
         )
+        assert result == 0
 
     runtest("odr", "explicit")
     runtest("signal.tests.test_ltisys", "TestImpulse2")

--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -48,9 +48,10 @@ def test_binom_ppf(selenium):
 @run_in_pyodide(packages=["pytest", "scipy-tests", "micropip"])
 async def test_scipy_pytest(selenium):
     import pytest
+
     import micropip
 
-    await micropip.install('hypothesis')
+    await micropip.install("hypothesis")
 
     def runtest(module, filter):
         result = pytest.main(


### PR DESCRIPTION
### Description

The scipy tests need hypothesis and without it the tests were exiting with exit code 4 (Pytest usage error) but we were not checking the exit code so basically not much was actually tested.

I needed to add `@pytest.mark.skip_pyproxy_check` otherwise I was getting the error below and from https://github.com/pyodide/pyodide/pull/4823#issuecomment-2143319334 I understood this is not really worth fixing?

```
conftest.py:231: in pytest_runtest_call
    yield from extra_checks_test_wrapper(
conftest.py:277: in extra_checks_test_wrapper
    assert (delta_proxies, delta_keys) == (0, 0) or delta_keys < 0
E   assert ((0, 8) == (0, 0)
```

### Checklists

I checked all of them because I don't think they are needed.

- [X] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [X] Add / update tests
- [X] Add new / update outdated documentation
