### PR TITLE
Fix OOT incompatible recipes

### DIFF
--- a/packages/hashlib/src/pyproject.toml
+++ b/packages/hashlib/src/pyproject.toml
@@ -10,7 +10,11 @@ version = "1.0.0"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
+ignore-vcs = true
 include = [
   "_hashlib.so",
 ]

--- a/packages/lzma/src/pyproject.toml
+++ b/packages/lzma/src/pyproject.toml
@@ -10,7 +10,11 @@ version = "1.0.0"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
+ignore-vcs = true
 include = [
   "lzma.py",
   "_lzma.so",

--- a/packages/pydecimal/src/pyproject.toml
+++ b/packages/pydecimal/src/pyproject.toml
@@ -10,7 +10,11 @@ version = "1.0.0"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
+ignore-vcs = true
 include = [
   "_pydecimal.py",
 ]

--- a/packages/pydoc_data/src/pyproject.toml
+++ b/packages/pydoc_data/src/pyproject.toml
@@ -10,7 +10,11 @@ version = "1.0.0"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
+ignore-vcs = true
 include = [
   "pydoc_data/",
 ]

--- a/packages/pygame-ce/test_pygame.py
+++ b/packages/pygame-ce/test_pygame.py
@@ -38,7 +38,7 @@ def test_keyboard_input():
 
     from auditwheel_emscripten import get_imports
 
-    dist_dir = Path(pytest.pyodide_dist_dir)
+    dist_dir = Path(pytest.pyodide_dist_dir)  # type: ignore[attr-defined]
     wheel_path = next(dist_dir.glob("pygame_ce-*.whl"))
     assert wheel_path.exists()
     all_libs = get_imports(wheel_path)

--- a/packages/pygame-ce/test_pygame.py
+++ b/packages/pygame-ce/test_pygame.py
@@ -38,7 +38,7 @@ def test_keyboard_input():
 
     from auditwheel_emscripten import get_imports
 
-    dist_dir = Path(__file__).parent / "dist"
+    dist_dir = Path(pytest.pyodide_dist_dir)
     wheel_path = next(dist_dir.glob("pygame_ce-*.whl"))
     assert wheel_path.exists()
     all_libs = get_imports(wheel_path)

--- a/packages/sharedlib-test-py/meta.yaml
+++ b/packages/sharedlib-test-py/meta.yaml
@@ -19,6 +19,6 @@ build:
     echo PYTHONPATH: $PYTHONPATH
     echo _PYTHON_HOST_PLATFORM: $_PYTHON_HOST_PLATFORM
   cflags: |
-    -I$(PYODIDE_ROOT)/packages/sharedlib-test/src/include
+    -I$(PKGDIR)/../sharedlib-test/src/include
   ldflags: |
-    $(PYODIDE_ROOT)/packages/sharedlib-test/build/sharedlib-test-1.0/dist/sharedlib-test.so
+    $(PKGDIR)/../sharedlib-test/build/sharedlib-test-1.0/dist/sharedlib-test.so

--- a/packages/sqlite3/src/pyproject.toml
+++ b/packages/sqlite3/src/pyproject.toml
@@ -10,7 +10,11 @@ version = "1.0.0"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
+ignore-vcs = true
 include = [
   "_sqlite3.so",
   "sqlite3/",

--- a/packages/ssl/src/pyproject.toml
+++ b/packages/ssl/src/pyproject.toml
@@ -10,7 +10,11 @@ version = "1.0.0"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
+ignore-vcs = true
 include = [
   "_ssl.so",
   "ssl.py",

--- a/packages/test/src/pyproject.toml
+++ b/packages/test/src/pyproject.toml
@@ -10,7 +10,11 @@ version = "1.0.0"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+ignore-vcs = true
+
 [tool.hatch.build.targets.wheel]
+ignore-vcs = true
 include = [
   "_test*.so",
   "_ctypes_test.so",


### PR DESCRIPTION
### Description

Update recipes that had issues building or testing out-of-tree.

- sharedlib-test-py: Fix relative path
- pygame: Fix wheel path
- cpython_modules: hatchling ignores files specified in [`.gitignore` by default](https://hatch.pypa.io/1.12/config/build/#vcs). It resulted in not including the `.so` file in the wheel. 
