### PR TITLE
Some improvements to the set of files in github releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           name: Zip build directory
           command: |
             tar cjf pyodide.tar.gz dist
-            tar cjf pyodide-core.tar.gz dist/pyodide{.js,.mjs,.asm.js,.asm.wasm} dist/{package,pyodide-lock}.json dist/python_stdlib.zip
+            tar cjf pyodide-core.tar.gz dist/pyodide{.js,.mjs,.asm.js,.asm.wasm} dist/*.d.ts dist/{package,pyodide-lock}.json dist/python_stdlib.zip
             tar cjf pyodide-static-libs.tar.gz -C cpython/installs  .
 
       - store_artifacts:
@@ -163,7 +163,7 @@ jobs:
           name: Zip build directory
           command: |
             tar cjf pyodide.tar.gz dist
-            tar cjf pyodide-core.tar.gz dist/pyodide{.js,.mjs,.asm.js,.asm.wasm} dist/{package,pyodide-lock}.json dist/python_stdlib.zip
+            tar cjf pyodide-core.tar.gz dist/pyodide{.js,.mjs,.asm.js,.asm.wasm} dist/*.d.ts dist/{package,pyodide-lock}.json dist/python_stdlib.zip
             tar cjf build-logs.tar.gz  packages/build-logs
 
       - run:
@@ -453,13 +453,14 @@ jobs:
       - run:
           name: Deploy Github Releases
           command: |
+            make clean-dist-dir
             mkdir -p /tmp/ghr/dist
             cp -r dist /tmp/ghr/pyodide
             cp -r xbuildenv /tmp/ghr/xbuildenv
             cp -r cpython/installs /tmp/ghr/static-libraries
             cd /tmp/ghr
             tar cjf dist/pyodide-${CIRCLE_TAG}.tar.bz2  pyodide/
-            tar cjf dist/pyodide-core-${CIRCLE_TAG}.tar.bz2 pyodide/pyodide{.js,.mjs,.asm.js,.asm.wasm} pyodide/{package,pyodide-lock}.json pyodide/python_stdlib.zip
+            tar cjf dist/pyodide-core-${CIRCLE_TAG}.tar.bz2 pyodide/pyodide{.js,.mjs,.asm.js,.asm.wasm} pyodide/*.d.ts pyodide/{package,pyodide-lock}.json pyodide/python_stdlib.zip
             tar cjf dist/xbuildenv-${CIRCLE_TAG}.tar.bz2  xbuildenv/
             tar cjf dist/static-libraries-${CIRCLE_TAG}.tar.bz2  static-libraries/
 
@@ -546,6 +547,7 @@ jobs:
           # Unlike the release version, we upload the dev version to S3 not to GitHub.
           name: Deploy release files to S3
           command: |
+            make clean-dist-dir
             mkdir -p /tmp/ghr/dist
             cp -r dist /tmp/ghr/pyodide
             cp -r xbuildenv /tmp/ghr/xbuildenv

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,23 @@ dist/module_webworker_dev.js: src/templates/module_webworker.js
 dist/webworker_dev.js: src/templates/webworker.js
 	cp $< $@
 
+
+# Prepare the dist directory for the release by removing unneeded files
+.PHONY: clean-dist-dir
+clean-dist-dir:
+	# Remove snapshot files
+	rm dist/makesnap.mjs
+	rm dist/snapshot.bin
+	rm dist/module_test.html dist/test.html
+	# TODO: Remove webworker.js too? Would require updating the docs I think.
+	rm dist/module_webworker_dev.js  dist/webworker_dev.js
+	
+	# TODO: Source maps aren't useful outside of debug builds I don't think. But
+	# removing them adds "missing sourcemap" warnings to JS console. We should
+	# not generate them in the first place?
+	# rm dist/*.map
+
+
 .PHONY: lint
 lint:
 	pre-commit run -a --show-diff-on-failure

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ clean-dist-dir:
 	rm dist/module_test.html dist/test.html
 	# TODO: Remove webworker.js too? Would require updating the docs I think.
 	rm dist/module_webworker_dev.js  dist/webworker_dev.js
-	
+
 	# TODO: Source maps aren't useful outside of debug builds I don't think. But
 	# removing them adds "missing sourcemap" warnings to JS console. We should
 	# not generate them in the first place?


### PR DESCRIPTION
Include type defintion files in pyodide-core.tar.gz
Remove snapshot related files.
Remove test files.

TODO in the future: Remove source maps and webworker.js?

As suggested in https://github.com/pyodide/pyodide/issues/4942

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
