### PR TITLE
Add `pythoninclude` to `pyodide config` CLI

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -16,6 +16,12 @@ myst:
 
 ## Unreleased
 
+- {{ Enhancement }} The `pyodide config list` command now shows an additional
+  config variable `pythoninclude` that can be used to access the location of
+  the Pyodide Python interpreter headers. This variable can be accessed through
+  `pyodide config get pythoninclude` as well for use in out-of-tree builds.
+  {pr}`4947`
+
 - {{ Enhancement }} Add unix-timezones module, which installs Unix compatible
   timezone data in /usr/share/zoneinfo, for use with C/C++ libraries which do
   timezone handling.

--- a/pyodide-build/pyodide_build/cli/config.py
+++ b/pyodide-build/pyodide_build/cli/config.py
@@ -9,6 +9,7 @@ app = typer.Typer(help="Manage config variables used in pyodide")
 PYODIDE_CONFIGS = {
     "emscripten_version": "PYODIDE_EMSCRIPTEN_VERSION",
     "python_version": "PYVERSION",
+    "pythoninclude": "PYTHONINCLUDE",
     "rustflags": "RUSTFLAGS",
     "cmake_toolchain_file": "CMAKE_TOOLCHAIN_FILE",
     "pyo3_config_file": "PYO3_CONFIG_FILE",

--- a/pyodide-build/pyodide_build/config.py
+++ b/pyodide-build/pyodide_build/config.py
@@ -211,8 +211,9 @@ DEFAULT_CONFIG_COMPUTED: dict[str, str] = {
     "pyo3_cross_include_dir": "$(PYTHONINCLUDE)",
     # Misc
     "stdlib_module_cflags": "$(CFLAGS_BASE) -I$(PYTHONINCLUDE) -I Include/ -I. -IInclude/internal/",  # TODO: remove this
-    # Paths to build dependencies
+    # Paths to build dependencies and config files
     "host_install_dir": "$(PYODIDE_ROOT)/packages/.artifacts",
     "host_site_packages": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages",
+    "pythoninclude": "$(PYTHONINCLUDE)",
     "numpy_lib": "$(PYODIDE_ROOT)/packages/.artifacts/lib/python$(PYMAJOR).$(PYMINOR)/site-packages/numpy/",
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This PR is based on https://github.com/pyodide/pyodide/issues/4551#issuecomment-2229172277. I thought of adding `python_interp_include_dir`, but that name felt too long, so I switched to `python_include_dir`, and I then noticed that `pythoninclude` already exists as a variable that is getting computed through `Makefile.envs`. So, instead of renaming it from `pythoninclude` to `python_include_dir` and inducing an unneeded breaking change, I've just exposed it verbatim here, such that it is both accessible through the `pyodide config get pythoninclude` command for out-of-tree builds and visible in the list of default variables through the `pyodide config list` command.

It is to be noted that `emscripten_version` is the only variable that seems to be in active use for the `pyodide config` CLI based on a quick [GitHub code search](https://github.com/search?q=%22pyodide+config+get%22&type=code); perhaps this is because it is the only one that has been [documented](https://pyodide.org/en/stable/development/building-and-testing-packages.html#set-up-emscripten) before, so even if we were to rename and switch up a few variables, we should be fine (but I would prefer not to, personally).

The rationale behind this change is that some packages might need to read through the [Python headers](https://github.com/python/cpython/tree/main/Include) for some reason or the other, such as #4936. The Emscripten toolchain already has this directory passed to it through the use of the `-I$(PYTHONINCLUDE)` flag, and there is no need for any package to link against Python itself, so I'm unsure if this is an entirely beneficial patch – please let me know! At least, the change is simple and shouldn't cause any regressions, so those who wish to use this variable for their needs can do so through this PR. The use cases I've thought of so far are when compiled extensions that are defined in a package's `setup.py` rely more on the `setuptools` machinery to pass options to CMake, rather than having CMake do its thing with `FindPython`. However, we never know when or if more packages might benefit from using it, so IMO it feels okay to add.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
