### PR TITLE
Pin Node.js version in conda env and fix mypy tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: codespell
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.10.0"
+    rev: "v1.11.0"
     hooks:
       - id: mypy
         files: ^(packages/.*/src|src|pyodide-build/pyodide_build)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
       - id: mypy
         name: mypy-tests
         args: [--ignore-missing-imports]
-        files: ^(packages/|docs|/conftest.py|src/tests|pyodide-build/pyodide_build/tests)
+        files: ^(packages/|docs|/conftest.py|src/tests)
         exclude: (^packages/.*/setup.py|/src|^packages/aiohttp/aiohttp_patch.py$)
         additional_dependencies: *mypy-deps
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
-  - nodejs>=18,<22.5  # Node.js 22.5 has some issues with installing packages https://github.com/nodejs/node/issues/53902
+  - nodejs>=18,<22.5 # Node.js 22.5 has some issues with installing packages https://github.com/nodejs/node/issues/53902
   - ccache
   - f2c
   - swig

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
-  - nodejs>=18
+  - nodejs>=18,<22.5  # Node.js 22.5 has some issues with installing packages https://github.com/nodejs/node/issues/53902
   - ccache
   - f2c
   - swig

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pre-commit
 build~=1.2.0
 sphinx-click
 hypothesis
-mypy>=1.10,<2
+mypy=1.11.0
 # (FIXME: 2024/01/28) The latest pytest-asyncio 0.23.3 is not compatible with pytest 8.0.0
 pytest<8.0.0
 pytest-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pre-commit
 build~=1.2.0
 sphinx-click
 hypothesis
-mypy=1.11.0
+mypy==1.11.0
 # (FIXME: 2024/01/28) The latest pytest-asyncio 0.23.3 is not compatible with pytest 8.0.0
 pytest<8.0.0
 pytest-asyncio

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -135,7 +135,7 @@ class PyodideFuture(Future[T]):
         """Equivalent to ``then(None, onrejected)``"""
         return self.then(None, onrejected)
 
-    def finally_(self, onfinally: Callable[[], None]) -> "PyodideFuture[T]":
+    def finally_(self, onfinally: Callable[[], Any]) -> "PyodideFuture[T]":
         """When the future is either resolved or rejected, call ``onfinally`` with
         no arguments.
         """
@@ -269,10 +269,10 @@ class WebLoop(asyncio.AbstractEventLoop):
     # Scheduling methods: use browser.setTimeout to schedule tasks on the browser event loop.
     #
 
-    def call_soon(
+    def call_soon(  # type: ignore[override]
         self,
         callback: Callable[..., Any],
-        *args: Any,  # type: ignore[override]
+        *args: Any,
         context: contextvars.Context | None = None,
     ) -> asyncio.Handle:
         """Arrange for a callback to be called as soon as possible.
@@ -285,10 +285,10 @@ class WebLoop(asyncio.AbstractEventLoop):
         delay = 0
         return self.call_later(delay, callback, *args, context=context)
 
-    def call_soon_threadsafe(
+    def call_soon_threadsafe(  # type: ignore[override]
         self,
         callback: Callable[..., Any],
-        *args: Any,  # type: ignore[override]
+        *args: Any,
         context: contextvars.Context | None = None,
     ) -> asyncio.Handle:
         """Like ``call_soon()``, but thread-safe.
@@ -369,7 +369,7 @@ class WebLoop(asyncio.AbstractEventLoop):
         delay = when - cur_time
         return self.call_later(delay, callback, *args, context=context)
 
-    def run_in_executor(self, executor, func, *args):
+    def run_in_executor(self, executor, func, *args):  # type: ignore[override]
         """Arrange for func to be called in the specified executor.
 
         This is normally supposed to run func(*args) in a separate process or
@@ -407,7 +407,7 @@ class WebLoop(asyncio.AbstractEventLoop):
         """
         return time.monotonic()
 
-    def create_task(self, coro, *, name=None):
+    def create_task(self, coro, *, name=None):  # type: ignore[override]
         """Schedule a coroutine object.
 
         Return a task object.


### PR DESCRIPTION
Recent releases of mypy 1.11 and Node.js 22.5 have some issues in our CI.

- mypy 1.11 is not happy with our typing in webloop.py

```
=========================== short test summary info ============================
FAILED test_static_typing.py::create_proxy - AssertionError: src/py/pyodide/webloop.py:147: error: Function does not return a value (it only ever returns None)  [func-returns-value]
  src/py/pyodide/webloop.py:272: error: Signature of "call_soon" incompatible with supertype "AbstractEventLoop"  [override]
  src/py/pyodide/webloop.py:272: note:      Superclass:
  src/py/pyodide/webloop.py:272: note:          def [_Ts`-1] call_soon(self, callback: Callable[[VarArg(*_Ts)], object], *args: *_Ts, context: Context | None = ...) -> Handle
  src/py/pyodide/webloop.py:272: note:      Subclass:
  src/py/pyodide/webloop.py:272: note:          def call_soon(self, callback: Callable[..., Any], *args: Any, context: Context | None = ...) -> Handle
  src/py/pyodide/webloop.py:288: error: Signature of "call_soon_threadsafe" incompatible with supertype "AbstractEventLoop"  [override]
  src/py/pyodide/webloop.py:288: note:      Superclass:
  src/py/pyodide/webloop.py:288: note:          def [_Ts`-1] call_soon_threadsafe(self, callback: Callable[[VarArg(*_Ts)], object], *args: *_Ts, context: Context | None = ...) -> Handle
  src/py/pyodide/webloop.py:288: note:      Subclass:
  src/py/pyodide/webloop.py:288: note:          def call_soon_threadsafe(self, callback: Callable[..., Any], *args: Any, context: Context | None = ...) -> Handle
  src/py/pyodide/webloop.py:372: error: Signature of "run_in_executor" incompatible with supertype "AbstractEventLoop"  [override]
  src/py/pyodide/webloop.py:372: note:      Superclass:
  src/py/pyodide/webloop.py:372: note:          def [_Ts`-1, _T] run_in_executor(self, executor: Any, func: Callable[[VarArg(*_Ts)], _T], *args: *_Ts) -> Future[_T]
  src/py/pyodide/webloop.py:372: note:      Subclass:
  src/py/pyodide/webloop.py:372: note:          def run_in_executor(self, executor: Any, func: Any, *args: Any) -> Any
  src/py/pyodide/webloop.py:410: error: Signature of "create_task" incompatible with supertype "AbstractEventLoop"  [override]
  src/py/pyodide/webloop.py:410: note:      Superclass:
  src/py/pyodide/webloop.py:410: note:          def [_T] create_task(self, coro: Coroutine[Any, Any, _T], *, name: str | None = ..., context: Context | None = ...) -> Task[_T]
  src/py/pyodide/webloop.py:410: note:      Subclass:
  src/py/pyodide/webloop.py:410: note:          def create_task(self, coro: Any, *, name: Any = ...) -> Any
  src/py/pyodide/webloop.py:275: error: Unused "type: ignore" comment  [unused-ignore]
  src/py/pyodide/webloop.py:291: error: Unused "type: ignore" comment  [unused-ignore]
  Found 7 errors in 1 file (checked 1 source file)
```

- Node.js 22.5 has some issues with installing packages. (https://github.com/nodejs/node/issues/53902)

This PR is a hot fix: pins Node.js version in conda env and adds mypy ignore.


