### PR TITLE
PERF Don't format attribute error in JsProxy_GetAttr

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -371,11 +371,10 @@ EM_JS_VAL(JsVal, JsProxy_GetAttr_js, (JsVal jsobj, const char* ptrkey), {
 static PyObject*
 JsProxy_GetAttr(PyObject* self, PyObject* attr)
 {
-  PyObject* result = PyObject_GenericGetAttr(self, attr);
-  if (result != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError)) {
+  PyObject* result = _PyObject_GenericGetAttrWithDict(self, attr, NULL, 1);
+  if (result != NULL || PyErr_Occurred()) {
     return result;
   }
-  PyErr_Clear();
 
   bool success = false;
   JsVal jsresult = JS_NULL;


### PR DESCRIPTION
This initial `PyObject_GenericGetAttr` is expected to fail, but it formats an expensive AttributeError whenever it does. The internal method `_PyObject_GenericGetAttrWithDict` has a `suppress` argument that makes it not do this.

This saves ~36% of the time spent in `JsProxy_GetAttr`.

Tested on the profile:
```js
o = {f(){}}
g = pyodide.runPython(`
def g(x):
   for _ in range(1000000):
       x.f()

g
`);
g(o);
```

<details><summary>Before</summary>
<p>

![image](https://github.com/user-attachments/assets/a6053094-1a56-4e07-ac71-8019b1d9bf2a)

</p>
</details> 


<details><summary>After</summary>
<p>

![image](https://github.com/user-attachments/assets/d21a9a5d-d50b-4dda-b7eb-c454af63b726)

</p>
</details> 

cc @laffra

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
