### PR TITLE
DOCS Set html_baseurl

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,8 @@ pygments_style = None
 
 # -- Options for HTML output -------------------------------------------------
 
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #


### PR DESCRIPTION
readthedocs used to set this automatically but they say they've deprecated that behavior.