### PR TITLE
Update HttpStatusError Message if status not between 400 and 599, and update raise_for_status if error code is 600 or more.

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -44,6 +44,9 @@ myst:
   speedup for methods with arguments is less drastic but still quite a lot.
   {pr}`4961`
 
+- {{ Fix }} `raise_for_status()` now raises for error codes greater or equal to
+  600 {pr}`4989`
+
 ### Packages
 
 - Upgraded `scikit-learn` to 1.5.0 {pr}`4823`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -44,9 +44,6 @@ myst:
   speedup for methods with arguments is less drastic but still quite a lot.
   {pr}`4961`
 
-- {{ Fix }} `raise_for_status()` now raises for error codes greater or equal to
-  600 {pr}`4989`
-
 ### Packages
 
 - Upgraded `scikit-learn` to 1.5.0 {pr}`4823`

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -224,7 +224,7 @@ class FetchResponse:
 
     def raise_for_status(self) -> None:
         """Raise an :py:exc:`HttpStatusError` if the status of the response is an error (4xx or 5xx)"""
-        if 400 <= self.status <= 600:
+        if 400 <= self.status < 600:
             raise HttpStatusError(self.status, self.status_text, self.url)
 
     def clone(self) -> "FetchResponse":

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -45,6 +45,13 @@ class HttpStatusError(OSError):
                 f"{status} Invalid error code not between 400 and 599: {status_text} for url: {url}"
             )
 
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (self.status, self.status_text, self.url),
+            self.__dict__,
+        )
+
 
 class BodyUsedError(OSError):
     def __init__(self, *args: Any) -> None:

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -40,9 +40,10 @@ class HttpStatusError(OSError):
             super().__init__(f"{status} Client Error: {status_text} for url: {url}")
         elif 500 <= status < 600:
             super().__init__(f"{status} Server Error: {status_text} for url: {url}")
-        raise ValueError(
-            f"Invalid error code not comprised between 400 and 599: {status}"
-        )
+        else:
+            super().__init__(
+                f"{status} Invalid error code not comprised between 400 and 599: {status_text} for url: {url}"
+            )
 
 
 class BodyUsedError(OSError):

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -42,7 +42,7 @@ class HttpStatusError(OSError):
             super().__init__(f"{status} Server Error: {status_text} for url: {url}")
         else:
             super().__init__(
-                f"{status} Invalid error code not comprised between 400 and 599: {status_text} for url: {url}"
+                f"{status} Invalid error code not between 400 and 599: {status_text} for url: {url}"
             )
 
 

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -216,8 +216,8 @@ class FetchResponse:
             raise BodyUsedError
 
     def raise_for_status(self) -> None:
-        """Raise an :py:exc:`OSError` if the status of the response is an error (4xx or 5xx)"""
-        if 400 <= self.status < 600:
+        """Raise an :py:class:`HttpStatusError` if the status of the response is an error (400 or more.)"""
+        if 400 <= self.status:
             raise HttpStatusError(self.status, self.status_text, self.url)
 
     def clone(self) -> "FetchResponse":

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -40,6 +40,9 @@ class HttpStatusError(OSError):
             super().__init__(f"{status} Client Error: {status_text} for url: {url}")
         elif 500 <= status < 600:
             super().__init__(f"{status} Server Error: {status_text} for url: {url}")
+        raise ValueError(
+            f"Invalid error code not comprised between 400 and 599: {status}"
+        )
 
 
 class BodyUsedError(OSError):

--- a/src/py/pyodide/http.py
+++ b/src/py/pyodide/http.py
@@ -223,8 +223,8 @@ class FetchResponse:
             raise BodyUsedError
 
     def raise_for_status(self) -> None:
-        """Raise an :py:class:`HttpStatusError` if the status of the response is an error (400 or more.)"""
-        if 400 <= self.status:
+        """Raise an :py:exc:`HttpStatusError` if the status of the response is an error (4xx or 5xx)"""
+        if 400 <= self.status <= 600:
             raise HttpStatusError(self.status, self.status_text, self.url)
 
     def clone(self) -> "FetchResponse":

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -130,6 +130,7 @@ async def test_pyfetch_raise_for_status_does_not_raise_200(
     assert error_900.value.status_text == "Wrong error code"
     assert error_900.value.url.endswith("status_900")
 
+
 @run_in_pyodide
 async def test_pyfetch_unpack_archive(selenium):
     import pathlib

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -122,7 +122,7 @@ async def test_pyfetch_raise_for_status_does_not_raise_200(
     resp = await pyfetch(raise_for_status_fixture["/status_900"])
     with pytest.raises(
         HttpStatusError,
-        match="900 Invalid error code not between 400 and 599: Wrong error code for url: .*/status_900",
+        match="900 Invalid error code not between 400 and 599: UNKNOWN for url: .*/status_900",
     ) as error_900:
         resp.raise_for_status()
 

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -120,15 +120,20 @@ async def test_pyfetch_raise_for_status_does_not_raise_200(
     assert error_504.value.url.endswith("status_504")
 
     resp = await pyfetch(raise_for_status_fixture["/status_900"])
+
+    # this should not raise as it is above 600.
+    resp.raise_for_status()
+
     with pytest.raises(
         HttpStatusError,
-        match="900 Invalid error code not between 400 and 599: UNKNOWN for url: .*/status_900",
+        match="900 Invalid error code not between 400 and 599: UNKNOWN for url: a_fake_url",
     ) as error_900:
-        resp.raise_for_status()
+        # check that even with >600 error code, we get a message that matches
+        raise HttpStatusError(900, "UNKNOWN", "a_fake_url")
 
     assert error_900.value.status == 900
-    assert error_900.value.status_text == "Wrong error code"
-    assert error_900.value.url.endswith("status_900")
+    assert error_900.value.status_text == "UNKNOWN"
+    assert error_900.value.url == "a_fake_url"
 
 
 @run_in_pyodide

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -114,21 +114,6 @@ async def test_pyfetch_raise_for_status_does_not_raise_200(
 
 
 @run_in_pyodide
-async def cant_create_invalid_HttpStatusErrors(selenium):
-    from pyodide.http import HttpStatusError
-
-    with pytest.raises(
-        ValueError, match="Invalid error code not comprised between 400 and 599"
-    ):
-        HttpStatusError(200, "Can't raise a success error code")
-
-    with pytest.raises(
-        ValueError, match="Invalid error code not comprised between 400 and 599"
-    ):
-        HttpStatusError(999, "Can't raise an unknown error code")
-
-
-@run_in_pyodide
 async def test_pyfetch_unpack_archive(selenium):
     import pathlib
 

--- a/src/tests/test_pyodide_http.py
+++ b/src/tests/test_pyodide_http.py
@@ -114,6 +114,21 @@ async def test_pyfetch_raise_for_status_does_not_raise_200(
 
 
 @run_in_pyodide
+async def cant_create_invalid_HttpStatusErrors(selenium):
+    from pyodide.http import HttpStatusError
+
+    with pytest.raises(
+        ValueError, match="Invalid error code not comprised between 400 and 599"
+    ):
+        HttpStatusError(200, "Can't raise a success error code")
+
+    with pytest.raises(
+        ValueError, match="Invalid error code not comprised between 400 and 599"
+    ):
+        HttpStatusError(999, "Can't raise an unknown error code")
+
+
+@run_in_pyodide
 async def test_pyfetch_unpack_archive(selenium):
     import pathlib
 


### PR DESCRIPTION
Because I was creating dummy errors somewhere else with an error code of 123 and took me 30min to figure out why the repr of the errors were empty.

It also seem like raise_for_status should raise if the error code is 600 or more, the docstring should be updated as well.


### Checklists


~~- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry~~
 - [x] Add / update tests
 - [x] Add new / update outdated documentation
