### PR TITLE
Remove third-party libraries from cross-build env

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -44,6 +44,10 @@ myst:
   speedup for methods with arguments is less drastic but still quite a lot.
   {pr}`4961`
 
+- {{ Breaking }} Prebuilt third-party libraries like `openblas`, `openssl`, `zlib` are
+  not included in the cross-build env anymore.
+  {pr}`4995`
+
 ### Packages
 
 - Upgraded `scikit-learn` to 1.5.0 {pr}`4823`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -47,7 +47,7 @@ myst:
 - {{ Breaking }} Prebuilt third-party libraries like `openblas`, `openssl`, `zlib` are
   not included in the cross-build env anymore.
   {pr}`4995`
-  
+
 - {{ Fix }} `pyimport("a.b")` won't fail when `a` is removed by `del sys.modules["a"]`
   {pr}`4993`
 

--- a/tools/create_xbuildenv.py
+++ b/tools/create_xbuildenv.py
@@ -52,13 +52,11 @@ def _copy_wasm_libs(
 
     pythoninclude = get_relative_path(pyodide_root, "PYTHONINCLUDE")
     sysconfig_dir = get_relative_path(pyodide_root, "SYSCONFIGDATA_DIR")
-    # TODO: remove libs from the xbuildenv
-    wasm_lib_dir = Path("packages") / ".libs"
+
     to_copy: list[Path] = [
         pythoninclude,
         sysconfig_dir,
         Path("Makefile.envs"),
-        wasm_lib_dir / "cmake",
         Path("dist/pyodide-lock.json"),
         Path("dist/python"),
         Path("dist/python_stdlib.zip"),
@@ -67,19 +65,6 @@ def _copy_wasm_libs(
     to_copy.extend(
         x.relative_to(pyodide_root) for x in (pyodide_root / "dist").glob("pyodide.*")
     )
-    # Some ad-hoc stuff here to moderate size. We'd like to include all of
-    # wasm_lib_dir but there's 180mb of it. Better to leave out all the video
-    # codecs and stuff.
-    for pkg in ["ssl", "libcrypto", "zlib", "xml", "mpfr", "lapack", "blas", "f2c"]:
-        to_copy.extend(
-            x.relative_to(pyodide_root)
-            for x in (pyodide_root / wasm_lib_dir / "include").glob(f"**/*{pkg}*")
-            if "boost" not in str(x)
-        )
-        to_copy.extend(
-            x.relative_to(pyodide_root)
-            for x in (pyodide_root / wasm_lib_dir / "lib").glob(f"**/*{pkg}*")
-        )
 
     for path in to_copy:
         if not (pyodide_root / path).exists():


### PR DESCRIPTION
### Description

Removes libraries from xbuildenv. Splitted off from #4987. It is weird to include a few selected libraries to xbuildenv, I think building these libraries is a responsibility for package maintainers.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
