### PR TITLE
Remove usage of `shared_library` key in pyodide lock file

### DIFF
--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -145,8 +145,6 @@ export type InternalPackageData = {
   sha256: string;
   imports: string[];
   depends: string[];
-  /** @deprecated */
-  shared_library: boolean;
 };
 
 /**
@@ -236,7 +234,6 @@ function recursiveDependencies(
         package_type: "package",
         imports: [],
         depends: [],
-        shared_library: false,
       },
     });
   }
@@ -341,7 +338,6 @@ async function installPackage(
       package_type: "package",
       imports: [] as string[],
       depends: [],
-      shared_library: false,
     };
   }
   const filename = pkg.file_name;


### PR DESCRIPTION
### Description

This key was deprecated and not used anymore, the final usage was removed in #4876. This PR removes it.

Node that even after removing this, we can retrieve the same value by checking `package_type` key in the lock file.
