### PR TITLE
Add quarto-live official backend use of Pyodide to related projects

### DIFF
--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -32,7 +32,7 @@
 - [quarto-live](https://github.com/r-wasm/quarto-live) uses Pyodide
   to create interactive code cells and exercises within a variety of
   [Quarto](https://quarto.org/) document.
-  
+
 ## Workarounds for common WASM and browser limitations
 
 - [pyodide-http](https://github.com/koenvo/pyodide-http) Provides patches for

--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -29,7 +29,10 @@
   [Quarto](https://quarto.org/) document formats like
   HTML Documents, RevealJS, Books, and Websites.
 - [PyCafe](https://py.cafe) lets you host, edit, and share Python apps in your browser with a single click.
-
+- [quarto-live](https://github.com/r-wasm/quarto-live) uses Pyodide
+  to create interactive code cells and exercises within a variety of
+  [Quarto](https://quarto.org/) document.
+  
 ## Workarounds for common WASM and browser limitations
 
 - [pyodide-http](https://github.com/koenvo/pyodide-http) Provides patches for

--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -30,8 +30,7 @@
   HTML Documents, RevealJS, Books, and Websites.
 - [PyCafe](https://py.cafe) lets you host, edit, and share Python apps in your browser with a single click.
 - [quarto-live](https://github.com/r-wasm/quarto-live) uses Pyodide
-  to create interactive code cells and exercises within a variety of
-  [Quarto](https://quarto.org/) document.
+  to create interactive Python code cells and exercises in [Quarto](https://quarto.org/) documents.
 
 ## Workarounds for common WASM and browser limitations
 


### PR DESCRIPTION
### Description

Adds to the related project list the official `quarto-live` backend that uses Pyodide to power interactive code cells and exercises. 

https://github.com/r-wasm/quarto-live

https://r-wasm.github.io/quarto-live/getting_started/editor.html

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation
