### PR TITLE
Upgrade scikit-image to 0.24.0

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -61,9 +61,9 @@ myst:
 - Upgraded `zengl` to 2.5.0 {pr}`4894`
 - Upgraded `sourmash` to 4.8.11 {pr}`4980`
 - Upgraded `scipy` to 1.13.0 {pr}`4719`
+- Upgraded `scikit-image` to 0.24.0 {pr}`5003`
 - Added `casadi` 3.6.5 {pr}`4936`
 - Added `rasterio` 1.13.10, `affine` 2.4.0 {pr}`4983`
-- Upgraded `scikit-image` to 0.24.0 {pr}`5003`
 
 ## Version 0.26.2
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -63,6 +63,7 @@ myst:
 - Upgraded `scipy` to 1.13.0 {pr}`4719`
 - Added `casadi` 3.6.5 {pr}`4936`
 - Added `rasterio` 1.13.10, `affine` 2.4.0 {pr}`4983`
+- Upgraded `scikit-image` to 0.24.0 {pr}`5003`
 
 ## Version 0.26.2
 

--- a/packages/scikit-image/meta.yaml
+++ b/packages/scikit-image/meta.yaml
@@ -33,3 +33,7 @@ about:
   PyPI: https://pypi.org/project/scikit-image
   summary: Image processing in Python
   license: Modified BSD
+extra:
+  recipe-maintainers:
+    - lagru
+    - mkcor

--- a/packages/scikit-image/meta.yaml
+++ b/packages/scikit-image/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: scikit-image
-  version: 0.23.2
+  version: 0.24.0
   top-level:
     - skimage
       # - doc  # scikit-image has top level `doc` directory... but it is too common name so we don't want to use it as a hint for top-level import.
 source:
   patches:
     - patches/make-tifffile-optional.patch
-  sha256: c9da4b2c3117e3e30364a3d14496ee5c72b09eb1a4ab1292b302416faa360590
-  url: https://files.pythonhosted.org/packages/24/ce/183ff64ed397911a9d3b671714f8a2618af407b427a40ca48550fb0f7bd7/scikit_image-0.23.2.tar.gz
+  sha256: 5d16efe95da8edbeb363e0c4157b99becbd650a60b77f6e3af5768b66cf007ab
+  url: https://files.pythonhosted.org/packages/5d/c5/bcd66bf5aae5587d3b4b69c74bee30889c46c9778e858942ce93a030e1f3/scikit_image-0.24.0.tar.gz
 
 build:
   script: |


### PR DESCRIPTION
Dear Pyodide community,

We are teaching a [scikit-image tutorial](https://pretalx.com/euroscipy-2024/talk/ZVBAKK/) at EuroSciPy 2024 in just a couple of weeks. Following in @glemaitre's [footsteps](https://github.com/glemaitre/euroscipy-2023-scikit-image), we thought we would use JupyterLite and rely on the Pyodide distribution.

We'll be fine running scikit-image 0.23.2 but *ideally* we would like to run scikit-image 0.24.0 (and NumPy version 2)! Of course, we don't *expect* that you will release a new version by August 26th, but we might as well try and submit this PR. I'll add a CHANGELOG entry right away! :innocent: 

/cc @lagru @stefanv

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
