### PR TITLE
linux/arm64 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ARG GECKODRIVER_VERSION="0.34.0"
 
 #============================================
 # Firefox & geckodriver
+# Available for Linux amd64 and Linux arm64
 #============================================
 # can specify Firefox version by FIREFOX_VERSION;
 #  e.g. latest
@@ -54,7 +55,22 @@ ARG GECKODRIVER_VERSION="0.34.0"
 # can specify Firefox geckodriver version by GECKODRIVER_VERSION;
 #============================================
 
-RUN if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" ] || [ $FIREFOX_VERSION = "devedition-latest" ] || [ $FIREFOX_VERSION = "esr-latest" ]; \
+# https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64-aarch64&lang=en-US
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    echo "Note: Firefox is available as nightly-latest on Linux arm64, using it"; \
+    FIREFOX_VERSION="nightly-latest"; \
+    FIREFOX_DOWNLOAD_URL="https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64-aarch64&lang=en-US"; \
+  fi \
+  if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+    GECKODRIVER_ARCH="linux64"; \
+  elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    GECKODRIVER_ARCH="linux-aarch64"; \
+  else \
+    echo "Unsupported platform: $TARGETPLATFORM"; \
+    exit 1; \
+  fi \
+  if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" ] || [ $FIREFOX_VERSION = "devedition-latest" ] || [ $FIREFOX_VERSION = "esr-latest" ]; \
   then FIREFOX_DOWNLOAD_URL="https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; \
   else FIREFOX_VERSION_FULL="${FIREFOX_VERSION}.0" && FIREFOX_DOWNLOAD_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION_FULL/linux-x86_64/en-US/firefox-$FIREFOX_VERSION_FULL.tar.bz2"; \
   fi \
@@ -63,7 +79,7 @@ RUN if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" 
   && rm /tmp/firefox.tar.bz2 \
   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
   && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/local/bin/firefox \
-  && wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
+  && wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-$GECKODRIVER_ARCH.tar.gz \
   && rm -rf /opt/geckodriver \
   && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
   && rm /tmp/geckodriver.tar.gz \
@@ -76,6 +92,8 @@ RUN if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" 
 
 #============================================
 # Google Chrome & Chrome webdriver
+# This is currently for Linux amd64 only
+#
 #============================================
 # can specify Chrome version by CHROME_VERSION;
 #  e.g. latest
@@ -83,23 +101,28 @@ RUN if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" 
 #       97
 #============================================
 
-RUN if [ $CHROME_VERSION = "latest" ]; \
-  then CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE"); \
-  else CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${CHROME_VERSION}"); \
-  fi \
-  && CHROME_DOWNLOAD_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION_FULL}-1_amd64.deb" \
-  && CHROMEDRIVER_DOWNLOAD_URL="https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION_FULL}/linux64/chromedriver-linux64.zip" \
-  && wget --no-verbose -O /tmp/google-chrome.deb ${CHROME_DOWNLOAD_URL} \
-  && apt-get update \
-  && apt install -qqy /tmp/google-chrome.deb \
-  && rm -f /tmp/google-chrome.deb \
-  && rm -rf /var/lib/apt/lists/* \
-  && wget --no-verbose -O /tmp/chromedriver-linux64.zip ${CHROMEDRIVER_DOWNLOAD_URL} \
-  && unzip /tmp/chromedriver-linux64.zip -d /opt/ \
-  && rm /tmp/chromedriver-linux64.zip \
-  && ln -fs /opt/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver \
-  && echo "Using Chrome version: $(google-chrome --version)" \
-  && echo "Using Chrome Driver version: $(chromedriver --version)"
+RUN \
+  if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    echo "Chrome and Chrome web driver aren't currently supported on arm64, skipping installation"; \
+  else \
+    if [ $CHROME_VERSION = "latest" ]; \
+    then CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE"); \
+    else CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${CHROME_VERSION}"); \
+    fi \
+    && CHROME_DOWNLOAD_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION_FULL}-1_amd64.deb" \
+    && CHROMEDRIVER_DOWNLOAD_URL="https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION_FULL}/linux64/chromedriver-linux64.zip" \
+    && wget --no-verbose -O /tmp/google-chrome.deb ${CHROME_DOWNLOAD_URL} \
+    && apt-get update \
+    && apt install -qqy /tmp/google-chrome.deb \
+    && rm -f /tmp/google-chrome.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget --no-verbose -O /tmp/chromedriver-linux64.zip ${CHROMEDRIVER_DOWNLOAD_URL} \
+    && unzip /tmp/chromedriver-linux64.zip -d /opt/ \
+    && rm /tmp/chromedriver-linux64.zip \
+    && ln -fs /opt/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver \
+    && echo "Using Chrome version: $(google-chrome --version)" \
+    && echo "Using Chrome Driver version: $(chromedriver --version)" \
+  fi
 
 COPY --from=node-image /usr/local/bin/node /usr/local/bin/
 COPY --from=node-image /usr/local/lib/node_modules /usr/local/lib/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     FIREFOX_VERSION="nightly-latest"; \
     FIREFOX_DOWNLOAD_URL="https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64-aarch64&lang=en-US"; \
   fi \
-  if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+  && if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
     GECKODRIVER_ARCH="linux64"; \
   elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     GECKODRIVER_ARCH="linux-aarch64"; \
@@ -70,9 +70,11 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     echo "Unsupported platform: $TARGETPLATFORM"; \
     exit 1; \
   fi \
-  if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" ] || [ $FIREFOX_VERSION = "devedition-latest" ] || [ $FIREFOX_VERSION = "esr-latest" ]; \
-  then FIREFOX_DOWNLOAD_URL="https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; \
-  else FIREFOX_VERSION_FULL="${FIREFOX_VERSION}.0" && FIREFOX_DOWNLOAD_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION_FULL/linux-x86_64/en-US/firefox-$FIREFOX_VERSION_FULL.tar.bz2"; \
+  && if [ "$FIREFOX_VERSION" = "latest" ] || [ "$FIREFOX_VERSION" = "nightly-latest" ] || [ "$FIREFOX_VERSION" = "devedition-latest" ] || [ "$FIREFOX_VERSION" = "esr-latest" ]; then \
+    FIREFOX_DOWNLOAD_URL="https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; \
+  else \
+    FIREFOX_VERSION_FULL="${FIREFOX_VERSION}.0" \
+    && FIREFOX_DOWNLOAD_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION_FULL/linux-x86_64/en-US/firefox-$FIREFOX_VERSION_FULL.tar.bz2"; \
   fi \
   && wget --no-verbose -O /tmp/firefox.tar.bz2 $FIREFOX_DOWNLOAD_URL \
   && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
@@ -87,7 +89,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
   && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
   && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/local/bin/geckodriver \
   && echo "Using Firefox version: $(firefox --version)" \
-  && echo "Using GeckoDriver version: "$GECKODRIVER_VERSION
+  && echo "Using GeckoDriver version: $GECKODRIVER_VERSION, built for $GECKODRIVER_ARCH"
 
 
 #============================================
@@ -105,23 +107,24 @@ RUN \
   if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     echo "Chrome and Chrome web driver aren't currently supported on arm64, skipping installation"; \
   else \
-    if [ $CHROME_VERSION = "latest" ]; \
-    then CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE"); \
-    else CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${CHROME_VERSION}"); \
+    if [ "$CHROME_VERSION" = "latest" ]; then \
+      CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE"); \
+    else \
+      CHROME_VERSION_FULL=$(wget --no-verbose -O - "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${CHROME_VERSION}"); \
     fi \
     && CHROME_DOWNLOAD_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION_FULL}-1_amd64.deb" \
     && CHROMEDRIVER_DOWNLOAD_URL="https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION_FULL}/linux64/chromedriver-linux64.zip" \
-    && wget --no-verbose -O /tmp/google-chrome.deb ${CHROME_DOWNLOAD_URL} \
+    && wget --no-verbose -O /tmp/google-chrome.deb "${CHROME_DOWNLOAD_URL}" \
     && apt-get update \
     && apt install -qqy /tmp/google-chrome.deb \
     && rm -f /tmp/google-chrome.deb \
     && rm -rf /var/lib/apt/lists/* \
-    && wget --no-verbose -O /tmp/chromedriver-linux64.zip ${CHROMEDRIVER_DOWNLOAD_URL} \
+    && wget --no-verbose -O /tmp/chromedriver-linux64.zip "${CHROMEDRIVER_DOWNLOAD_URL}" \
     && unzip /tmp/chromedriver-linux64.zip -d /opt/ \
     && rm /tmp/chromedriver-linux64.zip \
     && ln -fs /opt/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver \
     && echo "Using Chrome version: $(google-chrome --version)" \
-    && echo "Using Chrome Driver version: $(chromedriver --version)" \
+    && echo "Using Chrome Driver version: $(chromedriver --version)"; \
   fi
 
 COPY --from=node-image /usr/local/bin/node /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM node:20.11-bookworm-slim AS node-image
-FROM python:3.12.1-slim-bookworm
+FROM --platform=$TARGETPLATFORM node:20.11-bookworm-slim AS node-image
+FROM --platform=$TARGETPLATFORM python:3.12.1-slim-bookworm
+
+ARG TARGETPLATFORM
 
 # Requirements for building packages
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM --platform=$TARGETPLATFORM node:20.11-bookworm-slim AS node-image
-FROM --platform=$TARGETPLATFORM python:3.12.1-slim-bookworm
+FROM node:20.11-bookworm-slim AS node-image
+FROM python:3.12.1-slim-bookworm
 
 ARG TARGETPLATFORM
 

--- a/run_docker
+++ b/run_docker
@@ -24,17 +24,19 @@ function usage() {
   cat > /dev/stdout <<EOF
 Usage: run_docker [OPTIONS] [COMMAND] [ARG...]
 
-Runs COMMAND in a new Pyodide docker container. If no COMMAND is provided, starts a bash
+Runs COMMAND in a new Pyodide Docker container. If no COMMAND is provided, starts a bash
 shell in the container.
 
 Options:
   -h, --help                  Show this information and exit.
-  -p, --port <port>           System port to which to forward.
+  -p, --port <port>           System port to forward to.
                               This is ignored if the env var PYODIDE_SYSTEM_PORT is set.
-                              If set to 'none', docker instance will not bind to any port.
-  --non-interactive           Run docker without the --interactive flag.
+                              If set to 'none', the Docker instance will not bind to any port.
+  --non-interactive           Run Docker without the --interactive flag.
                               Useful for running in headless mode on CI server.
   --root                      Run as root user inside the container
+  --build                     Build the Docker image before running, instead of pulling a pre-built image
+  --no-cache                  Build the Docker image from the first layer, ignoring the cache
 
 Prerequisites:
   Docker has to be set up on your system.
@@ -45,6 +47,11 @@ function error() {
   usage
   exit 255
 }
+
+
+BUILD_IMAGE=false
+NO_CACHE=""
+
 
 while [[ $# -gt 0 ]]
 do
@@ -74,6 +81,14 @@ do
         USER_FLAG=()
         shift
       ;;
+      --build)
+        BUILD_IMAGE=true
+        shift
+      ;;
+      --no-cache)
+        NO_CACHE="--no-cache"
+        shift
+      ;;
       -*)
         >&2 echo "Unknown option $1"
         error
@@ -88,6 +103,21 @@ done
 PYODIDE_DOCKER_PORT=${PYODIDE_DOCKER_PORT:-"8000"}
 PYODIDE_SYSTEM_PORT=${PYODIDE_SYSTEM_PORT:-${DEFAULT_PYODIDE_SYSTEM_PORT}}
 PYODIDE_DOCKER_IMAGE=${PYODIDE_DOCKER_IMAGE:-${DEFAULT_PYODIDE_DOCKER_IMAGE}}
+
+HOST_ARCH=$(uname -m)
+if [ "$HOST_ARCH" = "x86_64" ]; then
+  DOCKER_PLATFORM="linux/amd64"
+elif [ "$HOST_ARCH" = "arm64" ]; then
+  DOCKER_PLATFORM="linux/arm64"
+else
+  echo "Unsupported architecture: $HOST_ARCH"
+  exit 1
+fi
+
+if [ "$BUILD_IMAGE" = true ]; then
+  echo "Building Docker image for $DOCKER_PLATFORM..."
+  docker buildx build --platform $DOCKER_PLATFORM $NO_CACHE -t "$PYODIDE_DOCKER_IMAGE" .
+fi
 
 # in case the port is not a number, do not bind the port
 case $PYODIDE_SYSTEM_PORT in
@@ -114,6 +144,7 @@ CONTAINER=$(\
     -v "$PWD":/src \
     --user root \
     --shm-size 2g \
+    --platform $DOCKER_PLATFORM \
     "${PYODIDE_DOCKER_IMAGE}" \
     /bin/bash -c " \
       groupadd --gid '$USER_GID' '$USER_NAME'; \

--- a/run_docker
+++ b/run_docker
@@ -115,7 +115,7 @@ else
 fi
 
 if [ "$BUILD_IMAGE" = true ]; then
-  echo "Building Docker image for $DOCKER_PLATFORM..."
+  echo "Building image and spinning up Docker container for $DOCKER_PLATFORM..."
   docker buildx build --platform $DOCKER_PLATFORM $NO_CACHE -t "$PYODIDE_DOCKER_IMAGE" .
 fi
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This PR adds closes #1386; it adds functionality for a linux/arm64 Docker image that can be used to spin up containers natively (without QEMU emulation) on ARM64/AArch64 devices, such as the Arm-powered AWS Graviton, Oracle Ampere A1, etc. and also on M-series macOS devices.

The `./run_docker` script has been updated to include a `--build` argument (and a `--no-cache` argument) in order to be able to build the image locally and spin up a container from it instead of trying to pull the image from a remote host. Other extra commands could be provided or functionality included to pass arbitrary additional arguments, but at that point, a user could rely on not using the script altogether :)

As described in https://github.com/pyodide/pyodide/issues/1386#issuecomment-2283823708, the Chrome browser and Chrome driver are not available for Linux ARM64/AArch64 yet: https://googlechromelabs.github.io/chrome-for-testing/. However, those for Chromium are available, and could be included, either here, or as a separate PR (please let me know your thoughts). As for Firefox, they have recently started providing nightly releases: https://blog.nightly.mozilla.org/2024/04/19/firefox-nightly-now-available-for-linux-on-arm64/. `geckodriver` has included support for Linux ARM64 since version 0.32.0, and we use 0.34.0 (though 0.35.0 was released last week, should we update it?)

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
