### PR TITLE
Add as_py_json method to appropriate JsProxies

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -51,6 +51,10 @@ myst:
 - {{ Fix }} `pyimport("a.b")` won't fail when `a` is removed by `del sys.modules["a"]`
   {pr}`4993`
 
+- {{ Enhancement }} Added `JsProxy.as_py_json` method to adapt from JavaScript
+  JSON (Arrays and Objects). to Python JSON (lists and dicts).
+  {pr}`4666`
+
 ### Packages
 
 - Upgraded `scikit-learn` to 1.5.0 {pr}`4823`

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -65,6 +65,8 @@
 #define IS_ASYNC_GENERATOR (1 << 17)
 #define IS_ASYNC_ITERATOR  (1 << 18)
 #define IS_ERROR           (1 << 19)
+#define IS_PY_JSON_DICT    (1 << 20)
+#define IS_PY_JSON_SEQUENCE (1 << 21)
 // clang-format on
 
 _Py_IDENTIFIER(get_event_loop);
@@ -226,6 +228,47 @@ JsProxy_getflags(PyObject* self)
   return result;
 }
 
+#define OBJMAP_HEREDITARY 1
+#define OBJMAP_PY_JSON 2
+
+int
+JsProxy_get_objmap_flags(PyObject* self)
+{
+  int flags = JsProxy_getflags(self);
+  bool py_json = !!(flags & (IS_PY_JSON_DICT | IS_PY_JSON_SEQUENCE));
+  bool objmap_hereditary = (flags & IS_OBJECT_MAP) && JsObjMap_HEREDITARY(self);
+  int result = 0;
+  if (py_json) {
+    result |= OBJMAP_PY_JSON;
+  }
+  if (objmap_hereditary) {
+    result |= OBJMAP_HEREDITARY;
+  }
+  return result;
+}
+
+int
+JsProxy_is_py_json(PyObject* self)
+{
+  return !!(JsProxy_getflags(self) & (IS_PY_JSON_DICT | IS_PY_JSON_SEQUENCE));
+}
+
+PyObject*
+js2python_objmap(JsVal jsval, int flags)
+{
+  PyObject* result = NULL;
+
+  result = js2python_immutable(jsval);
+  if (result != NULL) {
+    return result;
+  }
+  return JsProxy_create_objmap(jsval, flags);
+}
+
+#define INCLUDE_OBJMAP_METHODS(flags) \
+      !((flags) & (IS_ARRAY | IS_TYPEDARRAY | IS_NODE_LIST | IS_BUFFER |   \
+                   IS_DOUBLE_PROXY | IS_ITERATOR | IS_CALLABLE | IS_ERROR))
+
 static int
 JsProxy_clear(PyObject* self)
 {
@@ -272,7 +315,8 @@ finally:
 PyObject*
 JsProxy_bind_sig(PyObject* self, PyObject* sig)
 {
-  return JsProxy_create_with_this(JsProxy_VAL(self), JsMethod_THIS(self), sig);
+  return JsProxy_create_with_this(
+    JsProxy_VAL(self), JsMethod_THIS(self), sig, JsProxy_is_py_json(self));
 }
 
 static PyMethodDef JsProxy_bind_sig_MethodDef = {
@@ -569,9 +613,10 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
     goto success;
   }
   if (JsvFunction_Check(jsresult)) {
-    pyresult = JsProxy_create_with_this(jsresult, JsProxy_VAL(self), attr_sig);
+    pyresult =
+      JsProxy_create_with_this(jsresult, JsProxy_VAL(self), attr_sig, false);
   } else if (attr_sig) {
-    pyresult = JsProxy_create_with_this(jsresult, JS_NULL, attr_sig);
+    pyresult = JsProxy_create_with_this(jsresult, JS_NULL, attr_sig, false);
   } else {
     pyresult = js2python(jsresult);
   }
@@ -695,7 +740,7 @@ JsProxy_GetIter(PyObject* self)
 {
   JsVal iter = JsProxy_GetIter_js(JsProxy_VAL(self));
   FAIL_IF_JS_NULL(iter);
-  return js2python(iter);
+  return js2python_objmap(iter, JsProxy_get_objmap_flags(self));
 finally:
   return NULL;
 }
@@ -725,7 +770,7 @@ handle_next_result_js,
 });
 
 PySendResult
-handle_next_result(JsVal next_res, PyObject** result, bool obj_map_hereditary){
+handle_next_result(JsVal next_res, PyObject** result, int objmap_flags){
   PySendResult res = PYGEN_ERROR;
   char* msg = NULL;
   *result = NULL;
@@ -747,7 +792,7 @@ handle_next_result(JsVal next_res, PyObject** result, bool obj_map_hereditary){
   // so pyvalue will be set to Py_None.
   *result = js2python_immutable(jsresult);
   if (!*result) {
-    *result = JsProxy_create_objmap(jsresult, obj_map_hereditary);
+    *result = JsProxy_create_objmap(jsresult, objmap_flags);
   }
   FAIL_IF_NULL(*result);
   if(pyproxy_Check(jsresult)) {
@@ -778,7 +823,7 @@ JsProxy_am_send(PyObject* self, PyObject* arg, PyObject** result)
   JsVal next_res =
     JsvObject_CallMethodId_OneArg(JsProxy_VAL(self), &JsId_next, jsarg);
   FAIL_IF_JS_NULL(next_res);
-  ret = handle_next_result(next_res, result, JsObjMap_HEREDITARY(self));
+  ret = handle_next_result(next_res, result, JsProxy_get_objmap_flags(self));
 finally:
   if (arg) {
     destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
@@ -1007,7 +1052,7 @@ JsGenerator_throw_inner(PyObject* self,
   PyObject* result = NULL;
   JsVal throw_res = process_throw_args(self, typ, val, tb);
   FAIL_IF_JS_NULL(throw_res);
-  PySendResult ret = handle_next_result(throw_res, &result, false);
+  PySendResult ret = handle_next_result(throw_res, &result, 0);
   if (ret == PYGEN_RETURN) {
     if (Py_IsNone(result)) {
       PyErr_SetNone(PyExc_StopIteration);
@@ -1526,7 +1571,7 @@ JsArray_subscript(PyObject* self, PyObject* item)
       }
       FAIL();
     }
-    pyresult = js2python(jsresult);
+    pyresult = js2python_objmap(jsresult, JsProxy_get_objmap_flags(self));
     goto success;
   }
   if (PySlice_Check(item)) {
@@ -1544,7 +1589,7 @@ JsArray_subscript(PyObject* self, PyObject* item)
         JsvArray_slice(JsProxy_VAL(self), slicelength, start, stop, step);
     }
     FAIL_IF_JS_NULL(jsresult);
-    pyresult = js2python(jsresult);
+    pyresult = js2python_objmap(jsresult, JsProxy_get_objmap_flags(self));
     goto success;
   }
   PyErr_Format(PyExc_TypeError,
@@ -3001,6 +3046,25 @@ static PyMethodDef JsProxy_as_object_map_MethodDef = {
   METH_FASTCALL | METH_KEYWORDS
 };
 
+static PyObject*
+JsProxy_as_py_json(PyObject* self, PyObject* _unused)
+{
+  int flags = JsProxy_getflags(self);
+  if (flags & (IS_ARRAY | IS_NODE_LIST)) {
+    flags |= IS_PY_JSON_SEQUENCE;
+  } else {
+    flags |= IS_PY_JSON_DICT;
+  }
+  return JsProxy_create_with_type(
+    flags, JsProxy_VAL(self), JsMethod_THIS(self), NULL);
+}
+
+static PyMethodDef JsProxy_as_py_json_MethodDef = {
+  "as_py_json",
+  (PyCFunction)JsProxy_as_py_json,
+  METH_NOARGS
+};
+
 EM_JS_VAL(JsVal, JsObjMap_GetIter_js, (JsVal obj), {
   return Module.iterObject(obj);
 })
@@ -3058,7 +3122,7 @@ JsObjMap_subscript(PyObject* self, PyObject* pyidx)
   }
   pyresult = js2python_immutable(result);
   if (pyresult == NULL) {
-    pyresult = JsProxy_create_objmap(result, JsObjMap_HEREDITARY(self));
+    pyresult = JsProxy_create_objmap(result, JsProxy_get_objmap_flags(self));
   }
 
 finally:
@@ -3235,7 +3299,7 @@ JsMethod_descr_get(PyObject* self, PyObject* obj, PyObject* type)
 
   JsVal jsobj = python2js(obj);
   FAIL_IF_JS_NULL(jsobj);
-  result = JsProxy_create_with_this(JsProxy_VAL(self), jsobj, NULL);
+  result = JsProxy_create_with_this(JsProxy_VAL(self), jsobj, NULL, false);
 
 finally:
   return result;
@@ -3774,14 +3838,14 @@ JsProxy_create_subtype(int flags)
 
   int tp_flags = Py_TPFLAGS_DEFAULT;
 
-  bool obj_map = (flags & IS_OBJECT_MAP);
+  bool objmap = (flags & (IS_OBJECT_MAP | IS_PY_JSON_DICT));
   int mapping_flags = HAS_GET | HAS_LENGTH | IS_ITERABLE;
   bool mapping = (flags & mapping_flags) == mapping_flags;
   bool mutable_mapping = mapping && (flags & HAS_SET);
   char* type_name = "pyodide.ffi.JsProxy";
   int basicsize = sizeof(JsProxy);
-  mapping = mapping || obj_map;
-  mutable_mapping = mutable_mapping || obj_map;
+  mapping = mapping || objmap;
+  mutable_mapping = mutable_mapping || objmap;
 
   if (mapping) {
     methods[cur_method++] = JsMap_keys_MethodDef;
@@ -3797,7 +3861,7 @@ JsProxy_create_subtype(int flags)
     methods[cur_method++] = JsMap_setdefault_MethodDef;
   }
 
-  if (flags & IS_OBJECT_MAP) {
+  if (objmap) {
     slots[cur_slot++] =
       (PyType_Slot){ .slot = Py_tp_iter, .pfunc = (void*)JsObjMap_GetIter };
     slots[cur_slot++] =
@@ -4013,9 +4077,12 @@ skip_container_slots:
   if (flags & IS_DOUBLE_PROXY) {
     methods[cur_method++] = JsDoubleProxy_unwrap_MethodDef;
   }
-  if (!(flags & (IS_ARRAY | IS_TYPEDARRAY | IS_NODE_LIST | IS_BUFFER |
-                 IS_DOUBLE_PROXY | IS_ITERATOR))) {
+  if (INCLUDE_OBJMAP_METHODS(flags)) {
     methods[cur_method++] = JsProxy_as_object_map_MethodDef;
+    methods[cur_method++] = JsProxy_as_py_json_MethodDef;
+  }
+  if (flags & (IS_ARRAY | IS_NODE_LIST)) {
+    methods[cur_method++] = JsProxy_as_py_json_MethodDef;
   }
   if (flags & IS_ERROR) {
     type_name = "pyodide.ffi.JsException";
@@ -4185,7 +4252,7 @@ finally:
 #define SET_FLAG_IF_HAS_METHOD(flag, meth)                                     \
   SET_FLAG_IF(flag, hasMethod(obj, meth))
 
-EM_JS_NUM(int, JsProxy_compute_typeflags, (JsVal obj), {
+EM_JS_NUM(int, JsProxy_compute_typeflags, (JsVal obj, bool is_py_json), {
   let type_flags = 0;
   // clang-format off
   if (API.isPyProxy(obj) && !pyproxyIsAlive(obj)) {
@@ -4258,6 +4325,14 @@ EM_JS_NUM(int, JsProxy_compute_typeflags, (JsVal obj), {
         || constructorName === "DOMException"
       )
     ) && !(type_flags & (IS_CALLABLE | IS_BUFFER)));
+
+  if (is_py_json && (type_flags & (IS_ARRAY | IS_NODE_LIST | IS_ITERATOR))) {
+    // tagging IS_PY_JSON_SEQUENCE on IS_ITERATOR is a bit of a hack
+    type_flags |= IS_PY_JSON_SEQUENCE;
+  }
+  if (is_py_json && INCLUDE_OBJMAP_METHODS(type_flags)) {
+    type_flags |= IS_PY_JSON_DICT;
+  }
   // clang-format on
   return type_flags;
 });
@@ -4306,16 +4381,6 @@ finally:
   return result;
 }
 
-PyObject*
-JsProxy_create_objmap(JsVal object, bool objmap)
-{
-  int typeflags = JsProxy_compute_typeflags(object);
-  if (typeflags == 0 && objmap) {
-    typeflags |= IS_OBJECT_MAP;
-  }
-  return JsProxy_create_with_type(typeflags, object, JS_NULL, NULL);
-}
-
 EM_JS_BOOL(bool, is_comlink_proxy, (JsVal obj), {
   return !!(API.Comlink && value[API.Comlink.createEndpoint]);
 });
@@ -4327,14 +4392,17 @@ EM_JS_BOOL(bool, is_comlink_proxy, (JsVal obj), {
  * appropriate flags, then we get the appropriate type with JsProxy_get_subtype.
  */
 PyObject*
-JsProxy_create_with_this(JsVal object, JsVal this, PyObject* sig)
+JsProxy_create_with_this(JsVal object,
+                         JsVal this,
+                         PyObject* sig,
+                         bool is_py_json)
 {
   int type_flags = 0;
   if (is_comlink_proxy(object)) {
     // Comlink proxies are weird and break our feature detection pretty badly.
     type_flags = IS_CALLABLE | IS_AWAITABLE | IS_ARRAY;
   } else {
-    type_flags = JsProxy_compute_typeflags(object);
+    type_flags = JsProxy_compute_typeflags(object, is_py_json);
     if (type_flags == -1) {
       fail_test();
       PyErr_SetString(internal_error,
@@ -4348,7 +4416,18 @@ JsProxy_create_with_this(JsVal object, JsVal this, PyObject* sig)
 EMSCRIPTEN_KEEPALIVE PyObject*
 JsProxy_create(JsVal object)
 {
-  return JsProxy_create_with_this(object, JS_NULL, NULL);
+  return JsProxy_create_with_this(object, JS_NULL, NULL, false);
+}
+
+PyObject*
+JsProxy_create_objmap(JsVal object, int flags)
+{
+  bool is_py_json = !!(flags & OBJMAP_PY_JSON);
+  int typeflags = JsProxy_compute_typeflags(object, is_py_json);
+  if ((flags & OBJMAP_HEREDITARY) && INCLUDE_OBJMAP_METHODS(typeflags)) {
+    typeflags |= IS_OBJECT_MAP;
+  }
+  return JsProxy_create_with_type(typeflags, object, JS_NULL, NULL);
 }
 
 EMSCRIPTEN_KEEPALIVE bool

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -265,9 +265,9 @@ js2python_objmap(JsVal jsval, int flags)
   return JsProxy_create_objmap(jsval, flags);
 }
 
-#define INCLUDE_OBJMAP_METHODS(flags) \
-      !((flags) & (IS_ARRAY | IS_TYPEDARRAY | IS_NODE_LIST | IS_BUFFER |   \
-                   IS_DOUBLE_PROXY | IS_ITERATOR | IS_CALLABLE | IS_ERROR))
+#define INCLUDE_OBJMAP_METHODS(flags)                                          \
+  !((flags) & (IS_ARRAY | IS_TYPEDARRAY | IS_NODE_LIST | IS_BUFFER |           \
+               IS_DOUBLE_PROXY | IS_ITERATOR | IS_CALLABLE | IS_ERROR))
 
 static int
 JsProxy_clear(PyObject* self)
@@ -4693,6 +4693,8 @@ jsproxy_init(PyObject* core_module)
   AddFlag(IS_ASYNC_GENERATOR);
   AddFlag(IS_ASYNC_ITERATOR);
   AddFlag(IS_ERROR);
+  AddFlag(IS_PY_JSON_DICT);
+  AddFlag(IS_PY_JSON_SEQUENCE);
 
 #undef AddFlag
   FAIL_IF_MINUS_ONE(PyObject_SetAttrString(core_module, "js_flags", flag_dict));

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -14,7 +14,7 @@
  *
  */
 int
-JsProxy_compute_typeflags(JsVal obj);
+JsProxy_compute_typeflags(JsVal obj, bool is_json_adaptor);
 
 PyObject*
 JsProxy_create_with_type(int type_flags,
@@ -23,7 +23,7 @@ JsProxy_create_with_type(int type_flags,
                          PyObject* sig);
 
 PyObject*
-JsProxy_create_objmap(JsVal object, bool objmap);
+JsProxy_create_objmap(JsVal object, int flags);
 
 /**
  * Make a new JsProxy.
@@ -33,7 +33,10 @@ JsProxy_create_objmap(JsVal object, bool objmap);
  * @return The Python object wrapping the JavaScript object.
  */
 PyObject*
-JsProxy_create_with_this(JsVal object, JsVal this, PyObject* sig);
+JsProxy_create_with_this(JsVal object,
+                         JsVal this,
+                         PyObject* sig,
+                         bool is_json_adaptor);
 
 /**
  * Make a new JsProxy.

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1024,7 +1024,11 @@ class JsMap(JsIterable[KT], Generic[KT, VT_co], Mapping[KT, VT_co], metaclass=_A
     (idiomatically it should be called ``size``) and it must be iterable.
     """
 
-    _js_type_flags = ["HAS_GET | HAS_LENGTH | IS_ITERABLE", "IS_OBJECT_MAP"]
+    _js_type_flags = [
+        "HAS_GET | HAS_LENGTH | IS_ITERABLE",
+        "IS_OBJECT_MAP",
+        "IS_PY_JSON_DICT",
+    ]
 
     def __getitem__(self, idx: KT) -> VT_co:
         raise NotImplementedError
@@ -1079,7 +1083,11 @@ class JsMutableMap(
     ``JsMap`` .
     """
 
-    _js_type_flags = ["HAS_GET | HAS_SET | HAS_LENGTH | IS_ITERABLE", "IS_OBJECT_MAP"]
+    _js_type_flags = [
+        "HAS_GET | HAS_SET | HAS_LENGTH | IS_ITERABLE",
+        "IS_OBJECT_MAP",
+        "IS_PY_JSON_DICT",
+    ]
 
     @overload
     def pop(self, key: KT, /) -> VT: ...

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -241,6 +241,54 @@ class JsProxy(metaclass=_JsProxyMetaClass):
         """
         raise NotImplementedError
 
+    def as_py_json(self) -> "JsMutableMap[str, Any] | JsArray[Any]":
+        """Returns a new JsProxy that treats a JavaScript object as Python json.
+
+        It allows one to treat a JavaScript object that is a mixture of
+        JavaScript arrays and objects as a mixture of Python lists and dicts.
+
+        This method is not present on typed arrays, array buffers, functions,
+        and errors.
+
+        Examples
+        --------
+
+        >>> from pyodide.code import run_js # doctest: +RUN_IN_PYODIDE
+        >>> o1 = run_js("({x : {y: 2}})")
+        >>> o1.as_py_json()["x"]["y"]
+        2
+        >>> o2 = run_js("[{x: 2}, {x: 7}]")
+        >>> [e["x"] for e in o2.as_py_json()]
+        [2, 7]
+
+
+
+        You can use the following converter as the `default` argument to
+        :py:func:`json.dumps` to serialize a JavaScript object with
+
+        >>> from pyodide.ffi import JsProxy
+        >>> def default(obj):
+        ...   if isinstance(obj, JsProxy):
+        ...     if obj.constructor.name == "Array":
+        ...       return list(obj)
+        ...     return dict(obj)
+
+        For example:
+
+        >>> import json
+        >>> json.dumps(o1.as_py_json(), default=default)
+        '{"x": {"y": 2}}'
+        >>> json.dumps(o2.as_py_json(), default=default)
+        '[{"x": 2}, {"x": 7}]'
+
+        If you load the resulting json back into Python, the result is the same
+        as calling :py:meth:`JsProxy.to_py()`:
+
+        >>> assert json.loads(json.dumps(o1.as_py_json(), default=default)) == o1.to_py()
+        >>> assert json.loads(json.dumps(o2.as_py_json(), default=default)) == o2.to_py()
+        """
+        raise NotImplementedError
+
     def new(self, *args: Any, **kwargs: Any) -> "JsProxy":
         """Construct a new instance of the JavaScript object"""
         raise NotImplementedError

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1962,12 +1962,27 @@ def test_object_map_mapping_methods(selenium):
 @run_in_pyodide
 def test_as_object_map_heritable(selenium):
     import pytest
+    from _pyodide_core import js_flags
 
     from pyodide.code import run_js
+    from pyodide.ffi import JsMutableMap
+
+    flag = js_flags["IS_OBJECT_MAP"]
 
     o = run_js("({1:{2: 9, 3: 77}, 3:{6: 5, 12: 3, 2: 9}})")
     mh = o.as_object_map(hereditary=True)
     mn = o.as_object_map(hereditary=False)
+
+    assert mh._js_type_flags & flag != 0
+    assert mn._js_type_flags & flag != 0
+    assert isinstance(mh, JsMutableMap)
+    assert isinstance(mn, JsMutableMap)
+
+    assert mh["1"]._js_type_flags & flag != 0
+    assert mn["1"]._js_type_flags & flag == 0
+    assert isinstance(mh["1"], JsMutableMap)
+    assert not isinstance(mn["1"], JsMutableMap)
+
     assert mh["1"]["3"] == 77
 
     with pytest.raises(TypeError):
@@ -1986,16 +2001,16 @@ def test_as_object_map_heritable(selenium):
     o = run_js(
         """({0:[], 1:new Uint8Array(), 2:new Error(), 3:new ArrayBuffer()})"""
     ).as_object_map(hereditary=True)
-    assert "constructor" not in o["0"]
-    assert "constructor" not in o["1"]
-    with pytest.raises(TypeError):
-        "constructor" not in o["2"] # noq1:B015
-    with pytest.raises(TypeError):
-        "constructor" not in o["3"] # noq1:B015
+    assert o["0"]._js_type_flags & flag == 0
+    assert o["1"]._js_type_flags & flag == 0
+    assert o["2"]._js_type_flags & flag == 0
+    assert o["3"]._js_type_flags & flag == 0
 
-    o = run_js("""({1:{get(){}, "2": 1}, 2:new Map([["a", 1]])})""").as_object_map(
+    o = run_js("""({1:{get(){}, 2: 1}, 2:new Map([["a", 1]])})""").as_object_map(
         hereditary=True
     )
+    assert o["1"]._js_type_flags & flag != 0
+    assert o["2"]._js_type_flags & flag != 0
     assert "2" in o["1"]
     assert "a" not in o["2"]
 
@@ -2029,20 +2044,35 @@ def test_as_object_map_presence(selenium):
 
 @run_in_pyodide
 def test_as_py_json(selenium):
+    from _pyodide_core import js_flags
+
     from js import JSON
     from pyodide.code import run_js
-    from pyodide.ffi import JsProxy
+    from pyodide.ffi import JsArray, JsMap, JsProxy
+
+    dict_flag = js_flags["IS_PY_JSON_DICT"]
+    seq_flag = js_flags["IS_PY_JSON_SEQUENCE"]
+    either_flag = dict_flag | seq_flag
 
     o = run_js("({a: [1,2, {b: 7}]})").as_py_json()
+    assert o._js_type_flags & dict_flag
+    assert isinstance(o, JsMap)
     assert "a" in o
     assert len(o) == 1
+    assert o["a"]._js_type_flags & seq_flag != 0
     assert len(o["a"]) == 3
     assert o["a"][0] == 1
+    assert o["a"][-1]._js_type_flags & dict_flag != 0
     assert len(o["a"][-1]) == 1
     assert o["a"][-1]["b"] == 7
 
     assert list(o.keys()) == ["a"]
     assert [(k, v.to_py()) for (k, v) in o.items()] == [("a", [1, 2, {"b": 7}])]
+
+    o2 = run_js("([[1, 2], ()=>{}])").as_py_json()
+    assert o2._js_type_flags & seq_flag != 0
+    assert o2[0]._js_type_flags & seq_flag != 0
+    assert o2[1]._js_type_flags & either_flag == 0
 
     a = run_js("([{b: 1}, {b: 3}, {b: 7}])").as_py_json()
     l = [e["b"] for e in a]
@@ -2051,9 +2081,11 @@ def test_as_py_json(selenium):
 
     def default(obj):
         if isinstance(obj, JsProxy):
-            if obj.constructor.name == "Array":
+            if isinstance(obj, JsArray):
                 return list(obj)
-            return dict(obj)
+            if isinstance(obj, JsMap):
+                return dict(obj)
+        raise NotImplementedError
 
     for x in [o, a]:
         assert json.dumps(x, default=default).replace(" ", "") == JSON.stringify(x)


### PR DESCRIPTION
This is the Js to Python analogue of `asJsJson`. There's a fair amount of overlap in behavior with as_object_map here.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
