### PR TITLE
chore: bump PyArrow test timeout value

### DIFF
--- a/packages/pyarrow/test_pyarrow.py
+++ b/packages/pyarrow/test_pyarrow.py
@@ -1,6 +1,8 @@
+import pytest
 from pytest_pyodide import run_in_pyodide
 
 
+@pytest.mark.driver_timeout(120)
 @run_in_pyodide(packages=["pyarrow", "numpy", "pandas"])
 def test_read_write_parquet(selenium):
     import numpy as np


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

`test_pyarrow.py::test_read_write_parquet` (#4950) has faced intermittent timeouts in both the Chrome and the Firefox tests (which I have generally seen are slower than the Node.js ones), as noticed over the past few days in unrelated test failures in other PRs. This PR increases the timeout value so that the timeout is statistically unlikely.

Also, tagging @joemarshall as the recipe maintainer for PyArrow, just in case this is a known problem or something that would merit a deeper look.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

N/A
