### PR TITLE
Snapshots: Add support for custom serializer

### DIFF
--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -666,13 +666,17 @@ export class PyodideAPI {
     return orig;
   }
 
-  static makeMemorySnapshot(): Uint8Array {
+  static makeMemorySnapshot({
+    serializer,
+  }: {
+    serializer?: (obj: any) => any;
+  } = {}): Uint8Array {
     if (!API.config._makeSnapshot) {
       throw new Error(
         "Can only use pyodide.makeMemorySnapshot if the _makeSnapshot option is passed to loadPyodide",
       );
     }
-    return API.makeSnapshot();
+    return API.makeSnapshot(serializer);
   }
 }
 
@@ -751,6 +755,7 @@ export function jsFinderHook(o: object) {
  */
 API.finalizeBootstrap = function (
   snapshotConfig?: SnapshotConfig,
+  snapshotDeserializer?: (obj: any) => any,
 ): PyodideInterface {
   if (snapshotConfig) {
     syncUpSnapshotLoad1();
@@ -790,7 +795,7 @@ API.finalizeBootstrap = function (
   }
   const jsglobals = API.config.jsglobals;
   if (snapshotConfig) {
-    syncUpSnapshotLoad2(jsglobals, snapshotConfig);
+    syncUpSnapshotLoad2(jsglobals, snapshotConfig, snapshotDeserializer);
   } else {
     importhook.register_js_finder.callKwargs({ hook: jsFinderHook });
     importhook.register_js_module("js", jsglobals);

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -192,17 +192,15 @@ export async function loadPyodide(
      * @ignore
      */
     _node_mounts?: string[];
-    /**
-     * @ignore
-     */
+    /** @ignore */
     _makeSnapshot?: boolean;
-    /**
-     * @ignore
-     */
+    /** @ignore */
     _loadSnapshot?:
       | Uint8Array
       | ArrayBuffer
       | PromiseLike<Uint8Array | ArrayBuffer>;
+    /** @ignore */
+    _snapshotDeserializer?: (obj: any) => any;
   } = {},
 ): Promise<PyodideInterface> {
   await initNodeModules();
@@ -290,7 +288,10 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
     snapshotConfig = API.restoreSnapshot(snapshot);
   }
   // runPython works starting after the call to finalizeBootstrap.
-  const pyodide = API.finalizeBootstrap(snapshotConfig);
+  const pyodide = API.finalizeBootstrap(
+    snapshotConfig,
+    options._snapshotDeserializer,
+  );
   API.sys.path.insert(0, API.config.env.HOME);
 
   if (!pyodide.version.includes("dev")) {

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -430,9 +430,12 @@ export interface API {
   os: PyProxy;
 
   restoreSnapshot(snapshot: Uint8Array): SnapshotConfig;
-  makeSnapshot(): Uint8Array;
+  makeSnapshot(serializer?: (obj: any) => any): Uint8Array;
   saveSnapshot(): Uint8Array;
-  finalizeBootstrap: (fromSnapshot?: SnapshotConfig) => PyodideInterface;
+  finalizeBootstrap: (
+    fromSnapshot?: SnapshotConfig,
+    snapshotDeserializer?: (obj: any) => any,
+  ) => PyodideInterface;
   syncUpSnapshotLoad3(conf: SnapshotConfig): void;
   abortSignalAny: (signals: AbortSignal[]) => AbortSignal;
   version: string;


### PR DESCRIPTION
The user may pass a serializer function to `makeSnapshot`. It will be called with JavaScript objects that we don't know how to snapshot. It must return an object that we can `JSON.stringify`. When restoring the snapshot, the user must pass a corresponding deserializer that will take the object returned by the serializer and create the original JSON object.


- [x] Add / update tests

