### PR TITLE
Bump certificate bundle package certifi to 2024.7.4

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -60,6 +60,7 @@ myst:
 - Upgraded `scikit-learn` to 1.5.1 {pr}`4823`, {pr}`5016`
 - Upgraded `libcst` to 1.4.0 {pr}`4856`
 - Upgraded `lakers` to 0.3.3 {pr}`4885`
+- Upgraded `certifi` to 2024.7.4 {pr}`5035`
 - Upgraded `bokeh` to 3.4.2 {pr}`4888`
 - Upgraded `pandas` to 2.2.2 {pr}`4893`
 - Upgraded `zengl` to 2.5.0 {pr}`4894`

--- a/packages/certifi/meta.yaml
+++ b/packages/certifi/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: certifi
-  version: 2024.2.2
+  version: 2024.7.4
   top-level:
     - certifi
 source:
   url: https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl
-  sha256: dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
+  sha256: c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
 about:
   home: https://github.com/certifi/python-certifi
   PyPI: https://pypi.org/project/certifi

--- a/packages/certifi/meta.yaml
+++ b/packages/certifi/meta.yaml
@@ -4,7 +4,7 @@ package:
   top-level:
     - certifi
 source:
-  url: https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl
+  url: https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl
   sha256: c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
 about:
   home: https://github.com/certifi/python-certifi


### PR DESCRIPTION
This PR bumps the certificate bundle in `certifi` to 2024.7.4.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry