### PR TITLE
Return all prefixes of the import path from `find_imports`

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -55,6 +55,11 @@ myst:
   JSON (Arrays and Objects). to Python JSON (lists and dicts).
   {pr}`4666`
 
+- {{ Enhancement }} `find_imports("import pkg.module.submodule")` will now
+  return `["pkg", "pkg.module", "pkg.module.submodule"]`. This improves support
+  for namespace packages.
+  {pr}`5039`
+
 ### Packages
 
 - Upgraded `scikit-learn` to 1.5.1 {pr}`4823`, {pr}`5016`

--- a/src/py/_pyodide/_base.py
+++ b/src/py/_pyodide/_base.py
@@ -627,14 +627,18 @@ def find_imports(source: str) -> list[str]:
 
     Returns
     -------
-        A list of module names that are imported in ``source``. If ``source`` is not
-        syntactically correct Python code (after dedenting), returns an empty list.
+        A list of module names that are imported in ``source``. If ``source`` is
+        not syntactically correct Python code (after dedenting), returns an
+        empty list.
+
+        Given `import package.module`, `find_imports` will include both
+        `"package"` and `"package.module"` in the result.
 
     Examples
     --------
     >>> source = "import numpy as np; import scipy.stats"
     >>> find_imports(source)
-    ['numpy', 'scipy']
+    ['numpy', 'scipy', 'scipy.stats']
     """
     # handle mis-indented input from multi-line strings
     source = dedent(source)

--- a/src/py/_pyodide/_base.py
+++ b/src/py/_pyodide/_base.py
@@ -608,6 +608,14 @@ async def eval_code_async(
     )
 
 
+def _add_prefixes(s: set[str], mod: str) -> None:
+    [current, *rest] = mod.split(".")
+    s.add(current)
+    for part in rest:
+        current += f".{part}"
+        s.add(current)
+
+
 def find_imports(source: str) -> list[str]:
     """
     Finds the imports in a Python source code string
@@ -635,17 +643,17 @@ def find_imports(source: str) -> list[str]:
         mod = ast.parse(source)
     except SyntaxError:
         return []
-    imports = set()
+    imports: set[str] = set()
     for node in ast.walk(mod):
         if isinstance(node, ast.Import):
             for name in node.names:
                 node_name = name.name
-                imports.add(node_name.split(".")[0])
+                _add_prefixes(imports, node_name)
         elif isinstance(node, ast.ImportFrom):
             module_name = node.module
             if module_name is None:
                 continue
-            imports.add(module_name.split(".")[0])
+            _add_prefixes(imports, module_name)
     return list(sorted(imports))
 
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -24,7 +24,7 @@ def test_find_imports():
         import matplotlib.pyplot as plt
         """
     )
-    assert set(res) == {"numpy", "scipy", "matplotlib"}
+    assert set(res) == {"numpy", "scipy", "matplotlib", "matplotlib.pyplot"}
 
     # If there is a syntax error in the code, find_imports should return empty
     # list.


### PR DESCRIPTION
Instead of just returning `["a"]` when we find `import a.b.c`, return `["a", "a.b", "a.b.c"]`. 
This fixes CI in #5020. As an alternative, we might want to forbid dots in the top-level field, but in that case we should check for it when loading `meta.yaml`.

- [x] Update changelog
- [x] Update tests
- [x] Update documentation