### PR TITLE
Update pydantic and pydantic_core

### DIFF
--- a/packages/pydantic/meta.yaml
+++ b/packages/pydantic/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: pydantic
-  version: 2.7.0
+  version: 2.8.2
   top-level:
     - pydantic
 source:
-  sha256: b5ecdd42262ca2462e2624793551e80911a1e989f462910bb81aef974b4bb383
-  url: https://files.pythonhosted.org/packages/cd/fc/70fe71ff78f680d584eba9c55a30092f6ef0b9cf0c75a74bd35a24151a83/pydantic-2.7.0.tar.gz
+  sha256: 6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a
+  url: https://files.pythonhosted.org/packages/8c/99/d0a5dca411e0a017762258013ba9905cd6e7baa9a3fd1fe8b6529472902e/pydantic-2.8.2.tar.gz
 requirements:
   run:
     - typing-extensions

--- a/packages/pydantic_core/meta.yaml
+++ b/packages/pydantic_core/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: pydantic_core
-  version: 2.18.1
+  version: 2.23.1
   top-level:
     - pydantic_core
 source:
-  url: https://files.pythonhosted.org/packages/3d/28/d693aab237fca82da327990a88a983b2b84b890032076ee4a87e18038dbb/pydantic_core-2.18.1.tar.gz
-  sha256: de9d3e8717560eb05e28739d1b35e4eac2e458553a52a301e51352a7ffc86a35
+  url: https://files.pythonhosted.org/packages/60/a9/a64afaeecc30a42142f5e60bb61a1ec4817e90c2d1c0c7b242082f61ed00/pydantic_core-2.23.1.tar.gz
+  sha256: 12543919dbf3021e17b9e2cd5cd1b570c6585794fa487339b5b95564b9689452
 requirements:
   executable:
     - rustup


### PR DESCRIPTION
`pydantic_core` is not compatible with Python 3.12.5 without this update. This should reduce the change of problems.
