### PR TITLE
Fix LAPACK larfg function signature mismatch (SciPy)

### DIFF
--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -38,6 +38,7 @@ source:
     - patches/0015-Remove-f2py-generator.patch
     - patches/0016-Make-sf_error_state_lib-a-static-library.patch
     - patches/0017-Remove-test-modules-that-fail-to-build.patch
+    - patches/0018-Fix-lapack-larfg-function-signature.patch
 
 build:
   cflags: |

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -35,7 +35,7 @@ source:
     - patches/0012-Remove-chla_transtype.patch
     - patches/0013-Set-wrapper-return-type-to-int.patch
     - patches/0014-Skip-svd_gesdd-test.patch # remove with SciPy v1.15.0
-    - patches/0015-Remove-f2py-generator.patch
+    - patches/0015-Remove-f2py-generators.patch
     - patches/0016-Make-sf_error_state_lib-a-static-library.patch
     - patches/0017-Remove-test-modules-that-fail-to-build.patch
     - patches/0018-Fix-lapack-larfg-function-signature.patch

--- a/packages/scipy/patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
+++ b/packages/scipy/patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
@@ -1,7 +1,7 @@
 From 45a31145679c83f2719b6420f234d484b9459697 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 18 Mar 2022 16:25:39 -0700
-Subject: [PATCH 1/17] Fix dstevr in special/lapack_defs.h
+Subject: [PATCH 1/18] Fix dstevr in special/lapack_defs.h
 
 ---
  scipy/special/lapack_defs.h | 5 ++---

--- a/packages/scipy/patches/0002-int-to-string.patch
+++ b/packages/scipy/patches/0002-int-to-string.patch
@@ -1,7 +1,7 @@
 From d53ade3f03ba3557fd50fb38990d605f4ae7f8f1 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 25 Dec 2021 18:04:18 -0800
-Subject: [PATCH 2/17] int to string
+Subject: [PATCH 2/18] int to string
 
 f2c does not handle implicit casts of function arguments correctly. The msg
 argument of `xerrwv` is defined to be an `int *`, and then implicitly cast

--- a/packages/scipy/patches/0003-gemm_-no-const.patch
+++ b/packages/scipy/patches/0003-gemm_-no-const.patch
@@ -1,7 +1,7 @@
 From e528227dd37c8b0512381992c222789a114e3169 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 18 Dec 2021 11:41:15 -0800
-Subject: [PATCH 3/17] gemm_ no const
+Subject: [PATCH 3/18] gemm_ no const
 
 cgemm, dgemm, sgemm, and zgemm are declared with `const` in slu_cdefs.h, but
 other places don't have the cosnt causing compile errors.

--- a/packages/scipy/patches/0004-make-int-return-values.patch
+++ b/packages/scipy/patches/0004-make-int-return-values.patch
@@ -1,7 +1,7 @@
 From a86a2304fd925f815bbb0e0753e46a7b863e2de2 Mon Sep 17 00:00:00 2001
 From: Joe Marshall <joe.marshall@nottingham.ac.uk>
 Date: Wed, 6 Apr 2022 21:25:13 -0700
-Subject: [PATCH 4/17] make int return values
+Subject: [PATCH 4/18] make int return values
 
 The return values of f2c functions are insignificant in most cases, so often it
 is treated as returning void, when it really should return int (values are

--- a/packages/scipy/patches/0005-Fix-fitpack.patch
+++ b/packages/scipy/patches/0005-Fix-fitpack.patch
@@ -1,7 +1,7 @@
 From c784d3a1ee38da88943364de4ea847a3b9cd155f Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Tue, 30 Aug 2022 11:51:53 -0700
-Subject: [PATCH 5/17] Fix fitpack
+Subject: [PATCH 5/18] Fix fitpack
 
 ---
  scipy/interpolate/fitpack/dblint.f | 9 ++++-----

--- a/packages/scipy/patches/0006-Fix-gees-calls.patch
+++ b/packages/scipy/patches/0006-Fix-gees-calls.patch
@@ -1,7 +1,7 @@
 From 8addc1da35bc63df651946ef14c723797a431e0c Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Mon, 26 Jun 2023 20:12:25 -0700
-Subject: [PATCH 6/17] Fix gees calls
+Subject: [PATCH 6/18] Fix gees calls
 
 ---
  scipy/linalg/flapack_gen.pyf.src | 8 ++++----

--- a/packages/scipy/patches/0007-MAINT-linalg-Remove-id_dist-Fortran-files.patch
+++ b/packages/scipy/patches/0007-MAINT-linalg-Remove-id_dist-Fortran-files.patch
@@ -1,7 +1,7 @@
 From 12ba8a395ce04194074a24d362143c22e7ac54bd Mon Sep 17 00:00:00 2001
 From: Ilhan Polat <ilhanpolat@gmail.com>
 Date: Tue, 23 Apr 2024 09:26:38 +0200
-Subject: [PATCH 7/17] MAINT:linalg:Remove id_dist Fortran files
+Subject: [PATCH 7/18] MAINT:linalg:Remove id_dist Fortran files
 
 [skip ci]
 

--- a/packages/scipy/patches/0008-Mark-mvndst-functions-recursive.patch
+++ b/packages/scipy/patches/0008-Mark-mvndst-functions-recursive.patch
@@ -1,7 +1,7 @@
 From c11745d763407d9a2bb195a21e2a8afaf7635248 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 6 Jul 2024 22:38:55 +0200
-Subject: [PATCH 8/17] Mark mvndst functions recursive
+Subject: [PATCH 8/18] Mark mvndst functions recursive
 
 ---
  scipy/stats/mvndst.f | 8 ++++----

--- a/packages/scipy/patches/0009-Make-sreorth-recursive.patch
+++ b/packages/scipy/patches/0009-Make-sreorth-recursive.patch
@@ -1,7 +1,7 @@
 From e4d1a570fa8bd4c710e10400822f60232e6408eb Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 6 Jul 2024 22:33:51 +0200
-Subject: [PATCH 9/17] Make sreorth recursive
+Subject: [PATCH 9/18] Make sreorth recursive
 
 ---
  complex16/zreorth.F | 6 +++---

--- a/packages/scipy/patches/0010-Link-openblas-with-modules-that-require-f2c.patch
+++ b/packages/scipy/patches/0010-Link-openblas-with-modules-that-require-f2c.patch
@@ -1,7 +1,7 @@
 From ccbb0fa0884d567c6139eeed7dc2dc9f8db4db3a Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Sun, 28 Jul 2024 18:15:17 +0900
-Subject: [PATCH 10/17] Link openblas with modules that require f2c
+Subject: [PATCH 10/18] Link openblas with modules that require f2c
 
 Some fortran modules require symbols from f2c, which is provided by
 openblas.

--- a/packages/scipy/patches/0011-Remove-fpchec-inline-if-then-endif-constructs.patch
+++ b/packages/scipy/patches/0011-Remove-fpchec-inline-if-then-endif-constructs.patch
@@ -1,7 +1,7 @@
 From b43a231f8326d6953929030131c3fb6b2cb163bd Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Wed, 15 May 2024 21:29:02 +0530
-Subject: [PATCH 11/17] Remove fpchec inline if-then-endif constructs
+Subject: [PATCH 11/18] Remove fpchec inline if-then-endif constructs
 
 This PR removes the single-line if-then-endif constructs in fpchec.f
 that were causing syntactical errors when compiling with f2c, possibly

--- a/packages/scipy/patches/0012-Remove-chla_transtype.patch
+++ b/packages/scipy/patches/0012-Remove-chla_transtype.patch
@@ -1,7 +1,7 @@
 From 848c94e218e89d866978fbc883cbb2d919f56ce9 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 31 Jul 2024 10:29:47 +0200
-Subject: [PATCH 12/17] Remove chla_transtype
+Subject: [PATCH 12/18] Remove chla_transtype
 
 The signature should probably be `int chla_transtype(char* res, int *trans)`.
 This just deletes it entirely due to laziness.

--- a/packages/scipy/patches/0013-Set-wrapper-return-type-to-int.patch
+++ b/packages/scipy/patches/0013-Set-wrapper-return-type-to-int.patch
@@ -1,7 +1,7 @@
 From b5d05197de084ab3cab52241f163bae7519b6027 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 31 Jul 2024 11:48:12 +0200
-Subject: [PATCH 13/17] Set wrapper return type to int
+Subject: [PATCH 13/18] Set wrapper return type to int
 
 ---
  scipy/linalg/_generate_pyx.py | 2 +-

--- a/packages/scipy/patches/0014-Skip-svd_gesdd-test.patch
+++ b/packages/scipy/patches/0014-Skip-svd_gesdd-test.patch
@@ -1,7 +1,7 @@
 From 59d3efdf9e55958c6a3651e8eda2a9d6fe48e192 Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Fri, 9 Aug 2024 19:00:41 +0530
-Subject: [PATCH 14/17] Skip svd_gesdd test
+Subject: [PATCH 14/18] Skip svd_gesdd test
 
 This patch excludes a test for gesdd which was introduced in this PR:
 https://github.com/scipy/scipy/pull/20349. It is not useful for Pyodide

--- a/packages/scipy/patches/0015-Remove-f2py-generators.patch
+++ b/packages/scipy/patches/0015-Remove-f2py-generators.patch
@@ -1,7 +1,7 @@
 From 9b670bd5330bd7834d157a9ec3087a97b71d6516 Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Fri, 16 Aug 2024 22:59:26 +0530
-Subject: [PATCH 15/17] Remove f2py generator
+Subject: [PATCH 15/18] Remove f2py generators
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/packages/scipy/patches/0016-Make-sf_error_state_lib-a-static-library.patch
+++ b/packages/scipy/patches/0016-Make-sf_error_state_lib-a-static-library.patch
@@ -1,7 +1,7 @@
 From 9d93ca19f4ad0ca327964b6234316547d774b17f Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Sat, 17 Aug 2024 01:12:28 +0530
-Subject: [PATCH 16/17] Make `sf_error_state_lib` a static library
+Subject: [PATCH 16/18] Make `sf_error_state_lib` a static library
 
 wasm.ld does not support linkage with shared libraries. This patch
 changes `sf_error_state_lib` to a static one.

--- a/packages/scipy/patches/0017-Remove-test-modules-that-fail-to-build.patch
+++ b/packages/scipy/patches/0017-Remove-test-modules-that-fail-to-build.patch
@@ -1,7 +1,7 @@
 From e21f33695da3275ec81b5f94685f0e4ac92c9ad5 Mon Sep 17 00:00:00 2001
 From: Gyeongjae Choi <def6488@gmail.com>
 Date: Mon, 30 Oct 2023 14:35:04 +0000
-Subject: [PATCH 17/17] Remove test modules that fail to build
+Subject: [PATCH 17/18] Remove test modules that fail to build
 
 These are tests and they have both void vs int return value problems and implicit
 function argument cast problems. Not worth fixing for tests.

--- a/packages/scipy/patches/0018-Fix-lapack-larfg-function-signature.patch
+++ b/packages/scipy/patches/0018-Fix-lapack-larfg-function-signature.patch
@@ -1,0 +1,38 @@
+From 8b06e7fef50327f84140cb09a3d9237e18b38a35 Mon Sep 17 00:00:00 2001
+From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Date: Thu, 5 Sep 2024 21:14:20 +0530
+Subject: [PATCH 18/18] Fix lapack larfg function signature
+
+This patch fixes the signature of the LAPACK routine larfg. Please
+see https://github.com/pyodide/pyodide/issues/3379 for more details.
+
+Co-authored-by: Ilhan Polat <ilhanpolat@gmail.com>
+Suggested-by: Hood Chatham <roberthoodchatham@gmail.com>
+
+---
+ scipy/linalg/flapack_other.pyf.src | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/scipy/linalg/flapack_other.pyf.src b/scipy/linalg/flapack_other.pyf.src
+index 99d4886558..bf7256e605 100644
+--- a/scipy/linalg/flapack_other.pyf.src
++++ b/scipy/linalg/flapack_other.pyf.src
+@@ -2310,13 +2310,12 @@ function <prefix2c>lange(norm,m,n,a,lda,work) result(n2)
+     <ftype2> dimension(m+1),intent(cache,hide) :: work
+ end function <prefix2c>lange
+ 
+-subroutine <prefix>larfg(n, alpha, x, incx, tau, lx)
++subroutine <prefix>larfg(n, alpha, x, incx, tau)
+     integer intent(in), check(n>=1) :: n
+     <ftype> intent(in,out) :: alpha
+-    <ftype> intent(in,copy,out), dimension(lx) :: x
++    <ftype> intent(in,copy,out), dimension(*), depend(n,incx), check(len(x) >= (n-2)*incx) :: x
+     integer intent(in), check(incx>0||incx<0) :: incx = 1
+     <ftype> intent(out) :: tau
+-    integer intent(hide),depend(x,n,incx),check(lx > (n-2)*incx) :: lx = len(x)
+ end subroutine <prefix>larfg
+ 
+ subroutine <prefix>larf(side,m,n,v,incv,tau,c,ldc,work,lwork)
+-- 
+2.39.3 (Apple Git-146)
+

--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -100,6 +100,22 @@ def test_cpp_exceptions(selenium):
         lombscargle(x=[1], y=[1, 2], freqs=[1, 2, 3])
 
 
+# Regression test for LAPACK larfg signature mismatch
+# https://github.com/pyodide/pyodide/issues/3379
+@pytest.mark.driver_timeout(40)
+@run_in_pyodide(packages=["scipy", "numpy"])
+def test_lapack_larfg(selenium):
+    import numpy as np
+    from scipy.linalg.lapack import get_lapack_funcs
+
+    a = np.arange(16).reshape(4, 4)
+    a = a.T.dot(a)
+
+    (larfg,) = get_lapack_funcs(["larfg"], dtype="float64")
+    alpha, x, tau = larfg(a.shape[0] - 1, a[1, 0], a[2:, 0])
+    return (alpha, x, tau) is not None
+
+
 @pytest.mark.driver_timeout(40)
 @run_in_pyodide(packages=["scipy"])
 def test_logm(selenium_standalone):


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This PR closes #3379. It patches the function signature for the `larfg` subroutine in `scipy/linalg/flapack_other.pyf.src` to remove an `lx` additional argument that was being passed, resolving the original reproducer posted in the issue. However, I am not as acquainted with Fortran, so please let me know if there is a better way to do this and I can try to learn that.

@ilayn, I know that you had mentioned in https://github.com/pyodide/pyodide/issues/3379#issuecomment-2160587164 that you would do it when you would have got the chance; I hope it is okay with you for me to take it up because I felt that this was a reasonably easy fix to incorporate! I have granted you co-authorship in the patch file, thank you :)

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add / update tests
