### PR TITLE
Fix SciPy LAPACK larf function signature mismatch

### DIFF
--- a/packages/scipy/scipy-conftest.py
+++ b/packages/scipy/scipy-conftest.py
@@ -89,7 +89,6 @@ tests_to_mark = [
     # scipy/linalg tests
     ("test_blas.+test_complex_dotu", skip, todo_signature_mismatch_msg),
     ("test_cython_blas.+complex", skip, todo_signature_mismatch_msg),
-    ("test_lapack.py.+larfg_larf", skip, todo_signature_mismatch_msg),
     # scipy/ndimage/tests
     ("test_filters.py::TestThreading", xfail, thread_msg),
     # scipy/optimize/tests


### PR DESCRIPTION


<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

From #5059 – I added the relevant test in `test_scipy.py`, but forgot to remove the test skip from `scipy-conftest.py`.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add / update tests