### PR TITLE
DOC Adds a cibuildwheel github action example to out of tree build docs

### DIFF
--- a/docs/development/building-and-testing-packages.md
+++ b/docs/development/building-and-testing-packages.md
@@ -16,8 +16,8 @@ If your package is a pure Python package (i.e., if the wheel ends in
 `py3-none-any.whl`) then follow the official PyPA documentation on building
 [wheels](https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives)
 For binary packages, the manual steps are detailed below. In addition,
-[cibuildwheels](https://cibuildwheel.pypa.io/en/stable/) 2.19 or later provide
-support for building binary packages.
+[cibuildwheel](https://cibuildwheel.pypa.io/en/stable/) 2.19 or later provides
+support for building binary wheels with Pyodide as a target.
 
 ### Install pyodide-build
 

--- a/docs/development/building-and-testing-packages.md
+++ b/docs/development/building-and-testing-packages.md
@@ -15,7 +15,9 @@ Subsystem for Linux.
 If your package is a pure Python package (i.e., if the wheel ends in
 `py3-none-any.whl`) then follow the official PyPA documentation on building
 [wheels](https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives)
-Otherwise, the procedure is as follows.
+For binary packages, the manual steps are detailed below. In addition,
+[cibuildwheels](https://cibuildwheel.pypa.io/en/stable/) 2.19 or later provide
+support for building binary packages.
 
 ### Install pyodide-build
 
@@ -142,10 +144,10 @@ and you can pass options to it just like normal. Currently `subprocess` doesn't
 work, so if you have a test runner that uses `subprocess` then it cannot be
 used.
 
-## Build Github actions example
+## Build Github actions examples
 
-Here is a complete example of a Github Actions workflow for building a Python
-wheel out of tree:
+This is a complete example for building a Python wheel out of tree using
+`pyodide build` directly:
 
 ```yaml
 runs-on: ubuntu-22.04
@@ -153,14 +155,25 @@ runs-on: ubuntu-22.04
   - uses: actions/checkout@v4
   - uses: actions/setup-python@v5
     with:
-       python-version: 3.11.2
+       python-version: 3.12
   - run: |
-      pip install pyodide-build>=0.23.0
+      pip install pyodide-build>=0.28.0
       echo EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version) >> $GITHUB_ENV
   - uses: mymindstorm/setup-emsdk@v14
     with:
        version: ${{ env.EMSCRIPTEN_VERSION }}
   - run: pyodide build
+```
+
+And this is an example using `cibuildwheel` to build a Python wheel out of tree:
+
+```yaml
+runs-on: ubuntu-22.04
+  steps:
+  - uses: actions/checkout@v4
+  - uses: pypa/cibuildwheel@v2.20.0
+    env:
+       CIBW_PLATFORM: pyodide
 ```
 
 For an example "in the wild" of a github action to build and test a wheel

--- a/docs/development/building-and-testing-packages.md
+++ b/docs/development/building-and-testing-packages.md
@@ -144,13 +144,13 @@ and you can pass options to it just like normal. Currently `subprocess` doesn't
 work, so if you have a test runner that uses `subprocess` then it cannot be
 used.
 
-## Build Github actions examples
+## Github Actions build examples
 
-This is a complete example for building a Python wheel out of tree using
+This is a complete example for building a Pyodide wheel out of tree using
 `pyodide build` directly:
 
 ```yaml
-runs-on: ubuntu-22.04
+runs-on: ubuntu-22.04 # or ubuntu-latest
   steps:
   - uses: actions/checkout@v4
   - uses: actions/setup-python@v5
@@ -165,10 +165,10 @@ runs-on: ubuntu-22.04
   - run: pyodide build
 ```
 
-And this is an example using `cibuildwheel` to build a Python wheel out of tree:
+And this is an example using `cibuildwheel` to build a Pyodide wheel out of tree:
 
 ```yaml
-runs-on: ubuntu-22.04
+runs-on: ubuntu-22.04 # or ubuntu-latest
   steps:
   - uses: actions/checkout@v4
   - uses: pypa/cibuildwheel@v2.20.0


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Fixes #5061 by adding an example about how to use cibuildwheel to build pyodide out of tree binary packages. (I also took the chance to update the "normal" github actions example to use latest versions of some dependencies)

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add new / update outdated documentation
