### PR TITLE
Fix failing CI due to SciPy build trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,9 +242,20 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - id: check-build-trigger
-        name: Check build trigger
-        run: bash tools/check_build_trigger.sh
+      - name: Check build trigger
+        id: check-build-trigger
+        shell: bash
+        run: |
+          set -e -x
+
+          COMMIT_MSG=$(git log --no-merges -1 --oneline)
+
+          # The scipy tests will be triggered on push or on pull_request when the commit
+          # message contains "[scipy]"
+          if [[ "$GITHUB_EVENT_NAME" == push ||
+                "$COMMIT_MSG" =~ \[scipy\] ]]; then
+              echo "trigger=true" >> "$GITHUB_OUTPUT"
+          fi
 
   test-scipy:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

For some reason, GHA CI has been [failing](https://github.com/pyodide/pyodide/actions/runs/10772738037/job/29871051041?pr=5062) since the past few days. I brought the script over to the workflow file directly, since it's only a few lines of code.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

N/A
