### PR TITLE
jsbind: Add support for Json as a JS to python annotation

### DIFF
--- a/src/core/jsbind.c
+++ b/src/core/jsbind.c
@@ -313,7 +313,7 @@ python2js_inner(PyObject* x,
                 bool is_json_adaptor);
 
 static JsVal
-Py2Js_func_as_json_adaptor(PyObject* self, PyObject* pyval, JsVal proxies)
+Py2Js_func_as_js_json(PyObject* self, PyObject* pyval, JsVal proxies)
 {
   return python2js_inner(pyval,
                          proxies,
@@ -365,6 +365,14 @@ static PyObject*
 Js2Py_func_deep(PyObject* self, JsVal jsval, JsVal proxies)
 {
   PyObject* result = js2python_convert(jsval, -1, Jsv_undefined);
+  maybe_destroy_proxies(jsval, proxies);
+  return result;
+}
+
+static PyObject*
+Js2Py_func_as_py_json(PyObject* self, JsVal jsval, JsVal proxies)
+{
+  PyObject* result = js2python_as_py_json(jsval);
   maybe_destroy_proxies(jsval, proxies);
   return result;
 }
@@ -629,11 +637,12 @@ jsbind_init(PyObject* core_mod)
   ADD_TYPE(Py2JsConverter);
   ADD_TYPE(Js2PyConverter);
 
-  ADD_PY2JS(as_json_adaptor);
+  ADD_PY2JS(as_js_json);
   ADD_PY2JS(deep);
   ADD_PY2JS(default);
 
   ADD_JS2PY(deep);
+  ADD_JS2PY(as_py_json);
   ADD_JS2PY(default);
   ADD_JS2PY(default_call_result);
   ADD_JS2PY(promise);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -231,7 +231,7 @@ JsProxy_getflags(PyObject* self)
 #define OBJMAP_HEREDITARY 1
 #define OBJMAP_PY_JSON 2
 
-int
+static int
 JsProxy_get_objmap_flags(PyObject* self)
 {
   int flags = JsProxy_getflags(self);
@@ -253,7 +253,7 @@ JsProxy_is_py_json(PyObject* self)
   return !!(JsProxy_getflags(self) & (IS_PY_JSON_DICT | IS_PY_JSON_SEQUENCE));
 }
 
-PyObject*
+static PyObject*
 js2python_objmap(JsVal jsval, int flags)
 {
   PyObject* result = NULL;
@@ -263,6 +263,12 @@ js2python_objmap(JsVal jsval, int flags)
     return result;
   }
   return JsProxy_create_objmap(jsval, flags);
+}
+
+PyObject*
+js2python_as_py_json(JsVal jsval)
+{
+  return js2python_objmap(jsval, OBJMAP_PY_JSON);
 }
 
 #define INCLUDE_OBJMAP_METHODS(flags)                                          \

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -64,4 +64,7 @@ wrap_promise(JsVal promise, JsVal done_callback, PyObject* js2py_converter);
 int
 JsProxy_init(PyObject* core_module);
 
+PyObject*
+js2python_as_py_json(JsVal jsval);
+
 #endif /* JSPROXY_H */

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -117,7 +117,7 @@ class JsProxy(metaclass=_JsProxyMetaClass):
             return super().__new__(cls)
         raise TypeError(f"{cls.__name__} cannot be instantiated.")
 
-    def bind_sig(self, signature: Any) -> "JsProxy":
+    def bind_sig(self, signature: T) -> T:
         """Creates a copy of the JsProxy with a signature bound to it.
 
         .. admonition:: Experimental
@@ -125,7 +125,7 @@ class JsProxy(metaclass=_JsProxyMetaClass):
 
            This feature is not yet stable, nor really documented.
         """
-        return self
+        return signature
 
     @property
     def js_id(self) -> int:

--- a/src/py/_pyodide/jsbind.py
+++ b/src/py/_pyodide/jsbind.py
@@ -13,10 +13,11 @@ from _pyodide_core import (
     JsFuncSignature,
     Py2JsConverter,
     create_promise_converter,
+    js2py_as_py_json,
     js2py_deep,
     js2py_default,
     js2py_default_call_result,
-    py2js_as_json_adaptor,
+    py2js_as_js_json,
     py2js_deep,
     py2js_default,
 )
@@ -62,7 +63,8 @@ def js2py_bind(x):
 
 
 class Json:
-    py2js = py2js_as_json_adaptor
+    py2js = py2js_as_js_json
+    js2py = js2py_as_py_json
 
 
 class Deep:


### PR DESCRIPTION
This is a quick followup to #5010 that makes `jsbind` use `as_py_json` in the expected way. No changelog needed since it's still not public API.

- [x] Add / update tests

