### PR TITLE
Remove `-fexceptions` from `pybind11`-based projects: `iminuit` and `boost-histogram`, bump `boost-histogram` to 1.5.0

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -74,6 +74,7 @@ myst:
 - Upgraded `scipy` to 1.14.1 {pr}`4719`, {pr}`5011`, {pr}`5012`, {pr}`5031`
 - Upgraded `scikit-image` to 0.24.0 {pr}`5003`
 - Upgraded `contourpy` to 1.3.0 {pr}`5048`
+- Upgraded `boost-histogram` to 1.5.0 {pr}`5074`
 - Added `casadi` 3.6.6 {pr}`4936`, {pr}`5057`
 - Added `pyarrow` 17.0.0 {pr}`4950`
 - Added `rasterio` 1.13.10, `affine` 2.4.0 {pr}`4983`

--- a/packages/boost-histogram/meta.yaml
+++ b/packages/boost-histogram/meta.yaml
@@ -1,17 +1,14 @@
 package:
   name: boost-histogram
-  version: 1.4.1
+  version: 1.5.0
   top-level:
     - boost_histogram
 source:
-  url: https://files.pythonhosted.org/packages/60/68/a901fa3287fe62bde47e3936081286b6588b55f89bbcb9984be519414551/boost_histogram-1.4.1.tar.gz
-  sha256: 97146f735f467d506976a047f3f237ce59840a952fd231f5f431f897fb006cdd
+  url: https://files.pythonhosted.org/packages/8d/51/96712ed4e1d64618d3e76aac2d1f96e2f4856120012f0dad51adf42c78e4/boost_histogram-1.5.0.tar.gz
+  sha256: 0623f010e6c52e5d018767723959686090db07fc30f0d1d8475b5d663c5ddb2c
 requirements:
   run:
     - numpy # runtime only
-build:
-  cxxflags: -fexceptions
-  ldflags: -fexceptions
 about:
   home: https://github.com/scikit-hep/boost-histogram
   PyPI: https://pypi.org/project/boost-histogram

--- a/packages/iminuit/meta.yaml
+++ b/packages/iminuit/meta.yaml
@@ -10,9 +10,6 @@ test:
 requirements:
   run:
     - numpy # runtime only
-build:
-  cxxflags: -fexceptions
-  ldflags: -fexceptions
 about:
   home: http://github.com/scikit-hep/iminuit
   PyPI: https://pypi.org/project/iminuit


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Post https://github.com/pybind/pybind11/pull/5298 and https://github.com/pybind/pybind11/pull/5301, we can remove `-fexceptions` from the compiler and the linker flags, since `pybind11` version 2.13.3 and later will set those for us. I removed them from `iminuit` over from #5072 and from `boost-histogram`.

Additionally, bumped `boost-histogram` to version 1.5.0. Are there any more packages that I might be missing?

cc: @henryiii

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
