### PR TITLE
DOC find pyodide module even if in parent directories

### DIFF
--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -27,7 +27,8 @@ using a Vite plugin:
 ```js
 import { defineConfig } from "vite";
 import { copyFile, mkdir } from "fs/promises";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 
 export default defineConfig({
   optimizeDeps: { exclude: ["pyodide"] },
@@ -43,9 +44,10 @@ export default defineConfig({
           "pyodide.asm.wasm",
           "python_stdlib.zip",
         ];
+        const modulePath = fileURLToPath(import.meta.resolve("pyodide"));
         for (const file of files) {
           await copyFile(
-            join("node_modules/pyodide", file),
+            join(dirname(modulePath), file),
             join(assetsDir, file),
           );
         }


### PR DESCRIPTION
### Description

The code in the doc of the main branch only works if `node_modules` is in the project/current/root directory. But node will also find packages in `node_modules` under parent directories, like `../node_modules` in my case, or `../../node_modules` etc...

With this fix/enhancement the pyodide package directory will be found in any of these parent sub directories by using `import.meta.resolve`.