### PR TITLE
Add tree-sitter as a package

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -85,6 +85,7 @@ myst:
 - Added `rasterio` 1.13.10, `affine` 2.4.0 {pr}`4983`
 - Added `iminuit` 2.29.1 {pr}`4767`, {pr}`5072`
 - Added `arro3-core`, `arro3-io`, and `arro3-compute` 0.3.0, 0.4.0 {pr}`5020`, {pr}`5095`
+- Added `tree-sitter` 0.23.0 {pr}`5099`
 
 ## Version 0.26.2
 

--- a/packages/tree-sitter/meta.yaml
+++ b/packages/tree-sitter/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: tree-sitter
+  version: 0.23.0
+  top-level:
+    - tree_sitter
+source:
+  url: https://files.pythonhosted.org/packages/61/87/8b37aebd12e386533fad099bcc33f9fff73fb2104b7ab79f91da57fee9e2/tree-sitter-0.23.0.tar.gz
+  sha256: 4c0d186f262a6b186e155a327150064abbf02b5659f7bc580eb965374025f2c2
+about:
+  home: https://tree-sitter.github.io/tree-sitter
+  PyPI: https://pypi.org/project/tree-sitter
+  summary: Python bindings to the Tree-sitter parsing library
+  license: MIT
+extra:
+  recipe-maintainers:
+    - ericwb

--- a/packages/tree-sitter/test_tree_sitter.py
+++ b/packages/tree-sitter/test_tree_sitter.py
@@ -1,0 +1,10 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["tree-sitter"])
+def test_tree_sitter(selenium):
+    import tree_sitter
+
+
+    assert hasattr(tree_sitter, "Language")
+    assert hasattr(tree_sitter, "Node")

--- a/packages/tree-sitter/test_tree_sitter.py
+++ b/packages/tree-sitter/test_tree_sitter.py
@@ -5,6 +5,5 @@ from pytest_pyodide import run_in_pyodide
 def test_tree_sitter(selenium):
     import tree_sitter
 
-
     assert hasattr(tree_sitter, "Language")
     assert hasattr(tree_sitter, "Node")


### PR DESCRIPTION
This change includes tree-sitter the packages that pyodide can install. The tree-sitter library has C extensions so it won't install with micropip from PyPI.

Tree sitter is one of a few requirements in order to run a SAST in the browser with PyScript.

https://pypi.org/project/tree-sitter
https://tree-sitter.github.io/tree-sitter
https://github.com/tree-sitter/py-tree-sitter

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests

