### PR TITLE
Add tree-sitter-java, tree-sitter-go, tree-sitter-python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ pytest-pyodide
 tools/symlinks
 xbuildenv/
 .pyodide-xbuildenv*
+DS_Store

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -87,6 +87,9 @@ myst:
 - Added `iminuit` 2.29.1 {pr}`4767`, {pr}`5072`
 - Added `arro3-core`, `arro3-io`, and `arro3-compute` 0.3.0, 0.4.0 {pr}`5020`, {pr}`5095`
 - Added `tree-sitter` 0.23.0 {pr}`5099`
+- Added `tree-sitter-go` 0.23.1 {pr}`5102`
+- Added `tree-sitter-java` 0.23.2 {pr}`5102`
+- Added `tree-sitter-python` 0.23.2 {pr}`5102`
 
 ## Version 0.26.2
 

--- a/packages/tree-sitter-go/meta.yaml
+++ b/packages/tree-sitter-go/meta.yaml
@@ -4,8 +4,10 @@ package:
   top-level:
     - tree_sitter_go
 source:
-  url: https://files.pythonhosted.org/packages/0d/48/d168f527a0c7d00c2c40e46c52ff62e8916777d3f2d7c2a1325b1f8706a8/tree_sitter_go-0.23.1.tar.gz
-  sha256: a413bfb3d77a47fd84618e01849a6b4b35f794d694493c0b58dbb4a5da82f916
+  # Have to use github source to work around broken sdist
+  # https://github.com/tree-sitter/tree-sitter-go/pull/151
+  url: https://github.com/tree-sitter/tree-sitter-go/archive/refs/tags/v0.23.1.tar.gz
+  sha256: 4173bafc4c59be78642a0faf1bed8cb3854458aa59c506e8f51001a9f28da09b
 requirements:
   run:
     - tree-sitter

--- a/packages/tree-sitter-go/meta.yaml
+++ b/packages/tree-sitter-go/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: tree-sitter-go
+  version: 0.23.1
+  top-level:
+    - tree_sitter_go
+source:
+  url: https://files.pythonhosted.org/packages/0d/48/d168f527a0c7d00c2c40e46c52ff62e8916777d3f2d7c2a1325b1f8706a8/tree_sitter_go-0.23.1.tar.gz
+  sha256: a413bfb3d77a47fd84618e01849a6b4b35f794d694493c0b58dbb4a5da82f916
+requirements:
+  run:
+    - tree-sitter
+  host:
+    - tree-sitter
+about:
+  home: https://github.com/tree-sitter/tree-sitter-go
+  PyPI: https://pypi.org/project/tree-sitter-go
+  summary: Go grammar for tree-sitter
+  license: MIT
+extra:
+  recipe-maintainers:
+    - ericwb

--- a/packages/tree-sitter-go/test_tree_sitter_go.py
+++ b/packages/tree-sitter-go/test_tree_sitter_go.py
@@ -6,35 +6,36 @@ def test_tree_sitter_go(selenium):
     import textwrap
 
     import tree_sitter_go
-    from tree_sitter import Language
-    from tree_sitter import Parser
-
+    from tree_sitter import Language, Parser
 
     GO_LANGUAGE = Language(tree_sitter_go.language())
     parser = Parser(GO_LANGUAGE)
 
-    code = bytes(textwrap.dedent(
-        """
+    code = bytes(
+        textwrap.dedent(
+            """
         func foo() {
             if bar {
                 baz()
             }
         }
         """
-    ), "utf-8")
+        ),
+        "utf-8",
+    )
     tree = parser.parse(code)
     root_node = tree.root_node
 
     assert str(root_node) == (
         "(source_file "
-            "(function_declaration "
-                "name: (identifier) "
-                "parameters: (parameter_list) "
-                "body: (block "
-                    "(if_statement "
-                        "condition: (identifier) "
-                        "consequence: (block "
-                            "(expression_statement (call_expression "
-                                "function: (identifier) "
-                                "arguments: (argument_list))))))))"
+        "(function_declaration "
+        "name: (identifier) "
+        "parameters: (parameter_list) "
+        "body: (block "
+        "(if_statement "
+        "condition: (identifier) "
+        "consequence: (block "
+        "(expression_statement (call_expression "
+        "function: (identifier) "
+        "arguments: (argument_list))))))))"
     )

--- a/packages/tree-sitter-go/test_tree_sitter_go.py
+++ b/packages/tree-sitter-go/test_tree_sitter_go.py
@@ -1,0 +1,40 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["tree-sitter-go"])
+def test_tree_sitter_go(selenium):
+    import textwrap
+
+    import tree_sitter_go
+    from tree_sitter import Language
+    from tree_sitter import Parser
+
+
+    GO_LANGUAGE = Language(tree_sitter_go.language())
+    parser = Parser(GO_LANGUAGE)
+
+    code = bytes(textwrap.dedent(
+        """
+        func foo() {
+            if bar {
+                baz()
+            }
+        }
+        """
+    ), "utf-8")
+    tree = parser.parse(code)
+    root_node = tree.root_node
+
+    assert str(root_node) == (
+        "(source_file "
+            "(function_declaration "
+                "name: (identifier) "
+                "parameters: (parameter_list) "
+                "body: (block "
+                    "(if_statement "
+                        "condition: (identifier) "
+                        "consequence: (block "
+                            "(expression_statement (call_expression "
+                                "function: (identifier) "
+                                "arguments: (argument_list))))))))"
+    )

--- a/packages/tree-sitter-java/meta.yaml
+++ b/packages/tree-sitter-java/meta.yaml
@@ -4,8 +4,10 @@ package:
   top-level:
     - tree_sitter_java
 source:
-  url: https://files.pythonhosted.org/packages/43/f5/c3afaf20ef8fb6427b46c87439821c2efea3efaf091828499834d5f3a5d8/tree_sitter_java-0.23.2.tar.gz
-  sha256: f9969e75c79e5ab449ef5e2f9ae666b04a9266ba4d5d3127a0c1303926549406
+  # Have to use github url to work around broken sdist:
+  # https://github.com/tree-sitter/tree-sitter-java/pull/188
+  url: https://github.com/tree-sitter/tree-sitter-java/archive/refs/tags/v0.23.2.tar.gz
+  sha256: 062fe5746deb4e362ccb987228e7b41bfc017eb2b91a0413a7447719abaa07b2
 requirements:
   run:
     - tree-sitter

--- a/packages/tree-sitter-java/meta.yaml
+++ b/packages/tree-sitter-java/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: tree-sitter-java
+  version: 0.23.2
+  top-level:
+    - tree_sitter_java
+source:
+  url: https://files.pythonhosted.org/packages/43/f5/c3afaf20ef8fb6427b46c87439821c2efea3efaf091828499834d5f3a5d8/tree_sitter_java-0.23.2.tar.gz
+  sha256: f9969e75c79e5ab449ef5e2f9ae666b04a9266ba4d5d3127a0c1303926549406
+requirements:
+  run:
+    - tree-sitter
+  host:
+    - tree-sitter
+about:
+  home: https://github.com/tree-sitter/tree-sitter-java
+  PyPI: https://pypi.org/project/tree-sitter-java
+  summary: Java grammar for tree-sitter
+  license: MIT
+extra:
+  recipe-maintainers:
+    - ericwb

--- a/packages/tree-sitter-java/test_tree_sitter_java.py
+++ b/packages/tree-sitter-java/test_tree_sitter_java.py
@@ -1,0 +1,41 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["tree-sitter-java"])
+def test_tree_sitter_java(selenium):
+    import textwrap
+
+    import tree_sitter_java
+    from tree_sitter import Language
+    from tree_sitter import Parser
+
+
+    JAV_LANGUAGE = Language(tree_sitter_java.language())
+    parser = Parser(JAV_LANGUAGE)
+
+    code = bytes(textwrap.dedent(
+        """
+        void foo() {
+            if (bar) {
+                baz();
+            }
+        }
+        """
+    ), "utf-8")
+    tree = parser.parse(code)
+    root_node = tree.root_node
+
+    assert str(root_node) == (
+        "(program "
+            "(method_declaration "
+                "type: (void_type) "
+                "name: (identifier) "
+                "parameters: (formal_parameters) "
+                "body: (block "
+                    "(if_statement "
+                        "condition: (parenthesized_expression (identifier)) "
+                        "consequence: (block "
+                            "(expression_statement (method_invocation "
+                                "name: (identifier) "
+                                "arguments: (argument_list))))))))"
+    )

--- a/packages/tree-sitter-java/test_tree_sitter_java.py
+++ b/packages/tree-sitter-java/test_tree_sitter_java.py
@@ -6,36 +6,37 @@ def test_tree_sitter_java(selenium):
     import textwrap
 
     import tree_sitter_java
-    from tree_sitter import Language
-    from tree_sitter import Parser
-
+    from tree_sitter import Language, Parser
 
     JAV_LANGUAGE = Language(tree_sitter_java.language())
     parser = Parser(JAV_LANGUAGE)
 
-    code = bytes(textwrap.dedent(
-        """
+    code = bytes(
+        textwrap.dedent(
+            """
         void foo() {
             if (bar) {
                 baz();
             }
         }
         """
-    ), "utf-8")
+        ),
+        "utf-8",
+    )
     tree = parser.parse(code)
     root_node = tree.root_node
 
     assert str(root_node) == (
         "(program "
-            "(method_declaration "
-                "type: (void_type) "
-                "name: (identifier) "
-                "parameters: (formal_parameters) "
-                "body: (block "
-                    "(if_statement "
-                        "condition: (parenthesized_expression (identifier)) "
-                        "consequence: (block "
-                            "(expression_statement (method_invocation "
-                                "name: (identifier) "
-                                "arguments: (argument_list))))))))"
+        "(method_declaration "
+        "type: (void_type) "
+        "name: (identifier) "
+        "parameters: (formal_parameters) "
+        "body: (block "
+        "(if_statement "
+        "condition: (parenthesized_expression (identifier)) "
+        "consequence: (block "
+        "(expression_statement (method_invocation "
+        "name: (identifier) "
+        "arguments: (argument_list))))))))"
     )

--- a/packages/tree-sitter-python/meta.yaml
+++ b/packages/tree-sitter-python/meta.yaml
@@ -4,8 +4,10 @@ package:
   top-level:
     - tree_sitter_python
 source:
-  url: https://files.pythonhosted.org/packages/fe/fe/34663adbaeb139410f7fc5fbab7c16391c56458cc8083a91e85bb768fc39/tree_sitter_python-0.23.2.tar.gz
-  sha256: da6abb90a8061d70651f170403e19aed1db4e6e5bcf4b9396245421899c94070
+  # Have to use github url to work around broken sdist:
+  # https://github.com/tree-sitter/tree-sitter-python/pull/285
+  url: https://github.com/tree-sitter/tree-sitter-python/archive/refs/tags/v0.23.2.tar.gz
+  sha256: b38e5b1f5237377b506109978af76422975bda5859165835e3c7b5afee987383
 requirements:
   run:
     - tree-sitter

--- a/packages/tree-sitter-python/meta.yaml
+++ b/packages/tree-sitter-python/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: tree-sitter-python
+  version: 0.23.2
+  top-level:
+    - tree_sitter_python
+source:
+  url: https://files.pythonhosted.org/packages/fe/fe/34663adbaeb139410f7fc5fbab7c16391c56458cc8083a91e85bb768fc39/tree_sitter_python-0.23.2.tar.gz
+  sha256: da6abb90a8061d70651f170403e19aed1db4e6e5bcf4b9396245421899c94070
+requirements:
+  run:
+    - tree-sitter
+  host:
+    - tree-sitter
+about:
+  home: https://github.com/tree-sitter/tree-sitter-python
+  PyPI: https://pypi.org/project/tree-sitter-python
+  summary: Python grammar for tree-sitter
+  license: MIT
+extra:
+  recipe-maintainers:
+    - ericwb

--- a/packages/tree-sitter-python/test_tree_sitter_python.py
+++ b/packages/tree-sitter-python/test_tree_sitter_python.py
@@ -1,0 +1,38 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["tree-sitter-python"])
+def test_tree_sitter_python(selenium):
+    import textwrap
+
+    import tree_sitter_python
+    from tree_sitter import Language
+    from tree_sitter import Parser
+
+
+    PY_LANGUAGE = Language(tree_sitter_python.language())
+    parser = Parser(PY_LANGUAGE)
+
+    code = bytes(textwrap.dedent(
+        """
+        def foo():
+            if bar:
+                baz()
+        """
+    ), "utf-8")
+    tree = parser.parse(code)
+    root_node = tree.root_node
+
+    assert str(root_node) == (
+        "(module "
+            "(function_definition "
+                "name: (identifier) "
+                "parameters: (parameters) "
+                "body: (block "
+                    "(if_statement "
+                        "condition: (identifier) "
+                        "consequence: (block "
+                            "(expression_statement (call "
+                                "function: (identifier) "
+                                "arguments: (argument_list))))))))"
+    )

--- a/packages/tree-sitter-python/test_tree_sitter_python.py
+++ b/packages/tree-sitter-python/test_tree_sitter_python.py
@@ -6,33 +6,34 @@ def test_tree_sitter_python(selenium):
     import textwrap
 
     import tree_sitter_python
-    from tree_sitter import Language
-    from tree_sitter import Parser
-
+    from tree_sitter import Language, Parser
 
     PY_LANGUAGE = Language(tree_sitter_python.language())
     parser = Parser(PY_LANGUAGE)
 
-    code = bytes(textwrap.dedent(
-        """
+    code = bytes(
+        textwrap.dedent(
+            """
         def foo():
             if bar:
                 baz()
         """
-    ), "utf-8")
+        ),
+        "utf-8",
+    )
     tree = parser.parse(code)
     root_node = tree.root_node
 
     assert str(root_node) == (
         "(module "
-            "(function_definition "
-                "name: (identifier) "
-                "parameters: (parameters) "
-                "body: (block "
-                    "(if_statement "
-                        "condition: (identifier) "
-                        "consequence: (block "
-                            "(expression_statement (call "
-                                "function: (identifier) "
-                                "arguments: (argument_list))))))))"
+        "(function_definition "
+        "name: (identifier) "
+        "parameters: (parameters) "
+        "body: (block "
+        "(if_statement "
+        "condition: (identifier) "
+        "consequence: (block "
+        "(expression_statement (call "
+        "function: (identifier) "
+        "arguments: (argument_list))))))))"
     )


### PR DESCRIPTION
This is a follow-on to PR #5099 which added the dependency of tree-sitter to the packages.

This change adds tree-sitter-java, tree-sitter-go, tree-sitter-python packages and respective unit tests. Java, Go, and Python are popular languages, so its useful to add these grammars so a user can parse source code in those languages.

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests

