### PR TITLE
Bump tree-sitter to 0.23.1

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -87,6 +87,7 @@ myst:
 - Upgraded `boost-histogram` to 1.5.0 {pr}`5074`
 - Upgraded `duckdb` to 1.1.0 {pr}`5078`
 - Upgraded `sympy` to 1.13.3 {pr}`5098`
+- Upgraded `tree-sitter` to 0.23.1 {pr}`5110`
 - Added `casadi` 3.6.6 {pr}`4936`, {pr}`5057`
 - Added `pyarrow` 17.0.0 {pr}`4950`
 - Added `rasterio` 1.13.10, `affine` 2.4.0 {pr}`4983`

--- a/packages/tree-sitter/meta.yaml
+++ b/packages/tree-sitter/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: tree-sitter
-  version: 0.23.0
+  version: 0.23.1
   top-level:
     - tree_sitter
 source:
-  url: https://files.pythonhosted.org/packages/61/87/8b37aebd12e386533fad099bcc33f9fff73fb2104b7ab79f91da57fee9e2/tree-sitter-0.23.0.tar.gz
-  sha256: 4c0d186f262a6b186e155a327150064abbf02b5659f7bc580eb965374025f2c2
+  url: https://files.pythonhosted.org/packages/01/23/e001538062ece748d7ab1fcfbcd9fa766d85f60f0d5ae014a7caf4f07c70/tree-sitter-0.23.1.tar.gz
+  sha256: 28fe02aff6676b203cbe4213ca7116db0aaac08d6ca4c0b1f1af038991631838
 about:
   home: https://tree-sitter.github.io/tree-sitter
   PyPI: https://pypi.org/project/tree-sitter


### PR DESCRIPTION
Update to the latest version of tree-sitter. Tree sitter was recently fixed to worked properly with Python 3.13.

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry

