### PR TITLE
MAINT Inject Module and API for dynload functions

### DIFF
--- a/src/js/dynload.ts
+++ b/src/js/dynload.ts
@@ -2,37 +2,57 @@
 
 declare var DEBUG: boolean;
 
+import {
+  PackageManagerAPI,
+  PackageManagerModule,
+} from "./types";
+
 import { createLock } from "./common/lock";
 import { LoadDynlibFS, ReadFileType, InternalPackageData } from "./types";
 
-/**
+
+export class DynlibLoader {
+  private api: PackageManagerAPI;
+  private pyodideModule: PackageManagerModule;
+
+  // Emscripten has a lock in the corresponding code in library_browser.js. I
+  // don't know why we need it, but quite possibly bad stuff will happen without
+  // it.
+  private _lock = createLock();
+
+  constructor(api: PackageManagerAPI, pyodideModule: PackageManagerModule) {
+    this.api = api;
+    this.pyodideModule = pyodideModule
+  }
+
+  /**
  * Recursively get all subdirectories of a directory
  *
  * @param dir The absolute path to the directory
  * @returns A list of absolute paths to the subdirectories
  * @private
  */
-function* getSubDirs(dir: string): Generator<string> {
-  const dirs = Module.FS.readdir(dir);
+public *getSubDirs(dir: string): Generator<string> {
+  const dirs = this.pyodideModule.FS.readdir(dir);
 
   for (const d of dirs) {
     if (d === "." || d === "..") {
       continue;
     }
 
-    const subdir: string = Module.PATH.join2(dir, d);
-    const lookup = Module.FS.lookupPath(subdir);
+    const subdir: string = this.pyodideModule.PATH.join2(dir, d);
+    const lookup = this.pyodideModule.FS.lookupPath(subdir);
     if (lookup.node === null) {
       continue;
     }
 
     const mode = lookup.node.mode;
-    if (!Module.FS.isDir(mode)) {
+    if (!this.pyodideModule.FS.isDir(mode)) {
       continue;
     }
 
     yield subdir;
-    yield* getSubDirs(subdir);
+    yield* this.getSubDirs(subdir);
   }
 }
 
@@ -45,39 +65,39 @@ function* getSubDirs(dir: string): Generator<string> {
  * @returns A filesystem-like object
  * @private
  */
-function createDynlibFS(lib: string, searchDirs?: string[]): LoadDynlibFS {
+public createDynlibFS(lib: string, searchDirs?: string[]): LoadDynlibFS {
   const dirname = lib.substring(0, lib.lastIndexOf("/"));
 
   let _searchDirs = searchDirs || [];
-  _searchDirs = _searchDirs.concat(API.defaultLdLibraryPath, [dirname]);
+  _searchDirs = _searchDirs.concat(this.api.defaultLdLibraryPath, [dirname]);
 
   // TODO: add rpath to Emscripten dsos and remove this logic
   const resolvePath = (path: string) => {
     if (DEBUG) {
-      if (Module.PATH.basename(path) !== Module.PATH.basename(lib)) {
+      if (this.pyodideModule.PATH.basename(path) !== this.pyodideModule.PATH.basename(lib)) {
         console.debug(`Searching a library from ${path}, required by ${lib}.`);
       }
     }
 
     // If the path is absolute, we don't need to search for it.
-    if (Module.PATH.isAbs(path)) {
+    if (this.pyodideModule.PATH.isAbs(path)) {
       return path;
     }
 
     // Step 1) Try to find the library in the search directories
     for (const dir of _searchDirs) {
-      const fullPath = Module.PATH.join2(dir, path);
+      const fullPath = this.pyodideModule.PATH.join2(dir, path);
 
-      if (Module.FS.findObject(fullPath) !== null) {
+      if (this.pyodideModule.FS.findObject(fullPath) !== null) {
         return fullPath;
       }
     }
 
     // Step 2) try to find the library by searching child directories of the library directory
     //         (This should not be necessary in most cases, but some libraries have dependencies in the child directories)
-    for (const childDir of getSubDirs(dirname)) {
-      const fullPath = Module.PATH.join2(childDir, path);
-      if (Module.FS.findObject(fullPath) !== null) {
+    for (const childDir of this.getSubDirs(dirname)) {
+      const fullPath = this.pyodideModule.PATH.join2(childDir, path);
+      if (this.pyodideModule.FS.findObject(fullPath) !== null) {
         return fullPath;
       }
     }
@@ -86,11 +106,11 @@ function createDynlibFS(lib: string, searchDirs?: string[]): LoadDynlibFS {
   };
 
   const readFile: ReadFileType = (path: string) =>
-    Module.FS.readFile(resolvePath(path));
+    this.pyodideModule.FS.readFile(resolvePath(path));
 
   const fs: LoadDynlibFS = {
     findObject: (path: string, dontResolveLastLink: boolean) => {
-      let obj = Module.FS.findObject(resolvePath(path), dontResolveLastLink);
+      let obj = this.pyodideModule.FS.findObject(resolvePath(path), dontResolveLastLink);
       if (DEBUG) {
         if (obj === null) {
           console.debug(`Failed to find a library: ${resolvePath(path)}`);
@@ -104,104 +124,105 @@ function createDynlibFS(lib: string, searchDirs?: string[]): LoadDynlibFS {
   return fs;
 }
 
-// Emscripten has a lock in the corresponding code in library_browser.js. I
-// don't know why we need it, but quite possibly bad stuff will happen without
-// it.
-const acquireDynlibLock = createLock();
+  /**
+   * Load a dynamic library. This is an async operation and Python imports are
+   * synchronous so we have to do it ahead of time. When we add more support for
+   * synchronous I/O, we could consider doing this later as a part of a Python
+   * import hook.
+   *
+   * @param lib The file system path to the library.
+   * @param global Whether to make the symbols available globally.
+   * @param searchDirs Directories to search for the library.
+   * @private
+   */
+  public async loadDynlib(
+    lib: string,
+    global: boolean,
+    searchDirs?: string[],
+  ) {
+    const releaseDynlibLock = await this._lock();
 
-/**
- * Load a dynamic library. This is an async operation and Python imports are
- * synchronous so we have to do it ahead of time. When we add more support for
- * synchronous I/O, we could consider doing this later as a part of a Python
- * import hook.
- *
- * @param lib The file system path to the library.
- * @param global Whether to make the symbols available globally.
- * @param searchDirs Directories to search for the library.
- * @private
- */
-export async function loadDynlib(
-  lib: string,
-  global: boolean,
-  searchDirs?: string[],
-) {
-  const releaseDynlibLock = await acquireDynlibLock();
-
-  if (DEBUG) {
-    console.debug(`Loading a dynamic library ${lib} (global: ${global})`);
-  }
-
-  const fs = createDynlibFS(lib, searchDirs);
-  const localScope = global ? null : {};
-
-  try {
-    await Module.loadDynamicLibrary(
-      lib,
-      {
-        loadAsync: true,
-        nodelete: true,
-        allowUndefined: true,
-        global,
-        fs,
-      },
-      localScope,
-    );
-
-    // Emscripten saves the list of loaded libraries in LDSO.loadedLibsByName.
-    // However, since emscripten dylink metadata only contains the name of the
-    // library not the full path, we need to update it manually in order to
-    // prevent loading same library twice.
-    if (Module.PATH.isAbs(lib)) {
-      const libName: string = Module.PATH.basename(lib);
-      const dso: any = Module.LDSO.loadedLibsByName[libName];
-      if (!dso) {
-        Module.LDSO.loadedLibsByName[libName] =
-          Module.LDSO.loadedLibsByName[lib];
-      }
+    if (DEBUG) {
+      console.debug(`Loading a dynamic library ${lib} (global: ${global})`);
     }
-  } catch (e: any) {
-    if (e && e.message && e.message.includes("need to see wasm magic number")) {
-      console.warn(
-        `Failed to load dynlib ${lib}. We probably just tried to load a linux .so file or something.`,
+
+    const fs = this.createDynlibFS(lib, searchDirs);
+    const localScope = global ? null : {};
+
+    try {
+      await this.pyodideModule.loadDynamicLibrary(
+        lib,
+        {
+          loadAsync: true,
+          nodelete: true,
+          allowUndefined: true,
+          global,
+          fs,
+        },
+        localScope,
       );
-      return;
+
+      // Emscripten saves the list of loaded libraries in LDSO.loadedLibsByName.
+      // However, since emscripten dylink metadata only contains the name of the
+      // library not the full path, we need to update it manually in order to
+      // prevent loading same library twice.
+      if (this.pyodideModule.PATH.isAbs(lib)) {
+        const libName: string = this.pyodideModule.PATH.basename(lib);
+        const dso: any = this.pyodideModule.LDSO.loadedLibsByName[libName];
+        if (!dso) {
+          this.pyodideModule.LDSO.loadedLibsByName[libName] =
+            this.pyodideModule.LDSO.loadedLibsByName[lib];
+        }
+      }
+    } catch (e: any) {
+      if (e && e.message && e.message.includes("need to see wasm magic number")) {
+        console.warn(
+          `Failed to load dynlib ${lib}. We probably just tried to load a linux .so file or something.`,
+        );
+        return;
+      }
+      throw e;
+    } finally {
+      releaseDynlibLock();
     }
-    throw e;
-  } finally {
-    releaseDynlibLock();
+  }
+
+  /**
+   * Load dynamic libraries inside a package.
+   *
+   * This function handles some painful details of loading dynamic libraries:
+   * - We need to load libraries in the correct order considering dependencies.
+   * - We need to load libraries globally if they are required by other libraries.
+   * - We need to tell Emscripten where to search for libraries.
+   * - The dynlib metadata inside a wasm module only contains the library name, not the path.
+   *   So we need to handle them carefully to avoid loading the same library twice.
+   *
+   * @param pkg The package metadata
+   * @param dynlibPaths The list of dynamic libraries inside a package
+   * @private
+   */
+  public async loadDynlibsFromPackage(
+    pkg: InternalPackageData,
+    dynlibPaths: string[],
+  ) {
+    // assume that shared libraries of a package are located in <package-name>.libs directory,
+    // following the convention of auditwheel.
+    const auditWheelLibDir = `${this.api.sitepackages}/${
+      pkg.file_name.split("-")[0]
+    }.libs`;
+
+    for (const path of dynlibPaths) {
+      await this.loadDynlib(path, false, [auditWheelLibDir]);
+    }
   }
 }
 
-/**
- * Load dynamic libraries inside a package.
- *
- * This function handles some painful details of loading dynamic libraries:
- * - We need to load libraries in the correct order considering dependencies.
- * - We need to load libraries globally if they are required by other libraries.
- * - We need to tell Emscripten where to search for libraries.
- * - The dynlib metadata inside a wasm module only contains the library name, not the path.
- *   So we need to handle them carefully to avoid loading the same library twice.
- *
- * @param pkg The package metadata
- * @param dynlibPaths The list of dynamic libraries inside a package
- * @private
- */
-export async function loadDynlibsFromPackage(
-  pkg: InternalPackageData,
-  dynlibPaths: string[],
-) {
-  // assume that shared libraries of a package are located in <package-name>.libs directory,
-  // following the convention of auditwheel.
-  const auditWheelLibDir = `${API.sitepackages}/${
-    pkg.file_name.split("-")[0]
-  }.libs`;
+if (typeof API !== "undefined" && typeof Module !== "undefined") {
+  const singletonDynlibLoader = new DynlibLoader(API, Module);
 
-  for (const path of dynlibPaths) {
-    await loadDynlib(path, false, [auditWheelLibDir]);
-  }
-}
-
-if (typeof API !== "undefined") {
-  API.loadDynlib = loadDynlib;
-  API.loadDynlibsFromPackage = loadDynlibsFromPackage;
+  // TODO: Find a better way to register these functions
+  API.loadDynlib = singletonDynlibLoader.loadDynlib.bind(singletonDynlibLoader);
+  API.loadDynlibsFromPackage = singletonDynlibLoader.loadDynlibsFromPackage.bind(
+    singletonDynlibLoader,
+  );
 }

--- a/src/js/dynload.ts
+++ b/src/js/dynload.ts
@@ -65,7 +65,7 @@ export class DynlibLoader {
     const dirname = lib.substring(0, lib.lastIndexOf("/"));
 
     let _searchDirs = searchDirs || [];
-    _searchDirs = _searchDirs.concat(this.api.defaultLdLibraryPath, [dirname]);
+    _searchDirs = _searchDirs.concat(this.#api.defaultLdLibraryPath, [dirname]);
 
     // TODO: add rpath to Emscripten dsos and remove this logic
     const resolvePath = (path: string) => {

--- a/src/js/test/unit/package-manager.test.ts
+++ b/src/js/test/unit/package-manager.test.ts
@@ -1,10 +1,5 @@
-import {
-  PackageManager,
-} from "../../load-package.ts";
-import {
-  PackageManagerAPI,
-  PackageManagerModule,
-} from "../../types.ts";
+import { PackageManager } from "../../load-package.ts";
+import { PackageManagerAPI, PackageManagerModule } from "../../types.ts";
 
 describe("PackageManager", () => {
   // TODO: add more unittests
@@ -41,21 +36,23 @@ describe("PackageManager", () => {
         isDir: (mode: number) => true,
         findObject: (path: string, dontResolveLastLink?: boolean) => {},
         readFile: (path: string) => new Uint8Array(),
-        lookupPath: (path: string, options?: {
-          follow_mount?: boolean;
-        }) => {
+        lookupPath: (
+          path: string,
+          options?: {
+            follow_mount?: boolean;
+          },
+        ) => {
           return {
             node: {
               timestamp: 1,
               rdev: 2,
               contents: new Uint8Array(),
               mode: 3,
-            }
-          }
-        }
+            },
+          };
+        },
       },
     };
-
 
     const _ = new PackageManager(mockApi, mockMod);
   });

--- a/src/js/test/unit/package-manager.test.ts
+++ b/src/js/test/unit/package-manager.test.ts
@@ -1,8 +1,10 @@
 import {
   PackageManager,
+} from "../../load-package.ts";
+import {
   PackageManagerAPI,
   PackageManagerModule,
-} from "../../load-package.ts";
+} from "../../types.ts";
 
 describe("PackageManager", () => {
   // TODO: add more unittests
@@ -24,10 +26,36 @@ describe("PackageManager", () => {
       },
       lockfile_packages: {},
       bootstrapFinalizedPromise: Promise.resolve(),
+      sitepackages: "",
+      defaultLdLibraryPath: [],
     };
     const mockMod: PackageManagerModule = {
       reportUndefinedSymbols: () => {},
+      loadDynamicLibrary: () => {},
+      LDSO: {
+        loadedLibsByName: {},
+      },
+      PATH: {},
+      FS: {
+        readdir: (path: string) => [],
+        isDir: (mode: number) => true,
+        findObject: (path: string, dontResolveLastLink?: boolean) => {},
+        readFile: (path: string) => new Uint8Array(),
+        lookupPath: (path: string, options?: {
+          follow_mount?: boolean;
+        }) => {
+          return {
+            node: {
+              timestamp: 1,
+              rdev: 2,
+              contents: new Uint8Array(),
+              mode: 3,
+            }
+          }
+        }
+      },
     };
+
 
     const _ = new PackageManager(mockApi, mockMod);
   });

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -502,10 +502,7 @@ export type PackageManagerAPI = Pick<
  */
 export type PackageManagerModule = Pick<
   Module,
-  | "reportUndefinedSymbols"
-  | "PATH"
-  | "loadDynamicLibrary"
-  | "LDSO"
+  "reportUndefinedSymbols" | "PATH" | "loadDynamicLibrary" | "LDSO"
 > & {
   FS: Pick<FS, "readdir" | "lookupPath" | "isDir" | "findObject" | "readFile">;
 };

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -481,3 +481,31 @@ export interface API {
 
   LiteralMap: any;
 }
+
+// Subset of the API and Module that the package manager needs
+/**
+ * @hidden
+ */
+export type PackageManagerAPI = Pick<
+  API,
+  | "importlib"
+  | "package_loader"
+  | "lockfile_packages"
+  | "bootstrapFinalizedPromise"
+  | "sitepackages"
+  | "defaultLdLibraryPath"
+> & {
+  config: Pick<ConfigType, "indexURL" | "packageCacheDir">;
+};
+/**
+ * @hidden
+ */
+export type PackageManagerModule = Pick<
+  Module,
+  | "reportUndefinedSymbols"
+  | "PATH"
+  | "loadDynamicLibrary"
+  | "LDSO"
+> & {
+  FS: Pick<FS, "readdir" | "lookupPath" | "isDir" | "findObject" | "readFile">;
+};


### PR DESCRIPTION
### Description

Follow-up work of #5040. Modularize functions in dynload.ts into a class `DynlibLoader,` and make the Emscripten module and API an attribute of that class so it can be injected from outside.
