### PR TITLE
Test removal of `-Zlink-native-libraries=no` from `RUSTFLAGS`

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -11,8 +11,8 @@ export PYTHON_ARCHIVE_SHA256=d01ec6a33bc10009b09c17da95cc2759af5a580a7316b3a446e
 # to your fork to test the changes are working as expected.
 
 # v0.27.3
-export PYODIDE_BUILD_COMMIT=fac0109aa2acf14469320b049d710dd42639bf94
-export PYODIDE_BUILD_REPO=https://github.com/pyodide/pyodide-build
+export PYODIDE_BUILD_COMMIT=ddb39cd7f1c42328220d2afd94592bbd86e8ae10
+export PYODIDE_BUILD_REPO=https://github.com/hoodmane/pyodide-build
 
 ifdef CPYTHON_DEBUG
 	export CPYTHON_ABI_FLAGS=d


### PR DESCRIPTION
Testing:
https://github.com/pyodide/pyodide-build/pull/42
