### PR TITLE
use vite-plugin-static-copy in doc example of Vite

### DIFF
--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -31,7 +31,12 @@ import { viteStaticCopy } from "vite-plugin-static-copy";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-const PYODIDE_EXCLUDE = ["!**/package.json", "!**/*.{md,html}", "!**/*.d.ts"];
+const PYODIDE_EXCLUDE = [
+  "!**/*.{md,html}",
+  "!**/*.d.ts",
+  "!**/*.whl",
+  "!**/node_modules",
+];
 
 export function viteStaticCopyPyodide() {
   const pyodideDir = dirname(fileURLToPath(import.meta.resolve("pyodide")));

--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -10,50 +10,48 @@ project.
 ## Vite
 
 ```{note}
-The following instructions have been tested with Pyodide 0.26.0 and Vite 5.2.13.
+The following instructions have been tested with Pyodide 0.26.2, Vite 5.4.9, and
+vite-plugin-pyodide 2.0.0.
 ```
 
-First, install the Pyodide npm package:
+First, install the Pyodide and vite-plugin-pyodide npm packages:
 
 ```
-$ npm install pyodide
+$ npm install pyodide vite-plugin-static-copy
 ```
 
-Then, in your `vite.config.js` file, exclude Pyodide from [Vite's dependency
+Then, in your `vite.config.mjs` file, exclude Pyodide from [Vite's dependency
 pre-bundling][optimizedeps] by setting `optimizeDeps.exclude` and ensure that
 all Pyodide files will be available in `dist/assets` for production builds by
 using a Vite plugin:
 
 ```js
 import { defineConfig } from "vite";
-import { copyFile, mkdir } from "fs/promises";
+import { viteStaticCopy } from "vite-plugin-static-copy";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
+const PYODIDE_EXCLUDE = [
+  "!**/package.json",
+  "!**/*.{md,html}",
+  "!**/*.d.ts",
+];
+
+export function viteStaticCopyPyodide() {
+  const pyodideDir = dirname(fileURLToPath(import.meta.resolve("pyodide")));
+  return viteStaticCopy({
+    targets: [
+      {
+        src: [join(pyodideDir, "*")].concat(PYODIDE_EXCLUDE),
+        dest: "assets",
+      },
+    ],
+  });
+}
+
 export default defineConfig({
   optimizeDeps: { exclude: ["pyodide"] },
-  plugins: [
-    {
-      name: "vite-plugin-pyodide",
-      generateBundle: async () => {
-        const assetsDir = "dist/assets";
-        await mkdir(assetsDir, { recursive: true });
-        const files = [
-          "pyodide-lock.json",
-          "pyodide.asm.js",
-          "pyodide.asm.wasm",
-          "python_stdlib.zip",
-        ];
-        const modulePath = fileURLToPath(import.meta.resolve("pyodide"));
-        for (const file of files) {
-          await copyFile(
-            join(dirname(modulePath), file),
-            join(assetsDir, file),
-          );
-        }
-      },
-    },
-  ],
+  plugins: [viteStaticCopyPyodide()],
 });
 ```
 
@@ -64,12 +62,12 @@ You can test your setup with this `index.html` file:
 <html lang="en">
   <head>
     <title>Vite + Pyodide</title>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="main.mjs"></script>
   </head>
 </html>
 ```
 
-And this `src/main.js` file:
+And this `src/main.mjs` file:
 
 ```js
 import { loadPyodide } from "pyodide";

--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -31,11 +31,7 @@ import { viteStaticCopy } from "vite-plugin-static-copy";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-const PYODIDE_EXCLUDE = [
-  "!**/package.json",
-  "!**/*.{md,html}",
-  "!**/*.d.ts",
-];
+const PYODIDE_EXCLUDE = ["!**/package.json", "!**/*.{md,html}", "!**/*.d.ts"];
 
 export function viteStaticCopyPyodide() {
   const pyodideDir = dirname(fileURLToPath(import.meta.resolve("pyodide")));


### PR DESCRIPTION
This is for enhancement #5120.

I've tested it by just putting the 3 files described on this doc page into one folder, following the instructions on the page, with the package versions mentioned on the page.

Assuming vite-plugin-static-copy is stable and works, this seems like a better approach.

@pauleveritt, you might have some feedback since you made an example from which this is inspired, thank you!