### PR TITLE
Bump to DuckDB 1.1.2

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -83,6 +83,7 @@ myst:
 - Upgraded `sympy` to 1.13.3 {pr}`5098`
 - Upgraded `tree-sitter` to 0.23.1 {pr}`5110`
 - Upgraded `PyYAML` to 6.0.2 {pr}`5137`
+- Upgraded `duckdb` to 1.1.2 {pr}`5142`
 - Added `casadi` 3.6.6 {pr}`4936`, {pr}`5057`
 - Added `pyarrow` 17.0.0 {pr}`4950`
 - Added `rasterio` 1.13.10, `affine` 2.4.0 {pr}`4983`

--- a/packages/duckdb/meta.yaml
+++ b/packages/duckdb/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: duckdb
-  version: 1.1.0
+  version: 1.1.2
   top-level:
     - duckdb
 source:
-  url: https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-1.1.0-cp312-cp312-pyodide_2024_0_wasm32.whl
-  sha256: 5f6dffea55b467b41b329e8117120403cbd63fd8096a046daa740dfc94dfcb66
+  url: https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-1.1.2-cp312-cp312-pyodide_2024_0_wasm32.whl
+  sha256: aa794366f7acb924ddd1ecb32a349148a3c1343219a7d9d84812d3dcf47a4404
 about:
   home: https://github.com/duckdb/duckdb
   PyPI: https://pypi.org/project/duckdb


### PR DESCRIPTION
### Description
Bump DuckDB package to v1.1.2

### Checklists
- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry