### PR TITLE
CI Split library build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,10 +579,26 @@ workflows:
               only: /.*/
 
       - build-packages:
+          name: build-static-libraries
+          packages: "tag:static_library"
+          requires:
+            - build-core
+          filters:
+            tags:
+              only: /.*/
+          post-steps:
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - ./packages
+                  - ./dist
+
+      - build-packages:
           name: build-libraries
           packages: "tag:library"
           requires:
             - build-core
+            - build-static-libraries
           filters:
             tags:
               only: /.*/

--- a/packages/boost-cpp/meta.yaml
+++ b/packages/boost-cpp/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.84.0
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.gz
   sha256: 4d27e9efed0f6f152dc28db6430b9d3dfb40c0345da7342eaa5a987dde57bd95

--- a/packages/cpp-exceptions-test/meta.yaml
+++ b/packages/cpp-exceptions-test/meta.yaml
@@ -5,6 +5,7 @@ package:
     - core
     - pyodide.test
     - library
+    - shared_library
 source:
   path: src
 build:

--- a/packages/ffmpeg/meta.yaml
+++ b/packages/ffmpeg/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "4.4.1"
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n4.4.1.tar.gz
   sha256: 82b43cc67296bcd01a59ae6b327cdb50121d3a9e35f41a30de1edd71bb4a6666

--- a/packages/flint/meta.yaml
+++ b/packages/flint/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 3.0.1
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/flintlib/flint/releases/download/v3.0.1/flint-3.0.1.tar.gz
   sha256: 7b311a00503a863881eb8177dbeb84322f29399f3d7d72f3b1a4c9ba1d5794b4

--- a/packages/gdal/meta.yaml
+++ b/packages/gdal/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 3.8.3
   tag:
     - library
+    - shared_library
 source:
   url: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz
   sha256: f7a30387a8239e9da26200f787a02136df2ee6473e86b36d05ad682761a049ea

--- a/packages/geos/meta.yaml
+++ b/packages/geos/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 3.12.1
   tag:
     - library
+    - shared_library
 source:
   url: https://github.com/libgeos/geos/releases/download/3.12.1/geos-3.12.1.tar.bz2
   sha256: d6ea7e492224b51193e8244fe3ec17c4d44d0777f3c32ca4fb171140549a0d03

--- a/packages/glpk/meta.yaml
+++ b/packages/glpk/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "5.0"
   tag:
     - library
+    - static_library
 source:
   sha256: 4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15
   url: https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz

--- a/packages/libde265/meta.yaml
+++ b/packages/libde265/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.0.8
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/strukturag/libde265/releases/download/v1.0.8/libde265-1.0.8.tar.gz
   sha256: 24c791dd334fa521762320ff54f0febfd3c09fc978880a8c5fbc40a88f21d905

--- a/packages/libf2c/meta.yaml
+++ b/packages/libf2c/meta.yaml
@@ -9,6 +9,7 @@ package:
   version: CLAPACK-3.2.1
   tag:
     - library
+    - static_library
 source:
   sha256: 6dc4c382164beec8aaed8fd2acc36ad24232c406eda6db462bd4c41d5e455fac
   url: http://www.netlib.org/clapack/clapack.tgz

--- a/packages/libgmp/meta.yaml
+++ b/packages/libgmp/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 6.3.0
   tag:
     - library
+    - static_library
 source:
   url: https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz
   sha256: a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898

--- a/packages/libgsl/meta.yaml
+++ b/packages/libgsl/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "2.7"
   tag:
     - library
+    - static_library
 source:
   sha256: efbbf3785da0e53038be7907500628b466152dbc3c173a87de1b5eba2e23602b
   url: https://ftp.gnu.org/gnu/gsl/gsl-2.7.tar.gz

--- a/packages/libhdf5/meta.yaml
+++ b/packages/libhdf5/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.12.1
   tag:
     - library
+    - shared_library
 source:
   sha256: e6dde173c2d243551922d23a0387a79961205b018502e6a742acb30b61bc2d5f
   url: https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_1.tar.gz

--- a/packages/libheif/meta.yaml
+++ b/packages/libheif/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.12.0
   tag:
     - library
+    - shared_library
 source:
   url: https://github.com/strukturag/libheif/releases/download/v1.12.0/libheif-1.12.0.tar.gz
   sha256: e1ac2abb354fdc8ccdca71363ebad7503ad731c84022cf460837f0839e171718

--- a/packages/libiconv/meta.yaml
+++ b/packages/libiconv/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "1.16"
   tag:
     - library
+    - static_library
 source:
   url: https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz
   sha256: e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04

--- a/packages/liblzma/meta.yaml
+++ b/packages/liblzma/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 5.2.2
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/xz-mirror/xz/releases/download/v5.2.2/xz-5.2.2.tar.gz
   sha256: 73df4d5d34f0468bd57d09f2d8af363e95ed6cc3a4a86129d2f2c366259902a2

--- a/packages/libmagic/meta.yaml
+++ b/packages/libmagic/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "5.42"
   tag:
     - library
+    - shared_library
 source:
   url: https://github.com/file/file/archive/refs/tags/FILE5_42.tar.gz
   sha256: d7374d06451154a628831df58e835fa3263825d0ad593df0fb8a911418d27863

--- a/packages/libmpc/meta.yaml
+++ b/packages/libmpc/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.3.1
   tag:
     - library
+    - static_library
 source:
   url: https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz
   sha256: ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8

--- a/packages/libmpfr/meta.yaml
+++ b/packages/libmpfr/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 4.2.1
   tag:
     - library
+    - static_library
 source:
   url: https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz
   sha256: 277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2

--- a/packages/libnetcdf/meta.yaml
+++ b/packages/libnetcdf/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 4.9.2
   tag:
     - library
+    - static_library
 source:
   sha256: bc104d101278c68b303359b3dc4192f81592ae8640f1aee486921138f7f88cb7
   url: https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.2.tar.gz

--- a/packages/libproj/meta.yaml
+++ b/packages/libproj/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 9.3.1
   tag:
     - library
+    - static_library
 source:
   sha256: b0f919cb9e1f42f803a3e616c2b63a78e4d81ecfaed80978d570d3a5e29d10bc
   url: https://download.osgeo.org/proj/proj-9.3.1.tar.gz

--- a/packages/libtiff/meta.yaml
+++ b/packages/libtiff/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 4.4.0
   tag:
     - library
+    - static_library
 source:
   # TODO: The root certificate of `download.osgeo.org` has been expired and requires the latest version (2022.6.15) of certifi.
   # url: https://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz

--- a/packages/libwebp/meta.yaml
+++ b/packages/libwebp/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.2.2
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/webmproject/libwebp/archive/refs/tags/v1.2.2.tar.gz
   sha256: 51e9297aadb7d9eb99129fe0050f53a11fcce38a0848fb2b0389e385ad93695e

--- a/packages/libxml/meta.yaml
+++ b/packages/libxml/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 2.9.10
   tag:
     - library
+    - static_library
 source:
   sha256: aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
   url: http://xmlsoft.org/sources/libxml2-2.9.10.tar.gz

--- a/packages/libxslt/meta.yaml
+++ b/packages/libxslt/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.1.33
   tag:
     - library
+    - static_library
 source:
   sha256: 8e36605144409df979cab43d835002f63988f3dc94d5d3537c12796db90e38c8
   url: http://xmlsoft.org/sources/libxslt-1.1.33.tar.gz

--- a/packages/libyaml/meta.yaml
+++ b/packages/libyaml/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 0.2.1
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/yaml/libyaml/archive/0.2.1.zip
   sha256: 56070c9d4bf244a8dcc68e04613e5bbce5c8411ed97cdccc1f4b5fb46aebe5a8

--- a/packages/openblas/meta.yaml
+++ b/packages/openblas/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 0.3.26
   tag:
     - library
+    - shared_library
 source:
   sha256: 4e6e4f5cb14c209262e33e6816d70221a2fe49eb69eaf0a06f065598ac602c68
   url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.26/OpenBLAS-0.3.26.tar.gz

--- a/packages/openssl/meta.yaml
+++ b/packages/openssl/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.1.1w
   tag:
     - library
+    - shared_library
 source:
   url: https://www.openssl.org/source/openssl-1.1.1w.tar.gz
   sha256: cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8

--- a/packages/ppl/meta.yaml
+++ b/packages/ppl/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "1.2"
   tag:
     - library
+    - static_library
 source:
   url: https://mirrors.mit.edu/sage/spkg/upstream/ppl/ppl-1.2.tar.bz2
   sha256: 2d470b0c262904f190a19eac57fb5c2387b1bfc3510de25a08f3c958df62fdf1

--- a/packages/primecount/meta.yaml
+++ b/packages/primecount/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "7.9"
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/kimwalisch/primecount/archive/refs/tags/v7.9.tar.gz
   sha256: 872975ba2cbb43f5cc1ff5f5fda9ec4ec3f2be1eb3e3e906abe5d0b29a997f5b

--- a/packages/primesieve/meta.yaml
+++ b/packages/primesieve/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "11.2"
   tag:
     - library
+    - static_library
 source:
   url: https://github.com/kimwalisch/primesieve/archive/refs/tags/v11.2.tar.gz
   sha256: 86c31bae9c378340b19669eafef8c5e45849adf7b9c92af1d212a2a2bfa0a5db

--- a/packages/sharedlib-test/meta.yaml
+++ b/packages/sharedlib-test/meta.yaml
@@ -4,6 +4,7 @@ package:
   tag:
     - pyodide.test
     - library
+    - shared_library
 source:
   path: src
 

--- a/packages/suitesparse/meta.yaml
+++ b/packages/suitesparse/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 5.11.0
   tag:
     - library
+    - shared_library
 source:
   sha256: fdd957ed06019465f7de73ce931afaf5d40e96e14ae57d91f60868b8c123c4c8
   url: https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v5.11.0.tar.gz

--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.3.1
   tag:
     - library
+    - static_library
 source:
   sha256: 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
   url: https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz


### PR DESCRIPTION
Splits library build job as a workaround for the timeout. Builds static libraries first then build shared libraries.