### PR TITLE
Upgrade `pydantic` and `pydantic_core`

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -64,6 +64,8 @@ myst:
 
 ### Packages
 
+- Upgraded `pydantic_core` to 2.25.1 {pr}`5151`
+- Upgraded `pydantic` to 2.9.2 {pr}`5151`
 - Upgraded `msgpack` to 1.1.0 {pr}`5144`
 - Added `tiktoken` v0.8.0 in {pr}`5147`
 - Upgraded `protobuf` to 5.28.3 {pr}`5136`

--- a/packages/pydantic/meta.yaml
+++ b/packages/pydantic/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: pydantic
-  version: 2.8.2
+  version: 2.9.2
   top-level:
     - pydantic
 source:
-  sha256: 6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a
-  url: https://files.pythonhosted.org/packages/8c/99/d0a5dca411e0a017762258013ba9905cd6e7baa9a3fd1fe8b6529472902e/pydantic-2.8.2.tar.gz
+  sha256: d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f
+  url: https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz
 requirements:
   run:
     - typing-extensions

--- a/packages/pydantic_core/meta.yaml
+++ b/packages/pydantic_core/meta.yaml
@@ -1,14 +1,11 @@
 package:
   name: pydantic_core
-  version: 2.23.1
+  version: 2.25.1
   top-level:
     - pydantic_core
 source:
-  url: https://files.pythonhosted.org/packages/60/a9/a64afaeecc30a42142f5e60bb61a1ec4817e90c2d1c0c7b242082f61ed00/pydantic_core-2.23.1.tar.gz
-  sha256: 12543919dbf3021e17b9e2cd5cd1b570c6585794fa487339b5b95564b9689452
-requirements:
-  executable:
-    - rustup
+  url: https://github.com/pydantic/pydantic-core/releases/download/v2.25.1/pydantic_core-2.25.1-cp312-cp312-emscripten_3_1_58_wasm32.whl
+  sha256: f4b77016b1511e54a8c6bd833bb68e190b96989ba9997f9e0f023cfb0f8a16c2
 about:
   home: https://github.com/pydantic/pydantic-core
   PyPI: https://pypi.org/project/pydantic_core


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

- Standard upgrade for pydantic
- For `pydantic_core`, I upgraded the emscripten wheel in their repo (https://github.com/pydantic/pydantic-core/pull/1507), so rather than rebuilding it in pyodide, I think we can just use that directly? If I'm mistaken please let me know!

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
