### PR TITLE
Update msprime to 1.3.3

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -64,6 +64,7 @@ myst:
 
 ### Packages
 
+- Upgraded `msprime` to 1.3.3 {pr}`5159`
 - Upgraded `tskit` to 0.6.0 {pr}`5157`
 - Upgraded `pydantic_core` to 2.25.1 {pr}`5151`
 - Upgraded `pydantic` to 2.9.2 {pr}`5151`

--- a/packages/msprime/meta.yaml
+++ b/packages/msprime/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: msprime
-  version: 1.3.1
+  version: 1.3.3
   top-level:
     - msprime
 source:
-  url: https://files.pythonhosted.org/packages/9c/c6/d2c24086da4492fe2c9d281d237b5fd09e5bf5c92a8956efad7522cf96b1/msprime-1.3.1.tar.gz
-  sha256: b3f62cd516ad2e43c8412ea1f242acad1bc939391cfe9caa19625874e2e34835
+  url: https://files.pythonhosted.org/packages/70/84/72a914d91c3e9cea91b8089ddc2a32cc9bdee50eda7e8900be6be70d1fdb/msprime-1.3.3.tar.gz
+  sha256: d8ae798076167f632b8fd7eccd5089faaa84c9034ca69422f886425f94a5b01b
 build:
   script: |
     export LIBGSL_INCLUDE_PATH=$(pkg-config --cflags-only-I --dont-define-prefix gsl)


### PR DESCRIPTION
A few bugfixes and numpy 2 support in this release

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
