### PR TITLE
bump_version.py: `ast.Str` will be removed in Py314 so use `ast.Constant`

### DIFF
--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -6,7 +6,7 @@ import functools
 import itertools
 import pathlib
 import re
-from ast import Str
+from ast import Constant
 from collections import namedtuple
 from collections.abc import Callable
 
@@ -81,7 +81,7 @@ JS_TARGETS = [
 
 
 @functools.lru_cache
-def python_version_to_js_version(version: str) -> Str:
+def python_version_to_js_version(version: str) -> Constant:
     """
     Convert Python version name to JS version name
     These two are different in prerelease or dev versions.


### PR DESCRIPTION
```diff
- from ast import Str
+ from ast import Constant
```
Fixes the pytest warning:
```
tools/bump_version.py:9
  /home/runner/work/pyodide/pyodide/tools/bump_version.py:9: DeprecationWarning:
   ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
    from ast import Str
```
https://docs.python.org/3/library/ast.html#ast.AST.end_col_offset
> Changed in version 3.8: Class [`ast.Constant`](https://docs.python.org/3/library/ast.html#ast.Constant) is now used for all constants.

> Deprecated since version 3.8: Old classes `ast.Num`, `ast.Str`, `ast.Bytes`, `ast.NameConstant` and `ast.Ellipsis` are still available, but they will be removed in future Python releases. In the meantime, instantiating them will return an instance of a different class.