### PR TITLE
Main

### DIFF
--- a/packages/sqlite3/meta.yaml
+++ b/packages/sqlite3/meta.yaml
@@ -27,7 +27,39 @@ build:
       "Modules/_sqlite/util.c"
     )
 
-    embuilder build sqlite3 --pic
+    export SQLITE_WASM_VERSION=3450300
+    export SQLITE_WASM_YEAR=2024
+    wget -O sqlite.zip https://www.sqlite.org/${SQLITE_WASM_YEAR}/sqlite-src-${SQLITE_WASM_VERSION}.zip
+    unzip -q -o sqlite.zip -d sqlite
+    (cd sqlite/sqlite-src-${SQLITE_WASM_VERSION}/ && ./configure --enable-all && make sqlite3.c)
+    export SQLITE_FLAGS="\
+      -DSTDC_HEADERS=1 \
+      -DHAVE_SYS_TYPES_H=1 \
+      -DHAVE_SYS_STAT_H=1 \
+      -DHAVE_STDLIB_H=1 \
+      -DHAVE_STRING_H=1 \
+      -DHAVE_MEMORY_H=1 \
+      -DHAVE_STRINGS_H=1 \
+      -DHAVE_INTTYPES_H=1 \
+      -DHAVE_STDINT_H=1 \
+      -DHAVE_UNISTD_H=1 \
+      -DHAVE_FDATASYNC=1 \
+      -DHAVE_USLEEP=1 \
+      -DHAVE_LOCALTIME_R=1 \
+      -DHAVE_GMTIME_R=1 \
+      -DHAVE_DECL_STRERROR_R=1 \
+      -DHAVE_STRERROR_R=1 \
+      -DHAVE_POSIX_FALLOCATE=1 \
+      -DSQLITE_ENABLE_MATH_FUNCTIONS=1 \
+      -DSQLITE_ENABLE_FTS4=1 \
+      -DSQLITE_ENABLE_FTS5=1 \
+      -DSQLITE_ENABLE_RTREE=1 \
+      -DSQLITE_ENABLE_GEOPOLY=1 \
+      -DSQLITE_OMIT_POPEN=1 \
+      -DSQLITE_THREADSAFE=0 \
+      -DSQLITE_CORE"
+
+    emcc -c sqlite/sqlite-src-${SQLITE_WASM_VERSION}/sqlite3.c -o sqlite3.c.o -g3 -fPIC
 
     for file in "${FILES[@]}"; do
       emcc $STDLIB_MODULE_CFLAGS -c "${file}" -o "${file/.c/.o}"  \
@@ -35,8 +67,8 @@ build:
     done
 
     OBJECT_FILES=$(find Modules/_sqlite/ -name "*.o")
-    emcc $OBJECT_FILES -o ${PKG_BUILD_DIR}/_sqlite3.so $SIDE_MODULE_LDFLAGS \
-       -sUSE_SQLITE3 -lsqlite3
+    emcc $OBJECT_FILES sqlite3.c.o -o ${PKG_BUILD_DIR}/_sqlite3.so $SIDE_MODULE_LDFLAGS \
+       -sUSE_SQLITE3 
 
     cd Lib && tar --exclude=test -cf - sqlite3 | tar -C ${PKG_BUILD_DIR} -xf -
 about:


### PR DESCRIPTION

This allows us to use sqlite extensions (such as https://github.com/asg017/sqlite-vec/issues/135 )

 * Upgrade sqlite to a version at least compatible with https://github.com/asg017/sqlite-vec/issues/116
 * build/compile sqlite3 outselves so we can control the flags, and enable
 * TODO: build Python with PY_SQLITE_ENABLE_LOAD_EXTENSION since those flags are used when compiling the Python extension (I manually changed pyconfig.h by hand, but I guess it's a configure flag in pyodide about how to build Python, that I could not find).



