### PR TITLE
`make_test_list.py`: Parse the version out of Makefile.envs

### DIFF
--- a/src/tests/make_test_list.py
+++ b/src/tests/make_test_list.py
@@ -4,16 +4,39 @@ Generate a list of test modules in the CPython distribution.
 
 import os
 from pathlib import Path
-from sys import version
 from typing import Any
+import subprocess
 
 import ruamel.yaml
 
 yaml = ruamel.yaml.YAML()
 PYODIDE_ROOT = Path(__file__).parents[2]
-LIB_DIR = PYODIDE_ROOT / "cpython/build" f"/Python-{version.split(' ')[0]}" f"/Lib/"
-
 PYTHON_TESTS_YAML = Path(__file__).parent / "python_tests.yaml"
+
+
+def get_makefile_envs():
+    result = subprocess.run(
+        ["make", "-f", str(PYODIDE_ROOT / "Makefile.envs"), ".output_vars"],
+        capture_output=True,
+        text=True,
+        env={"PYODIDE_ROOT": str(PYODIDE_ROOT)},
+    )
+
+    if result.returncode != 0:
+        logger.error("ERROR: Failed to load environment variables from Makefile.envs")
+        exit_with_stdio(result)
+
+    environment = {}
+    for line in result.stdout.splitlines():
+        equalPos = line.find("=")
+        if equalPos != -1:
+            varname = line[0:equalPos]
+
+            value = line[equalPos + 1 :]
+            value = value.strip("'").strip()
+            environment[varname] = value
+
+    return environment
 
 
 def get_old_yaml():
@@ -69,6 +92,8 @@ def update_tests(doc_group, tests):
 
 if __name__ == "__main__":
     doc = get_old_yaml()
+    version = get_makefile_envs()["PYVERSION"]
+    LIB_DIR = PYODIDE_ROOT / "cpython/build" f"/Python-{version}/Lib/"
     update_tests(doc, collect_tests(LIB_DIR / "test"))
 
     yaml.dump(doc, PYTHON_TESTS_YAML)

--- a/src/tests/make_test_list.py
+++ b/src/tests/make_test_list.py
@@ -4,6 +4,7 @@ Generate a list of test modules in the CPython distribution.
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -23,8 +24,8 @@ def get_makefile_envs():
     )
 
     if result.returncode != 0:
-        logger.error("ERROR: Failed to load environment variables from Makefile.envs")
-        exit_with_stdio(result)
+        print("ERROR: Failed to load environment variables from Makefile.envs")
+        sys.exit(1)
 
     environment = {}
     for line in result.stdout.splitlines():

--- a/src/tests/make_test_list.py
+++ b/src/tests/make_test_list.py
@@ -93,7 +93,7 @@ def update_tests(doc_group, tests):
 if __name__ == "__main__":
     doc = get_old_yaml()
     version = get_makefile_envs()["PYVERSION"]
-    LIB_DIR = PYODIDE_ROOT / "cpython/build" f"/Python-{version}/Lib/"
+    LIB_DIR = PYODIDE_ROOT / "cpython/build/Python-{version}/Lib/"
     update_tests(doc, collect_tests(LIB_DIR / "test"))
 
     yaml.dump(doc, PYTHON_TESTS_YAML)

--- a/src/tests/make_test_list.py
+++ b/src/tests/make_test_list.py
@@ -3,9 +3,9 @@ Generate a list of test modules in the CPython distribution.
 """
 
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
-import subprocess
 
 import ruamel.yaml
 


### PR DESCRIPTION
This fixes `make_test_list.py` so it can be run with any version of Python as opposed to having to match the Python version Pyodide uses.

