### PR TITLE
DRAFT: pre-commit: Only run the slow mypy on pre-push and manual

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
     rev: "v1.11.0"
     hooks:
       - id: mypy
+        stages: [pre-push, manual]
         files: ^(packages/.*/src|src|pyodide-build/pyodide_build)
         exclude: (setup.py|.*test.*)
         args: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ pytest-cov
 pytest-httpserver
 pytest-benchmark
 pytest-pyodide==0.58.3
+setuptools; python_version >= '3.12'
+# TODO(cclauss): Remove the Selenium line.
+selenium==4.25.0


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

As discussed at https://github.com/pyodide/pyodide/pull/5177#issuecomment-2466105227 some contributors may be avoiding the use of pre-commit because of slow pre-commit jobs like `mypy`.  Disabling pre-commit puts extra stress on our continuous integration jobs on issues that could have been fixed before modifications were pushed.

The proposed changes will cause the slower `mypy` job to be executed only on pre-push or manual runs.  Other (faster) pre-commit jobs will be executed in all stages but the `mypy` job will be run at least once before changes are sent to our continuous integration.
* https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

Q: `stages: [pre-commit, pre-merge-commit, pre-push, manual]` -- Should `pre-merge-commit` be added?

The manual `pre-commit run --all-files` can take about 20 seconds.
* https://results.pre-commit.ci/run/github/122663163/1731166378.P2xoksEbSaKXB2K3F96vzQ

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
