### PR TITLE
requirements.txt: Pin selenium==4.25.0 to fix ci failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ pytest-cov
 pytest-httpserver
 pytest-benchmark
 pytest-pyodide==0.58.3
+setuptools; python_version >= '3.12'
+# TODO(cclauss): Remove the Selenium line.
+selenium==4.25.0


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description
Related to:
* #5149 
* #5181 

As discussed in the two pull requests above, the fixes in SeleniumHQ/Selenium #14699 are causing numerous failures in our continuous integration tests.  See ❌'s at https://github.com/pyodide/pyodide/pulls 
* SeleniumHQ/selenium#14699

While those fixes will be included in a future [Selenium release](https://github.com/SeleniumHQ/selenium/releases), they are not yet on the Nightly build so let's pin selenium==4.25.0 to get our CI ✅ again.

@hoodmane says at https://github.com/pyodide/pyodide/pull/5149#issuecomment-2465272103
> I'm okay with using the downgraded selenium for now. @ryanking13 you have any objection?

@ryanking13 says at https://github.com/pyodide/pyodide/pull/5149#issuecomment-2466006322
> No objection.

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
