### PR TITLE
Add `clingo` package

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -106,6 +106,7 @@ myst:
 - Added `tree-sitter-python` 0.23.2 {pr}`5102`
 - Added `Narwhals` 1.9.4 {pr}`5121`
 - Added `libzfp` and `zfpy` 1.0.1 {pr}`5172`
+- Added `clingo` 5.7.1 {pr}`5184`
 
 ## Version 0.26.3
 

--- a/packages/clingo/meta.yaml
+++ b/packages/clingo/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: clingo
+  version: 5.7.1
+  top-level:
+    - clingo
+source:
+  url: https://files.pythonhosted.org/packages/3b/b3/c7b464426f70fe100cb4f3e5b45623e3eb82ea50f1dffdc2f820f1418fe0/clingo-5.7.1.tar.gz
+  sha256: 17400a1894da46b2d4941a4a85012c98fa8b3c67a5c6b4c73dcd8c8facbc059f
+about:
+  home: https://github.com/potassco/clingo
+  PyPI: https://pypi.org/project/clingo
+  summary: CFFI-based bindings to the clingo solver.
+  license: MIT
+requirements:
+  host:
+    - cffi
+  run:
+    - cffi
+extra:
+  recipe-maintainers:
+    - peter-gy

--- a/packages/clingo/test_clingo.py
+++ b/packages/clingo/test_clingo.py
@@ -17,14 +17,8 @@ def test_clingo(selenium):
         print(m)
 
     ctl = Control()
-    ctl.add(
-        "base",
-        [],
-        """
-    p(@inc(10)).
-    q(@seq(1,2)).
-    """,
-    )
+    program = '\n'.join(['p(@inc(10)).', 'q(@seq(1,2)).'])
+    ctl.add("base", [], program)
 
     ctl.ground([("base", [])], context=Context())
     solution = ctl.solve(on_model=on_model)

--- a/packages/clingo/test_clingo.py
+++ b/packages/clingo/test_clingo.py
@@ -17,10 +17,14 @@ def test_clingo(selenium):
         print(m)
 
     ctl = Control()
-    ctl.add("base", [], """
+    ctl.add(
+        "base",
+        [],
+        """
     p(@inc(10)).
     q(@seq(1,2)).
-    """)
+    """,
+    )
 
     ctl.ground([("base", [])], context=Context())
     solution = ctl.solve(on_model=on_model)

--- a/packages/clingo/test_clingo.py
+++ b/packages/clingo/test_clingo.py
@@ -17,7 +17,7 @@ def test_clingo(selenium):
         print(m)
 
     ctl = Control()
-    program = '\n'.join(['p(@inc(10)).', 'q(@seq(1,2)).'])
+    program = "\n".join(["p(@inc(10)).", "q(@seq(1,2))."])
     ctl.add("base", [], program)
 
     ctl.ground([("base", [])], context=Context())

--- a/packages/clingo/test_clingo.py
+++ b/packages/clingo/test_clingo.py
@@ -1,0 +1,27 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["clingo"])
+def test_clingo(selenium):
+    from clingo.control import Control
+    from clingo.symbol import Number
+
+    class Context:
+        def inc(self, x):
+            return Number(x.number + 1)
+
+        def seq(self, x, y):
+            return [x, y]
+
+    def on_model(m):
+        print(m)
+
+    ctl = Control()
+    ctl.add("base", [], """
+    p(@inc(10)).
+    q(@seq(1,2)).
+    """)
+
+    ctl.ground([("base", [])], context=Context())
+    solution = ctl.solve(on_model=on_model)
+    assert solution.satisfiable


### PR DESCRIPTION
### Description

Adds https://pypi.org/project/clingo/, a powerful Answer Set Programming (ASP) solver.
Other projects also brought Clingo to web via WASM:

- https://github.com/Aluriak/webclingo-example
- https://github.com/domoritz/wasm-clingo
- https://github.com/domoritz/clingo-wasm
- https://github.com/cmudig/draco2 (custom Pyodide build, deployed to https://dig.cmu.edu/draco2/jupyterlite/static/pyodide/console.html)

However, it would be the nicest to have the recipe as part of the official Pyodide repo.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
