### PR TITLE
Fix sessionStorage-related crash when running in sandboxed iframe

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -62,6 +62,9 @@ myst:
   [Emscripten docs](https://emscripten.org/docs/api_reference/Filesystem-API.html#FS.trackingDelegate[callback%20name])
   for more information.
 
+- {{ Fix }} Fix sessionStorage-related crash when running in sandboxed iframe.
+  {pr}`5186`
+
 ### Packages
 
 - Upgraded `crc32c` to 2.7.1 {pr}`5169`

--- a/src/js/environments.ts
+++ b/src/js/environments.ts
@@ -33,7 +33,7 @@ export const IN_BROWSER_MAIN_THREAD =
   typeof window === "object" &&
   typeof document === "object" &&
   typeof document.createElement === "function" &&
-  typeof sessionStorage === "object" &&
+  "sessionStorage" in window &&
   typeof importScripts !== "function";
 
 /** @private */


### PR DESCRIPTION
Fixes this problem when Pyodide is running within a [sandboxed](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) iframe:

> Uncaught SecurityError: Failed to read the 'sessionStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.

![image](https://github.com/user-attachments/assets/b07464dd-b596-473b-97b3-8f513d930506)

The above screenshot is from Chrome. I haven't tested whether Firefox and Safari also throw and error for this.

The workaround in the meantime:
```js
delete window.sessionStorage
window.sessionStorage = {}
// now load Pyodide...
```