### PR TITLE
MAINT Switch to a different mirror for Autoconf 2.71

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -q -O - https://sh.rustup.rs | \
     RUSTUP_HOME=/usr CARGO_HOME=/usr sh -s -- -y --profile minimal --no-modify-path
 
 # install autoconf 2.71, required by upstream libffi
-RUN wget https://mirrors.sarata.com/gnu/autoconf/autoconf-2.71.tar.xz \
+RUN wget https://mirrors.ocf.berkeley.edu/gnu/autoconf/autoconf-2.71.tar.xz \
     && tar -xf autoconf-2.71.tar.xz \
     && cd autoconf-2.71 \
     && ./configure \


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

The current mirror has been failing for some time (intermittently) because of a "403: Forbidden" error. I've changed it to point to a different source in this PR.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

N/A
