### PR TITLE
MAINT Fix cross-build metadata update workflow, open issue on failures

### DIFF
--- a/.github/workflows/update_cross_build_releases.yml
+++ b/.github/workflows/update_cross_build_releases.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version number"
+        description: "Version number to update to. This should not contain the 'v' prefix, since our releases on GitHub do not have it."
         required: true
 
 env:

--- a/.github/workflows/update_cross_build_releases.yml
+++ b/.github/workflows/update_cross_build_releases.yml
@@ -10,7 +10,7 @@ on:
         required: true
 
 env:
-  version: ${{ github.event_name == 'release' && github.event.release.name || github.event.inputs.version }}
+  version: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}
 
 jobs:
   update_cross_build_releases:

--- a/.github/workflows/update_cross_build_releases.yml
+++ b/.github/workflows/update_cross_build_releases.yml
@@ -42,8 +42,9 @@ jobs:
           commit-message: Update cross-build metadata file for version ${{ env.version }} [skip ci]
           title: Update cross-build metadata file for version ${{ env.version }}
           body: |
-            This PR updates the cross-build metadata file for version ${{ env.VERSION }}
-          branch: update-cross-build-metadata-${{ env.VERSION }}
+            This PR updates the cross-build metadata file for the new version ${{ env.version }}.
+            Requesting a review from the @pyodide/core team.
+          branch: update-cross-build-metadata-${{ env.version }}
           base: main
           branch-suffix: timestamp
           draft: true

--- a/.github/workflows/update_cross_build_releases.yml
+++ b/.github/workflows/update_cross_build_releases.yml
@@ -9,6 +9,9 @@ on:
         description: "Version number"
         required: true
 
+env:
+  version: ${{ github.event_name == 'release' && github.event.release.name || github.event.inputs.version }}
+
 jobs:
   update_cross_build_releases:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_cross_build_releases.yml
+++ b/.github/workflows/update_cross_build_releases.yml
@@ -49,8 +49,6 @@ jobs:
           base: main
           branch-suffix: timestamp
           draft: true
-          add-paths: |
-            pyodide-cross-build-environments.json
 
       - name: Create an issue if the update fails
         if: failure() || steps.update_cross_build_metadata.outcome == 'failure'

--- a/.github/workflows/update_cross_build_releases.yml
+++ b/.github/workflows/update_cross_build_releases.yml
@@ -31,6 +31,7 @@ jobs:
           make pyodide_build
 
       - name: Update cross-build metadata file
+        id: update_cross_build_metadata
         working-directory: tools
         run: |
           python update_cross_build_releases.py "${{ env.version }}"
@@ -50,3 +51,22 @@ jobs:
           draft: true
           add-paths: |
             pyodide-cross-build-environments.json
+
+      - name: Create an issue if the update fails
+        if: failure() || steps.update_cross_build_metadata.outcome == 'failure'
+        uses: dacbd/create-issue-action@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Update cross-build metadata file for version ${{ env.VERSION }} failed
+          body: |
+            ## Description
+
+            The update of the cross-build metadata file for version ${{ env.VERSION }} failed.
+
+            ## Additional information
+
+            Please check the logs at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            for more information and update the metadata file manually if necessary.
+
+          labels:
+          assignees: ${{ github.actor }}

--- a/.github/workflows/update_cross_build_releases.yml
+++ b/.github/workflows/update_cross_build_releases.yml
@@ -30,27 +30,17 @@ jobs:
           python -m pip install --upgrade pip
           make pyodide_build
 
-      - name: Get version number (release)
-        if: github.event_name == 'release'
-        run: |
-          echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-
-      - name: Get version number (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-
       - name: Update cross-build metadata file
         working-directory: tools
         run: |
-          python update_cross_build_releases.py "${{ env.VERSION }}"
+          python update_cross_build_releases.py "${{ env.version }}"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update cross-build metadata file for version ${{ env.VERSION }} [skip ci]
-          title: Update cross-build metadata file for version ${{ env.VERSION }}
+          commit-message: Update cross-build metadata file for version ${{ env.version }} [skip ci]
+          title: Update cross-build metadata file for version ${{ env.version }}
           body: |
             This PR updates the cross-build metadata file for version ${{ env.VERSION }}
           branch: update-cross-build-metadata-${{ env.VERSION }}

--- a/tools/update_cross_build_releases.py
+++ b/tools/update_cross_build_releases.py
@@ -15,6 +15,7 @@ from pyodide_build.xbuildenv_releases import (
     CrossBuildEnvReleaseSpec,
 )
 
+# This file must be called from the root of the repository for the path to work
 METADATA_FILE = Path(__file__).parents[1] / "pyodide-cross-build-environments.json"
 
 BASE_URL = "https://github.com/pyodide/pyodide/releases/download/{version}/xbuildenv-{version}.tar.bz2"


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Continuing from https://github.com/pyodide/pyodide/pull/5168#issuecomment-2462387339, this PR updates the `update_cross_build_releases.yml` workflow to open an issue in the repository, since [the 0.26.3 update workflow run failed](https://github.com/pyodide/pyodide/actions/runs/11417310347) and we did not realise that was the case. Additionally, it fixes the cause of the failure by using `github.event.release.name` instead of `tag_name` which is sometimes inexplicably empty (and the tag name and the release name are the same in our case). I tested it on my fork with a workflow dispatch trigger: agriyakhetarpal/pyodide#2 and with a release: agriyakhetarpal/pyodide#4, and the update worked in both cases. I didn't test the issue creation job because I've kept issues disabled for my fork.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

N/A
