### PR TITLE
fix: npe from API.lockfile_info.version

### DIFF
--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -46,7 +46,7 @@ export async function initializePackageIndex(
   if (lockfile.info.version !== API.version) {
     throw new Error(
       "Lock file version doesn't match Pyodide version.\n" +
-        `   lockfile version: ${API.lockfile_info.version}\n` +
+        `   lockfile version: ${lockfile.info.version}\n` +
         `   pyodide  version: ${API.version}`,
     );
   }


### PR DESCRIPTION
Fixes an NPE on `API.lockfile_info.version` since its not assigned from `lockfile.info.version`

cc @hoodmane 