### PR TITLE
Delete failing syncify_not_supported2 test

### DIFF
--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -53,41 +53,13 @@ def test_syncify_awaitable_type_errors(selenium):
 
 
 @pytest.mark.xfail_browsers(node="Scopes don't work as needed")
-def test_syncify_not_supported1(selenium_standalone_noload):
+def test_syncify_not_supported(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     selenium.run_js(
         """
         // Ensure that it's not supported by deleting WebAssembly.Suspender
         delete WebAssembly.Suspender;
         delete WebAssembly.Suspending;
-        let pyodide = await loadPyodide({});
-        await assertThrowsAsync(
-          async () => await pyodide._api.pyodide_code.eval_code.callPromising("1+1"),
-          "Error",
-          "WebAssembly stack switching not supported in this JavaScript runtime"
-        );
-        await assertThrows(
-          () => pyodide.runPython(`
-            from pyodide.ffi import run_sync
-            run_sync(1)
-          `),
-          "PythonError",
-          "RuntimeError: WebAssembly stack switching not supported in this JavaScript runtime"
-        );
-        """
-    )
-
-
-@pytest.mark.xfail_browsers(
-    node="Scopes don't work as needed", safari="Doesn't have WebAssembly.Function?"
-)
-def test_syncify_not_supported2(selenium_standalone_noload):
-    selenium = selenium_standalone_noload
-    selenium.run_js(
-        """
-        // Disable direct instantiation of WebAssembly.Modules
-        // Note: only will work with newer runtimes that have WebAssembly.Function
-        WebAssembly.Module = new Proxy(WebAssembly.Module, {construct(){throw new Error("NOPE!");}});
         let pyodide = await loadPyodide({});
         await assertThrowsAsync(
           async () => await pyodide._api.pyodide_code.eval_code.callPromising("1+1"),


### PR DESCRIPTION
It fails because `WebAssembly.Function` does not exist anymore without the `--experimental-webassembly` flag.