### PR TITLE
Get PYVERSION from pyproject.toml project.requires-python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           path: |
             /tmp/ccache
-          key: ${{ hashFiles('pyproject.toml') }}-${{ runner.os }}-v20211025-
+          key: ${{ hashFiles('Makefile.env') }}-${{ runner.os }}-v20211025-
 
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,26 +12,15 @@ env:
   FORCE_COLOR: 3
 
 jobs:
-  get_python_version:
-    runs-on: ubuntu-latest
-    outputs:
-      PYVERSION: ${{ steps.get_python_version.outputs.PYVERSION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Read the Python version from Makefile.envs
-        id: get_python_version
-        run: |
-          echo "PYVERSION=$(git grep 'export PYVERSION ?=' Makefile.envs | cut -d' ' -f4)"  >> "$GITHUB_OUTPUT"
   test-python:
     runs-on: ubuntu-latest
-    needs: get_python_version
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ needs.get_python_version.outputs.PYVERSION }}
+          python-version-file: pyproject.toml
       - name: Install requirements
         shell: bash -l {0}
         run: |
@@ -77,7 +66,7 @@ jobs:
         with:
           path: |
             /tmp/ccache
-          key: ${{ hashFiles('Makefile.envs') }}-${{ runner.os }}-v20211025-
+          key: ${{ hashFiles('pyproject.toml') }}-${{ runner.os }}-v20211025-
 
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           path: |
             /tmp/ccache
-          key: ${{ hashFiles('Makefile.env') }}-${{ runner.os }}-v20211025-
+          key: ${{ hashFiles('Makefile.envs') }}-${{ runner.os }}-v20211025-
 
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/update_cross_build_releases.yml
+++ b/.github/workflows/update_cross_build_releases.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version-file: pyproject.toml
 
       - name: Install pyodide-build
         run: |

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -1,4 +1,12 @@
-export PYVERSION ?= 3.12.7
+export PYVERSION ?= $(python3 <<EOF
+import sys, tomllib
+with open("pyproject.toml", "rb") as in_file:
+    requires_python = tomllib.load(in_file).get("project", {}).get("requires-python")
+assert requires_python, "requires-python not found in pyproject.toml"
+sys.stdout.write(f"{requires_python}\n")
+EOF
+)
+
 export PYODIDE_EMSCRIPTEN_VERSION ?= 3.1.58
 export PYODIDE_VERSION ?= 0.27.0.dev0
 export PYODIDE_ABI_VERSION ?= 2024_0

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -1,12 +1,6 @@
-export PYVERSION ?= $(python3 <<EOF
-import sys, tomllib
-with open("pyproject.toml", "rb") as in_file:
-    requires_python = tomllib.load(in_file).get("project", {}).get("requires-python")
-assert requires_python, "requires-python not found in pyproject.toml"
-sys.stdout.write(f"{requires_python}\n")
-EOF
-)
+# Read project.requires-python from the pyproject.toml file.
 
+export PYVERSION ?= $(shell python3 tools/get_python_version.py)
 export PYODIDE_EMSCRIPTEN_VERSION ?= 3.1.58
 export PYODIDE_VERSION ?= 0.27.0.dev0
 export PYODIDE_ABI_VERSION ?= 2024_0

--- a/cpython/tools/get_python_version.py
+++ b/cpython/tools/get_python_version.py
@@ -1,0 +1,12 @@
+# https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires
+
+import sys
+import tomllib
+
+if __name__ == "__main__":
+    with open("../pyproject.toml", "rb") as in_file:
+        requires_python = (
+            tomllib.load(in_file).get("project", {}).get("requires-python")
+        )
+    assert requires_python, "requires-python not found in ../pyproject.toml"
+    sys.stdout.write(f"{requires_python}\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = "3.12.7"  # Format must be an exact major.minor.micro version specification.
+
 [tool.mypy]
 python_version = "3.12"
 mypy_path = ["src/py", "pyodide-build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-requires-python = "3.12.7"  # Format must be an exact major.minor.micro version specification.
+requires-python = "==3.12.7"  # Format must be an exact major.minor.micro version specification.
 
 [tool.mypy]
 python_version = "3.12"

--- a/tools/get_python_version.py
+++ b/tools/get_python_version.py
@@ -1,0 +1,12 @@
+# https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires
+
+import sys
+import tomllib
+
+if __name__ == "__main__":
+    with open("../pyproject.toml", "rb") as in_file:
+        requires_python = (
+            tomllib.load(in_file).get("project", {}).get("requires-python")
+        )
+    assert requires_python, "requires-python not found in ../pyproject.toml"
+    sys.stdout.write(f"{requires_python}\n")


### PR DESCRIPTION
`pyproject.toml`:
```toml
[project]
requires-python = "==3.12.7"
```
As discussed at https://pyodide.org/en/stable/development/maintainers.html#steps we should try to hardcode the version of Python in fewer places.

Use [`pyproject.toml` `[project]` `requires-python`](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#python-requires) as the source of the `major.minor.micro` version of Python to build and use.

* [x] Use GitHub Action [`setup-python` `python-version-file`](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-file-input) to enable GitHub Actions to read that value directly.
```
Run actions/setup-python@v5
  with:
    python-version-file: pyproject.toml
Extracted ==3.12.7 from pyproject.toml
Installed versions
  Successfully set up CPython (3.12.7)
```
Perhaps the proposed changes do not deliver sufficient improvement.

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
