### PR TITLE
Introducing Pyodide Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![PyPI Latest Release](https://img.shields.io/pypi/v/pyodide-py.svg)](https://pypi.org/project/pyodide-py/)
 [![Build Status](https://circleci.com/gh/pyodide/pyodide.png)](https://circleci.com/gh/pyodide/pyodide)
 [![Documentation Status](https://readthedocs.org/projects/pyodide/badge/?version=stable)](https://pyodide.readthedocs.io/?badge=stable)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Pyodide%20Guru-006BFF)](https://gurubase.io/g/pyodide)
 
 Pyodide is a Python distribution for the browser and Node.js based on WebAssembly.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Pyodide Guru](https://gurubase.io/g/pyodide) to Gurubase. Pyodide Guru uses the data from this repo and data from the [docs](https://pyodide.org/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Pyodide Guru", which highlights that Pyodide now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Pyodide Guru in Gurubase, just let me know that's totally fine.
