### PR TITLE
requirements.txt: Selenium v4.27.0 fixes TypeError on Safari init

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,10 @@ build~=1.2.0
 sphinx-click
 hypothesis
 mypy==1.11.0
-# (FIXME: 2024/01/28) The latest pytest-asyncio 0.23.3 is not compatible with pytest 8.0.0
-pytest<8.0.0
+pytest
 pytest-asyncio
 pytest-cov
 pytest-httpserver
 pytest-benchmark
 pytest-pyodide==0.58.3
 setuptools; python_version >= '3.12'
-# TODO(cclauss): Remove the Selenium line.
-selenium==4.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ build~=1.2.0
 sphinx-click
 hypothesis
 mypy==1.11.0
-pytest
+# (FIXME: 2024/01/28) The latest pytest-asyncio 0.23.3 is not compatible with pytest 8.0.0
+pytest<8.0.0
 pytest-asyncio
 pytest-cov
 pytest-httpserver


### PR DESCRIPTION
Reverts the Selenium change in:
* #5182

Selenium v4.27.0 fixes TypeError when init Safari webdriver
* https://github.com/SeleniumHQ/selenium/releases/tag/selenium-4.27.0

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
