### PR TITLE
 Update lakers-python package to 0.4.1

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -116,6 +116,7 @@ myst:
 - Upgraded `tree-sitter-go` to 0.23.3 {pr}`5185`
 - Upgraded `tree-sitter-java` to 0.23.4 {pr}`5185`
 - Upgraded `tree-sitter-python` to 0.23.4 {pr}`5185`
+- Upgraded `lakers-python` to 0.4.1 {pr}`5225`
 
 ## Version 0.26.4
 

--- a/packages/lakers-python/meta.yaml
+++ b/packages/lakers-python/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: lakers-python
-  version: 0.3.3
+  version: 0.4.1
   top-level:
     - lakers
 source:
-  url: https://files.pythonhosted.org/packages/0b/53/4c942f81eb87be878f82331b63c04c7bff6268a837403837a07dfe129e7a/lakers_python-0.3.3.tar.gz
-  sha256: c0b3cfbc82478bde7dedcf06db275bdce328656361660bae7f527e6de617550c
+  url: https://files.pythonhosted.org/packages/0e/82/41fcc21dfaeda9646067c403b7e8112fd012766e463ce7d7b7839245d063/lakers_python-0.4.1.tar.gz
+  sha256: eb0d6e32b75ade0a6d6478c2f1d21af6da130a3aefee667433c5dde2ac2e21f8
 requirements:
   executable:
     - rustup


### PR DESCRIPTION
### Description

The lakers-python package has had a new release, and 0.4.1 is the version on which aiocoap will depend in its next release.

Upgrading from 0.3.3 to 0.4.1 mainly matters from a compatibility point of view: The 0.3.3 release had a flaw in its message generation in a particular mode, and thus was incompatible with RFC9528 implementations once that feature was used. 

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- N/A Add / update tests
- N/A Add new / update outdated documentation
