### PR TITLE
Bump certifi to 2024.8.30

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -80,7 +80,7 @@ myst:
 - Upgraded `scikit-learn` to 1.5.2 {pr}`4823`, {pr}`5016`, {pr}`5072`
 - Upgraded `libcst` to 1.4.0 {pr}`4856`
 - Upgraded `lakers` to 0.3.3 {pr}`4885`
-- Upgraded `certifi` to 2024.7.4 {pr}`5035`
+- Upgraded `certifi` to 2024.8.30 {pr}`5227`
 - Upgraded `bokeh` to 3.6.0 {pr}`4888`, {pr}`5047`, {pr}`5118`
 - Upgraded `pandas` to 2.2.2 {pr}`4893`
 - Upgraded `zengl` to 2.5.0 {pr}`4894`
@@ -117,7 +117,6 @@ myst:
 - Upgraded `tree-sitter-java` to 0.23.4 {pr}`5185`
 - Upgraded `tree-sitter-python` to 0.23.4 {pr}`5185`
 - Upgraded `lakers-python` to 0.4.1 {pr}`5225`
-- Upgraded `certifi` to 2024.8.30 {pr}`5227`
 
 ## Version 0.26.4
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -117,6 +117,7 @@ myst:
 - Upgraded `tree-sitter-java` to 0.23.4 {pr}`5185`
 - Upgraded `tree-sitter-python` to 0.23.4 {pr}`5185`
 - Upgraded `lakers-python` to 0.4.1 {pr}`5225`
+- Upgraded `certifi` to 2024.8.30 {pr}`5227`
 
 ## Version 0.26.4
 

--- a/packages/certifi/meta.yaml
+++ b/packages/certifi/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: certifi
-  version: 2024.7.4
+  version: 2024.8.30
   top-level:
     - certifi
 source:
-  url: https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl
-  sha256: c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
+  url: https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl
+  sha256: 922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8
 about:
   home: https://github.com/certifi/python-certifi
   PyPI: https://pypi.org/project/certifi


### PR DESCRIPTION
Bumps certifi

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
