### PR TITLE
Bump Rust toolchain again, to nightly 2024-12-02 (libc 0.2.167)

### DIFF
--- a/packages/rust-abi-test/test_rust_abi.py
+++ b/packages/rust-abi-test/test_rust_abi.py
@@ -1,8 +1,6 @@
-import pytest
 from pytest_pyodide import run_in_pyodide
 
 
-@pytest.mark.xfail(reason="TODO: Fix me")
 @run_in_pyodide(packages=["rust-abi-test"])
 def test_rust_abi(selenium):
     from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ markers = [
 [tool._pyodide]
 
 [tool.pyodide.build]
-rust_toolchain = "nightly-2024-12-01"
+rust_toolchain = "nightly-2024-12-02"
 
 [tool.codespell]
 ignore-words = 'tools/codespell_ignore_words.txt'


### PR DESCRIPTION


<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Based on rust-lang/rust@ec7caab and https://github.com/pyodide/pyodide/pull/5237#issuecomment-2526069957 by @kleisauke, this PR bumps the Rust toolchain to include the libc version bump.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add / update tests
