### PR TITLE
Update dependencies for building the documentation

### DIFF
--- a/docs/_static/css/pyodide.css
+++ b/docs/_static/css/pyodide.css
@@ -87,3 +87,7 @@ code.literal {
   color: #fff;
   background-color: #dc3545;
 }
+
+a {
+  text-decoration: none;
+}

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,12 +1,10 @@
 autodocsumm
-docutils
-myst-parser
+docutils>=0.21.2
+myst-parser>=4.0
 packaging   # required by micropip at import time
 sphinx>=5.3.0
 sphinx-argparse-cli>=1.6.0
-sphinx_book_theme>=0.4.0rc1
-# A dependency of the above theme, which had some breaking changes in 0.13.2
-pydata_sphinx_theme < 0.13.2
+sphinx_book_theme
 sphinx-issues
 # Use my branch of sphinx-click with fix for warnings:
 # CRITICAL: Unexpected section title or transition
@@ -22,4 +20,4 @@ pyodide-build>=0.27.3
 micropip==0.7.1
 jinja2>=3.0
 ruamel.yaml
-sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@1428f1547b510a1574c227ced4356ba546a21f74
+sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@23ae2e43cd7ff935f3949e2fc0496e9d628f11a3


### PR DESCRIPTION
We can now use up to date myst-parser, sphinx_book_theme, and sphinx. For a long time we were stuck on old versions due to a tangle of upstream version caps.