### PR TITLE
expand lightgbm test, move more build settings into --config-settings

### DIFF
--- a/packages/lightgbm/meta.yaml
+++ b/packages/lightgbm/meta.yaml
@@ -5,10 +5,13 @@ source:
   url: https://files.pythonhosted.org/packages/4d/e6/41be1f8642257e21b4170e798c9a84e4268656ebfa3019586d82bfd281c9/lightgbm-4.5.0.tar.gz
   sha256: e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba
 build:
-  backend-flags: cmake.define.USE_OPENMP=OFF
+  # skbuild.cmake.verbose should be switched to skbuild.build.verbose when
+  # upgrading to lightgbm>4.5.0 (the first release to set a minimum of scikit-build-core>=0.10)
+  backend-flags: |
+    skbuild.cmake.define.USE_OPENMP=OFF
+    skbuild.cmake.verbose=true
   exports: requested
   script: |
-    sed -i 's/build.verbose = false/build.verbose = true/g' pyproject.toml
     export CMAKE_GENERATOR="Unix Makefiles"
 requirements:
   run:

--- a/packages/lightgbm/test_lightgbm.py
+++ b/packages/lightgbm/test_lightgbm.py
@@ -9,13 +9,31 @@ def test_train_predict(selenium):
     import lightgbm as lgb
     import numpy as np
 
-    data = np.random.rand(50, 10)  # 50 entities, each contains 10 features
-    label = np.random.randint(2, size=50)  # binary target
-    train_data = lgb.Dataset(data, label=label)
-    param = {"num_leaves": 11, "objective": "binary", "metric": "auc"}
+    # --- train ---#
+    data = np.random.rand(500, 10)
+    label = np.random.randint(2, size=data.shape[0])  # binary target
+    # use min_data_in_bin=1 for lgb.Dataset() and min_data_in_leaf=1 for lgb.train(),
+    # to ensure at least some splits are made
+    train_data = lgb.Dataset(data, label=label, params={"min_data_in_bin": 1})
+    param = {"num_leaves": 11, "objective": "binary", "metric": "auc", "min_data_in_leaf": 1}
     num_round = 10
-    bst = lgb.train(param, train_data, num_round)
+    bst = lgb.train(param, train_data, num_boost_round=num_round)
+
+    # --- predict ---#
     data = np.random.rand(7, 10)
     ypred = bst.predict(data)
     print(ypred)
     assert ypred.shape == (7,)
+
+    # --- serialize model ---#
+    model_json = bst.dump_model()
+    assert model_json["objective"] == "binary sigmoid:1"
+
+    model_str = bst.model_to_string()
+    assert "objective=binary" in model_str
+
+    # model should successfully survive serialization-deserialization roundtrip
+    np.testing.assert_allclose(
+        lgb.Booster(model_str=model_str).predict(data),
+        ypred
+    )

--- a/packages/lightgbm/test_lightgbm.py
+++ b/packages/lightgbm/test_lightgbm.py
@@ -15,7 +15,12 @@ def test_train_predict(selenium):
     # use min_data_in_bin=1 for lgb.Dataset() and min_data_in_leaf=1 for lgb.train(),
     # to ensure at least some splits are made
     train_data = lgb.Dataset(data, label=label, params={"min_data_in_bin": 1})
-    param = {"num_leaves": 11, "objective": "binary", "metric": "auc", "min_data_in_leaf": 1}
+    param = {
+        "num_leaves": 11,
+        "objective": "binary",
+        "metric": "auc",
+        "min_data_in_leaf": 1,
+    }
     num_round = 10
     bst = lgb.train(param, train_data, num_boost_round=num_round)
 
@@ -33,7 +38,4 @@ def test_train_predict(selenium):
     assert "objective=binary" in model_str
 
     # model should successfully survive serialization-deserialization roundtrip
-    np.testing.assert_allclose(
-        lgb.Booster(model_str=model_str).predict(data),
-        ypred
-    )
+    np.testing.assert_allclose(lgb.Booster(model_str=model_str).predict(data), ypred)


### PR DESCRIPTION
### Description

Follow-up to #5265 and #5266

Proposes the following changes to `lightgbm` builds here:

* use `--config-settings` to set CMake verbosity instead of `sed`
* prefix config settings destined for `scikit-build-core` with `skbuild.`, to reduce the risk of conflicts with other build backends
  - ref: https://scikit-build-core.readthedocs.io/en/latest/configuration.html#configuration
* expand testing to cover more of the API:
  - opt out of overfitting protections that could result in a model of decision stubs (0-split trees) being trained
  - test model serialization (to custom text format and JSON) and deserialization (from custom text format)

cc @agriyakhetarpal @ryanking13 

### Checklists

- [x] Add / update tests
- [x] Add new / update outdated documentation

### Notes for Reviewers

This is my first contribution here, thanks in advance for your patience.