### PR TITLE
Fix build regressions for `orjson`, `cramjam`, and PyXIRR due to Maturin 1.8

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -99,6 +99,7 @@ myst:
 - Upgraded `shapely` to 2.0.6 {pr}`4925`
 - Upgraded `threadpoolctl` to 3.5.0 {pr}`4925`
 - Upgraded `unyt` to 3.0.3 {pr}`4925`
+- Upgraded `pyxel` to 2.2.10 {pr}`5283`
 - Upgraded `xarray` to 2024.10.0 {pr}`4925`
 - Upgraded `zarr` to 2.18.3 {pr}`4925`
 - Upgraded `h5py` to 3.12.1 {pr}`4925`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -125,6 +125,7 @@ myst:
 - Upgraded `bokeh` to 3.6.0 {pr}`4888`, {pr}`5047`, {pr}`5118`
 - Upgraded `awkward-cpp` to 43 {pr}`5214`, {pr}`5247`
 - Upgraded `zengl` to 2.5.0 {pr}`4894`
+- Upgraded `orjson` to 3.10.13 {pr}`5283`
 - Upgraded `protobuf` to 5.29.1 {pr}`5257`
 - Upgraded `sourmash` to 4.8.11 {pr}`4980`
 - Upgraded `scipy` to 1.14.1 {pr}`4719`, {pr}`5011`, {pr}`5012`, {pr}`5031`

--- a/packages/cramjam/meta.yaml
+++ b/packages/cramjam/meta.yaml
@@ -6,8 +6,13 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/0d/f2/a7c127e61dcb7878f3ec5bf07fbf472805ea8108fd63335a51ab0bd1a432/cramjam-2.8.3.tar.gz
   sha256: 6b1fa0a6ea8183831d04572597c182bd6cece62d583a36cde1e6a86e72ce2389
+  patches:
+    # Drop when upgrading to the next version, i.e., when
+    # https://github.com/milesgranger/cramjam/pull/196
+    # makes it into a release
+    - packages/cramjam/patches/Add-version-key-in-pyproject.patch
 about:
-  home: ""
+  home: https://github.com/milesgranger/cramjam
   PyPI: https://pypi.org/project/cramjam
   summary: Thin Python bindings to de/compression algorithms in Rust
   license: MIT

--- a/packages/cramjam/patches/Add-version-key-in-pyproject.patch
+++ b/packages/cramjam/patches/Add-version-key-in-pyproject.patch
@@ -1,0 +1,23 @@
+From 7a993e9d4418a5e44c0c775a11c438f248b333c7 Mon Sep 17 00:00:00 2001
+From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Date: Mon, 30 Dec 2024 19:49:23 +0530
+Subject: [PATCH] Add a `version` key in the `[project]` table
+
+---
+ pyproject.toml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 038e21a..acb2a18 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,6 @@
+ [project]
+ name = "cramjam"
++version = "2.9.1"
+ keywords = ["compression", "decompression", "snappy", "zstd", "bz2", "gzip", "lz4", "brotli", "deflate", "blosc2"]
+ requires-python = ">=3.8"
+ license = { file = "LICENSE" }
+-- 
+2.47.1
+

--- a/packages/orjson/meta.yaml
+++ b/packages/orjson/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: orjson
-  version: 3.10.1
+  version: 3.10.13
   top-level:
     - orjson
 source:
-  url: https://files.pythonhosted.org/packages/f5/af/0daa12a907215a5af6d97db8adf301ef14a1b1c651f7e176ee04e0998433/orjson-3.10.1.tar.gz
-  sha256: a883b28d73370df23ed995c466b4f6c708c1f7a9bdc400fe89165c96c7603204
+  url: https://files.pythonhosted.org/packages/45/0b/8c7eaf1e2152f1e0fb28ae7b22e2b35a6b1992953a1ebe0371ba4d41d3ad/orjson-3.10.13.tar.gz
+  sha256: eb9bfb14ab8f68d9d9492d4817ae497788a15fd7da72e14dfabc289c3bb088ec
 requirements:
   executable:
     - rustup

--- a/packages/pyxel/meta.yaml
+++ b/packages/pyxel/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: pyxel
-  version: 1.9.10
+  version: 2.2.10
 source:
-  url: https://github.com/kitao/pyxel/archive/refs/tags/v1.9.10.tar.gz
-  sha256: e23a0c52daaa9c4967c402b3ad2c623f33c4a01e36c4b37b884d7b8c726521f4
+  url: https://github.com/kitao/pyxel/archive/refs/tags/v2.2.10.tar.gz
+  sha256: 978a911d3be5beeea1eee7cbc187fd763608f0b51daa5ed9a0bca1835c1623db
 build:
   script: |
     embuilder build sdl2 --pic

--- a/packages/pyxirr/meta.yaml
+++ b/packages/pyxirr/meta.yaml
@@ -6,6 +6,11 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/c5/4a/3d2dc1bf565605a4f0e3ae6d5592518bb26698f4d929140d3ea16a4bb478/pyxirr-0.10.6.tar.gz
   sha256: f0ed1fc8607f0769c238ffaf85f0bd3ddac7d383c125f1d9ff16d3a4b86a3cdf
+  patches:
+    # Drop when upgrading to the next version, i.e.,
+    # when https://github.com/Anexen/pyxirr/pull/64
+    # makes it into a release
+    - patches/Add-version-key-in-pyproject.patch
 about:
   home: https://github.com/Anexen/pyxirr
   PyPI: https://pypi.org/project/pyxirr

--- a/packages/pyxirr/patches/Add-version-key-in-pyproject.patch
+++ b/packages/pyxirr/patches/Add-version-key-in-pyproject.patch
@@ -1,0 +1,23 @@
+From b72f4cf08beeb0b1c790259eed5aa2c313e102a4 Mon Sep 17 00:00:00 2001
+From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Date: Mon, 30 Dec 2024 17:13:48 +0530
+Subject: [PATCH] Add a `version` key in `[project]` table
+
+---
+ pyproject.toml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index be1a7b7..7205d8d 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,6 @@
+ [project]
+ name = "pyxirr"
++version = "0.10.6"
+ description-content-type = "text/markdown; charset=UTF-8; variant=GFM"
+ requires-python = ">=3.7,<3.14"
+ classifiers = [
+-- 
+2.47.1
+


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Through https://github.com/PyO3/maturin/pull/2391 via the recently released [Maturin version 1.8.0](https://github.com/PyO3/maturin/releases/tag/v1.8.0), builds for PyXIRR (added in #4513) and `orjson` (added in #4036) have been failing.

Builds for other packages such as `cramjam` have been failing as well due to the same reason.

I've applied this PR for PyXIRR, which I submitted upstream: https://github.com/Anexen/pyxirr/pull/64, as a patch here, which can be dropped later. Tagging @Anexen as the listed recipe maintainer for visibility.

For `orjson`, bumping to the [newly released version 3.10.13](https://github.com/ijl/orjson/releases/tag/3.10.13) should work. Tagging @spicy-sauce as the listed recipe maintainer for visibility, no action needed.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry

