### PR TITLE
Documentation: warning on multi-threading/processing

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -30,7 +30,7 @@ def _can_start_thread() -> bool:
 can_start_thread = _can_start_thread()
 
 if not can_start_thread:
-  # set n_threads = 1
+  n_threads = 1
 ```
 
 If there is no wheel on PyPI, but you believe there is nothing preventing it (it

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -17,6 +17,18 @@ Most pure Python packages can be installed directly from PyPI with
 {func}`micropip.install` if they have a pure Python wheel. Check if this is the
 case by trying `micropip.install("package-name")`.
 
+Due to [current limitations of webassemly](https://pyodide.org/en/stable/usage/wasm-constraints.html),
+packages that make heavy use of multi-threading and multi-processing **may not** work
+without explicit support from maintainers. A workaround could be to avoid creating multiple
+threads when on wasm using a check like:
+
+```py
+is_wasm = sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"]
+
+if is_wasm:
+  # set n_threads = 1
+```
+
 If there is no wheel on PyPI, but you believe there is nothing preventing it (it
 is a Python package without C extensions):
 

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -20,7 +20,7 @@ case by trying `micropip.install("package-name")`.
 Due to [current limitations of WebAssembly](https://pyodide.org/en/stable/usage/wasm-constraints.html),
 packages that make heavy use of multi-threading and multi-processing **may not** work
 without explicit support from maintainers. A workaround could be to avoid creating multiple
-threads when on wasm using a check like:
+threads when on WASM using a check like:
 
 ```py
 is_wasm = sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"]

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -24,7 +24,7 @@ packages that use threading or multiprocessing will not work without a patch to 
 is_wasm = sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"]
 
 if is_wasm:
-  # set n_threads = 1
+  n_threads = 1
 ```
 
 If there is no wheel on PyPI, but you believe there is nothing preventing it (it

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -17,10 +17,8 @@ Most pure Python packages can be installed directly from PyPI with
 {func}`micropip.install` if they have a pure Python wheel. Check if this is the
 case by trying `micropip.install("package-name")`.
 
-Due to [current limitations of WebAssembly](https://pyodide.org/en/stable/usage/wasm-constraints.html),
-packages that make heavy use of multi-threading and multi-processing **may not** work
-without explicit support from maintainers. A workaround could be to avoid creating multiple
-threads when on WASM using a check like:
+Because Pyodide [does not support threading or multiprocessing](https://pyodide.org/en/stable/usage/wasm-constraints.html),
+packages that use threading or multiprocessing will not work without a patch to disable it. For example,
 
 ```py
 is_wasm = sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"]

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -19,12 +19,18 @@ case by trying `micropip.install("package-name")`.
 
 Because Pyodide [does not support threading or multiprocessing](https://pyodide.org/en/stable/usage/wasm-constraints.html),
 packages that use threading or multiprocessing will not work without a patch to disable it. For example,
+the following snippet will determine if the platform supports creating new threads.
 
 ```py
-is_wasm = sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"]
+def _can_start_thread() -> bool:
+    if sys.platform == "emscripten":
+        return sys._emscripten_info.pthreads
+    return platform.machine() not in ("wasm32", "wasm64")
 
-if is_wasm:
-  n_threads = 1
+can_start_thread = _can_start_thread()
+
+if not can_start_thread:
+  # set n_threads = 1
 ```
 
 If there is no wheel on PyPI, but you believe there is nothing preventing it (it

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -17,7 +17,7 @@ Most pure Python packages can be installed directly from PyPI with
 {func}`micropip.install` if they have a pure Python wheel. Check if this is the
 case by trying `micropip.install("package-name")`.
 
-Due to [current limitations of webassemly](https://pyodide.org/en/stable/usage/wasm-constraints.html),
+Due to [current limitations of WebAssembly](https://pyodide.org/en/stable/usage/wasm-constraints.html),
 packages that make heavy use of multi-threading and multi-processing **may not** work
 without explicit support from maintainers. A workaround could be to avoid creating multiple
 threads when on wasm using a check like:

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -469,3 +469,19 @@ pyodide.runPython(`
     print(js_lambda, js_lambda_, js_lambda__) # 7, 7, 8
 `);
 ```
+
+## Can i use multi-threading/processing?
+
+Due to the limitation of current [wasm](https://pyodide.org/en/stable/usage/wasm-constraints.html)
+all packages that uses parallelism (eg. rely on _fork_ and _pthread_)
+**may not work**. Accepting the performance degradation, a workaround
+consists of locking the number of threads down to `1` like shown below:
+
+```py
+is_wasm = sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"]
+
+if is_wasm:
+  # set n_threads = 1
+```
+
+Ultimately, developers will need to add specific support for the platform.

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -470,7 +470,7 @@ pyodide.runPython(`
 `);
 ```
 
-## Can i use multi-threading/processing?
+## Can I use multi-threading/processing?
 
 Due to the limitation of current [wasm](https://pyodide.org/en/stable/usage/wasm-constraints.html)
 all packages that uses parallelism (eg. rely on _fork_ and _pthread_)

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -483,4 +483,3 @@ is_wasm = sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm
 if is_wasm:
   # set n_threads = 1
 ```
-

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -472,10 +472,7 @@ pyodide.runPython(`
 
 ## Can I use threading/multiprocessing/subprocess?
 
-Due to the limitation of current [wasm](https://pyodide.org/en/stable/usage/wasm-constraints.html)
-all packages that use parallelism (eg. rely on _fork_ and _pthread_)
-**may not work**. Accepting the performance degradation, a workaround
-consists of locking the number of threads down to `1` like shown below:
+No, fork and pthreads do not work in Pyodide. Attempts to use `threading`, `multiprocessing`, or `subprocess` will raise an `OSError`. You may be able to work around this by setting the number of threads to 1:
 
 ```py
 is_wasm = sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"]

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -485,7 +485,7 @@ def _can_start_thread() -> bool:
 can_start_thread = _can_start_thread()
 
 if not can_start_thread:
-  # set n_threads = 1
+  n_threads = 1
 ```
 
 You can still import the packages and use the general info API, but you cannot

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -484,4 +484,3 @@ if is_wasm:
   # set n_threads = 1
 ```
 
-Ultimately, developers will need to add specific support for the platform.

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -473,7 +473,7 @@ pyodide.runPython(`
 ## Can I use multi-threading/processing?
 
 Due to the limitation of current [wasm](https://pyodide.org/en/stable/usage/wasm-constraints.html)
-all packages that uses parallelism (eg. rely on _fork_ and _pthread_)
+all packages that use parallelism (eg. rely on _fork_ and _pthread_)
 **may not work**. Accepting the performance degradation, a workaround
 consists of locking the number of threads down to `1` like shown below:
 

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -488,7 +488,7 @@ if not can_start_thread:
   # set n_threads = 1
 ```
 
-Bear in mind that you can still import the packages and use the general info API, but you cannot
+You can still import the packages and use the general info API, but you cannot
 start any asynchronous work without receiving a `RuntimeError`.
 
 ```pycon

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -470,7 +470,7 @@ pyodide.runPython(`
 `);
 ```
 
-## Can I use multi-threading/processing?
+## Can I use threading/multiprocessing/subprocess?
 
 Due to the limitation of current [wasm](https://pyodide.org/en/stable/usage/wasm-constraints.html)
 all packages that use parallelism (eg. rely on _fork_ and _pthread_)

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -512,5 +512,4 @@ Traceback (most recent call last):
   File "/lib/python312.zip/threading.py", line 994, in start
     _start_new_thread(self._bootstrap, ())
 RuntimeError: can't start new thread
->>>
 ```


### PR DESCRIPTION
### Documentation update on multi-threading/processing

This PR documents current limitation for multi-processing packages and shows  a workaround (paying a performance cost) as in https://github.com/pyodide/pyodide/pull/5281

- [x] Add new / update outdated documentation
