### PR TITLE
Remove cffi from cross-build package

### DIFF
--- a/packages/cffi/meta.yaml
+++ b/packages/cffi/meta.yaml
@@ -9,8 +9,6 @@ requirements:
 source:
   url: https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz
   sha256: 1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
-build:
-  cross-build-env: true
 about:
   home: http://cffi.readthedocs.org
   PyPI: https://pypi.org/project/cffi

--- a/packages/pycparser/meta.yaml
+++ b/packages/pycparser/meta.yaml
@@ -6,8 +6,6 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
   sha256: c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
-build:
-  cross-build-env: true
 about:
   home: https://github.com/eliben/pycparser
   PyPI: https://pypi.org/project/pycparser


### PR DESCRIPTION
I have a doubt about cffi being a cross build package. We set cffi as a cross-build package to make sure the build time cffi version is equal to the runtime cffi version, but is it a really necessary requirement?

In native environment, package built with cffi version A should be able to run with other cffi versions as ABI compatibility is guaranteed (if not, it is cffi's problem, not ours).

