### PR TITLE
chore: Add css-inline 0.14.6

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,7 @@ myst:
 
 - Upgraded `protobuf` to 5.29.2 {pr}`5298`
 - Added `apsw` 3.47.2.0 {pr}`5251`
+- Added `css_inline` 0.14.6 {pr}`5304`
 
 ## Version 0.27.0
 

--- a/packages/css-inline/meta.yaml
+++ b/packages/css-inline/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: css-inline
+  version: 0.14.6
+  top-level:
+    - css_inline
+source:
+  url: https://github.com/Stranger6667/css-inline/releases/download/python-v0.14.6/css_inline-0.14.6-cp37-abi3-pyodide_2024_0_wasm32.whl
+  sha256: d8ba5ceb0362092d051683a3f56dd04d34bfd34c00ab646d3ca04972bb852d03
+about:
+  home: https://github.com/Stranger6667/css-inline
+  summary: High-performance library for inlining CSS into HTML 'style' attributes
+  license: MIT
+extra:
+  recipe-maintainers:
+    - Stranger6667

--- a/packages/css-inline/test_css_inline.py
+++ b/packages/css-inline/test_css_inline.py
@@ -1,0 +1,17 @@
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["css_inline"])
+def test_inline_html(selenium):
+    import css_inline
+
+    html = """<html>
+  <head>
+    <style>h1 { color:blue; }</style>
+  </head>
+  <body>
+    <h1>Big Text</h1>
+  </body>
+</html>"""
+
+    assert '<h1 style="color: blue;">Big Text</h1>' in css_inline.inline(html)


### PR DESCRIPTION
This adds support for `css_inline` originally requested [here](https://github.com/Stranger6667/css-inline/issues/411)