### PR TITLE
Update nlopt to v2.9.1

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -21,6 +21,7 @@ myst:
 - Upgraded `protobuf` to 5.29.2 {pr}`5298`
 - Added `apsw` 3.47.2.0 {pr}`5251`
 - Added `css_inline` 0.14.6 {pr}`5304`
+- Upgraded `nlopt` 2.9.1 {pr}`5305`
 
 ## Version 0.27.0
 

--- a/packages/nlopt/meta.yaml
+++ b/packages/nlopt/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: nlopt
-  version: 2.7.0
+  version: 2.9.1
   top-level:
     - nlopt
 
 source:
-  url: https://github.com/stevengj/nlopt/archive/v2.7.0.tar.gz
-  sha256: b881cc2a5face5139f1c5a30caf26b7d3cb43d69d5e423c9d78392f99844499f
+  url: https://github.com/stevengj/nlopt/archive/v2.9.1.tar.gz
+  sha256: 1e6c33f8cbdc4138d525f3326c231f14ed50d99345561e85285638c49b64ee93
 
   extras:
     - - extras/setup.py

--- a/packages/nlopt/meta.yaml
+++ b/packages/nlopt/meta.yaml
@@ -25,3 +25,7 @@ build:
 about:
   home: https://github.com/stevengj/nlopt
   license: LGPL-2.1+
+extra:
+  recipe-maintainers:
+    - mgreminger
+    - tom-dudley

--- a/packages/nlopt/test_nlopt.py
+++ b/packages/nlopt/test_nlopt.py
@@ -53,7 +53,7 @@ def test_nlopt(selenium):
 
     opt.add_inequality_constraint(h)
 
-    opt.set_ftol_rel(1.0e-6)
+    opt.set_ftol_rel(1.0e-2)
 
     x0 = np.array([5, 11])
 


### PR DESCRIPTION
### Description

This updates `nlopt` from `v2.7.0` to `v2.9.1`.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
~~Add new / update outdated documentation~~
