### PR TITLE
fix: Prevent ReferenceError for id in workerApi.js example.

### DIFF
--- a/docs/usage/webworker.md
+++ b/docs/usage/webworker.md
@@ -125,18 +125,18 @@ function getId() {
 // When we get such a response, use it to resolve the promise.
 function requestResponse(worker, msg) {
   const { promise, resolve } = getPromiseAndResolve();
-  const id = getId();
+  const idWorker = getId();
   worker.addEventListener("message", function listener(event) {
-    if (event.data?.id !== id) {
+    if (event.data?.id !== idWorker) {
       return;
     }
     // This listener is done so remove it.
     worker.removeEventListener("message", listener);
     // Filter the id out of the result
-    const { id, ...rest } = data;
+    const { id, ...rest } = event.data;
     resolve(rest);
   });
-  worker.postMessage({ id, ...msg });
+  worker.postMessage({ id: idWorker, ...msg });
   return promise;
 }
 


### PR DESCRIPTION
### Description

Example code for workerApi current fails due to local variable referencing. This is what happens right now if using the examples as-is:
```
Uncaught ReferenceError: Cannot access 'id' before initialization at Worker.listener (workerApi.js:23:28)
listener	@	workerApi.js:23
```
It appears to have been because it is trying to use "id" from:
```
const { id, ...rest } = data;
```
Instead of using the id outside the closure. If the id variable outside is changed (or inside), then it works. I chose to update the one outside to hopefully make it clearer. With this change, no more crash using the example.

I did not notice any open PRs or Issues for this, apologies if I overlooked anything. 

### Checklists

- [x] Add new / update outdated documentation
