### PR TITLE
fix: add author name to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ panels_add_bootstrap_css = False
 # -- Project information -----------------------------------------------------
 
 project = "Pyodide"
+author = "Pyodide contributors"
 copyright = "2019-2024, Pyodide contributors and Mozilla"
 
 suppress_warnings = ["config.cache"]


### PR DESCRIPTION
### Description

-   Add `author` field to `docs/conf.py` so that "Pyodide contributors" will
    be listed as author in footer of documentation pages.

Closes #5296.
