### PR TITLE
Update cbor-edn package to 1.1.0

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -22,6 +22,7 @@ myst:
 - Added `apsw` 3.47.2.0 {pr}`5251`
 - Added `css_inline` 0.14.6 {pr}`5304`
 - Upgraded `nlopt` 2.9.1 {pr}`5305`
+- Upgraded `cbor-diag` 1.1.0 {pr}`5326`
 
 ## Version 0.27.0
 

--- a/packages/cbor-diag/meta.yaml
+++ b/packages/cbor-diag/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: cbor-diag
-  version: 1.0.1
+  version: 1.1.0
   top-level:
     - cbor_diag
 source:
-  url: https://files.pythonhosted.org/packages/94/87/29ce613f876cd0ceb99ed1db71f7e3d90460c1babd2133ce30f18d5f540d/cbor_diag-1.0.1.tar.gz
-  sha256: 77e25a27681d59b0074a07aa494da0ab71f0ea6a826a2fd28167048d08a7ebcc
+  url: https://files.pythonhosted.org/packages/db/f6/9921162053f195eaa7e22cae9172e0d3bdda62282d76480163d1de872f35/cbor_diag-1.1.0.tar.gz
+  sha256: 78a85ab1165c43d224dc6b93e1ee791aec2f392c55d219d11937f78974f4e6c3
 build:
   script: |
     cargo update -p proc-macro2 --precise 1.0.60

--- a/packages/cbor-diag/test_cbor_diag.py
+++ b/packages/cbor-diag/test_cbor_diag.py
@@ -5,4 +5,6 @@ from pytest_pyodide import run_in_pyodide
 def test_cbor_diag(selenium_standalone):
     from cbor_diag import diag2cbor
 
-    assert diag2cbor('{1: "hello"}') == bytes.fromhex("a1016568656c6c6f")
+    assert diag2cbor("{1: test'hello'}", to999=True) == bytes.fromhex(
+        "a101d903e78264746573746568656c6c6f"
+    )


### PR DESCRIPTION
### Description

This updates the cbor-edn package, which is used as part of aiocoap demos that use pyodide and Jupyter. The new version supports processing the full range of the notation as it is being updated, and brings readability enhancements by converting tagged data into application oriented literals.

Before: `{1:54(h'20010db8000000000000000000000001'),3:1(1736861269)}`

After: `{1: IP'2001:db8::1', 3: DT'2025-01-14T13:27:49Z'}`

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- N/A Add new / update outdated documentation
