### PR TITLE
Update create_pyproxies in docs

### DIFF
--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -328,7 +328,7 @@ proxy.destroy();
 ```
 As an alternative, if you wish to assert that the object should be fully
 converted and no proxies should be created, you can use
-`proxy.toJs({create_proxies : false})`. If a proxy would be created, a
+`proxy.toJs({create_pyproxies : false})`. If a proxy would be created, a
 {py:exc}`~pyodide.ffi.ConversionError` is raised instead.
 ````
 


### PR DESCRIPTION
### Description

Fixes a typo, aligning `create_proxies` with [`create_pyproxies`](https://github.com/pyodide/pyodide/blob/0.27.0/src/core/pyproxy.ts#L742) in the JS API.

### Checklists

- [x] Add new / update outdated documentation
