### PR TITLE
Bump rust version to nightly-2025-01-15

### DIFF
--- a/packages/clarabel/meta.yaml
+++ b/packages/clarabel/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: clarabel
   version: 0.9.0
+  # Clarabel is broken against the rust main branch since 2024-12-15. Reenable
+  # when they fix it. See oxfordcontrol/Clarabel.rs#154
+  _disabled: true
   top-level:
     - clarabel
 source:

--- a/packages/clarabel/meta.yaml
+++ b/packages/clarabel/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: clarabel
   version: 0.9.0
-  # Clarabel is broken against the rust main branch since 2024-12-15. Reenable
+  # Clarabel is broken against the rust main branch since 2024-12-15. Re-enable
   # when they fix it. See oxfordcontrol/Clarabel.rs#154
   _disabled: true
   top-level:

--- a/packages/primecount/meta.yaml
+++ b/packages/primecount/meta.yaml
@@ -1,5 +1,6 @@
 package:
   name: primecount
+  _disabled: true
   version: "7.9"
   tag:
     - library

--- a/packages/river/meta.yaml
+++ b/packages/river/meta.yaml
@@ -15,10 +15,6 @@ requirements:
     - numpy
     - pandas
     - scipy
-build:
-  script: |
-    # https://github.com/pyodide/pyodide/issues/5321
-    cargo update -p pyo3 --precise 0.23.1
 test:
   imports:
     - river

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ markers = [
 [tool._pyodide]
 
 [tool.pyodide.build]
-rust_toolchain = "nightly-2024-12-01"
+rust_toolchain = "nightly-2025-01-15"
 
 [tool.codespell]
 ignore-words = 'tools/codespell_ignore_words.txt'


### PR DESCRIPTION
Today's nightly is the first one with all the commits needed for wasm eh #5320. Bump the main branch to use the same rust version.