### PR TITLE
fix chromedriver link

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -18,7 +18,7 @@ and third-party applications that use Pyodide.
 > See: [pytest-pyodide](https://github.com/pyodide/pytest-pyodide) for more information.
 
 2. Install [geckodriver](https://github.com/mozilla/geckodriver/releases) or
-   [chromedriver](https://sites.google.com/a/chromium.org/chromedriver/downloads)
+   [chromedriver](https://developer.chrome.com/docs/chromedriver/downloads)
    and check that they are in your `PATH`.
 
 3. To run the test suite, run `pytest` from the root directory of Pyodide:


### PR DESCRIPTION
Chrome driver link was broken (went to 404), now it's not.