### PR TITLE
Upgrade pydantic to 2.10.5 and add tests

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,8 @@ myst:
 
 - Added `httpx` 0.28.1 {pr}`5302`
 - Upgraded `scikit-learn` to 1.6.1 {pr}`5342`
+- Upgraded `pydantic` to 2.10.5 and fixed a version mismatch with
+  `pydantic_core` {pr}`5368`
 
 ## Version 0.27.1
 

--- a/packages/pydantic/meta.yaml
+++ b/packages/pydantic/meta.yaml
@@ -15,43 +15,44 @@ requirements:
     - annotated-types
 test:
   imports:
-    - aliases
-    - alias_generators
-    - annotated_handlers
-    - class_validators
-    - color
-    - config
-    - dataclasses
-    - datetime_parse
-    - decorator
-    - deprecated
-    - env_settings
-    - errors
-    - error_wrappers
-    - experimental
-    - fields
-    - functional_serializers
-    - functional_validators
-    - generics
-    - json
-    - json_schema
-    - main
-    - mypy
-    - networks
-    - parse
-    - plugin
-    - root_model
-    - schema
-    - tools
-    - type_adapter
-    - types
-    - typing
-    - utils
-    - v1
-    - validate_call_decorator
-    - validators
-    - version
-    - warnings
+    - pydantic
+    - pydantic.aliases
+    - pydantic.alias_generators
+    - pydantic.annotated_handlers
+    - pydantic.class_validators
+    - pydantic.color
+    - pydantic.config
+    - pydantic.dataclasses
+    - pydantic.datetime_parse
+    - pydantic.decorator
+    - pydantic.deprecated
+    - pydantic.env_settings
+    - pydantic.errors
+    - pydantic.error_wrappers
+    - pydantic.experimental
+    - pydantic.fields
+    - pydantic.functional_serializers
+    - pydantic.functional_validators
+    - pydantic.generics
+    - pydantic.json
+    - pydantic.json_schema
+    - pydantic.main
+    # - pydantic.mypy # Requires extra mypy depdendency
+    - pydantic.networks
+    - pydantic.parse
+    - pydantic.plugin
+    - pydantic.root_model
+    - pydantic.schema
+    - pydantic.tools
+    - pydantic.type_adapter
+    - pydantic.types
+    - pydantic.typing
+    - pydantic.utils
+    - pydantic.v1
+    - pydantic.validate_call_decorator
+    - pydantic.validators
+    - pydantic.version
+    - pydantic.warnings
 about:
   home: https://github.com/samuelcolvin/pydantic
   PyPI: https://pypi.org/project/pydantic

--- a/packages/pydantic/meta.yaml
+++ b/packages/pydantic/meta.yaml
@@ -37,7 +37,7 @@ test:
     - pydantic.json
     - pydantic.json_schema
     - pydantic.main
-    # - pydantic.mypy # Requires extra mypy depdendency
+    # - pydantic.mypy # Requires extra mypy dependency
     - pydantic.networks
     - pydantic.parse
     - pydantic.plugin

--- a/packages/pydantic/meta.yaml
+++ b/packages/pydantic/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: pydantic
-  version: 2.9.2
+  version: 2.10.5
   top-level:
     - pydantic
 source:
-  sha256: d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f
-  url: https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz
+  url: https://files.pythonhosted.org/packages/6a/c7/ca334c2ef6f2e046b1144fe4bb2a5da8a4c574e7f2ebf7e16b34a6a2fa92/pydantic-2.10.5.tar.gz
+  sha256: 278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff
 requirements:
   run:
     - typing-extensions

--- a/packages/pydantic/meta.yaml
+++ b/packages/pydantic/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pydantic
   version: 2.10.5
+  # Warning: pydantic has a pin on pydantic_core, they need to be updated
+  # together
   top-level:
     - pydantic
 source:
@@ -16,3 +18,6 @@ about:
   PyPI: https://pypi.org/project/pydantic
   summary: Data validation and settings management using python type hints
   license: MIT
+extra:
+  recipe-maintainers:
+    - samuelcolvin

--- a/packages/pydantic/meta.yaml
+++ b/packages/pydantic/meta.yaml
@@ -13,6 +13,45 @@ requirements:
     - typing-extensions
     - pydantic_core
     - annotated-types
+test:
+  imports:
+    - aliases
+    - alias_generators
+    - annotated_handlers
+    - class_validators
+    - color
+    - config
+    - dataclasses
+    - datetime_parse
+    - decorator
+    - deprecated
+    - env_settings
+    - errors
+    - error_wrappers
+    - experimental
+    - fields
+    - functional_serializers
+    - functional_validators
+    - generics
+    - json
+    - json_schema
+    - main
+    - mypy
+    - networks
+    - parse
+    - plugin
+    - root_model
+    - schema
+    - tools
+    - type_adapter
+    - types
+    - typing
+    - utils
+    - v1
+    - validate_call_decorator
+    - validators
+    - version
+    - warnings
 about:
   home: https://github.com/samuelcolvin/pydantic
   PyPI: https://pypi.org/project/pydantic

--- a/packages/pydantic/test_pydantic.py
+++ b/packages/pydantic/test_pydantic.py
@@ -1,11 +1,10 @@
-import json
-from datetime import datetime
-
 from pytest_pyodide import run_in_pyodide
 
 
 @run_in_pyodide(packages=["pydantic"])
 def test_pydantic(selenium):
+    import json
+    from datetime import datetime
     import pydantic
 
     class NestedModel(pydantic.BaseModel):

--- a/packages/pydantic/test_pydantic.py
+++ b/packages/pydantic/test_pydantic.py
@@ -5,6 +5,7 @@ from pytest_pyodide import run_in_pyodide
 def test_pydantic(selenium):
     import json
     from datetime import datetime
+
     import pydantic
 
     class NestedModel(pydantic.BaseModel):

--- a/packages/pydantic/test_pydantic.py
+++ b/packages/pydantic/test_pydantic.py
@@ -1,0 +1,99 @@
+import json
+from datetime import datetime
+
+from pytest_pyodide import run_in_pyodide
+
+
+@run_in_pyodide(packages=["pydantic"])
+def test_pydantic(selenium):
+    import pydantic
+
+    class NestedModel(pydantic.BaseModel):
+        a: int
+
+    class PydanticModel(pydantic.BaseModel):
+        f_str: str
+        f_int: int
+        f_float: float
+        f_datetime: datetime
+        f_list: list[int]
+        f_dict: dict[str, int]
+        f_nested: NestedModel
+
+    m = PydanticModel(
+        f_str=b"hello",
+        f_int="123",
+        f_float="3.14",
+        f_datetime="2021-01-01T00:00:00",
+        f_list=(1, 2, 3),
+        f_dict={"a": 1, "b": "2"},
+        f_nested={"a": b"1"},
+    )
+    expected_dict = {
+        "f_str": "hello",
+        "f_int": 123,
+        "f_float": 3.14,
+        "f_datetime": datetime(2021, 1, 1, 0, 0),
+        "f_list": [1, 2, 3],
+        "f_dict": {"a": 1, "b": 2},
+        "f_nested": {"a": 1},
+    }
+    assert m.model_dump() == expected_dict
+    m_json = PydanticModel.model_validate_json(
+        '{"f_str":"hello","f_int":123,"f_float":3.14,"f_datetime":"2021-01-01T00:00:00","f_list":[1,2,3],'
+        '"f_dict":{"a":1,"b":2},"f_nested":{"a":1}}'
+    )
+    assert m_json.model_dump() == expected_dict
+
+    assert json.loads(m.model_dump_json()) == {
+        "f_str": "hello",
+        "f_int": 123,
+        "f_float": 3.14,
+        "f_datetime": "2021-01-01T00:00:00",
+        "f_list": [1, 2, 3],
+        "f_dict": {"a": 1, "b": 2},
+        "f_nested": {"a": 1},
+    }
+
+    assert PydanticModel.model_json_schema() == {
+        "$defs": {
+            "NestedModel": {
+                "properties": {"a": {"title": "A", "type": "integer"}},
+                "required": ["a"],
+                "title": "NestedModel",
+                "type": "object",
+            }
+        },
+        "properties": {
+            "f_str": {"title": "F Str", "type": "string"},
+            "f_int": {"title": "F Int", "type": "integer"},
+            "f_float": {"title": "F Float", "type": "number"},
+            "f_datetime": {
+                "format": "date-time",
+                "title": "F Datetime",
+                "type": "string",
+            },
+            "f_list": {
+                "items": {"type": "integer"},
+                "title": "F List",
+                "type": "array",
+            },
+            "f_dict": {
+                "additionalProperties": {"type": "integer"},
+                "title": "F Dict",
+                "type": "object",
+            },
+            "f_nested": {"$ref": "#/$defs/NestedModel"},
+        },
+        "required": [
+            "f_str",
+            "f_int",
+            "f_float",
+            "f_datetime",
+            "f_list",
+            "f_dict",
+            "f_nested",
+        ],
+        "title": "PydanticModel",
+        "type": "object",
+    }

--- a/packages/pydantic_core/meta.yaml
+++ b/packages/pydantic_core/meta.yaml
@@ -1,13 +1,11 @@
 package:
   name: pydantic_core
-  version: 2.25.1
-  # TODO: re-enable once we have a build for abi 2025_0
-  _disabled: true
+  version: 2.27.2
   top-level:
     - pydantic_core
 source:
-  url: https://github.com/pydantic/pydantic-core/releases/download/v2.25.1/pydantic_core-2.25.1-cp312-cp312-emscripten_3_1_58_wasm32.whl
-  sha256: f4b77016b1511e54a8c6bd833bb68e190b96989ba9997f9e0f023cfb0f8a16c2
+  url: https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz
+  sha256: eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39
 about:
   home: https://github.com/pydantic/pydantic-core
   PyPI: https://pypi.org/project/pydantic_core

--- a/packages/pydantic_core/meta.yaml
+++ b/packages/pydantic_core/meta.yaml
@@ -6,6 +6,9 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz
   sha256: eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39
+requirements:
+  executable:
+    - rustup
 about:
   home: https://github.com/pydantic/pydantic-core
   PyPI: https://pypi.org/project/pydantic_core

--- a/packages/pydantic_core/meta.yaml
+++ b/packages/pydantic_core/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pydantic_core
   version: 2.27.2
+  # Warning: pydantic has a pin on pydantic_core, they need to be updated
+  # together
   top-level:
     - pydantic_core
 source:
@@ -14,3 +16,6 @@ about:
   PyPI: https://pypi.org/project/pydantic_core
   summary: ""
   license: MIT
+extra:
+  recipe-maintainers:
+    - samuelcolvin


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

This builds on top of #5367, but is a separate PR as I'm not sure I'm doing things correctly.

I'm trying to upgrade pydantic and pydantic-core since:
* `pydantic-core` was previously marked as disable
* issue reported in #5336
* I really really need pydantic 2.10 for a project I'm working on 🙏 

I have no idea if:
* this is the right way to upgrade a package - I manually calculated the hashes
* if the tests pass - I've tried for ages to get tests to run, but I can't avoid the test getting skipped with `(package 'pydantic' is not built.)`

I can confirm build seems to be working correctly.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
