### PR TITLE
Increase timeout for webworker test

### DIFF
--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -191,7 +191,7 @@ def test_runpythonasync_numpy(selenium_standalone):
 @pytest.mark.xfail_browsers(
     firefox="Timeout in WebWorker when using numpy in Firefox 87"
 )
-@pytest.mark.driver_timeout(30)
+@pytest.mark.driver_timeout(60)
 def test_runwebworker_numpy(selenium_webworker_standalone):
     output = selenium_webworker_standalone.run_webworker(
         """


### PR DESCRIPTION
This test timeouts these days. I don't know whether 1) it is failing but showing as timeout or 2) it actually timeouts.

Increasing timeout to see if latter is the case.