### PR TITLE
Fix Pyodide version 0.27.2 in changelog

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -19,7 +19,7 @@ myst:
 - ABI break: Upgraded Emscripten to 3.1.63 {pr}`5343` {pr}`5350` {pr}`5357`
   {pr}`5334` {pr}`5363`
 
-## Version 0.27.1
+## Version 0.27.2
 
 _January 23, 2025_
 


### PR DESCRIPTION
### Description

There are currently two 0.27.1 sections in the [changelog](https://pyodide.org/en/stable/project/changelog.html):
![image](https://github.com/user-attachments/assets/6f936054-1b9a-4034-978e-d500b90098f1)

### Checklists

I checked everything as non applicable, not sure how much you actually care about these check-boxes.

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [X] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [X] Add / update tests
- [X] Add new / update outdated documentation
