### PR TITLE
removed debug prints from httpx

### DIFF
--- a/packages/httpx/meta.yaml
+++ b/packages/httpx/meta.yaml
@@ -6,8 +6,8 @@ package:
 
 source:
   # Until the PR for emscripten support gets merged, build it from the PR source
-  url: https://github.com/joemarshall/httpx/archive/refs/heads/pyodide_0_28_1.zip
-  sha256: 0d9f57da2f5859df7ca147dc32334ee64bc133d2ea9d240964f3c4665c0e0072
+  url: https://github.com/joemarshall/httpx/archive/refs/tags/pyodide_release_2.zip
+  sha256: 345b2d01e1bbd7d1f2239163eae37dff441b02c98cce5b80cdd462587259e41b
 
 test:
   imports:


### PR DESCRIPTION
Removed some annoying debug printouts from httpx pyodide package. Should fix #5381 I think.