### PR TITLE
Update PyWavelets to version 1.8.0, remove optional dependencies from requirements

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -31,6 +31,7 @@ _January 23, 2025_
 - Upgraded `pydantic` to 2.10.5 and fixed a version mismatch with
   `pydantic_core` {pr}`5368`
 - Upgraded `packaging` to 24.2 {pr}`5370`
+- Upgraded `PyWavelets` to 1.8.0 {pr}`5387`
 
 ## Version 0.27.1
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -31,7 +31,7 @@ _January 23, 2025_
 - Upgraded `pydantic` to 2.10.5 and fixed a version mismatch with
   `pydantic_core` {pr}`5368`
 - Upgraded `packaging` to 24.2 {pr}`5370`
-- Upgraded `PyWavelets` to 1.8.0 {pr}`5387`
+- Upgraded `PyWavelets` to 1.8.0 {pr}`5387`. Optional runtime requirements SciPy and Matplotlib have been removed, please install them separately.
 
 ## Version 0.27.1
 

--- a/packages/pywavelets/meta.yaml
+++ b/packages/pywavelets/meta.yaml
@@ -1,18 +1,16 @@
 package:
   name: pywavelets
-  version: 1.7.0
+  version: 1.8.0
   top-level:
     - pywt
 source:
-  sha256: b47250e5bb853e37db5db423bafc82847f4cde0ffdf7aebb06336a993bc174f6
-  url: https://files.pythonhosted.org/packages/94/0a/c235e7dd60d136b14cd8793c440e8d22e7880df5588162feb02d6d6118a3/pywavelets-1.7.0.tar.gz
+  sha256: f3800245754840adc143cbc29534a1b8fc4b8cff6e9d403326bd52b7bb5c35aa
+  url: https://files.pythonhosted.org/packages/48/45/bfaaab38545a33a9f06c61211fc3bea2e23e8a8e00fedeb8e57feda722ff/pywavelets-1.8.0.tar.gz
 requirements:
   host:
     - numpy
   run:
     - numpy
-    - matplotlib
-    - scipy
 about:
   home: https://github.com/PyWavelets/pywt
   PyPI: https://pypi.org/project/pywavelets


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This pull request updates PyWavelets to its 1.8.0 release, and drops SciPy and Matplotlib from the requirements. SciPy is an optional dependency for PyWavelets, and Matplotlib is used in some examples, but is not declared as a dependency.

As requested in https://github.com/PyWavelets/pywt/pull/741#issuecomment-2620738505.

cc: @rgommers

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
