### PR TITLE
Update sha256 checksum for pyxel recipe

### DIFF
--- a/docs/usage/examples/console_webworker.html
+++ b/docs/usage/examples/console_webworker.html
@@ -72,7 +72,8 @@
         padding: 4px;
       }
       #description-header h1 {
-        font-family: "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
+        font-family:
+          "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
       }
     </style>
   </head>

--- a/packages/pyxel/meta.yaml
+++ b/packages/pyxel/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: pyxel
-  version: 2.3.6
+  version: 1.9.10
 source:
-  url: https://github.com/kitao/pyxel/archive/refs/tags/v2.3.6.tar.gz
-  sha256: 1f0a3df02a6c7beb4567711f2d59f2d4a409f3f3de933ae18be17bae61cda84f
+  url: https://github.com/kitao/pyxel/archive/refs/tags/v1.9.10.tar.gz
+  sha256: fee625e7a0d10570174fe3f228b9d56ffee625e6f388009af65533b3f2c3efd7
 build:
   script: |
     embuilder build sdl2 --pic
@@ -16,6 +16,8 @@ build:
 requirements:
   executable:
     - rustup
+  constraint:
+    - maturin < 1.8
 test:
   imports:
     - pyxel

--- a/packages/pyxel/meta.yaml
+++ b/packages/pyxel/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.9.10
 source:
   url: https://github.com/kitao/pyxel/archive/refs/tags/v1.9.10.tar.gz
-  sha256: fee625e7a0d10570174fe3f228b9d56ffee625e6f388009af65533b3f2c3efd7
+  sha256: a784221be6f32fd57bdc6a1a8f30e8f68c78f83d8c84790beaf6ec2be062982f
 build:
   script: |
     embuilder build sdl2 --pic

--- a/packages/pyxel/meta.yaml
+++ b/packages/pyxel/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: pyxel
-  version: 1.9.10
+  version: 2.3.6
 source:
-  url: https://github.com/kitao/pyxel/archive/refs/tags/v1.9.10.tar.gz
-  sha256: fee625e7a0d10570174fe3f228b9d56ffee625e6f388009af65533b3f2c3efd7
+  url: https://github.com/kitao/pyxel/archive/refs/tags/v2.3.6.tar.gz
+  sha256: 1f0a3df02a6c7beb4567711f2d59f2d4a409f3f3de933ae18be17bae61cda84f
 build:
   script: |
     embuilder build sdl2 --pic
@@ -16,8 +16,6 @@ build:
 requirements:
   executable:
     - rustup
-  constraint:
-    - maturin < 1.8
 test:
   imports:
     - pyxel

--- a/packages/pyxel/meta.yaml
+++ b/packages/pyxel/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.9.10
 source:
   url: https://github.com/kitao/pyxel/archive/refs/tags/v1.9.10.tar.gz
-  sha256: e23a0c52daaa9c4967c402b3ad2c623f33c4a01e36c4b37b884d7b8c726521f4
+  sha256: fee625e7a0d10570174fe3f228b9d56ffee625e6f388009af65533b3f2c3efd7
 build:
   script: |
     embuilder build sdl2 --pic


### PR DESCRIPTION
Looks like GitHub updated the file content, resulting in checksum change.