### PR TITLE
Add pytest --collect-only job to ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,10 @@ jobs:
           mkdir test-results
           make pyodide_build
           python3 -m pip install -r requirements.txt -r requirements-deploy.txt
+      - name: Check test collection
+        shell: bash -l {0}
+        run: |
+          PYODIDE_ROOT=. pytest --collect-only
       - name: Run tests
         shell: bash -l {0}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,12 +126,15 @@ norecursedirs = [
     "build",
     "cpython",
     "emsdk",
+    "packages/.libs",
 ]
 addopts = '''
 --doctest-modules
 --ignore-glob="**/dist/"
 --ignore-glob="src/py/_pyodide/jsbind.py"
 --ignore-glob="packages/**/extras/"
+--ignore-glob="packages/aiohttp/aiohttp_patch.py"
+--ignore-glob="packages/scipy/cmdline_test_file.py"
 --tb=short
 --dist-dir=dist'''
 testpaths = [


### PR DESCRIPTION
There's a surprising number of things to fix here. We suggest running `pytest` without any modifications here:
https://pyodide.org/en/stable/development/testing.html#running-the-python-test-suite
So probably we should check that test collection doesn't fail when you do that.