### PR TITLE
Support the context parameter in WebLoop.create_task()

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -19,6 +19,7 @@ myst:
 - ABI break: Upgraded Emscripten to 3.1.63 {pr}`5343` {pr}`5350` {pr}`5357`
   {pr}`5334` {pr}`5363`
 - Added `jiter` 0.8.2 {pr}`5388`
+- Added the `context` parameter to `WebLoop.create_task()` {pr}`5431`
 
 ### Packages
 

--- a/docs/usage/examples/console_webworker.html
+++ b/docs/usage/examples/console_webworker.html
@@ -72,7 +72,8 @@
         padding: 4px;
       }
       #description-header h1 {
-        font-family: "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
+        font-family:
+          "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
       }
     </style>
   </head>

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -5,7 +5,7 @@ import sys
 import time
 import traceback
 from asyncio import Future, Task
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, TypeVar, overload
 
 from .ffi import IN_BROWSER, create_once_callable, run_sync
@@ -407,7 +407,13 @@ class WebLoop(asyncio.AbstractEventLoop):
         """
         return time.monotonic()
 
-    def create_task(self, coro, *, name=None):  # type: ignore[override]
+    def create_task(
+        self,
+        coro: Coroutine[T, Any, Any],
+        *,
+        name: str | None = None,
+        context: contextvars.Context | None = None,
+    ) -> Task[T]:
         """Schedule a coroutine object.
 
         Return a task object.
@@ -416,7 +422,7 @@ class WebLoop(asyncio.AbstractEventLoop):
         """
         self._check_closed()
         if self._task_factory is None:
-            task = PyodideTask(coro, loop=self, name=name)
+            task = PyodideTask(coro, loop=self, name=name, context=context)
             if task._source_traceback:  # type: ignore[attr-defined]
                 # Added comment:
                 # this only happens if get_debug() returns True.


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

In Python 3.11, commit [9523c0d](https://github.com/python/cpython/commit/9523c0d84f351a610dc651b234461eb015fa3b82) added support for passing a custom context to the various AsycncIO `create_task()` functions. This PR adds that support to `WebLoop.create_task()`.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [X] Add / update tests
- [ ] Add new / update outdated documentation
