### PR TITLE
Add `pcodec` (lossless compression/decompression for numerical sequences)

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -24,6 +24,7 @@ myst:
 
 - Upgraded `narwhals` to 1.24.1 {pr}`5386`
 - Upgraded `rateslib` to 1.7.0 {pr}`5400`
+- Added `pcodec` 0.3.3 {pr}`5432`
 
 ## Version 0.27.2
 

--- a/docs/usage/examples/console_webworker.html
+++ b/docs/usage/examples/console_webworker.html
@@ -72,7 +72,8 @@
         padding: 4px;
       }
       #description-header h1 {
-        font-family: "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
+        font-family:
+          "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
       }
     </style>
   </head>

--- a/packages/pcodec/meta.yaml
+++ b/packages/pcodec/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: pcodec
+  version: 0.3.3
+  top-level:
+    - pcodec
+source:
+  url: https://files.pythonhosted.org/packages/source/p/pcodec/pcodec-0.3.3.tar.gz
+  sha256: 759505b08db98a28ef8964b23044cc73b137df133d5b07225a6c8ee9540286bf
+requirements:
+  executable:
+    - rustup
+    - cargo
+  constraint:
+    - maturin <2.0
+  run:
+    - numpy
+test:
+  imports:
+    - pcodec
+about:
+  home: https://github.com/mwlon/pcodec
+  PyPI: https://pypi.org/project/pcodec
+  summary: Good compression for numerical sequences
+  license: Apache-2.0

--- a/packages/pcodec/test_pcodec.py
+++ b/packages/pcodec/test_pcodec.py
@@ -1,0 +1,54 @@
+import pytest
+from pytest_pyodide import run_in_pyodide
+
+
+@pytest.mark.parametrize("dtype", ["f4", "f8", "i4", "i8", "u4", "u8"])
+@run_in_pyodide(packages=["pcodec", "numpy"])
+def test_simple_round_trip(selenium, dtype):
+    """Test basic compression and decompression with different dtypes."""
+    import numpy as np
+    from pcodec import ChunkConfig, standalone
+
+    np.random.seed(42)
+
+    data = np.random.uniform(0, 1000, size=100).astype(dtype)
+    compressed = standalone.simple_compress(data, ChunkConfig())
+    decompressed = standalone.simple_decompress(compressed)
+
+    np.testing.assert_array_equal(data, decompressed)
+
+
+@run_in_pyodide(packages=["pcodec", "numpy"])
+def test_partial_decompression(selenium):
+    """Test decompressing a part of the data into a smaller array."""
+    import numpy as np
+    from pcodec import ChunkConfig, standalone
+
+    np.random.seed(42)
+
+    data = np.random.uniform(0, 1000, size=50).astype(np.float32)
+    compressed = standalone.simple_compress(data, ChunkConfig())
+
+    out = np.zeros(10, dtype=np.float32)
+    progress = standalone.simple_decompress_into(compressed, out)
+
+    np.testing.assert_array_equal(out, data[:10])
+    assert progress.n_processed == 10
+    assert not progress.finished
+
+
+@pytest.mark.parametrize("length", [0, 100, 1000])
+@run_in_pyodide(packages=["pcodec", "numpy"])
+def test_different_lengths(selenium, length):
+    """Test compression/decompression with different array lengths."""
+    import numpy as np
+    from pcodec import ChunkConfig, standalone
+
+    np.random.seed(42)
+
+    data = np.random.uniform(0, 1000, size=length).astype(np.float64)
+
+    compressed = standalone.simple_compress(data, ChunkConfig())
+    decompressed = standalone.simple_decompress(compressed)
+
+    np.testing.assert_array_equal(data, decompressed)


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This is yet another dependency for `numcodecs`, coming from upstream changes that I keep observing from time to time as a part of https://github.com/zarr-developers/numcodecs/pull/529. This is a package based on a Rust toolchain with a `maturin`-based build system. 

The source code is available at https://github.com/mwlon/pcodec, and the Python source in specific is at https://github.com/mwlon/pcodec/tree/main/pco_python. They ship a compliant sdist on PyPI. I've added a few tests based on my understanding of the API, derived from the `test/` folder.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
