### PR TITLE
Increase timeout for tarfile test

### DIFF
--- a/src/tests/python_tests.yaml
+++ b/src/tests/python_tests.yaml
@@ -706,6 +706,7 @@
 - test_syslog
 - test_tabnanny
 - test_tarfile:
+    timeout: 120
     skip:
       - test_sly_relative0
 - test_tcl

--- a/src/tests/test_core_python.py
+++ b/src/tests/test_core_python.py
@@ -43,10 +43,12 @@ def test_cpython_core(main_test, selenium, request):
     possibly_skip_test(request, info)
 
     ignore_tests = info.get("skip", [])
+    timeout = info.get("timeout", 30)
     if not isinstance(ignore_tests, list):
         raise Exception("Invalid python_tests.yaml entry: 'skip' should be a list")
 
     selenium.load_package(["test"])
+    selenium.set_script_timeout(timeout)
     try:
         res = selenium.run(
             dedent(


### PR DESCRIPTION
This test often timeouts these days (in chrome and node). I am not sure when it started.