### PR TITLE
Add a "rust" tag to all Rust packages, and add missing docs for supported tags

### DIFF
--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -201,10 +201,19 @@ the core test suite is installed, including "micropip", "pyparsing", "pytz",
 meta-package. Other supported meta-packages are,
 
 - "tag:min-scipy-stack": includes the "core" meta-package as well as some
-  core packages from the scientific python stack and their dependencies:
+  core packages from the Scientific Python stack and their dependencies:
   "numpy", "scipy", "pandas", "matplotlib", "scikit-learn", "joblib",
   "pytest". This option is non exhaustive and is mainly intended to make build
   faster while testing a diverse set of scientific packages.
+- "tag:library": includes all shared and static libraries.
+- "tag:shared_library": includes all shared libraries. Added in conjunction with
+  the "library" tag.
+- "tag:static_library": includes all static libraries. Added in conjunction with
+  the "library" tag.
+- "tag:pyodide-test": includes all packages built to test the Pyodide build
+  system's behaviour.
+- "tag:rust": includes all packages that require a Rust toolchain to build,
+  and their dependencies.
 - "\*" builds all packages
 - You can exclude a package by prefixing it with "!".
 

--- a/docs/development/meta-yaml.md
+++ b/docs/development/meta-yaml.md
@@ -49,11 +49,17 @@ as a top-level import names.
 
 The list of tags of the package. This is meta information used to group
 packages by functionality. Normally this is not needed.
-The following tags are currently used in Pyodide:
+The following tags are currently used in Pyodide, for better CI grouping
+or for testing purposes:
 
 - always: This package is always built.
 - core: This package is used in the Pyodide core test suite.
-- min-scipy-stack: This package is part of the minimal scipy stack.
+- min-scipy-stack: This package is part of the minimal Scientific Python stack.
+- library: This package is a shared or static library.
+- shared_library: This package is a shared library.
+- static_library: This package is a static library.
+- pyodide-test: This package is used to test the Pyodide build system.
+- rust: This package requires a Rust toolchain to build.
 
 ## `source`
 

--- a/packages/bcrypt/meta.yaml
+++ b/packages/bcrypt/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: bcrypt
   version: 4.1.2
+  tag:
+    - rust
   top-level:
     - bcrypt
 source:

--- a/packages/cbor-diag/meta.yaml
+++ b/packages/cbor-diag/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: cbor-diag
   version: 1.0.1
+  tag:
+    - rust
   top-level:
     - cbor_diag
 source:

--- a/packages/clarabel/meta.yaml
+++ b/packages/clarabel/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: clarabel
   version: 0.9.0
+  tag:
+    - rust
   # Clarabel is broken against the rust main branch since 2024-12-15. Re-enable
   # when they fix it. See oxfordcontrol/Clarabel.rs#154
   _disabled: true

--- a/packages/cramjam/meta.yaml
+++ b/packages/cramjam/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: cramjam
   version: 2.8.3
+  tag:
+    - rust
   top-level:
     - cramjam
 source:

--- a/packages/cryptography/meta.yaml
+++ b/packages/cryptography/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: cryptography
   version: 42.0.5
+  tag:
+    - rust
   top-level:
     - cryptography
 source:

--- a/packages/lakers-python/meta.yaml
+++ b/packages/lakers-python/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: lakers-python
   version: 0.4.1
+  tag:
+    - rust
   top-level:
     - lakers
 source:

--- a/packages/libcst/meta.yaml
+++ b/packages/libcst/meta.yaml
@@ -1,13 +1,20 @@
 package:
   name: libcst
   version: 1.4.0
+  tag:
+    - rust
   top-level:
     - libcst
 source:
   url: https://files.pythonhosted.org/packages/e4/bd/ff41d7a8efc4f60a61d903c3f9823565006f44f2b8b11c99701f552b0851/libcst-1.4.0.tar.gz
   sha256: 449e0b16604f054fa7f27c3ffe86ea7ef6c409836fe68fe4e752a1894175db00
+requirements:
+  run:
+    - pyyaml
+  executable:
+    - rustup
 about:
-  home: ""
+  home: https://libcst.readthedocs.io
   PyPI: https://pypi.org/project/libcst
   summary:
     A concrete syntax tree with AST-like properties for Python 3.0 through
@@ -16,8 +23,3 @@ about:
 extra:
   recipe-maintainers:
     - zsol
-requirements:
-  run:
-    - pyyaml
-  executable:
-    - rustup

--- a/packages/nh3/meta.yaml
+++ b/packages/nh3/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: nh3
   version: 0.2.17
+  tag:
+    - rust
   top-level:
     - nh3
 source:
@@ -12,7 +14,7 @@ requirements:
   constraint:
     - maturin < 1.8
 about:
-  home: ""
+  home: https://nh3.readthedocs.io
   PyPI: https://pypi.org/project/nh3
   summary: Python bindings to the ammonia HTML sanitization library.
   license: MIT

--- a/packages/orjson/meta.yaml
+++ b/packages/orjson/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: orjson
   version: 3.10.1
+  tag:
+    - rust
   top-level:
     - orjson
 source:

--- a/packages/pcodec/meta.yaml
+++ b/packages/pcodec/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pcodec
   version: 0.3.3
+  tag:
+    - rust
   top-level:
     - pcodec
 source:
@@ -11,7 +13,7 @@ requirements:
     - rustup
     - cargo
   constraint:
-    - maturin <2.0
+    - maturin < 2.0
   run:
     - numpy
 test:

--- a/packages/pydantic/meta.yaml
+++ b/packages/pydantic/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pydantic
   version: 2.10.5
+  tag:
+    - rust
   # Warning: pydantic has a pin on pydantic_core, they need to be updated
   # together
   top-level:

--- a/packages/pydantic_core/meta.yaml
+++ b/packages/pydantic_core/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pydantic_core
   version: 2.27.2
+  tag:
+    - rust
   # Warning: pydantic has a pin on pydantic_core, they need to be updated
   # together
   top-level:

--- a/packages/pyxel/meta.yaml
+++ b/packages/pyxel/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pyxel
   version: 1.9.10
+  tag:
+    - rust
 source:
   url: https://github.com/kitao/pyxel/archive/refs/tags/v1.9.10.tar.gz
   sha256: a784221be6f32fd57bdc6a1a8f30e8f68c78f83d8c84790beaf6ec2be062982f

--- a/packages/pyxirr/meta.yaml
+++ b/packages/pyxirr/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pyxirr
   version: 0.10.6
+  tag:
+    - rust
   top-level:
     - pyxirr
 source:
@@ -15,6 +17,7 @@ requirements:
   executable:
     - rustup
     - cargo
+  # Undo this when https://github.com/Anexen/pyxirr/commit/f012d1499f449024ad92b42a26f571d58ba330b2 makes it to a release
   constraint:
     - maturin < 1.8
 extra:

--- a/packages/rateslib/meta.yaml
+++ b/packages/rateslib/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: rateslib
   version: 1.7.0
+  tag:
+    - rust
   top-level:
     - rateslib
 source:

--- a/packages/river/meta.yaml
+++ b/packages/river/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: river
   version: 0.22.0
+  tag:
+    - rust
   top-level:
     - river
 source:

--- a/packages/rpds-py/meta.yaml
+++ b/packages/rpds-py/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: rpds-py
   version: 0.18.0
+  tag:
+    - rust
   top-level:
     - rpds
 source:
@@ -12,7 +14,7 @@ requirements:
   constraint:
     - maturin < 1.8
 about:
-  home:
+  home: https://rpds.readthedocs.io
   PyPI: https://pypi.org/project/rpds-py
   summary: Python bindings to Rust's persistent data structures (rpds)
   license: MIT

--- a/packages/rust-abi-test/meta.yaml
+++ b/packages/rust-abi-test/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: rust-abi-test
   version: "1.0"
+  tag:
+    - rust
 source:
   path: src
 requirements:

--- a/packages/rust-panic-test/meta.yaml
+++ b/packages/rust-panic-test/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: rust-panic-test
   version: "1.0"
+  tag:
+    - rust
 source:
   path: src
 build:

--- a/packages/sourmash/meta.yaml
+++ b/packages/sourmash/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: sourmash
   version: 4.8.11
+  tag:
+    - rust
   top-level:
     - sourmash
 requirements:

--- a/packages/tiktoken/meta.yaml
+++ b/packages/tiktoken/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: tiktoken
   version: 0.8.0
+  tag:
+    - rust
   top-level:
     - tiktoken
     - tiktoken_ext


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This makes it easier to manage all Rust-based packages, say, if we bump the Rust toolchain to a new nightly version and want to build all Rust-based packages with one command invocation. I've added some documentation for this tag in the "building from sources" instructions and in the Pyodide recipe format page, as well as for other missing tags that we use but weren't documented (please let me know if they were undocumented for a reason, I feel it is okay to document them 😅). Additionally, I went in and added URLs for the `home:` sections where I found them to be empty.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add new / update outdated documentation
