### PR TITLE
Add `loadPackageSetStd[out|err]` functions to override the default output handler for package loading

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -20,6 +20,8 @@ myst:
   {pr}`5334` {pr}`5363`
 - Added `jiter` 0.8.2 {pr}`5388`
 - Added the `context` parameter to `WebLoop.create_task()` {pr}`5431`
+- Added the `loadPackageSetStdout` and `loadPackageSetStderr` functions to override the
+  default output handlers during package loading {pr}`5442`
 
 ### Packages
 

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -1,7 +1,7 @@
 import { ffi } from "./ffi";
 import { CanvasInterface, canvas } from "./canvas";
 
-import { loadPackage, loadedPackages } from "./load-package";
+import { loadPackage, loadedPackages, loadPackageSetStderr, loadPackageSetStdout } from "./load-package";
 import { type PyProxy, type PyDict } from "generated/pyproxy";
 import { loadBinaryFile, nodeFSMod } from "./compat";
 import { version } from "./version";
@@ -115,9 +115,13 @@ export class PyodideAPI {
   /** @hidden */
   static version = version;
   /** @hidden */
-  static loadPackage = loadPackage;
+  static loadPackage = loadPackage;  
   /** @hidden */
   static loadedPackages = loadedPackages;
+  /** @hidden */
+  static loadPackageSetStdout = loadPackageSetStdout;
+  /** @hidden */
+  static loadPackageSetStderr = loadPackageSetStderr;
   /** @hidden */
   static ffi = ffi;
   /** @hidden */

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -1,7 +1,12 @@
 import { ffi } from "./ffi";
 import { CanvasInterface, canvas } from "./canvas";
 
-import { loadPackage, loadedPackages, loadPackageSetStderr, loadPackageSetStdout } from "./load-package";
+import {
+  loadPackage,
+  loadedPackages,
+  loadPackageSetStderr,
+  loadPackageSetStdout,
+} from "./load-package";
 import { type PyProxy, type PyDict } from "generated/pyproxy";
 import { loadBinaryFile, nodeFSMod } from "./compat";
 import { version } from "./version";
@@ -115,7 +120,7 @@ export class PyodideAPI {
   /** @hidden */
   static version = version;
   /** @hidden */
-  static loadPackage = loadPackage;  
+  static loadPackage = loadPackage;
   /** @hidden */
   static loadedPackages = loadedPackages;
   /** @hidden */

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -541,6 +541,14 @@ export class PackageManager {
   public logStderr(message: string, logger?: (message: string) => void) {
     logger ? logger(message) : this.stderr(message);
   }
+
+  public setStdout(logger: (message: string) => void) {
+    this.stdout = logger;
+  }
+
+  public setStderr(logger: (message: string) => void) {
+    this.stderr = logger;
+  }
 }
 
 function filterPackageData({
@@ -582,6 +590,8 @@ export let loadPackage: typeof PackageManager.prototype.loadPackage;
  * source for a particular `package_name`.
  */
 export let loadedPackages: LoadedPackages;
+export let loadPackageSetStdout: typeof PackageManager.prototype.setStdout;
+export let loadPackageSetStderr: typeof PackageManager.prototype.setStderr;
 
 if (typeof API !== "undefined" && typeof Module !== "undefined") {
   const singletonPackageManager = new PackageManager(API, Module);
@@ -597,6 +607,13 @@ if (typeof API !== "undefined" && typeof Module !== "undefined") {
    * install location for a particular ``package_name``.
    */
   loadedPackages = singletonPackageManager.loadedPackages;
+
+  loadPackageSetStdout = singletonPackageManager.setStdout.bind(
+    singletonPackageManager,
+  );
+  loadPackageSetStderr = singletonPackageManager.setStderr.bind(
+    singletonPackageManager,
+  );
 
   // TODO: Find a better way to register these functions
   API.recursiveDependencies =

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -546,7 +546,7 @@ export class PackageManager {
    * Sets the default output handler that is used during package loading.
    * By default, the handler is set to `console.log`.
    *
-   * @param handler The handler is called with a string whenver an output
+   * @param handler The handler is called with a string whenever an output
    * message is emitted during package loading.
    */
   public setStdout(handler: (message: string) => void) {
@@ -557,7 +557,7 @@ export class PackageManager {
    * Sets the default error handler that is used during package loading.
    * By default, the handler is set to `console.error`.
    *
-   * @param handler The handler is called with a string whenver an error
+   * @param handler The handler is called with a string whenever an error
    * message is emitted during package loading.
    */
   public setStderr(handler: (message: string) => void) {

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -542,12 +542,26 @@ export class PackageManager {
     logger ? logger(message) : this.stderr(message);
   }
 
-  public setStdout(logger: (message: string) => void) {
-    this.stdout = logger;
+  /**
+   * Sets the default output handler that is used during package loading.
+   * By default, the handler is set to `console.log`.
+   *
+   * @param handler The handler is called with a string whenver an output
+   * message is emitted during package loading.
+   */
+  public setStdout(handler: (message: string) => void) {
+    this.stdout = handler;
   }
 
-  public setStderr(logger: (message: string) => void) {
-    this.stderr = logger;
+  /**
+   * Sets the default error handler that is used during package loading.
+   * By default, the handler is set to `console.error`.
+   *
+   * @param handler The handler is called with a string whenver an error
+   * message is emitted during package loading.
+   */
+  public setStderr(handler: (message: string) => void) {
+    this.stderr = handler;
   }
 }
 


### PR DESCRIPTION
### Description

Add `loadPackageSetStd[out|err]` functions to override the default output handler for package loading. The default, `console.[log|error]` is unchanged. These functions are useful when you want to redirect the output but don't control every call to `loadPackage`. Calls to `loadPackage` that want to change the redirection just for their call can still do so.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation
