### PR TITLE
Skip wasm-gc on iOS Safari where it's borked

### DIFF
--- a/cpython/patches/0001-Public-pymain_run_python.patch
+++ b/cpython/patches/0001-Public-pymain_run_python.patch
@@ -1,4 +1,4 @@
-From 4869db3f4eeab51e3b83d978b63f1173ac228457 Mon Sep 17 00:00:00 2001
+From f8a9e2d38252a032bdb617db396a047154f1bb6e Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sun, 17 Jul 2022 14:40:39 +0100
 Subject: [PATCH 1/9] Public pymain_run_python

--- a/cpython/patches/0001-Public-pymain_run_python.patch
+++ b/cpython/patches/0001-Public-pymain_run_python.patch
@@ -1,7 +1,7 @@
-From c37e3894a271ee8b406ffc41a0ce6f5c248914ee Mon Sep 17 00:00:00 2001
+From 4869db3f4eeab51e3b83d978b63f1173ac228457 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sun, 17 Jul 2022 14:40:39 +0100
-Subject: [PATCH 1/8] Public pymain_run_python
+Subject: [PATCH 1/9] Public pymain_run_python
 
 Discussion here:
 https://discuss.python.org/t/unstable-api-for-pymain-run-python-run-python-cli-but-dont-finalize-interpreter/44675
@@ -23,5 +23,5 @@ index b602272b78b..d06d3c926b9 100644
  {
      PyObject *main_importer_path = NULL;
 -- 
-2.34.1
+2.48.1
 

--- a/cpython/patches/0002-Add-emscripten-platform-support-to-ctypes.util.find_.patch
+++ b/cpython/patches/0002-Add-emscripten-platform-support-to-ctypes.util.find_.patch
@@ -1,7 +1,7 @@
-From 83ce578076b86b0231739b81ed9231bf8d9ca800 Mon Sep 17 00:00:00 2001
+From d09b02862d583a6af31d56ba18a07eefa3b883ca Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 2 Dec 2022 11:36:44 +0000
-Subject: [PATCH 2/8] Add emscripten platform support to
+Subject: [PATCH 2/9] Add emscripten platform support to
  ctypes.util.find_library
 
 ---
@@ -44,5 +44,5 @@ index c550883e7c7..c25c8f63e77 100644
      # AIX has two styles of storing shared libraries
      # GNU auto_tools refer to these as svr4 and aix
 -- 
-2.34.1
+2.48.1
 

--- a/cpython/patches/0002-Add-emscripten-platform-support-to-ctypes.util.find_.patch
+++ b/cpython/patches/0002-Add-emscripten-platform-support-to-ctypes.util.find_.patch
@@ -1,4 +1,4 @@
-From d09b02862d583a6af31d56ba18a07eefa3b883ca Mon Sep 17 00:00:00 2001
+From 74f68027172f2b646b8ab9a8d73380b12f864cb7 Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 2 Dec 2022 11:36:44 +0000
 Subject: [PATCH 2/9] Add emscripten platform support to

--- a/cpython/patches/0003-Allow-multiprocessing.connection-top-level-import.patch
+++ b/cpython/patches/0003-Allow-multiprocessing.connection-top-level-import.patch
@@ -1,7 +1,7 @@
-From da79a0ddc090407c1ea1d8e25da67931d1863642 Mon Sep 17 00:00:00 2001
+From c985e31543257173ce4c2f094c9154d01b5b17ef Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Mon, 19 Dec 2022 09:09:14 -0800
-Subject: [PATCH 3/8] Allow multiprocessing.connection top level import
+Subject: [PATCH 3/9] Allow multiprocessing.connection top level import
 
 Upstream PR:
 https://github.com/python/cpython/pull/114808
@@ -26,5 +26,5 @@ index d0582e3cd54..b96b2454d3d 100644
  from . import util
  
 -- 
-2.34.1
+2.48.1
 

--- a/cpython/patches/0003-Allow-multiprocessing.connection-top-level-import.patch
+++ b/cpython/patches/0003-Allow-multiprocessing.connection-top-level-import.patch
@@ -1,4 +1,4 @@
-From c985e31543257173ce4c2f094c9154d01b5b17ef Mon Sep 17 00:00:00 2001
+From 32155f0ed7043dde694b7910db46f4c97f2e41d9 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Mon, 19 Dec 2022 09:09:14 -0800
 Subject: [PATCH 3/9] Allow multiprocessing.connection top level import

--- a/cpython/patches/0004-Make-Emscripten-trampolines-work-with-JSPI.patch
+++ b/cpython/patches/0004-Make-Emscripten-trampolines-work-with-JSPI.patch
@@ -1,7 +1,7 @@
-From b86ebf295ad48ade5810032e83f98edb0e642abf Mon Sep 17 00:00:00 2001
+From 1b2b71618ae201dc14382b7b589d898afe80f670 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 28 Jun 2023 10:46:19 -0700
-Subject: [PATCH 4/8] Make Emscripten trampolines work with JSPI
+Subject: [PATCH 4/9] Make Emscripten trampolines work with JSPI
 
 There is a WIP proposal to enable webassembly stack switching which have been
 implemented in v8:
@@ -382,5 +382,5 @@ index d0d54050286..85c6d2f71ae 100644
  )
  AC_SUBST([PLATFORM_HEADERS])
 -- 
-2.34.1
+2.48.1
 

--- a/cpython/patches/0004-Make-Emscripten-trampolines-work-with-JSPI.patch
+++ b/cpython/patches/0004-Make-Emscripten-trampolines-work-with-JSPI.patch
@@ -1,4 +1,4 @@
-From 1b2b71618ae201dc14382b7b589d898afe80f670 Mon Sep 17 00:00:00 2001
+From a761e476e8abab81106ed4f8b4422732404b65d2 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 28 Jun 2023 10:46:19 -0700
 Subject: [PATCH 4/9] Make Emscripten trampolines work with JSPI

--- a/cpython/patches/0005-Use-wasm-gc-based-call-adaptor-if-available.patch
+++ b/cpython/patches/0005-Use-wasm-gc-based-call-adaptor-if-available.patch
@@ -1,7 +1,7 @@
-From 2d2732b55d57008545e818fc1b5ef4dca5625b9e Mon Sep 17 00:00:00 2001
+From 4973dd56cf6e46973ef8cf879d65d82e38b3f90d Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Tue, 22 Oct 2024 15:16:03 +0200
-Subject: [PATCH 5/8] Use wasm-gc based call adaptor if available
+Subject: [PATCH 5/9] Use wasm-gc based call adaptor if available
 
 Part of the ongoing quest to support JSPI. The JSPI spec removed its dependence on
 JS type reflection, and now the plan is for runtimes to ship JSPI while keeping
@@ -408,5 +408,5 @@ index a7981bc4877..ab03729266c 100644
  
  PyStatus
 -- 
-2.34.1
+2.48.1
 

--- a/cpython/patches/0005-Use-wasm-gc-based-call-adaptor-if-available.patch
+++ b/cpython/patches/0005-Use-wasm-gc-based-call-adaptor-if-available.patch
@@ -1,4 +1,4 @@
-From 4973dd56cf6e46973ef8cf879d65d82e38b3f90d Mon Sep 17 00:00:00 2001
+From 13370805f9652e70bc19447381443afde82c9b93 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Tue, 22 Oct 2024 15:16:03 +0200
 Subject: [PATCH 5/9] Use wasm-gc based call adaptor if available

--- a/cpython/patches/0006-Fix-LONG_BIT-constant-to-be-always-32bit.patch
+++ b/cpython/patches/0006-Fix-LONG_BIT-constant-to-be-always-32bit.patch
@@ -1,4 +1,4 @@
-From 8be73c9def45f6464873dd5173fb65383bb9631f Mon Sep 17 00:00:00 2001
+From 6f2d305e8eba14fd3c49f54790f13c19fa41860b Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 12 Jan 2024 00:52:57 +0900
 Subject: [PATCH 6/9] Fix LONG_BIT constant to be always 32bit

--- a/cpython/patches/0006-Fix-LONG_BIT-constant-to-be-always-32bit.patch
+++ b/cpython/patches/0006-Fix-LONG_BIT-constant-to-be-always-32bit.patch
@@ -1,7 +1,7 @@
-From d9e6867695c02c07420d8a15d4ae1b96ea41f553 Mon Sep 17 00:00:00 2001
+From 8be73c9def45f6464873dd5173fb65383bb9631f Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 12 Jan 2024 00:52:57 +0900
-Subject: [PATCH 6/8] Fix LONG_BIT constant to be always 32bit
+Subject: [PATCH 6/9] Fix LONG_BIT constant to be always 32bit
 
 Starting from Emscripten 3.1.50, there is an issue where LONG_BIT is
 calculated to 64 for some reason. This is very strange because LONG_MAX
@@ -29,5 +29,5 @@ index e2bac3bf504..ae1c1a40260 100644
  #define LONG_BIT (8 * SIZEOF_LONG)
  #endif
 -- 
-2.34.1
+2.48.1
 

--- a/cpython/patches/0007-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
+++ b/cpython/patches/0007-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
@@ -1,4 +1,4 @@
-From b088e2e23b5c41d636230c42532b80baa0cc2a05 Mon Sep 17 00:00:00 2001
+From 566d1c20df2370c4a47f21561086fb7e5f51299c Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:28:57 +0200
 Subject: [PATCH 7/9] Warn if ZoneInfo is imported without tzdata

--- a/cpython/patches/0007-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
+++ b/cpython/patches/0007-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
@@ -1,7 +1,7 @@
-From a35c57ed8c7f2657a7a82d900184ebe649dedfdf Mon Sep 17 00:00:00 2001
+From b088e2e23b5c41d636230c42532b80baa0cc2a05 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:28:57 +0200
-Subject: [PATCH 7/8] Warn if ZoneInfo is imported without tzdata
+Subject: [PATCH 7/9] Warn if ZoneInfo is imported without tzdata
 
 ---
  Lib/zoneinfo/_common.py | 6 ++++++
@@ -25,5 +25,5 @@ index 98cdfe37ca6..35d19eae9f0 100644
          # to "we cannot find this key":
          #
 -- 
-2.34.1
+2.48.1
 

--- a/cpython/patches/0008-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
+++ b/cpython/patches/0008-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
@@ -1,7 +1,7 @@
-From ff4534318481437542f2e49348033a00354a069d Mon Sep 17 00:00:00 2001
+From 12e3147e58d9b666801b33640c0259a88599eb6e Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:41:37 +0200
-Subject: [PATCH 8/8] Add call to `JsProxy_GetMethod` to help remove temporary
+Subject: [PATCH 8/9] Add call to `JsProxy_GetMethod` to help remove temporary
 
 `_PyObject_GetMethod` is a special attribute lookup function that won't call the
 `__get__` descriptor on a method to avoid creating a temporary PyMethodObject.
@@ -56,5 +56,5 @@ index 6b2e0aeaab9..9240b33b08a 100644
          *method = PyObject_GetAttr(obj, name);
          return 0;
 -- 
-2.34.1
+2.48.1
 

--- a/cpython/patches/0008-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
+++ b/cpython/patches/0008-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
@@ -1,4 +1,4 @@
-From 12e3147e58d9b666801b33640c0259a88599eb6e Mon Sep 17 00:00:00 2001
+From f09bfe83d146697b936799d97d8fe0110c61b86d Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:41:37 +0200
 Subject: [PATCH 8/9] Add call to `JsProxy_GetMethod` to help remove temporary

--- a/cpython/patches/0009-Skip-wasm-gc-on-iOS-Safari-where-it-s-broken.patch
+++ b/cpython/patches/0009-Skip-wasm-gc-on-iOS-Safari-where-it-s-broken.patch
@@ -1,4 +1,4 @@
-From 40e14aaf37dd758c457a12754a89fa5a17bfe7bc Mon Sep 17 00:00:00 2001
+From c627686651a46118b2a653fa61673dfc158442d4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C5=81ukasz=20Langa?= <lukasz@langa.pl>
 Date: Fri, 21 Feb 2025 19:24:41 +0100
 Subject: [PATCH 9/9] Skip wasm-gc on iOS Safari where it's broken
@@ -10,24 +10,50 @@ macOS Safari 18.3 does not surface the issue.
 
 Confirmed on device that disabling this restores interpreter function.
 ---
- Python/emscripten_trampoline.c | 4 ++++
- 1 file changed, 4 insertions(+)
+ Python/emscripten_trampoline.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/Python/emscripten_trampoline.c b/Python/emscripten_trampoline.c
-index e78a94e5e99..a6dbc4637f6 100644
+index e78a94e5e99..ff57f9e91d8 100644
 --- a/Python/emscripten_trampoline.c
 +++ b/Python/emscripten_trampoline.c
-@@ -80,6 +80,10 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
+@@ -79,7 +79,13 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
+ //         i32.const -1
  //     )
  // )
- addOnPreRun(() => {
-+    let isIOS = /iPad|iPhone|iPod/.test(navigator.platform);
+-addOnPreRun(() => {
++
++function getPyEMCountArgsPtr() {
++    let isIOS = globalThis.navigator && /iPad|iPhone|iPod/.test(navigator.platform);
 +    if (isIOS) {
-+        return;
++        return 0;
 +    }
++
      // Try to initialize countArgsFunc
      const code = new Uint8Array([
          0x00, 0x61, 0x73, 0x6d, // \0asm magic number
+@@ -151,15 +157,19 @@ addOnPreRun(() => {
+             0x41, 0x7f,       // i32.const -1
+             0x0b // end function
+     ]);
+-    let ptr = 0;
+     try {
+         const mod = new WebAssembly.Module(code);
+         const inst = new WebAssembly.Instance(mod, { e: { t: wasmTable } });
+-        ptr = addFunction(inst.exports.f);
++        return addFunction(inst.exports.f);
+     } catch (e) {
+         // If something goes wrong, we'll null out _PyEM_CountFuncParams and fall
+         // back to the JS trampoline.
++        return 0;
+     }
++}
++
++addOnPreRun(() => {
++    const ptr = getPyEMCountArgsPtr();
+     Module._PyEM_CountArgsPtr = ptr;
+     const offset = HEAP32[__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET / 4];
+     HEAP32[(__PyRuntime + offset) / 4] = ptr;
 -- 
 2.48.1
 

--- a/cpython/patches/0009-Skip-wasm-gc-on-iOS-Safari-where-it-s-broken.patch
+++ b/cpython/patches/0009-Skip-wasm-gc-on-iOS-Safari-where-it-s-broken.patch
@@ -1,0 +1,33 @@
+From 40e14aaf37dd758c457a12754a89fa5a17bfe7bc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C5=81ukasz=20Langa?= <lukasz@langa.pl>
+Date: Fri, 21 Feb 2025 19:24:41 +0100
+Subject: [PATCH 9/9] Skip wasm-gc on iOS Safari where it's broken
+
+As of iOS 18.3.1, enabling wasm-gc is making the interpreter fail to load.
+Downstream pyodide issue: pyodide/pyodide#5428.
+
+macOS Safari 18.3 does not surface the issue.
+
+Confirmed on device that disabling this restores interpreter function.
+---
+ Python/emscripten_trampoline.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Python/emscripten_trampoline.c b/Python/emscripten_trampoline.c
+index e78a94e5e99..a6dbc4637f6 100644
+--- a/Python/emscripten_trampoline.c
++++ b/Python/emscripten_trampoline.c
+@@ -80,6 +80,10 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
+ //     )
+ // )
+ addOnPreRun(() => {
++    let isIOS = /iPad|iPhone|iPod/.test(navigator.platform);
++    if (isIOS) {
++        return;
++    }
+     // Try to initialize countArgsFunc
+     const code = new Uint8Array([
+         0x00, 0x61, 0x73, 0x6d, // \0asm magic number
+-- 
+2.48.1
+


### PR DESCRIPTION
As of iOS 18.3.1, enabling wasm-gc is making the interpreter fail to load. Upstream pull request: python/cpython#130418.

macOS Safari 18.3 does not surface the issue.

Confirmed on device that disabling this restores interpreter function.

Resolves #5428.
