### PR TITLE
Add test for pyodide/pyodide-build#108

### DIFF
--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -538,3 +538,52 @@ def test_cpp_exceptions(selenium, venv):
     print(result.stderr)
     assert result.returncode == 1
     assert "ImportError: oops" in result.stderr
+
+
+@only_node
+def test_pip_install_sys_platform_condition_kept(selenium, venv):
+    """impure Python package built with Pyodide"""
+    result = install_pkg(venv, "regex; sys_platform == 'emscripten'")
+    assert result.returncode == 0
+    assert (
+        clean_pkg_install_stdout(result.stdout)
+        == dedent(
+            """
+            Looking in links: .../dist
+            Processing ./dist/regex-*-cpxxx-cpxxx-pyodide_*_wasm32.whl
+            Installing collected packages: regex
+            Successfully installed regex-*
+            """
+        ).strip()
+    )
+
+    result = subprocess.run(
+        [
+            venv / "bin/python",
+            "-c",
+            dedent(
+                r"""
+                import regex
+                m = regex.match(r"(?:(?P<word>\w+) (?P<digits>\d+)\n)+", "one 1\ntwo 2\nthree 3\n")
+                print(m.capturesdict())
+                """
+            ),
+        ],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert result.returncode == 0
+    assert (
+        result.stdout
+        == "{'word': ['one', 'two', 'three'], 'digits': ['1', '2', '3']}" + "\n"
+    )
+
+
+@only_node
+def test_pip_install_sys_platform_condition_skipped(selenium, venv):
+    """impure Python package built with Pyodide"""
+    result = install_pkg(venv, "regex; sys_platform != 'emscripten'")
+    assert result.returncode == 0
+    ignoring = """Ignoring regex: markers 'sys_platform != "emscripten"' don't match your environment"""
+    assert ignoring in result.stdout


### PR DESCRIPTION
The pyodide venv doesn't evaluate the sys_platform marker correctly with pip >= 25. This adds a test for the fix.

