### PR TITLE
MAINT Don't force pyodide-lock.json in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ $(CPYTHONLIB): emsdk/emsdk/.complete
 	@date +"[%F %T] done building cpython..."
 
 
-dist/pyodide-lock.json: FORCE
+dist/pyodide-lock.json:
 	make pyodide_build
 	@date +"[%F %T] Building packages..."
 	make -C packages


### PR DESCRIPTION
I find this rule quite annoying when developing Pyodide. In particular, any time I type `make` we reinstall `pyodide-build` and make a bunch of pip mess on the console. Then we overwrite `pyodide-lock.json` with some random subset of the packages that I am testing.