### PR TITLE
DOCS Installing pyodide-build from git submodule

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -16,7 +16,7 @@ sphinx-autodoc-typehints>=1.21.7
 sphinx-design>=0.3.0
 pydantic
 # TODO: separate document for pyodide-build?
-pyodide-build>=0.27.3
+-e ../pyodide-build
 # Version should be consistent with packages/micropip/meta.yaml
 micropip==0.7.1
 jinja2>=3.0


### PR DESCRIPTION
Rather than from pypi.