### PR TITLE
Python CLI: Add NODEFLAGS environment variable

### DIFF
--- a/src/templates/python
+++ b/src/templates/python
@@ -43,4 +43,7 @@ fi
 
 RESOLVED_DIR=$(dirname $(realpath "$0"))
 
-exec node "$ARGS" $RESOLVED_DIR/python_cli_entry.mjs --this-program="$($REALPATH "$0")" "$@"
+# Compute our own path, not following symlinks and pass it in so that
+# node_entry.mjs can set sys.executable correctly.
+# Intentionally allow word splitting on $NODEFLAGS.
+exec node $NODEFLAGS "$ARGS" $RESOLVED_DIR/python_cli_entry.mjs --this-program="$($REALPATH "$0")" "$@"


### PR DESCRIPTION
Most frequently I use this to debug with `NODEFLAGS=--inspect-brk`. But it's also helpful for other stuff.
