### PR TITLE
TST Remove pyodide_build usage in test if possible

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,10 +11,10 @@ from collections.abc import Sequence
 
 import pytest
 
-ROOT_PATH = pathlib.Path(__file__).parents[0].resolve()
-DIST_PATH = ROOT_PATH / "dist"
+PYODIDE_ROOT = pathlib.Path(__file__).parents[0].resolve()
+DIST_PATH = PYODIDE_ROOT / "dist"
 
-sys.path.append(str(ROOT_PATH / "src" / "py"))
+sys.path.append(str(PYODIDE_ROOT / "src" / "py"))
 
 # importing this fixture has a side effect of making the safari webdriver reused during the session
 from pytest_pyodide import get_global_config

--- a/packages/_tests/test_packages_common.py
+++ b/packages/_tests/test_packages_common.py
@@ -5,9 +5,9 @@ from typing import Any, TypedDict
 import pytest
 from pyodide_lock import PyodideLockSpec
 
-from conftest import ROOT_PATH
+from conftest import PYODIDE_ROOT
 
-PKG_DIR = ROOT_PATH / "packages"
+PKG_DIR = PYODIDE_ROOT / "packages"
 
 
 UNSUPPORTED_PACKAGES: dict[str, list[str]] = {
@@ -25,7 +25,7 @@ XFAIL_PACKAGES: dict[str, str] = {
     "matplotlib-inline": "circular dependency with IPython",
 }
 
-LOCKFILE_PATH = ROOT_PATH / "dist" / "pyodide-lock.json"
+LOCKFILE_PATH = PYODIDE_ROOT / "dist" / "pyodide-lock.json"
 
 
 class ImportTestCase(TypedDict):

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -9,7 +9,7 @@ from pytest_pyodide.fixture import selenium_common
 from pytest_pyodide.server import spawn_web_server
 from pytest_pyodide.utils import parse_driver_timeout, set_webdriver_script_timeout
 
-from conftest import DIST_PATH, ROOT_PATH
+from conftest import DIST_PATH, PYODIDE_ROOT
 
 
 def get_pyparsing_wheel_name() -> str:
@@ -69,7 +69,7 @@ def test_load_relative_url(
     request, runtime, web_server_main, playwright_browsers, tmp_path
 ):
     url, port, _ = web_server_main
-    test_html = (ROOT_PATH / "src/templates/test.html").read_text()
+    test_html = (PYODIDE_ROOT / "src/templates/test.html").read_text()
     test_html = test_html.replace("./pyodide.js", f"http://{url}:{port}/pyodide.js")
     (tmp_path / "test_temp.html").write_text(test_html)
     pytz_wheel = get_pytz_wheel_name()

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1732,7 +1732,9 @@ def test_static_import(selenium_standalone_noload, tmp_path):
     shutil.move(tmp_path / "pyodide.asm.js", tmp_path / hiding_dir / "pyodide.asm.js")
 
     # make sure the test html references the new directory when importing pyodide.asm.js
-    test_html = (PYODIDE_ROOT / "src/templates/module_static_import_test.html").read_text()
+    test_html = (
+        PYODIDE_ROOT / "src/templates/module_static_import_test.html"
+    ).read_text()
     test_html = test_html.replace("./pyodide.asm.js", f"./{hiding_dir}/pyodide.asm.js")
     (tmp_path / "module_static_import_test.html").write_text(test_html)
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -11,9 +11,8 @@ import pytest
 from pytest_pyodide import run_in_pyodide
 from pytest_pyodide.server import spawn_web_server
 
-from conftest import DIST_PATH, ROOT_PATH, strip_assertions_stderr
+from conftest import DIST_PATH, PYODIDE_ROOT, strip_assertions_stderr
 from pyodide.code import CodeRunner, eval_code, find_imports, should_quiet  # noqa: E402
-from pyodide_build.build_env import get_pyodide_root
 
 
 def test_find_imports():
@@ -1589,7 +1588,7 @@ def test_relative_index_url(selenium, tmp_path):
     tmp_dir = Path(tmp_path)
     subprocess.run(["node", "-v"], encoding="utf8", check=True)
 
-    shutil.copy(ROOT_PATH / "dist/pyodide.js", tmp_dir / "pyodide.js")
+    shutil.copy(PYODIDE_ROOT / "dist/pyodide.js", tmp_dir / "pyodide.js")
 
     result = subprocess.run(
         [
@@ -1605,7 +1604,7 @@ def test_relative_index_url(selenium, tmp_path):
             main();
             """,
         ],
-        cwd=ROOT_PATH,
+        cwd=PYODIDE_ROOT,
         capture_output=True,
         encoding="utf8",
         check=False,
@@ -1625,7 +1624,7 @@ def test_relative_index_url(selenium, tmp_path):
         result.check_returncode()
 
     try:
-        assert result.stdout.strip().split("\n")[-1] == str(ROOT_PATH / "dist") + "/"
+        assert result.stdout.strip().split("\n")[-1] == str(DIST_PATH) + "/"
     finally:
         print_result(result)
 
@@ -1709,7 +1708,7 @@ def test_csp(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     target_path = DIST_PATH / "test_csp.html"
     try:
-        shutil.copy(get_pyodide_root() / "src/templates/test_csp.html", target_path)
+        shutil.copy(PYODIDE_ROOT / "src/templates/test_csp.html", target_path)
         selenium.goto(f"{selenium.base_url}/test_csp.html")
         selenium.javascript_setup()
         selenium.load_pyodide()
@@ -1722,7 +1721,7 @@ def test_static_import(selenium_standalone_noload, tmp_path):
     selenium = selenium_standalone_noload
 
     # copy dist to tmp_path to perform file changes safely
-    shutil.copytree(ROOT_PATH / "dist", tmp_path, dirs_exist_ok=True)
+    shutil.copytree(DIST_PATH, tmp_path, dirs_exist_ok=True)
 
     # define the directory to hide the statically imported pyodide.asm.js in
     hiding_dir = "hide_pyodide_asm_for_test"
@@ -1733,7 +1732,7 @@ def test_static_import(selenium_standalone_noload, tmp_path):
     shutil.move(tmp_path / "pyodide.asm.js", tmp_path / hiding_dir / "pyodide.asm.js")
 
     # make sure the test html references the new directory when importing pyodide.asm.js
-    test_html = (ROOT_PATH / "src/templates/module_static_import_test.html").read_text()
+    test_html = (PYODIDE_ROOT / "src/templates/module_static_import_test.html").read_text()
     test_html = test_html.replace("./pyodide.asm.js", f"./{hiding_dir}/pyodide.asm.js")
     (tmp_path / "module_static_import_test.html").write_text(test_html)
 
@@ -1783,8 +1782,8 @@ def test_python_version(selenium):
 @pytest.mark.skip_pyproxy_check
 def test_custom_python_stdlib_URL(selenium_standalone_noload, runtime):
     selenium = selenium_standalone_noload
-    stdlib_target_path = ROOT_PATH / "dist/python_stdlib2.zip"
-    shutil.copy(ROOT_PATH / "dist/python_stdlib.zip", stdlib_target_path)
+    stdlib_target_path = DIST_PATH / "python_stdlib2.zip"
+    shutil.copy(DIST_PATH / "python_stdlib.zip", stdlib_target_path)
 
     try:
         selenium.run_js(


### PR DESCRIPTION
As discussed in https://github.com/pyodide/pyodide/pull/5479#discussion_r1975262224, remove pyodide_build from core test suites if possible.

I untouched `test_cmdline_runner.py` which we will probably move to pyodide-build later.