### PR TITLE
Bump duckdb to the latest release (1.2.0)

### DIFF
--- a/packages/duckdb/meta.yaml
+++ b/packages/duckdb/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: duckdb
-  version: 1.1.2
+  version: 1.2.0
   # TODO: re-enable once we have a build for abi 2025_0
   _disabled: true
   top-level:
     - duckdb
 source:
-  url: https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-1.1.2-cp312-cp312-pyodide_2024_0_wasm32.whl
-  sha256: aa794366f7acb924ddd1ecb32a349148a3c1343219a7d9d84812d3dcf47a4404
+  url: https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-1.2.0-cp312-cp312-pyodide_2024_0_wasm32.whl
+  sha256: 48ace5ee2bf26d13943e2260c3143ae3eb87c727c268f6020d5424e2fbe6d2ea
 about:
   home: https://github.com/duckdb/duckdb
   PyPI: https://pypi.org/project/duckdb


### PR DESCRIPTION
### Description

This PR bumps the DuckDB package to the latest release, 1.2.0.

### Checklists

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
