### PR TITLE
added python emoji favicon

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -30,6 +30,8 @@ myst:
   versions of Emscripten this would crash but was fixed over a year ago.
   {pr}`5477`
 
+- {{ Enhancement }} Added simple Python emoji (🐍) favicon to `Console` {pr}`5492`
+
 ### Packages
 
 - Upgraded `rateslib` to 1.7.0 {pr}`5400`

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -17,6 +17,10 @@
       href="https://cdn.jsdelivr.net/npm/jquery.terminal@2.35.2/css/jquery.terminal.min.css"
       rel="stylesheet"
     />
+    <link
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐍</text></svg>"
+      rel="icon"
+    />
     <style>
       .terminal {
         --size: 1.5;


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

- Very minor update to add a simple Python emoji (🐍) as the default favicon to the `Console`, currently if the `Console` is deployed standalone it will not have any favicon.



### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
  - Not sure if a CHANGELOG entry was needed for this minor change but I went ahead and added one.
- [x] ~~Add / update tests~~ (N/A)
- [x] ~~Add new / update outdated documentation~~ (N/A)
