### PR TITLE
Disable pygame which was broken by setuptools 76

### DIFF
--- a/packages/pygame-ce/meta.yaml
+++ b/packages/pygame-ce/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pygame-ce
   version: 2.4.1
+  # Broken by setuptools 76 release, requirements.constraint doesn't fix it
+  _disabled: true
   top-level:
     - pygame
 source:


### PR DESCRIPTION
Adding `requirements.constraint: - setuptools < 76` doesn't help.
