### PR TITLE
Fix pygame-ce

### DIFF
--- a/packages/pygame-ce/meta.yaml
+++ b/packages/pygame-ce/meta.yaml
@@ -1,8 +1,6 @@
 package:
   name: pygame-ce
   version: 2.4.1
-  # Broken by setuptools 76 release, requirements.constraint doesn't fix it
-  _disabled: true
   top-level:
     - pygame
 source:
@@ -12,6 +10,9 @@ source:
     - patches/0001-Replace-OpenAudioDevice-with-OpenAudio.patch
     - patches/0001-freetype-init.patch
     - patches/0001-wasm_unify_pygame_web_pyodide_static_Freetype_init.patch
+requirements:
+  constraint:
+    - setuptools < 75
 build:
   script: |
     embuilder build sdl2 sdl2_ttf sdl2_image sdl2_mixer sdl2_gfx libjpeg libpng giflib harfbuzz vorbis mpg123 libmodplug freetype libhtml5 --pic

--- a/packages/rpds-py/meta.yaml
+++ b/packages/rpds-py/meta.yaml
@@ -11,8 +11,6 @@ source:
 requirements:
   executable:
     - rustup
-  constraint:
-    - maturin < 1.8
 about:
   home: https://rpds.readthedocs.io
   PyPI: https://pypi.org/project/rpds-py

--- a/packages/xarray/meta.yaml
+++ b/packages/xarray/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: xarray
-  version: 2025.01.2
+  version: 2025.1.2
 
   top-level:
     - xarray


### PR DESCRIPTION
It doesn't work with setuptools >= 75.

We need the changes from
https://github.com/pyodide/pyodide-build/pull/135

Otherwise build system deps don't have the constraints correctly applied to them.
