### PR TITLE
Updated python-sat to version 1.8.dev16.

### DIFF
--- a/packages/python-sat/meta.yaml
+++ b/packages/python-sat/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python-sat
-  version: 1.8.dev14
+  version: 1.8.dev16
   top-level:
     - pysat
 source:
-  sha256: bbec9e329f2fc5b19b1517a9476b632dc1df39a755b29ddb805b78fad5f5d722
-  url: https://files.pythonhosted.org/packages/3e/44/92239f998dca4bff108e1feb824c53bbba6c9f87c6d3625268c3887cb302/python_sat-1.8.dev14.tar.gz
+  sha256: df4752cf290a551aff52f07da3bd8c827f51b286f11e29e67832bb4fffc0e32b
+  url: https://files.pythonhosted.org/packages/f9/35/7ebe9e31e97b3a2b7efaab800bb8a44f1a6179c392f77abf5ce4a0038dd6/python-sat-1.8.dev16.tar.gz
 
   patches:
     - patches/force_malloc.patch

--- a/packages/python-sat/patches/force_malloc.patch
+++ b/packages/python-sat/patches/force_malloc.patch
@@ -8,12 +8,12 @@ index c4d2ead..a0a30db 100644
  #include <stdio.h>
 +#include <stdlib.h>
  #include <Python.h>
- 
+
  #include "card.hh"
 @@ -122,8 +123,14 @@ static struct PyModuleDef module_def = {
  	NULL,              /* m_free */
  };
- 
+
 +static volatile int *_dummy_malloc;
 +
  PyMODINIT_FUNC PyInit_pycard(void)
@@ -23,7 +23,7 @@ index c4d2ead..a0a30db 100644
 +	free((void *)_dummy_malloc);
 +
  	PyObject *m = PyModule_Create(&module_def);
- 
+
  	if (m == NULL)
 diff --git a/solvers/pysolvers.cc b/solvers/pysolvers.cc
 index c2ef77d..67a3303 100644
@@ -35,12 +35,12 @@ index c2ef77d..67a3303 100644
  #include <stdio.h>
 +#include <stdlib.h>
  #include <vector>
- 
+
  #ifdef WITH_CADICAL103
-@@ -848,8 +849,14 @@ static struct PyModuleDef module_def = {
+@@ -871,8 +872,14 @@ static struct PyModuleDef module_def = {
  	NULL,              /* m_free */
  };
- 
+
 +static volatile int *_dummy_malloc;
 +
  PyMODINIT_FUNC PyInit_pysolvers(void)
@@ -50,5 +50,5 @@ index c2ef77d..67a3303 100644
 +	free((void *)_dummy_malloc);
 +
  	PyObject *m = PyModule_Create(&module_def);
- 
+
  	if (m == NULL)


### PR DESCRIPTION
The PR updates `python-sat` to version `1.8.dev16`. This update fixes arbitrary formula classification when it contains constants. It also brings a way to customise and use randomness features of Glucose 4.2.1.