### PR TITLE
use `this.logStdout` not `console.log` in `load-package.ts`

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -34,6 +34,7 @@ myst:
 
 - {{ Enhancement }} Added simple Python emoji (🐍) favicon to `Console` {pr}`5492`
 - {{ Fix }} Replaced uses of the deprecated `File.lastModifiedDate` property. {pr}`5426`
+- {{ Fix }} Correct use of `console.log` to `this.logStdout` in `load-package.ts` {pr}`5514`
 
 ### Packages
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -426,13 +426,13 @@ export class PackageManager {
         throw e;
       }
     }
-    console.log(
+    this.logStdout(
       `Didn't find package ${fileName} locally, attempting to load from ${this.cdnURL}`,
     );
     // If we are IN_NODE, download the package from the cdn, then stash it into
     // the node_modules directory for future use.
     let binary = await loadBinaryFile(this.cdnURL + fileName);
-    console.log(
+    this.logStdout(
       `Package ${fileName} loaded from ${this.cdnURL}, caching the wheel in node_modules for future use.`,
     );
     await nodeFsPromisesMod.writeFile(uri, binary);


### PR DESCRIPTION
### Description

Related to https://github.com/pyodide/pyodide/discussions/5512, discovered while working on https://github.com/pydantic/pydantic-ai/pull/1140.

This code was using `console.log` meaning that customising `this.stdout` was having no effect.

### Checklists

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
