### PR TITLE
Patch `statsmodels.datasets.get_rdataset` network access

### DIFF
--- a/packages/statsmodels/meta.yaml
+++ b/packages/statsmodels/meta.yaml
@@ -6,6 +6,8 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/1f/3b/963a015dd8ea17e10c7b0e2f14d7c4daec903baf60a017e756b57953a4bf/statsmodels-0.14.4.tar.gz
   sha256: 5d69e0f39060dc72c067f9bb6e8033b6dccdb0bae101d76a7ef0bcc94e898b67
+  patches:
+    - packages/statsmodels/patches/0001-Patch-get_rdataset-network-access.patch
 
 build:
   ldflags: |
@@ -23,6 +25,7 @@ requirements:
     - pandas
     - patsy
     - packaging
+    - pyodide-http
 
 test:
   imports:

--- a/packages/statsmodels/patches/0001-Patch-get_rdataset-network-access.patch
+++ b/packages/statsmodels/patches/0001-Patch-get_rdataset-network-access.patch
@@ -1,0 +1,59 @@
+From 4cf745c5daf0b926e3228a4bfa3798668539f9c9 Mon Sep 17 00:00:00 2001
+From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
+Date: Mon, 17 Mar 2025 19:41:50 +0530
+Subject: [PATCH] Patch get_rdataset network access
+
+---
+ pyproject.toml                |  3 ++-
+ statsmodels/datasets/utils.py | 15 +++++++++++++++
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index a00dd1c34..f7873296f 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,7 +6,8 @@ requires = [
+     "cython>=3.0.10,<4",  # Sync with CYTHON_MIN_VER in setup
+     "numpy>=2.0.0,<3",
+     "scipy>=1.13,<2",
+-    "setuptools_scm[toml]>=8,<9"
++    "setuptools_scm[toml]>=8,<9",
++    "pyodide-http"
+ ]
+ build-backend = "setuptools.build_meta"
+ 
+diff --git a/statsmodels/datasets/utils.py b/statsmodels/datasets/utils.py
+index 09972f7ea..2f7291ad4 100644
+--- a/statsmodels/datasets/utils.py
++++ b/statsmodels/datasets/utils.py
+@@ -130,12 +130,27 @@ def _open_cache(cache_path):
+         return zlib.decompress(zf.read())
+ 
+ 
++def _is_jupyterlite() -> bool:
++    try:
++        import pyodide_kernel
++    except (ImportError, ModuleNotFoundError):
++        return False
++    return True
++
++
+ def _urlopen_cached(url, cache):
+     """
+     Tries to load data from cache location otherwise downloads it. If it
+     downloads the data and cache is not None then it will put the downloaded
+     data in the cache path.
+     """
++
++    # if we are in a jupyterlite environment, we will want
++    # to patch urllib, requests, etc. for usage in Pyodide
++    if _is_jupyterlite():
++        import pyodide_http
++        pyodide_http.patch_all()
++
+     from_cache = False
+     if cache is not None:
+         file_name = url.split("://")[-1].replace('/', ',')
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

[`statsmodels` calls `urllib.request.urlopen`](https://github.com/statsmodels/statsmodels/blob/3082d8469cdd39e28cacf20681692620d7e670af/statsmodels/datasets/utils.py#L160) to fetch datasets in CSV/JSON/etc. via [`statsmodels.datasets.get_rdataset`](https://www.statsmodels.org/stable/datasets/statsmodels.datasets.get_rdataset.html). from raw GitHub URLs; it won't work without patching `urllib`. This PR makes `pyodide-http` a dependency for the package so that we can use `statsmodels.datasets.get_rdataset` rather than having to install `pyodide-http` and running it explicitly. This benefits https://github.com/statsmodels/statsmodels/pull/9536, as a reasonable bunch of user-facing interactive API examples rely on such networking functionality and won't work without it. However, I don't think it is reasonable to upstream this patch; otherwise, it adds another dependency for the package that isn't useful on conventional platforms.

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

N/A
