### PR TITLE
Update pyo3 in rust-abi-test and rust-panic-test

### DIFF
--- a/packages/rust-abi-test/src/Cargo.toml
+++ b/packages/rust-abi-test/src/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-pyo3 = { version = "0.22.3" }
+pyo3 = { version = "0.24.0" }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/packages/rust-panic-test/src/Cargo.toml
+++ b/packages/rust-panic-test/src/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-pyo3 = { version = "0.20.2" }
+pyo3 = { version = "0.24.0" }
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/packages/rust-panic-test/src/src/lib.rs
+++ b/packages/rust-panic-test/src/src/lib.rs
@@ -1,6 +1,6 @@
+use pyo3::prelude::*;
 
-
-#[pyo3::prelude::pyfunction]
+#[pyfunction]
 fn panic_test(data: &[u8]) -> bool {
     if data[0] < 6 {
         panic!("this is a {} {message:?}", "fancy", message = data);
@@ -10,9 +10,9 @@ fn panic_test(data: &[u8]) -> bool {
 
 
 
-#[pyo3::prelude::pymodule]
-fn rust_panic_test(py: pyo3::Python<'_>, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> {
+#[pymodule]
+fn rust_panic_test(m: &Bound<'_, PyModule>) -> pyo3::PyResult<()> {
     m.add_function(pyo3::wrap_pyfunction!(panic_test, m)?)?;
-    m.add("PanicException", py.get_type::<pyo3::panic::PanicException>())?;
+    m.add("PanicException", m.py().get_type::<pyo3::panic::PanicException>())?;
     Ok(())
 }


### PR DESCRIPTION
Necessary for Python 3.13 support. Split from
https://github.com/pyodide/pyodide/pull/5498