### PR TITLE
Update to zar 3.0.5

### DIFF
--- a/packages/zarr/meta.yaml
+++ b/packages/zarr/meta.yaml
@@ -1,18 +1,22 @@
 package:
   name: zarr
-  version: 2.18.3
-  # zarr 3.x uses threading
-  pinned: true
+  version: 3.0.5
   top-level:
     - zarr
 source:
-  sha256: 2580d8cb6dd84621771a10d31c4d777dca8a27706a1a89b29f42d2d37e2df5ce
-  url: https://files.pythonhosted.org/packages/23/c4/187a21ce7cf7c8f00c060dd0e04c2a81139bb7b1ab178bba83f2e1134ce2/zarr-2.18.3.tar.gz
+  sha256: 4ac0a09d66875d398ab53c95fd4bddca2f3d757a04454831fc2d54bfbafcb7e5
+  url: https://files.pythonhosted.org/packages/source/z/zarr/zarr-3.0.5.tar.gz
+  patches:
+    - patches/0001-Don-t-use-threads.patch
 requirements:
   run:
     - numpy
     - asciitree
     - numcodecs
+    - typing-extensions
+    - donfig
+    - crc32c
+    - packaging
 about:
   home: https://github.com/zarr-developers/zarr-python
   PyPI: https://pypi.org/project/zarr

--- a/packages/zarr/patches/0001-Don-t-use-threads.patch
+++ b/packages/zarr/patches/0001-Don-t-use-threads.patch
@@ -1,0 +1,27 @@
+From 4ab762ea0371e99661153cadb8d7449478c506e2 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Mon, 17 Mar 2025 17:48:25 +0100
+Subject: [PATCH] Don't use threads
+
+---
+ src/zarr/core/sync.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/zarr/core/sync.py b/src/zarr/core/sync.py
+index d9b4839e..1ceb0ed3 100644
+--- a/src/zarr/core/sync.py
++++ b/src/zarr/core/sync.py
+@@ -133,6 +133,10 @@ def sync(
+     --------
+     >>> sync(async_function(), existing_loop)
+     """
++    from pyodide.ffi import run_sync
++
++    return run_sync(coro)
++
+     if loop is None:
+         # NB: if the loop is not running *yet*, it is OK to submit work
+         # and we will wait for it
+-- 
+2.34.1
+

--- a/packages/zarr/test_zarr.py
+++ b/packages/zarr/test_zarr.py
@@ -20,9 +20,3 @@ def test_zarr(selenium):
     zarr.save("/tmp/example.zarr", a1)
     a2 = zarr.load("/tmp/example.zarr")
     np.testing.assert_equal(a1, a2)
-
-    # test compressor
-    compressor = Blosc(cname="zstd", clevel=3, shuffle=Blosc.BITSHUFFLE)
-    data = np.arange(10000, dtype="i4").reshape(100, 100)
-    z = zarr.array(data, chunks=(10, 10), compressor=compressor)
-    assert z.compressor == compressor

--- a/packages/zarr/test_zarr.py
+++ b/packages/zarr/test_zarr.py
@@ -5,7 +5,6 @@ from pytest_pyodide import run_in_pyodide
 def test_zarr(selenium):
     import numpy as np
     import zarr
-    from numcodecs import Blosc
 
     # basic test
     z = zarr.zeros((1000, 1000), chunks=(100, 100), dtype="i4")


### PR DESCRIPTION
Needed for Python 3.13 support, but it seems to be more async than previous versions, which is troublesome while JSPI is still not available in most runtimes.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
