### PR TITLE
TST Stop generating fiona-tests manually

### DIFF
--- a/packages/fiona/meta.yaml
+++ b/packages/fiona/meta.yaml
@@ -33,15 +33,9 @@ build:
     echo ${GDAL_CONFIG}
     echo ${GDAL_DATA}
     echo ${PROJ_LIB}
-    rm tests/test_fio* # CLI tests
-    rm tests/test_data_paths.py # CLI tests
-    rm tests/test_datetime.py # CLI tests
-    rm tests/test_vfs.py # No module named "boto3"
-    rm tests/test_env.py # No module named "boto3"
 
 about:
   home: http://github.com/Toblerity/Fiona
   PyPI: https://pypi.org/project/fiona
   summary: Fiona reads and writes spatial data files
   license: BSD-3-Clause
-# Note: this package needs to be manually upgraded to the next version

--- a/packages/fiona/meta.yaml
+++ b/packages/fiona/meta.yaml
@@ -39,10 +39,6 @@ build:
     rm tests/test_vfs.py # No module named "boto3"
     rm tests/test_env.py # No module named "boto3"
 
-    mkdir fiona-tests
-    mv tests fiona-tests
-    tar -cf ${DISTDIR}/fiona-tests.tar fiona-tests
-
 about:
   home: http://github.com/Toblerity/Fiona
   PyPI: https://pypi.org/project/fiona

--- a/packages/fiona/test_fiona.py
+++ b/packages/fiona/test_fiona.py
@@ -13,6 +13,7 @@ def test_supported_drivers(selenium):
 @run_in_pyodide(packages=["fiona"])
 def test_geometry_collection_round_trip(selenium):
     from fiona._geometry import geometryRT
+
     geom = {
         "type": "GeometryCollection",
         "geometries": [

--- a/packages/fiona/test_fiona.py
+++ b/packages/fiona/test_fiona.py
@@ -10,37 +10,17 @@ def test_supported_drivers(selenium):
     assert fiona.driver_count() > 0
 
 
-@pytest.mark.driver_timeout(60)
-@run_in_pyodide(packages=["fiona-tests", "pytest"])
-def test_fiona(selenium_standalone):
-    import site
-    import sys
+@run_in_pyodide(packages=["fiona"])
+def test_geometry_collection_round_trip(selenium):
+    from fiona._geometry import geometryRT
+    geom = {
+        "type": "GeometryCollection",
+        "geometries": [
+            {"type": "Point", "coordinates": (0.0, 0.0)},
+            {"type": "LineString", "coordinates": [(0.0, 0.0), (1.0, 1.0)]},
+        ],
+    }
 
-    import pytest
-
-    sys.path.append(site.getsitepackages()[0] + "/fiona-tests")
-
-    def runtest(test_filter):
-        ret = pytest.main(
-            [
-                "--pyargs",
-                "tests",
-                "--continue-on-collection-errors",
-                # "-v",
-                "-k",
-                test_filter,
-            ]
-        )
-        assert ret == 0
-
-    runtest(
-        " not ordering "  # hangs
-        " and not env "  # No module named "boto3"
-        " and not slice "  # GML file format not supported
-        " and not GML "  # GML file format not supported
-        " and not TestNonCountingLayer "  # GPX file format not supported
-        " and not test_schema_default_fields_wrong_type "  # GPX file format not supported
-        " and not http "
-        " and not FlatGeobuf"  # assertion error
-        " and not esri_only_wkt"  # format not supported
-    )
+    result = geometryRT(geom)
+    assert len(result["geometries"]) == 2
+    assert [g["type"] for g in result["geometries"]] == ["Point", "LineString"]


### PR DESCRIPTION
### Description

Stops generating Fiona test suites manually in the recipe. We don't want to test all of its features in our CI (actually, it was [my fault](https://github.com/pyodide/pyodide/pull/3213)).

This is required for https://github.com/pyodide/pyodide-build/pull/116.
