### PR TITLE
Add python_cli_entry.mjs to the xbuildenv

### DIFF
--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -519,6 +519,29 @@ def test_package_index(tmp_path):
     )
 
 
+def test_xbuildenv_runner_works(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            pyodide_root / "tools" / "create_xbuildenv.py",
+            tmp_path,
+            "--skip-missing-files",
+        ],
+        check=False,
+    )
+    assert result.returncode == 0
+
+    xbuildenv_python = tmp_path / "xbuildenv/pyodide-root/dist/python"
+    result = subprocess.run(
+        [xbuildenv_python, "-c", "print('hello!')"],
+        text=True,
+        check=False,
+        capture_output=True,
+    )
+    assert result.returncode == 0
+    assert result.stdout == "hello!\n"
+
+
 def test_sys_exit(selenium, venv):
     result = subprocess.run(
         [venv / "bin/python", "-c", "import sys; sys.exit(0)"],

--- a/tools/create_xbuildenv.py
+++ b/tools/create_xbuildenv.py
@@ -60,6 +60,7 @@ def _copy_wasm_libs(
         Path("Makefile.envs"),
         Path("dist/pyodide-lock.json"),
         Path("dist/python"),
+        Path("dist/python_cli_entry.mjs"),
         Path("dist/python_stdlib.zip"),
         Path("tools/constraints.txt"),
     ]


### PR DESCRIPTION
@ryanking13 should we be doing some basic validity checks on the nightly xbuildenvs? Or in CI?

Resolves #5532.