### PR TITLE
DOCS Improve the `Getting Stated` section of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,18 @@ your browser. For further information, see the
 
 ## Getting Started
 
-Pyodide offers three different ways to get started depending on your needs and
-technical resources. These include:
-
-- Use a hosted distribution of Pyodide: see the [Getting
+- If you wish to use a hosted distribution of Pyodide: see the [Getting
   Started](https://pyodide.org/en/stable/usage/quickstart.html) documentation.
-- Download a version of Pyodide from the [releases
-  page](https://github.com/pyodide/pyodide/releases/) and serve it
-  with a web server.
-- [Build Pyodide from source](https://pyodide.org/en/stable/development/building-from-sources.html)
-  - Build natively with `make`: primarily for Linux users who want to
-    experiment or contribute back to the project.
-  - [Use a Docker image](https://pyodide.org/en/stable/development/building-from-sources.html#using-docker):
-    recommended for Windows and macOS users and for Linux users who prefer a
-    Debian-based Docker image with the dependencies already installed.
+- If you wish to host Pyodide yourself, you can download Pyodide from the [releases
+  page](https://github.com/pyodide/pyodide/releases/) and serve it with a web server.
+- If you wish to use Pyodide with a bundler, see [the documentation on Working with
+  Bundlers](https://pyodide.org/en/stable/usage/working-with-bundlers.html)
+- If you are a Python package maintainer, see [the documentation on building and testing Python
+  packages](https://pyodide.org/en/stable/development/building-and-testing-packages.html).
+- If you want to add a package to the Pyodide distribution, [see the documentation on adding
+  a package to the Pyodide distribution](https://pyodide.org/en/stable/development/new-packages.html)
+- If you wish to experiment or contribute back to the Pyodide runtime, see the documentation on
+  [building Pyodide from source](https://pyodide.org/en/stable/development/building-from-sources.html)
 
 ## History
 

--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -1,6 +1,6 @@
-(building_from_sources)=
+(building_from_source)=
 
-# Building from sources
+# Building from source
 
 ```{warning}
 If you are building the latest development version of Pyodide from the `main`

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -55,7 +55,7 @@ To contribute code, see the following steps,
 
    This will run a set of linters for each commit.
 
-7. Follow {ref}`building_from_sources` instructions.
+7. Follow {ref}`building_from_source` instructions.
 
 8. See {ref}`testing` documentation.
 

--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -1,12 +1,12 @@
 (new-packages)=
 
-# Creating a Pyodide package
+# Adding a package to the Pyodide Distribution
 
 It is recommended to look into how other similar packages are built in Pyodide.
 If you encounter difficulties in building your package after trying the steps
 listed here, open a [new Pyodide issue](https://github.com/pyodide/pyodide/issues).
 
-## Determining if creating a Pyodide package is necessary
+## Determining if adding a package is necessary
 
 If you wish to use a package in Pyodide that is not already included in the
 [`packages` folder](https://github.com/pyodide/pyodide/tree/main/packages), first you

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,22 @@ Try Pyodide in a
 `REPL <./console.html>`_ directly in
 your browser (no installation needed).
 
+Where should I go?
+------------------
+
+- If you wish to use a hosted distribution of Pyodide: see the :ref:`quickstart`
+  documentation.
+- If you wish to host Pyodide yourself, you can download Pyodide from the `releases
+  page <https://github.com/pyodide/pyodide/releases/>`_ and serve it with a web server.
+- If you wish to use Pyodide with a bundler, see the documentation on
+  :ref:`working-with-bundlers`.
+- If you are a Python package maintainer, see the documentation
+  :ref:`building-and-testing-packages-out-of-tree`.
+- If you want to add a package to the Pyodide distribution, see the documentation on :ref:`new-packages`.
+- If you wish to experiment or contribute back to the Pyodide runtime, see the documentation on
+  :ref:`building_from_source`.
+
+
 
 Table of contents
 -----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,8 +31,8 @@ Try Pyodide in a
 `REPL <./console.html>`_ directly in
 your browser (no installation needed).
 
-Where should I go?
-------------------
+What should I look at first?
+----------------------------
 
 - If you wish to use a hosted distribution of Pyodide: see the :ref:`quickstart`
   documentation.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -35,8 +35,10 @@ application.
 
 ```{note}
 To avoid confusion, note that:
- - `cdn.jsdelivr.net/pyodide/` distributes Python packages built with Pyodide as well as `pyodide.js`
- - `cdn.jsdelivr.net/npm/pyodide@0.19.0/` is a mirror of the Pyodide NPM package, which includes none of the WASM files
+ - `cdn.jsdelivr.net/pyodide/` distributes Python packages built with Pyodide as well
+    as `pyodide.js`
+ - `cdn.jsdelivr.net/npm/pyodide@0.19.0/` is a mirror of the Pyodide NPM package which
+    includes only the Pyodide runtime, not any of the wheels.
 ```
 
 ### Supported browsers
@@ -60,11 +62,13 @@ so we recommend using a browser version at least equal to or higher than these.
 By default, WebAssembly runs in the main browser thread, and it can make UI
 non-responsive for long-running computations.
 
-To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker <using_from_webworker>`.
+To avoid this situation, one solution is to run {ref}`Pyodide in a WebWorker
+<using_from_webworker>`.
 
 It's also possible to run {ref}`Pyodide in a Service Worker <using_from_service_worker>`.
 
-If you're not sure whether you need web workers or service workers, here's an [overview and comparison of the two](https://web.dev/workers-overview/).
+If you're not sure whether you need web workers or service workers, here's an [overview and
+comparison of the two](https://web.dev/workers-overview/).
 
 ## Node.js
 
@@ -73,40 +77,30 @@ Starting with Pyodide 0.25.0, Node.js < 18 is no longer officially supported.
 Older versions of Node.js might still work, but they are not tested or guaranteed to work.
 ```
 
-```{note}
-The following instructions have been tested with Node.js 18.5.0. To use
-Pyodide with older versions of Node, you might need to use  additional command line
-arguments, see below.
-```
-
-It is now possible to install the
-[Pyodide npm package](https://www.npmjs.com/package/pyodide) in Node.js. To
-follow these instructions you need at least Pyodide 0.21.0.
-You can explicitly ask npm to use
-the alpha version:
+It is possible to install the [Pyodide npm package](https://www.npmjs.com/package/pyodide) in
+Node.js.
 
 ```
-$ npm install "pyodide@>=0.21.0-alpha.2"
+$ npm install pyodide
 ```
 
 Once installed, you can run the following simple script:
 
 ```js
-// hello_python.js
-const { loadPyodide } = require("pyodide");
+// hello_python.mjs
+import { loadPyodide } from "pyodide";
 
 async function hello_python() {
   let pyodide = await loadPyodide();
   return pyodide.runPythonAsync("1+1");
 }
 
-hello_python().then((result) => {
-  console.log("Python says that 1+1 =", result);
-});
+const result = await hello_python();
+console.log("Python says that 1+1 =", result);
 ```
 
 ```
-$ node hello_python.js
+$ node hello_python.mjs
 Python says that 1+1= 2
 ```
 
@@ -117,7 +111,7 @@ await, use `node --experimental-repl-await`:
 $ node --experimental-repl-await
 Welcome to Node.js v18.5.0.
 Type ".help" for more information.
-> const { loadPyodide } = require("pyodide");
+> const { loadPyodide } = await import("pyodide");
 undefined
 > let pyodide = await loadPyodide();
 undefined


### PR DESCRIPTION
We didn't suggest anything for package maintainers, for people who want to use bundlers, or for people who want to use it in node. This provides some more suggestions for first links for people to look at depending on their needs.
