### PR TITLE
Rename FS interface to FSType

### DIFF
--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -7,7 +7,7 @@ import { loadBinaryFile, nodeFSMod } from "./compat";
 import { version } from "./version";
 import { setStdin, setStdout, setStderr } from "./streams";
 import { scheduleCallback } from "./scheduler";
-import { TypedArray, PackageData, type FS } from "./types";
+import { TypedArray, PackageData, FSType } from "./types";
 import { IN_NODE, detectEnvironment } from "./environments";
 // @ts-ignore
 import LiteralMap from "./common/literal-map";
@@ -151,7 +151,7 @@ export class PyodideAPI {
    * are available as members of ``FS.filesystems``:
    * ``IDBFS``, ``NODEFS``, ``PROXYFS``, ``WORKERFS``.
    */
-  static FS = {} as FS;
+  static FS = {} as FSType;
   /**
    * An alias to the `Emscripten Path API
    * <https://github.com/emscripten-core/emscripten/blob/main/src/library_path.js>`_.

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -41,9 +41,9 @@
   "main": "pyodide.js",
   "exports": {
     ".": {
+      "types": "./pyodide.d.ts",
       "require": "./pyodide.js",
-      "import": "./pyodide.mjs",
-      "types": "./pyodide.d.ts"
+      "import": "./pyodide.mjs"
     },
     "./ffi": {
       "types": "./ffi.d.ts"

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -13,7 +13,7 @@ import { createSettings } from "./emscripten-settings";
 import { version } from "./version";
 
 import type { PyodideInterface } from "./api.js";
-import type { TypedArray, Module, PackageData } from "./types";
+import type { TypedArray, Module, PackageData, FSType } from "./types";
 import type { EmscriptenSettings } from "./emscripten-settings";
 import type { SnapshotConfig } from "./snapshot";
 export type { PyodideInterface, TypedArray };

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -29,7 +29,7 @@ declare global {
 declare global {
   export const stringToNewUTF8: (str: string) => number;
   export const UTF8ToString: (ptr: number) => string;
-  export const FS: FS;
+  export const FS: FSType;
   export const stackAlloc: (sz: number) => number;
   export const stackSave: () => number;
   export const stackRestore: (ptr: number) => void;
@@ -212,11 +212,9 @@ export type FSStreamOpsGen<T> = {
 };
 
 /**
- * TODO: Consider renaming the type to FSType to avoid collisions between FS and
- * FSType.
  * @hidden
  */
-export interface FS {
+export interface FSType {
   unlink: (path: string) => void;
   mkdirTree: (path: string, mode?: number) => void;
   chdir: (path: string) => void;
@@ -300,7 +298,7 @@ export interface Module {
   ENV: { [key: string]: string };
   PATH: any;
   TTY: any;
-  FS: FS;
+  FS: FSType;
   LDSO: LDSO;
   canvas?: HTMLCanvasElement;
   addRunDependency(id: string): void;
@@ -536,5 +534,5 @@ export type PackageManagerModule = Pick<
   Module,
   "reportUndefinedSymbols" | "PATH" | "loadDynamicLibrary" | "LDSO"
 > & {
-  FS: Pick<FS, "readdir" | "lookupPath" | "isDir" | "findObject" | "readFile">;
+  FS: Pick<FSType, "readdir" | "lookupPath" | "isDir" | "findObject" | "readFile">;
 };

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -534,5 +534,8 @@ export type PackageManagerModule = Pick<
   Module,
   "reportUndefinedSymbols" | "PATH" | "loadDynamicLibrary" | "LDSO"
 > & {
-  FS: Pick<FSType, "readdir" | "lookupPath" | "isDir" | "findObject" | "readFile">;
+  FS: Pick<
+    FSType,
+    "readdir" | "lookupPath" | "isDir" | "findObject" | "readFile"
+  >;
 };


### PR DESCRIPTION
To avoid name conflicts. Listed as a TODO in a comment.