### PR TITLE
test_xbuildenv_runner_works requires Pyodide to be built first

### DIFF
--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -519,7 +519,8 @@ def test_package_index(tmp_path):
     )
 
 
-def test_xbuildenv_runner_works(tmp_path):
+@only_node
+def test_xbuildenv_runner_works(selenium, tmp_path):
     result = subprocess.run(
         [
             sys.executable,
@@ -527,6 +528,7 @@ def test_xbuildenv_runner_works(tmp_path):
             tmp_path,
             "--skip-missing-files",
         ],
+        text=True,
         check=False,
     )
     assert result.returncode == 0
@@ -542,6 +544,7 @@ def test_xbuildenv_runner_works(tmp_path):
     assert result.stdout == "hello!\n"
 
 
+@only_node
 def test_sys_exit(selenium, venv):
     result = subprocess.run(
         [venv / "bin/python", "-c", "import sys; sys.exit(0)"],
@@ -563,6 +566,7 @@ def test_sys_exit(selenium, venv):
     assert result.stderr == ""
 
 
+@only_node
 def test_cpp_exceptions(selenium, venv):
     result = install_pkg(venv, "cpp-exceptions-test2")
     print(result.stdout)


### PR DESCRIPTION
Adds the `selenium` fixture to `test_xbuildenv_runner_works` so that it isn't until pyodide is built
