### PR TITLE
Remove test for `pyodide venv` failure when venv already exists

### DIFF
--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -222,25 +222,6 @@ def test_venv_success_log(selenium, capsys):
 
 
 @only_node
-@needs_emscripten
-def test_venv_fail_log(selenium, capsys):
-    path = Path(".venv-pyodide-tmp-test")
-    try:
-        path.mkdir()
-        with pytest.raises(SystemExit, match="1"):
-            with venv_ctxmgr(path):
-                pass
-    finally:
-        shutil.rmtree(path, ignore_errors=True)
-    msg = dedent("Creating Pyodide virtualenv at .venv-pyodide-tmp-test")
-    captured = capsys.readouterr()
-    assert captured.out.strip() == msg
-    assert (
-        "ERROR: dest directory '.venv-pyodide-tmp-test' already exists" in captured.err
-    )
-
-
-@only_node
 def test_venv_version(selenium, venv):
     result = subprocess.run(
         [venv / "bin/python", "--version"],


### PR DESCRIPTION
@agriyakhetarpal  tells me that this is a nonstandard behavior.
