### PR TITLE
FFI: Make sure we can call js callables that don't inherit from function

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -27,6 +27,10 @@ myst:
   {pr}`5320`
 - {{ Enhancement }} Upgrade to Python 3.13.1. {pr}`5498`
 
+- {{ Fix }} It's now possible to call JavaScript callables that do not inherit
+  from `Function` from the JS FFI.
+  {pr}`5555`
+
 ### `python` CLI entrypoint
 
 - {{ Fix }} The `python` CLI now mounts the `/tmp` directory. In

--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -339,11 +339,11 @@ EM_JS_BOOL(bool, JsvFunction_Check, (JsVal obj), {
 });
 
 EM_JS_VAL(JsVal, JsvFunction_CallBound, (JsVal func, JsVal this_, JsVal args), {
-  return nullToUndefined(func.apply(this_, args));
+  return nullToUndefined(Function.prototype.apply.apply(func, [this_, args]));
 });
 
 EM_JS_VAL(JsVal, JsvFunction_Call_OneArg, (JsVal func, JsVal arg), {
-  return nullToUndefined(func.apply(null, [arg]));
+  return nullToUndefined(func(arg));
 });
 
 // clang-format off

--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -339,7 +339,7 @@ EM_JS_BOOL(bool, JsvFunction_Check, (JsVal obj), {
 });
 
 EM_JS_VAL(JsVal, JsvFunction_CallBound, (JsVal func, JsVal this_, JsVal args), {
-  return nullToUndefined(Function.prototype.apply.apply(func, [this_, args]));
+  return nullToUndefined(Function.prototype.apply.apply(func, [ this_, args ]));
 });
 
 EM_JS_VAL(JsVal, JsvFunction_Call_OneArg, (JsVal func, JsVal arg), {

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -2025,3 +2025,22 @@ def test_to_js_no_leak(selenium):
 
     d = {"key": Object()}
     to_js(d)
+
+
+@run_in_pyodide
+def test_js_callable_not_function(selenium):
+    from pyodide.code import run_js
+    import js
+
+    o = run_js(
+        """
+        function nonFuncCallable (...params) {
+            console.log(this);
+            return [this, ...params]
+        }
+        Object.setPrototypeOf(nonFuncCallable, {})
+        const o = {nonFuncCallable};
+        o
+        """
+    )
+    assert list(o.nonFuncCallable(1, 2, 3)) == [o, 1, 2, 3]

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -2030,7 +2030,6 @@ def test_to_js_no_leak(selenium):
 @run_in_pyodide
 def test_js_callable_not_function(selenium):
     from pyodide.code import run_js
-    import js
 
     o = run_js(
         """


### PR DESCRIPTION
Another weird edgecase. Useful for cloudflare because its rpc objects are non function callables.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
