### PR TITLE
MAINT: Use suffix with #embed for better compiler performance

### DIFF
--- a/src/core/pyodide_pre.c
+++ b/src/core/pyodide_pre.c
@@ -3,8 +3,7 @@
 __attribute__((used))
 __attribute__((section("em_js"),
                aligned(1))) char __em_js__pyodide_js_init[] = {
-#embed "pyodide_pre.gen.dat" \
-	suffix(, 0)
+#embed "pyodide_pre.gen.dat" suffix(, 0)
 };
 
 void

--- a/src/core/pyodide_pre.c
+++ b/src/core/pyodide_pre.c
@@ -3,9 +3,8 @@
 __attribute__((used))
 __attribute__((section("em_js"),
                aligned(1))) char __em_js__pyodide_js_init[] = {
-#embed "pyodide_pre.gen.dat"
-  ,
-  0
+#embed "pyodide_pre.gen.dat" \
+	suffix(, 0)
 };
 
 void


### PR DESCRIPTION
See:
https://thephd.dev/implementing-embed-c-and-c++#4-recognize-when-something-is-not-built-in-able
