### PR TITLE
Fix `thisArg` when making js calls while taking snapshot

### DIFF
--- a/src/js/snapshot.ts
+++ b/src/js/snapshot.ts
@@ -16,6 +16,7 @@ API.getExpectedKeys = function () {
 };
 
 const getAccessorList = Symbol("getAccessorList");
+const getObject = Symbol('getObject');
 /**
  * @private
  */
@@ -27,6 +28,9 @@ export function makeGlobalsProxy(
     get(target, prop, receiver) {
       if (prop === getAccessorList) {
         return accessorList;
+      }
+      if (prop === getObject) {
+        return target;
       }
       // @ts-ignore
       const orig = Reflect.get(...arguments);
@@ -44,6 +48,9 @@ export function makeGlobalsProxy(
         return orig;
       }
       return makeGlobalsProxy(orig, [...accessorList, prop]);
+    },
+    apply(target, thisArg, argumentList) {
+      return Reflect.apply(target, thisArg?.[getObject] ?? thisArg, argumentList);
     },
     getPrototypeOf() {
       // @ts-ignore

--- a/src/tests/test_snapshots.py
+++ b/src/tests/test_snapshots.py
@@ -255,3 +255,25 @@ def test_syncify_in_snapshot_load(selenium_standalone_noload):
         `)
         """
     )
+
+
+def test_make_snapshot_fetch(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+    # It's okay for the fetch to succeed (node) or fail with TypeError: Failed to fetch ()
+    # TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
+    try:
+        selenium.run_js(
+            """
+            const py1 = await loadPyodide({_makeSnapshot: true});
+            await py1.runPythonAsync(`
+                from js import fetch
+
+                await fetch("https://example.com")
+            `);
+            """
+        )
+    except selenium.JavascriptException as e:
+        # Chrome
+        assert "Illegal invocation" not in str(e)
+        # Firefox
+        assert "an object that does not implement interface Window." not in str(e)


### PR DESCRIPTION
If we pass `_makeSnapshot: true` to `loadPyodide`, it wraps `globalThis` in this `makeGlobalsProxy` function so we can serialize top level imports. This breaks functions like `fetch` which in Chrome raises:
```
Failed to execute 'fetch' on 'Window': Illegal invocation
```
In order to fix this, before calling a function we should unwrap the target.
