### PR TITLE
suppress errors generated by `which` test in pyodide_env.sh

### DIFF
--- a/pyodide_env.sh
+++ b/pyodide_env.sh
@@ -9,7 +9,7 @@ ROOT=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P)
 # shellcheck source=/dev/null
 source "$ROOT/emsdk/emsdk/emsdk_env.sh" 2> /dev/null || true
 export PATH="$ROOT/node_modules/.bin/:$ROOT/emsdk/emsdk/ccache/git-emscripten_64bit/bin:$PATH:$ROOT/packages/.artifacts/bin/"
-EMCC_PATH=$(which emcc.py || echo ".")
+EMCC_PATH=$(which emcc.py 2>/dev/null || echo ".")
 EM_DIR=$(dirname "$EMCC_PATH")
 export EM_DIR
 


### PR DESCRIPTION
Just a very small change. I noticed a lot of long error messages generated by the `which` command that fails to find `emcc.py`:

The build logs would then contain a lot of these lines:
```bash
which: no emcc.py in (<full-system-path>)
```
where the <full-system-path> easily spanns > 1k chars.

With this change, the error messages are redirected to /dev/null and the correct output is not redirected.