### PR TITLE
Add `eager_converter` arg to `to_js` to override default conversions

### DIFF
--- a/src/core/jsbind.c
+++ b/src/core/jsbind.c
@@ -302,7 +302,8 @@ Py2Js_func_deep(PyObject* self, PyObject* pyval, JsVal proxies)
                           /* depth=*/-1,
                           proxies,
                           my_dict_converter(),
-                          /*default_converter=*/JS_NULL);
+                          /*default_converter=*/JS_NULL,
+                          /*eager_converter=*/JS_NULL);
 }
 
 JsVal

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -779,6 +779,14 @@ export class PyProxy {
       convert: (obj: PyProxy) => any,
       cacheConversion: (obj: PyProxy, result: any) => void,
     ) => any;
+    /**
+     * Optional callback to convert objects which gets called after `string`,
+     * `number`, `boolean`, `undefined`/`null`, and `PyProxy` are converted but
+     * _before_ any default conversions are applied to standard data structures.
+     *
+     * Its arguments are the same as `dict_converter`.
+     * See the documentation of :meth:`~pyodide.ffi.to_js`.
+     */
     eager_converter?: (
       obj: PyProxy,
       convert: (obj: PyProxy) => any,

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -742,6 +742,7 @@ export class PyProxy {
     create_pyproxies = true,
     dict_converter = undefined,
     default_converter = undefined,
+    eager_converter = undefined,
   }: {
     /** How many layers deep to perform the conversion. Defaults to infinite */
     depth?: number;
@@ -778,6 +779,11 @@ export class PyProxy {
       convert: (obj: PyProxy) => any,
       cacheConversion: (obj: PyProxy, result: any) => void,
     ) => any;
+    eager_converter?: (
+      obj: PyProxy,
+      convert: (obj: PyProxy) => any,
+      cacheConversion: (obj: PyProxy, result: any) => void,
+    ) => any;
   } = {}): any {
     let ptrobj = _getPtr(this);
     let result;
@@ -795,8 +801,9 @@ export class PyProxy {
         ptrobj,
         depth,
         proxies,
-        dict_converter || null,
-        default_converter || null,
+        dict_converter ?? null,
+        default_converter ?? null,
+        eager_converter ?? null,
       );
       Py_EXIT();
     } catch (e) {

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -780,9 +780,9 @@ export class PyProxy {
       cacheConversion: (obj: PyProxy, result: any) => void,
     ) => any;
     /**
-     * Optional callback to convert objects which gets called after `string`,
-     * `number`, `boolean`, `undefined`/`null`, and `PyProxy` are converted but
-     * _before_ any default conversions are applied to standard data structures.
+     * Optional callback to convert objects which gets called after ``str``,
+     * ``int``, ``float``, ``bool``, ``None``, and ``JsProxy`` are converted but
+     * *before* any default conversions are applied to standard data structures.
      *
      * Its arguments are the same as `dict_converter`.
      * See the documentation of :meth:`~pyodide.ffi.to_js`.

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -57,7 +57,8 @@ python2js_custom(PyObject* x,
                  int depth,
                  JsVal proxies,
                  JsVal dict_converter,
-                 JsVal default_converter);
+                 JsVal default_converter,
+                 JsVal eager_converter);
 
 int
 python2js_init(PyObject* core);

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -95,6 +95,13 @@ declare global {
           convert: (obj: PyProxy) => any,
           cacheConversion: (obj: PyProxy, result: any) => void,
         ) => any),
+    eager_converter:
+      | null
+      | ((
+          obj: PyProxy,
+          convert: (obj: PyProxy) => any,
+          cacheConversion: (obj: PyProxy, result: any) => void,
+        ) => any),
   ) => any;
 
   export const _pyproxy_getflags: (

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1336,6 +1336,16 @@ def create_proxy(
 # from python2js
 
 
+class ToJsConverter(Protocol):
+    def __call__(
+        self,
+        /,
+        value: Any,
+        converter: Callable[[Any], JsProxy],
+        cache: Callable[[Any, JsProxy], None],
+    ) -> JsProxy: ...
+
+
 @overload
 def to_js(
     obj: list[Any] | tuple[Any],
@@ -1345,12 +1355,8 @@ def to_js(
     pyproxies: JsProxy | None = None,
     create_pyproxies: bool = True,
     dict_converter: Callable[[Iterable[JsArray[Any]]], JsProxy] | None = None,
-    default_converter: (
-        Callable[
-            [Any, Callable[[Any], JsProxy], Callable[[Any, JsProxy], None]], JsProxy
-        ]
-        | None
-    ) = None,
+    default_converter: ToJsConverter | None = None,
+    eager_converter: ToJsConverter | None = None,
 ) -> JsArray[Any]: ...
 
 
@@ -1363,12 +1369,8 @@ def to_js(
     pyproxies: JsProxy | None,
     create_pyproxies: bool,
     dict_converter: None,
-    default_converter: (
-        Callable[
-            [Any, Callable[[Any], JsProxy], Callable[[Any, JsProxy], None]], JsProxy
-        ]
-        | None
-    ) = None,
+    default_converter: ToJsConverter | None = None,
+    eager_converter: ToJsConverter | None = None,
 ) -> JsMap[Any, Any]: ...
 
 
@@ -1381,12 +1383,8 @@ def to_js(
     pyproxies: JsProxy | None = None,
     create_pyproxies: bool = True,
     dict_converter: Callable[[Iterable[JsArray[Any]]], JsProxy] | None = None,
-    default_converter: (
-        Callable[
-            [Any, Callable[[Any], JsProxy], Callable[[Any, JsProxy], None]], JsProxy
-        ]
-        | None
-    ) = None,
+    default_converter: ToJsConverter | None = None,
+    eager_converter: ToJsConverter | None = None,
 ) -> Any: ...
 
 
@@ -1398,12 +1396,8 @@ def to_js(
     pyproxies: JsProxy | None = None,
     create_pyproxies: bool = True,
     dict_converter: Callable[[Iterable[JsArray[Any]]], JsProxy] | None = None,
-    default_converter: (
-        Callable[
-            [Any, Callable[[Any], JsProxy], Callable[[Any, JsProxy], None]], JsProxy
-        ]
-        | None
-    ) = None,
+    default_converter: ToJsConverter | None = None,
+    eager_converter: ToJsConverter | None = None,
 ) -> Any:
     """Convert the object to JavaScript.
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1370,6 +1370,7 @@ class ToJsConverter(Protocol):
                 result.push(convert(value.second))
                 return result
     """
+
     def __call__(
         self,
         /,

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1338,7 +1338,7 @@ def create_proxy(
 
 class ToJsConverter(Protocol):
     """Protocol for the ``default_converter`` and ``eager_converter`` arguments
-    of `to_js`.
+    of :py:func:`to_js`.
 
     Parameters
     ----------
@@ -1482,10 +1482,10 @@ def to_js(
 
     eager_converter:
         If present will be invoked whenever the object is not an ``int``,
-        ``float``, ``bool``, or ``None``. It is called before the default
-        conversions are applied to lists, tuples, dictionaries, and sets, so it
-        can be used to override these. By contrast, ``default_converter`` is
-        used as a fallback.
+        ``float``, ``bool``, ``None``, or a ``JsProxy``. It is called before the
+        default conversions are applied to lists, tuples, dictionaries, and
+        sets, so it can be used to override these. By contrast,
+        ``default_converter`` is used as a fallback.
 
         If ``eager_converter`` raises an error, the error will be allowed to
         propagate. Otherwise, the object returned will be used as the
@@ -1539,8 +1539,9 @@ def to_js(
 
     .. code-block:: python
 
-        from datetime import datetime from js import Date def
-        default_converter(value, _ignored1, _ignored2):
+        from datetime import datetime
+        from js import Date
+        def default_converter(value, _ignored1, _ignored2):
             if isinstance(value, datetime):
                 return Date.new(value.timestamp() * 1000)
             return value
@@ -1562,7 +1563,8 @@ def to_js(
 
         class Pair:
             def __init__(self, first, second):
-                self.first = first self.second = second
+                self.first = first
+                self.second = second
 
     We can use the following ``default_converter`` to convert ``Pair`` to
     :js:class:`Array`:
@@ -1574,8 +1576,10 @@ def to_js(
         def default_converter(value, convert, cache):
             if not isinstance(value, Pair):
                 return value
-            result = Array.new() cache(value, result)
-            result.push(convert(value.first)) result.push(convert(value.second))
+            result = Array.new()
+            cache(value, result)
+            result.push(convert(value.first))
+            result.push(convert(value.second))
             return result
 
     Note that we have to cache the conversion of ``value`` before converting
@@ -1601,7 +1605,8 @@ def to_js(
             return convert(value)
 
 
-    The following `eager_converter` will fail the conversion if a tuple is passed:
+    The following `eager_converter` will fail the conversion if a tuple is
+    passed:
 
     .. code-block:: python
 

--- a/src/py/pyodide/ffi/__init__.py
+++ b/src/py/pyodide/ffi/__init__.py
@@ -52,6 +52,7 @@ __all__ = [
     "JsDomElement",
     "JsCallable",
     "JsTypedArray",
+    "ToJsConverter",
     "create_once_callable",
     "create_proxy",
     "destroy_proxies",


### PR DESCRIPTION
The `default_converter` argument is called after the builtin conversions so it cannot be used to modify the normal behavior. @dom96 needed a way to block converting tuples. This adds a way to do this.

One API question is whether we want to allow the default behavior by calling `convert()` or by returning a special value. I have implemented it via `convert()` which leads to some slightly messy special case handling. It would be possible to do a fallback when `None` is returned, but what if the actual intention was to convert to `undefined`? Other special values would be hard to come by either in Python or in JS or both. So I think this is fine.


### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
