### PR TITLE
Make jsbind destinguish properly between class instances and classes

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -332,6 +332,30 @@ static PyMethodDef JsProxy_bind_sig_MethodDef = {
   METH_O,
 };
 
+PyObject*
+JsProxy_bind_class(PyObject* self, PyObject* sig)
+{
+  PyObject* result = NULL;
+
+  // Call `sig = jsbind.bind_class_sig(sig)` and then delegate to
+  // JsProxy_bind_sig.
+  // bind_class_sig takes sig and returns type[sig].
+  _Py_IDENTIFIER(bind_class_sig);
+  PyObject* class_sig =
+    _PyObject_CallMethodIdOneArg(jsbind, &PyId_bind_class_sig, sig);
+  FAIL_IF_NULL(class_sig);
+  result = JsProxy_bind_sig(self, class_sig);
+finally:
+  Py_CLEAR(class_sig);
+  return result;
+}
+
+static PyMethodDef JsProxy_bind_class_MethodDef = {
+  "bind_class",
+  (PyCFunction)JsProxy_bind_class,
+  METH_O,
+};
+
 /**
  * repr overload, does `obj.toString()` which produces a low-quality repr.
  */
@@ -3867,6 +3891,7 @@ JsProxy_create_subtype(int flags)
   int cur_getset = 0;
 
   methods[cur_method++] = JsProxy_bind_sig_MethodDef;
+  methods[cur_method++] = JsProxy_bind_class_MethodDef;
   methods[cur_method++] = JsProxy_Dir_MethodDef;
   methods[cur_method++] = JsProxy_toPy_MethodDef;
   methods[cur_method++] = JsProxy_object_entries_MethodDef;

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -117,7 +117,33 @@ class JsProxy(metaclass=_JsProxyMetaClass):
             return super().__new__(cls)
         raise TypeError(f"{cls.__name__} cannot be instantiated.")
 
-    def bind_sig(self, signature: T) -> T:
+    def bind_class(self, signature: T) -> T:
+        """Creates a copy of the JsProxy with a signature bound to it.
+
+        ``proxy.bind_class(A)`` treats ``proxy`` as a class shaped like ``A``.
+        ``proxy.bind_sig(A)`` treats ``proxy`` as an instance of ``A``.
+
+        At runtime, ``proxy.bind_class(A)`` is equivalent to
+        ``proxy.bind_class(type[A])``, it only needs to be a separate method to
+        help mypy.
+
+        .. admonition:: Experimental
+           :class: warning
+
+           This feature is not yet stable, nor really documented.
+        """
+        raise NotImplementedError
+
+    # First overload is for if we bind a class, second overload is for if we
+    # bind a function.
+
+    @overload
+    def bind_sig(self, signature: type[T]) -> T: ...
+
+    @overload
+    def bind_sig(self, signature: T) -> T: ...
+
+    def bind_sig(self, signature: Any) -> Any:
         """Creates a copy of the JsProxy with a signature bound to it.
 
         .. admonition:: Experimental
@@ -125,7 +151,7 @@ class JsProxy(metaclass=_JsProxyMetaClass):
 
            This feature is not yet stable, nor really documented.
         """
-        return signature
+        raise NotImplementedError
 
     @property
     def js_id(self) -> int:

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -2759,7 +2759,7 @@ def test_bind_jsfunc_sig(selenium):
         raise NotImplementedError
 
     assert (
-        repr(func_to_sig_inner(f))
+        repr(func_to_sig_inner(f, None))
         == "<JsSignature (a: dict[str, int], /) -> list[int]>"
     )
 


### PR DESCRIPTION
I changed the signature of `bind_sig` to be `type[T] -> T` so that `proxy.bind_sig(SomeClass)` returns an object typed like an instance of `SomeClass`. I added `proxy.bind_class(SomeClass)` to return an object typed as the class `SomeClass`. At runtime, `bind_class` just calls `bind_sig(type(SomeClass))`, but in a way that mypy understands.

I also fixed the handling for non-static methods. They should have one fewer argument. We fix this by calling `__get__`.

- [x] Add / update tests
- [x] Add new / update outdated documentation
