### PR TITLE
Fix test_package_index test

### DIFF
--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -495,8 +495,7 @@ def test_package_index(tmp_path):
     assert result.returncode == 0
     stdout = re.sub(r"(?<=[<>=-])([\d+]\.?)+", "*", result.stdout)
     assert (
-        stdout.strip().rsplit("\n", 1)[-1]
-        == "Successfully installed attrs-* micropip-* numpy-* packaging-* sharedlib-test-py-*"
+        "Successfully installed attrs-* micropip-* numpy-* packaging-* sharedlib-test-py-*" in stdout.strip().rsplit("\n", 1)[-1]
     )
 
 

--- a/src/tests/test_cmdline_runner.py
+++ b/src/tests/test_cmdline_runner.py
@@ -495,7 +495,8 @@ def test_package_index(tmp_path):
     assert result.returncode == 0
     stdout = re.sub(r"(?<=[<>=-])([\d+]\.?)+", "*", result.stdout)
     assert (
-        "Successfully installed attrs-* micropip-* numpy-* packaging-* sharedlib-test-py-*" in stdout.strip().rsplit("\n", 1)[-1]
+        "Successfully installed attrs-* micropip-* numpy-* packaging-* sharedlib-test-py-*"
+        in stdout.strip().rsplit("\n", 1)[-1]
     )
 
 


### PR DESCRIPTION
It started to fail a few days ago, because of some extra terminal output.