### PR TITLE
Constraint cython versions for a few packages

### DIFF
--- a/packages/coolprop/meta.yaml
+++ b/packages/coolprop/meta.yaml
@@ -26,7 +26,8 @@ requirements:
   run:
     - numpy
     - matplotlib
-
+  constraint:
+    - cython < 3.1.0
 test:
   imports:
     - CoolProp

--- a/packages/pysam/meta.yaml
+++ b/packages/pysam/meta.yaml
@@ -13,6 +13,8 @@ source:
 requirements:
   host:
     - zlib
+  constraint:
+    - cython < 3.1.0
 build:
   cflags: |
     -I$(WASM_LIBRARY_DIR)/include

--- a/packages/python-flint/meta.yaml
+++ b/packages/python-flint/meta.yaml
@@ -17,6 +17,8 @@ build:
   ldflags: |
     -L$(WASM_LIBRARY_DIR)/lib -lflint -lmpfr -lgmp
   unvendor-tests: false
+  constraint:
+    - cython < 3.1.0
 about:
   home: https://github.com/flintlib/python-flint
   PyPI: https://pypi.org/project/python-flint

--- a/packages/python-flint/meta.yaml
+++ b/packages/python-flint/meta.yaml
@@ -8,6 +8,8 @@ requirements:
     - flint
     - libgmp
     - libmpfr
+  constraint:
+    - cython < 3.1.0
 source:
   url: https://files.pythonhosted.org/packages/16/3a/d129f056475191377a823efe9876656a81d563bb7463d0f8568ebee81ef6/python-flint-0.6.0.tar.gz
   sha256: f829e00774534891b38de41bc511cf6c7d6d216544a6a84b92d9e1f159de0878
@@ -17,8 +19,6 @@ build:
   ldflags: |
     -L$(WASM_LIBRARY_DIR)/lib -lflint -lmpfr -lgmp
   unvendor-tests: false
-  constraint:
-    - cython < 3.1.0
 about:
   home: https://github.com/flintlib/python-flint
   PyPI: https://pypi.org/project/python-flint


### PR DESCRIPTION
It looks like the latest cython release (3.1.0) is not compatible with some packages.