### PR TITLE
CI Pin autoconf version in conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,8 @@ dependencies:
   # there was a fix (https://github.com/conda-forge/pkg-config-feedstock/pull/31), but it is not released.
   # - pkg-config
   - texinfo
-  - autoconf
+  # Not sure but the autoconf version should match with the one used in the configure.ac file in cpython.
+  - autoconf<2.72
   - automake
   - libtool
   - wget

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   # there was a fix (https://github.com/conda-forge/pkg-config-feedstock/pull/31), but it is not released.
   # - pkg-config
   - texinfo
-  # Not sure but the autoconf version should match with the one used in the configure.ac file in cpython.
+  # Not sure but it looks like the autoconf version should not be greater than the one used in the configure.ac file in cpython.
   - autoconf<2.72
   - automake
   - libtool


### PR DESCRIPTION
I don't understand why, but it seems like autoconf 2.72 (updated in conda-forge yesterday) is incompatible with the current CPython configure script.