### PR TITLE
add newer libtool to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update \
         bzip2 ccache f2c g++ gfortran git make \
         patch pkg-config swig unzip wget xz-utils \
         autoconf autotools-dev automake texinfo dejagnu \
-        build-essential libtool libltdl-dev \
+        build-essential libltdl-dev \
         gnupg2 libdbus-glib-1-2 sudo sqlite3 \
-        ninja-build jq \
+        ninja-build jq cmake bison \
   && rm -rf /var/lib/apt/lists/*
 
 # install autoconf 2.71, required by upstream libffi
@@ -20,6 +20,14 @@ RUN wget https://mirrors.ocf.berkeley.edu/gnu/autoconf/autoconf-2.71.tar.xz \
     && make install \
     && cp /usr/local/bin/autoconf /usr/bin/autoconf \
     && rm -rf autoconf-2.71
+
+# install libtool 2.5.4, required for emscripten support
+RUN wget https://mirrors.ocf.berkeley.edu/gnu/libtool/libtool-2.5.4.tar.xz \
+    && tar -xf libtool-2.5.4.tar.xz \
+    && cd libtool-2.5.4 \
+    && ./configure \
+    && make install \
+    && rm -rf libtool-2.5.4
 
 ADD requirements.txt /
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

This adds a newer libtool version that has support for building emscripten shared libraries which is needed for #5601 

### Checklists

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes, or mark them as checked. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
