### PR TITLE
Use lockfileURL instead of IndexURL when resolving package URL

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -35,6 +35,11 @@ myst:
 - {{ Fix }} Add the current working directory to the path instead of `$HOME`.
   {pr}`5630`
 
+- {{ Breadking }} When `lockfileURL` is given to `loadPyodide`, the
+  base URL for the packages is now calculated from the lockfile URL, not from
+  the `indexURL`.
+  {pr}`5652`
+
 ### `python` CLI entrypoint
 
 - {{ Fix }} The `python` CLI now mounts the `/tmp` directory. In

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -35,7 +35,7 @@ myst:
 - {{ Fix }} Add the current working directory to the path instead of `$HOME`.
   {pr}`5630`
 
-- {{ Breadking }} When `lockfileURL` is given to `loadPyodide`, the
+- {{ Breaking }} When `lockfileURL` is given to `loadPyodide`, the
   base URL for the packages is now calculated from the lockfile URL, not from
   the `indexURL`.
   {pr}`5652`

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -692,6 +692,14 @@ export class PyodideAPI {
   static get lockfile() {
     return API.lockfile;
   }
+
+  /**
+   * Returns the base URL of the lockfile, which is used to locate the packages
+   * distributed with the lockfile.
+   */
+  static get lockfileBaseUrl() {
+    return API.lockfileBaseUrl;
+  }
 }
 
 /** @hidden */

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -146,14 +146,14 @@ export class PackageManager {
       this.#api.config.lockFileURL.substring(
         0,
         this.#api.config.lockFileURL.lastIndexOf("/") + 1,
-      ) || location.toString();
+      ) || globalThis.location?.toString();
 
     if (IN_NODE) {
       this.installBaseUrl = this.#api.config.packageCacheDir ?? lockfileBase;
     } else {
       this.installBaseUrl = lockfileBase;
     }
-    
+
     this.stdout = (msg: string) => {
       const sp = this.#module.stackSave();
       try {

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -140,17 +140,18 @@ export class PackageManager {
     this.#module = pyodideModule;
     this.#installer = new Installer(api, pyodideModule);
 
+    // use lockFileURL as the base URL for the packages
+    // if lockFileURL is relative, use location as the base URL
+    const lockfileBase =
+      this.#api.config.lockFileURL.substring(
+        0,
+        this.#api.config.lockFileURL.lastIndexOf("/") + 1,
+      ) || location.toString();
+
     if (IN_NODE) {
-      this.installBaseUrl = this.#api.config.packageCacheDir;
+      this.installBaseUrl = this.#api.config.packageCacheDir ?? lockfileBase;
     } else {
-      // use lockFileURL as the base URL for the packages
-      // if lockFileURL is relative, set it to undefined, and it will be treated as
-      // relative to the current page URL.
-      this.installBaseUrl =
-        this.#api.config.lockFileURL.substring(
-          0,
-          this.#api.config.lockFileURL.lastIndexOf("/") + 1,
-        ) || location.toString();
+      this.installBaseUrl = lockfileBase;
     }
   }
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -146,10 +146,11 @@ export class PackageManager {
       // use lockFileURL as the base URL for the packages
       // if lockFileURL is relative, set it to undefined, and it will be treated as
       // relative to the current page URL.
-      this.installBaseUrl = this.#api.config.lockFileURL.substring(
-        0,
-        this.#api.config.lockFileURL.lastIndexOf("/") + 1,
-      ) || location.toString();
+      this.installBaseUrl =
+        this.#api.config.lockFileURL.substring(
+          0,
+          this.#api.config.lockFileURL.lastIndexOf("/") + 1,
+        ) || location.toString();
     }
   }
 

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -125,7 +125,7 @@ export class PackageManager {
 
   private _lock = createLock();
 
-  private installBaseUrl: string;
+  public installBaseUrl: string;
 
   /**
    * The function to use for stdout and stderr, defaults to console.log and console.error
@@ -397,11 +397,11 @@ export class PackageManager {
 
   /**
    * Download a package. If `channel` is `DEFAULT_CHANNEL`, look up the wheel URL
-   * relative to packageCacheDir (when IN_NODE), or indexURL from `pyodide-lock.json`, otherwise use the URL specified by
+   * relative to packageCacheDir (when IN_NODE), or to lcokfileURL, otherwise use the URL specified by
    * `channel`.
    * @param pkg The package to download
    * @param channel Either `DEFAULT_CHANNEL` or the absolute URL to the
-   * wheel or the path to the wheel relative to packageCacheDir (when IN_NODE), or indexURL.
+   * wheel or the path to the wheel relative to packageCacheDir (when IN_NODE), or lockfileURL.
    * @param checkIntegrity Whether to check the integrity of the downloaded
    * package.
    * @returns The binary data for the package
@@ -642,6 +642,8 @@ if (typeof API !== "undefined" && typeof Module !== "undefined") {
   API.setCdnUrl = singletonPackageManager.setCdnUrl.bind(
     singletonPackageManager,
   );
+
+  API.lockfileBaseUrl = singletonPackageManager.installBaseUrl;
 
   if (API.lockFilePromise) {
     API.packageIndexReady = initializePackageIndex(API.lockFilePromise);

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -398,7 +398,7 @@ export class PackageManager {
 
   /**
    * Download a package. If `channel` is `DEFAULT_CHANNEL`, look up the wheel URL
-   * relative to packageCacheDir (when IN_NODE), or to lcokfileURL, otherwise use the URL specified by
+   * relative to packageCacheDir (when IN_NODE), or to lockfileURL, otherwise use the URL specified by
    * `channel`.
    * @param pkg The package to download
    * @param channel Either `DEFAULT_CHANNEL` or the absolute URL to the

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -219,7 +219,6 @@ export async function loadPyodide(
     lockFileURL: indexURL + "pyodide-lock.json",
     args: [],
     env: {},
-    packageCacheDir: indexURL,
     packages: [],
     enableRunUntilComplete: false,
     checkAPIVersion: true,

--- a/src/js/test/unit/test-helper.ts
+++ b/src/js/test/unit/test-helper.ts
@@ -13,7 +13,7 @@ export const genMockAPI = (): PackageManagerAPI => {
       },
     },
     config: {
-      indexURL: "",
+      lockFileURL: "",
       packageCacheDir: "",
     },
     lockfile_packages: {},

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -475,6 +475,7 @@ export interface API {
   lockfile_packages: Record<string, InternalPackageData>;
   repodata_packages: Record<string, InternalPackageData>;
   repodata_info: LockfileInfo;
+  lockfileBaseUrl: string;
   defaultLdLibraryPath: string[];
   sitepackages: string;
   loadBinaryFile: (

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -534,7 +534,7 @@ export type PackageManagerAPI = Pick<
   | "sitepackages"
   | "defaultLdLibraryPath"
 > & {
-  config: Pick<ConfigType, "indexURL" | "packageCacheDir">;
+  config: Pick<ConfigType, "lockFileURL" | "packageCacheDir">;
 };
 /**
  * @hidden

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -708,7 +708,11 @@ def test_custom_lockfile_different_dir(selenium_standalone_noload, tmp_path):
 
     with spawn_web_server(tmp_path) as web_server:
         url, port, _ = web_server
-        lockfile_url = f"http://{url}:{port}/{custom_lockfile_name}"
+
+        if selenium.browser == "node":
+            lockfile_url = f"{custom_lockfile_path.resolve()}"
+        else:
+            lockfile_url = f"http://{url}:{port}/{custom_lockfile_name}"
         selenium.run_js(
             f"""
             let pyodide = await loadPyodide({{fullStdLib: false, lockFileURL: {lockfile_url!r} }});

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -678,6 +678,46 @@ def test_custom_lockfile(selenium_standalone_noload):
         custom_lockfile.unlink()
 
 
+def test_custom_lockfile_different_dir(selenium_standalone_noload, tmp_path):
+    selenium = selenium_standalone_noload
+
+    orig_lockfile = DIST_PATH / "pyodide-lock.json"
+    custom_lockfile_name = "custom-lockfile.json"
+
+    test_file_name = "dummy_pkg-0.1.0-py3-none-any.whl"
+    test_file_path = Path(__file__).parent / "wheels" / test_file_name
+
+    lockfile_content = json.loads(orig_lockfile.read_text())
+    lockfile_content["packages"] = {
+        "dummy-pkg": {
+            "name": "dummy_pkg",
+            "version": "0.1.0",
+            "unvendor_tests": False,
+            "sha256": "22fc6330153be71220aea157ab135c53c7d34ff1a6d1d1a4705c95eef1a6f262",
+            "depends": [],
+            "file_name": test_file_name,
+            "install_dir": "site",
+            "package_type": "package",
+            "imports": [],
+        }
+    }
+
+    custom_lockfile_path = tmp_path / "custom-lockfile.json"
+    custom_lockfile_path.write_text(json.dumps(lockfile_content))
+    shutil.copy(test_file_path, tmp_path / test_file_name)
+
+    with spawn_web_server(tmp_path) as web_server:
+        url, port, _ = web_server
+        lockfile_url = f"http://{url}:{port}/{custom_lockfile_name}"
+        selenium.run_js(
+            f"""
+            let pyodide = await loadPyodide({{fullStdLib: false, lockFileURL: {lockfile_url!r} }});
+            await pyodide.loadPackage("dummy_pkg", {{ checkIntegrity: false }});
+            return pyodide.runPython("import dummy_pkg;")
+            """
+        )
+
+
 @pytest.mark.parametrize(
     "load_name, normalized_name, real_name",
     [


### PR DESCRIPTION
### Description

This pull request changes how remote package URLs are resolved when a custom lockfile is used. Previously, we used indexURL as a base URL for resolving packages, while this PR changes it to use lockFileURL as a base URL. This PR is required from a package unvendoring perspective.

Consider the following scenario:

1. We release Pyodide 0.28 with a certain set of packages.
2. After 0.28 release, we add a few more packages to our distribution, and release it in `pyodide-recipes` repository.
3. There is a user who wants to use the newly added packages in Pyodide 0.28; he/she download the packages and the lockfile from the `pyodide-recipes` repository, host it somewhere, and use the `lockFileURL` parameter to use that package.

Then, he/she will load Pyodide such as:

```ts
await loadPyodide({
  indexURL: "https://cdn.jsdelivr.net/pyodide/v0.28.0/full",
  lockFileURL: "https://my.custom.website/pyodide-lock.json",
})
```

In this case, the new packages will be hosted in `https://my.custom.web.site`, not in our CDN, so it would be more natural to use the lockFileURL, as a base URL for the package installation.

### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
