### PR TITLE
Fix regression in symbol resolution and enable pyxel

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -100,6 +100,7 @@ export PYCOMPILE_EXCLUDE_FILES=\
 export DBGFLAGS_NODEBUG=-g0
 export DBGFLAGS_WASMDEBUG=-g2
 export DBGFLAGS_SOURCEMAPDEBUG=-g3
+export DBG_LDFLAGS_DYLINK=-sDYLINK_DEBUG=2
 export DBG_LDFLAGS_SOURCEMAPDEBUG=-gseparate-dwarf
 
 export DBGFLAGS=$(DBGFLAGS_NODEBUG)
@@ -113,11 +114,12 @@ endif
 ifdef PYODIDE_SOURCEMAP
 	# Debug with source maps (less useful than WASMDEBUG but easier if it helps)
 	export DBGFLAGS=$(DBGFLAGS_SOURCEMAPDEBUG)
-	export DBG_LDFLAGS=$(DBG_LDFLAGS_SOURCEMAPDEBUG)
+	export DBG_LDFLAGS=$(DBG_LDFLAGS_SOURCEMAPDEBUG) $(DBG_LDFLAGS_DYLINK)
 else
 	ifdef PYODIDE_SYMBOLS
 		# Include debug symbols but no source maps (most useful)
 		export DBGFLAGS=$(DBGFLAGS_WASMDEBUG)
+		export DBG_LDFLAGS=$(DBG_LDFLAGS_DYLINK)
 	endif
 endif
 

--- a/packages/pyxel/meta.yaml
+++ b/packages/pyxel/meta.yaml
@@ -1,22 +1,13 @@
 package:
   name: pyxel
-  version: 2.3.18
+  version: 1.9.10
   tag:
     - rust
 source:
-  url: https://github.com/kitao/pyxel/archive/refs/tags/v2.3.18.tar.gz
-  sha256: acea88bb99078053d012d02a5caf104e78940eeaad853592bb3e8f7a1ddb2dec
+  url: https://github.com/kitao/pyxel/archive/refs/tags/v1.9.10.tar.gz
+  sha256: a784221be6f32fd57bdc6a1a8f30e8f68c78f83d8c84790beaf6ec2be062982f
 build:
   script: |
-    # copy pyproject.toml and python source code to the build directory
-    cp -r python/* .
-
-    # fix relative paths in pyproject.toml
-    sed -i 's|"../|"./|g' pyproject.toml
-
-    # LICENSE file is duplicated, which causes an error
-    rm -f LICENSE
-
     embuilder build sdl2 --pic
     export RUSTFLAGS="\
       $RUSTFLAGS \

--- a/packages/pyxel/meta.yaml
+++ b/packages/pyxel/meta.yaml
@@ -1,16 +1,22 @@
 package:
   name: pyxel
-  version: 1.9.10
-  # Broken by Emscripten 4.0.6 update.
-  # Build succeeds, but get function sig mismatch or null in several tests.
-  _disabled: true
+  version: 2.3.18
   tag:
     - rust
 source:
-  url: https://github.com/kitao/pyxel/archive/refs/tags/v1.9.10.tar.gz
-  sha256: a784221be6f32fd57bdc6a1a8f30e8f68c78f83d8c84790beaf6ec2be062982f
+  url: https://github.com/kitao/pyxel/archive/refs/tags/v2.3.18.tar.gz
+  sha256: acea88bb99078053d012d02a5caf104e78940eeaad853592bb3e8f7a1ddb2dec
 build:
   script: |
+    # copy pyproject.toml and python source code to the build directory
+    cp -r python/* .
+
+    # fix relative paths in pyproject.toml
+    sed -i 's|"../|"./|g' pyproject.toml
+
+    # LICENSE file is duplicated, which causes an error
+    rm -f LICENSE
+
     embuilder build sdl2 --pic
     export RUSTFLAGS="\
       $RUSTFLAGS \

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -62,7 +62,7 @@ const errNoRet = () => {
 };
 
 // For no-dylink build, this is a no-op.
-Module.reportUndefinedSymbols ||= () => {};
+Module.reportUndefinedSymbols ??= () => {};
 
 const nullToUndefined = (x) => (x === null ? undefined : x);
 

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -61,7 +61,8 @@ const errNoRet = () => {
   );
 };
 
-Module.reportUndefinedSymbols = () => {};
+// For no-dylink build, this is a no-op.
+Module.reportUndefinedSymbols ||= () => {};
 
 const nullToUndefined = (x) => (x === null ? undefined : x);
 


### PR DESCRIPTION
### Description

Related: #5584 (I'll close this issue manually after verifying that it works after the merge)

This fixes a symbol resolution issue that started to occur after we updated Emscripten version from 4.0.3 to 4.0.6.

#### What happened?

In `pre.js`, we set `Module.reportUndefinedSymbols` to no-op, and this was for no-dylink build.

Before Emscripten 4.0.6, the pre.js was applied before the Emscripten updates the attributes in the module. Therefore, in regular (dylink enabled) build, the `reportUndefinedSymbols` function was replaced with a normal one that Emscripten provides.

But this behavior was silently changed in Emscripten 4.0.6 (or 4.0.5 or 4.0.4, I am not sure), and the no-op implementation provided by `pre.js` is not overwritten by the Emscripten implementation.

So what happens is in the stable branch (0.27.6), the reportUndefinedSymbols is correctly set, 

```js
console.log(pyodide._module.reportUndefinedSymbols)

()=>{for(var[symName,entry]of Object.entries(GOT)){if(entry.value==0){var value=resolveGlobalSymbol(symName,true).sym;if(!value&&!entry.required){continue}if(typeof value=="function"){entry.value=add…
```

but in the master branch, it is set to no-op

```js
console.log(pyodide._module.reportUndefinedSymbols)

()=>{}
```

This caused an issue in the symbol resolution, resulting in a bug in resolving JS symbols from the side module (SDL).
