### PR TITLE
DOC Update path to nightly Rust toolchain sysroot

### DIFF
--- a/docs/development/abi.md
+++ b/docs/development/abi.md
@@ -166,7 +166,7 @@ sysroot. To install the Emscripten sysroot use:
 
 ```sh
 rustup toolchain install nightly-2025-02-01
-TOOLCHAIN_ROOT=$(rustup which --toolchain nightly-2025-02-01 rustc)
+TOOLCHAIN_ROOT=$(rustup run nightly-2025-02-01 rustc --print sysroot)
 RUSTLIB=$TOOLCHAIN_ROOT/lib/rustlib
 wget https://github.com/pyodide/rust-emscripten-wasm-eh-sysroot/releases/download/emcc-4.0.9_nightly-2025-02-01/emcc-4.0.9_nightly-2025-02-01.tar.bz2
 tar -xf emcc-4.0.9_nightly-2025-02-01.tar.bz2 --directory=$RUSTLIB


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

When installing our custom Rust sysroot stored from https://github.com/pyodide/rust-emscripten-wasm-eh-sysroot/releases/, I noticed that this snippet in the docs does not work because `rustup which --toolchain nightly-2025-02-01 rustc` command returns `/Users/<username>/.rustup/toolchains/nightly-2025-02-01-aarch64-apple-darwin/bin/rustc`, which is not a directory but rather the `rustc` executable. We want to install into `lib/rustlib/` one level back (outside of `bin/`) instead.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add new / update outdated documentation
