### PR TITLE
Fix builds for `libgmp` from macOS

### DIFF
--- a/packages/libgmp/meta.yaml
+++ b/packages/libgmp/meta.yaml
@@ -12,13 +12,16 @@ build:
   type: static_library
   script: |
     emconfigure ./configure \
-        CFLAGS="-fPIC" \
-        --disable-dependency-tracking \
-        --host none \
-        --disable-shared \
-        --enable-static \
-        --enable-cxx \
-        --prefix=${WASM_LIBRARY_DIR}
+      CFLAGS="-fPIC" \
+      HOST_CC=$(which clang) \
+      --host=wasm32-unknown-emscripten \
+      --build=$(./config.guess) \
+      --disable-assembly \
+      --disable-shared \
+      --enable-static \
+      --enable-cxx \
+      --prefix=${WASM_LIBRARY_DIR} \
+      ac_cv_prog_cc_cross=yes
     emmake make -j ${PYODIDE_JOBS:-3}
     emmake make install
 about:


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Apparently `libgmp` has an incorrectly configured `configure` file (likely!), which is why build failures don't show up on Linux builds, but I've had trouble compiling it to WASM on my macOS machine. This PR updates the recipe to set `HOST_CC` to `clang` (as `emsdk` can sometimes set it to Emscripten's Clang, which wouldn't work as a host compiler: https://github.com/emscripten-core/emscripten/issues/16358), sets both `--host` and `--build` triplets, and lastly, removes the deprecated `--disable-dependency-tracking` in favour of `--disable-assembly`. I've also set `ac_cv_prog_cc_cross=yes` to ensure that we always cross-compile.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
