### PR TITLE
Backport DOC Replace plausible with CF web analytics [skip ci] (#5619)

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,7 +1,7 @@
 {% extends '!layout.html' %} {%- block extrahead %} {{ super() }}
 <script
   defer
-  data-domain="pyodide.org"
-  src="https://plausible.io/js/plausible.js"
+  src="https://static.cloudflareinsights.com/beacon.min.js"
+  data-cf-beacon='{"token": "4405a86c36a84efca5dbde1b25edd153"}'
 ></script>
 {%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,7 +234,7 @@ def write_console_html(app):
             # insert the analytics script after the end of the inline CSS block
             console_html_lines.insert(
                 idx,
-                '<script defer data-domain="pyodide.org" src="https://plausible.io/js/plausible.js"></script>\n',
+                "<script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{\"token\": \"4405a86c36a84efca5dbde1b25edd153\"}'></script>\n",
             )
             break
     else:


### PR DESCRIPTION
Backports https://github.com/pyodide/pyodide/pull/5619 to the `stable` branch, otherwise I keep seeing lots of traffic coming from the stable deploy, until https://github.com/pyodide/pyodide/issues/5650 is released.

cc @ryanking13 