### PR TITLE
Better Python -> JS interoperability

### DIFF
--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -2218,7 +2218,7 @@ const PyProxyHandlers = {
     // 2. The result of getattr
     let result = python_getattr(jsobj, jskey);
 
-    // allow `dict[key]` to work as falback
+    // allow `dict[key]` to work as fallback
     return result === undefined && jsobj instanceof PyDict && jsobj.has(jskey)
       ? jsobj.get(jskey)
       : result;


### PR DESCRIPTION
This MR goal is to show how to improve Python -> JS interoperability by doing the following things:

  * `has` and `get` traps for Python dictionaries translates into `key in dict` and `dict[key]` in *JS*, allowing the usage of PyProxy without needing to convert these for the entirety of the Web APIs that expects object literals and not "*maps*" out there: `document.addEventListener(type, fn, { "once": True })` as example would just work withou *ffi* or *to_js* and, most importantly, without surprises when native JS APIs are used
* user defined callbacks pass through the *FinalizationRegistry* out of the box too so that `create_proxy` is not needed because when we use 3rd party APIs we never know when or even if these will call passed callbacks ... 

We have seen people using `create_proxy` all over the place but also `to_js` and then many complained something "*is slow*" but the reality is that they don't care about destroying proxies, they can't control when callbacks are de-referenced so that "*guarding*" the memory easily backfires with tons of often unnecessary or redundant operations.

**Please Note** I have no idea if this would be *the best approach* to solve this issue but I've put a 1:1 built demo on npm to test this and so far results are super smooth and code way more clean + I have a global *Proxy* patch ready to land in case this approach or the idea of simplifying interoperability will be discarded from this team but patching globals to do what these few lines do feels like not the best we both can offer to our users.

Ideally I'd like to have this feature behind a `loadPyodide` flag so that I don't need to fork this project and maintain my own build or I don't need to patch globally the *Proxy* but I am overly-open to any discussion or conclusion or way forward, this MR is merely an example of what we'd love to have in *Pyodide* to stop explaining why things are broken or not working as expected, especially when 3rd party JS libraries are used out there.

Thanks in advance for any sort of suggestion, comment, hint or eventual discussion to help this topic forward 🙏

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

This MR allows the following code to work out of the box:

```python
from js import document

document.addEventListener("click", lambda e: print(e.type), { "once": True })
```

No `create_proxy` needed and no `to_js` needed, the listener is invoked only **once** and the internal *FinalizationRegistry* handles the callback automatically.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
