### PR TITLE
Minor js perf improvements

### DIFF
--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -22,18 +22,15 @@ function js2python_string(value) {
   let ptr = _PyUnicode_Data(result);
   if (max_code_point > 0xffff) {
     for (let i = 0; i < num_code_points; i++) {
-      ASSIGN_U32(ptr, 0, code_points[i]);
-      ptr += 4;
+      ASSIGN_U32(ptr, i, code_points[i]);
     }
   } else if (max_code_point > 0xff) {
     for (let i = 0; i < num_code_points; i++) {
-      ASSIGN_U16(ptr, 0, code_points[i]);
-      ptr += 2;
+      ASSIGN_U16(ptr, i, code_points[i]);
     }
   } else {
     for (let i = 0; i < num_code_points; i++) {
-      ASSIGN_U8(ptr, 0, code_points[i]);
-      ptr += 1;
+      ASSIGN_U8(ptr, i, code_points[i]);
     }
   }
 

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -6,13 +6,14 @@ function js2python_string(value) {
   // to determine if is needs to be a 1-, 2- or 4-byte string, since
   // Python handles all 3.
   let max_code_point = 0;
-  let num_code_points = 0;
+  const code_points = [];
   for (let c of value) {
-    num_code_points++;
     let code_point = c.codePointAt(0);
+    code_points.push(code_point);
     max_code_point = code_point > max_code_point ? code_point : max_code_point;
   }
 
+  let num_code_points = code_points.length;
   let result = _PyUnicode_New(num_code_points, max_code_point);
   if (result === 0) {
     throw new PropagateError();
@@ -20,18 +21,18 @@ function js2python_string(value) {
 
   let ptr = _PyUnicode_Data(result);
   if (max_code_point > 0xffff) {
-    for (let c of value) {
-      ASSIGN_U32(ptr, 0, c.codePointAt(0));
+    for (let i = 0; i < num_code_points; i++) {
+      ASSIGN_U32(ptr, 0, code_points[i]);
       ptr += 4;
     }
   } else if (max_code_point > 0xff) {
-    for (let c of value) {
-      ASSIGN_U16(ptr, 0, c.codePointAt(0));
+    for (let i = 0; i < num_code_points; i++) {
+      ASSIGN_U16(ptr, 0, code_points[i]);
       ptr += 2;
     }
   } else {
-    for (let c of value) {
-      ASSIGN_U8(ptr, 0, c.codePointAt(0));
+    for (let i = 0; i < num_code_points; i++) {
+      ASSIGN_U8(ptr, 0, code_points[i]);
       ptr += 1;
     }
   }

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -14,6 +14,10 @@ function getTypeTag(x) {
 }
 API.getTypeTag = getTypeTag;
 
+const hasOwn =
+  Object.hasOwn ||
+  ((obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop));
+
 /**
  * Safe property check
  *
@@ -26,7 +30,7 @@ API.getTypeTag = getTypeTag;
 function hasProperty(obj, prop) {
   try {
     while (obj) {
-      if (Object.getOwnPropertyDescriptor(obj, prop)) {
+      if (hasOwn(obj, prop)) {
         return true;
       }
       obj = Object.getPrototypeOf(obj);
@@ -70,7 +74,7 @@ const nullToUndefined = (x) => (x === null ? undefined : x);
 function isPromise(obj) {
   try {
     // clang-format off
-    return !!obj && typeof obj.then === "function";
+    return typeof obj?.then === "function";
     // clang-format on
   } catch (e) {
     return false;
@@ -95,7 +99,7 @@ API.typedArrayAsUint8Array = bufferAsUint8Array;
 
 Module.iterObject = function* (object) {
   for (let k in object) {
-    if (Object.prototype.hasOwnProperty.call(object, k)) {
+    if (hasOwn(object, k)) {
       yield k;
     }
   }

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -14,15 +14,13 @@ function getTypeTag(x) {
 }
 API.getTypeTag = getTypeTag;
 
-const hasOwn =
-  Object.hasOwn ||
-  ((obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop));
-
 /**
  * Safe property check
  *
  * Observe whether a property exists or not without invoking getters.
  * Should never throw as long as arguments have the correct types.
+ * This check is better than `prop in obj` because it works also with
+ * primitives where `"length" in "str"`, as example, would throw.
  *
  * obj: an object
  * prop: a string or symbol
@@ -30,7 +28,7 @@ const hasOwn =
 function hasProperty(obj, prop) {
   try {
     while (obj) {
-      if (hasOwn(obj, prop)) {
+      if (Object.hasOwn(obj, prop)) {
         return true;
       }
       obj = Object.getPrototypeOf(obj);
@@ -99,7 +97,7 @@ API.typedArrayAsUint8Array = bufferAsUint8Array;
 
 Module.iterObject = function* (object) {
   for (let k in object) {
-    if (hasOwn(object, k)) {
+    if (Object.hasOwn(object, k)) {
       yield k;
     }
   }

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -2146,6 +2146,13 @@ function python_pop(jsobj: any, pop_start: boolean): any {
   return res;
 }
 
+const filteredHasKeySet: Set<string | symbol> = new Set([
+  "name",
+  "length",
+  "caller",
+  "arguments",
+]);
+
 function filteredHasKey(
   jsobj: PyProxy,
   jskey: string | symbol,
@@ -2159,17 +2166,12 @@ function filteredHasKey(
     return (
       jskey in jsobj &&
       !(
-        [
-          "name",
-          "length",
-          "caller",
-          "arguments",
-          // we are required by JS law to return `true` for `"prototype" in pycallable`
-          // but we are allowed to return the value of `getattr(pycallable, "prototype")`.
-          // So we filter prototype out of the "get" trap but not out of the "has" trap
-          filterProto ? "prototype" : undefined,
-        ] as (string | symbol)[]
-      ).includes(jskey)
+        filteredHasKeySet.has(jskey) ||
+        // we are required by JS law to return `true` for `"prototype" in pycallable`
+        // but we are allowed to return the value of `getattr(pycallable, "prototype")`.
+        // So we filter prototype out of the "get" trap but not out of the "has" trap
+        (filterProto && jskey === "prototype")
+      )
     );
   } else {
     return jskey in jsobj;
@@ -2341,6 +2343,14 @@ const PyProxySequenceHandlers = {
   },
 };
 
+const PyProxyJsonAdaptorDictHandlersSet = new Set([
+  "copy",
+  "constructor",
+  "$$flags",
+  "toString",
+  "destroy",
+]);
+
 const PyProxyJsonAdaptorDictHandlers = {
   isExtensible(): boolean {
     return true;
@@ -2360,9 +2370,7 @@ const PyProxyJsonAdaptorDictHandlers = {
   get(jsobj: PyProxy, jskey: any): any {
     let result;
     if (
-      ["copy", "constructor", "$$flags", "toString", "destroy"].includes(
-        jskey,
-      ) ||
+      PyProxyJsonAdaptorDictHandlersSet.has(jskey) ||
       typeof jskey === "symbol"
     ) {
       // @ts-ignore


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

The goal of this MR is to improve some low hanging fruits around TS/JS perf, most notably:

  * avoid unnecessary creation of descriptors to actually find if a property is *own* + use the modern `Object.hasOwn` when available and fallback with `hasOwnProperty` instead of `getOwnPropertyDescriptor` as that creates each time a new object even with the same ref and key
  * avoid runtime creation and crawl of always the same array of strings and use a set to have predictable *O(1)* checks for something super frequent/common (critical path)
  * avoid retrieving N times char points

**edit** tried the following, it doesn't work - feel free to ignore

- - -

About latest point though, I wonder if Python would handle just as fine `ASSIGN_U16` so that the whole JS to Python string conversion could be actually simplified as much as this:

```js
function js2python_string(value) {
  let result = _PyUnicode_New(value.length, 0xffff);
  if (result === 0) {
    throw new PropagateError();
  }

  for (let ptr = _PyUnicode_Data(result), i = 0; i < value.length; i++) {
    ASSIGN_U16(ptr, 0, value.charCodeAt(i));
    ptr += 2;
  }
  return result;
}
```

If that works, that might be not the most space-efficient way but surely it'll be the easiest/most straight forward way to go?

Anyway, happy to change/improve/ignore anything you like.
