### PR TITLE
DOC Pin cattrs temporarily to fix readthedocs build error

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -23,3 +23,5 @@ micropip==0.7.1
 jinja2>=3.0
 ruamel.yaml
 sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@781dc61870a802222051bcc8f6b2a592cd5eec7b
+# In 25.1.0, we get the error "cattrs.errors.StructureHandlerNotFoundError: Unsupported type: 'Attribute'. Register a structure hook for it."
+cattrs < 25.1.0


### PR DESCRIPTION
We are getting the following error with the latest cattrs release.

<details><summary>Traceback</summary>
<p>

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx/events.py", line 404, in emit
    results.append(listener.handler(self.app, *args))
                   ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx_js/__init__.py", line 97, in analyze
    app._sphinxjs_analyzer = analyzer.from_disk(  # type:ignore[attr-defined]
                             ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        abs_source_paths, app, root_for_relative_paths
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx_js/typedoc.py", line 140, in from_disk
    json, extra_data = typedoc_output(
                       ~~~~~~~~~~~~~~^
        abs_source_paths,
        ^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        ts_sphinx_js_config=app.config.ts_sphinx_js_config,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx_js/typedoc.py", line 106, in typedoc_output
    return ir.json_to_ir(json_ir), extra_data
           ~~~~~~~~~~~~~^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx_js/ir.py", line 349, in json_to_ir
    return converter.structure(json, list[TopLevelUnion])
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 576, in structure
    return self._structure_func.dispatch(cl)(obj, cl)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 133, in dispatch_without_caching
    res = self._function_dispatch.dispatch(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 75, in dispatch
    return handler(typ, self._converter)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/cols.py", line 113, in list_structure_factory
    handler = converter.get_structure_hook(elem_type)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 592, in get_structure_hook
    self._structure_func.dispatch(type)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 133, in dispatch_without_caching
    res = self._function_dispatch.dispatch(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 76, in dispatch
    return handler(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 670, in _gen_attrs_union_structure
    dis_fn = self._get_dis_func(cl, use_literals=use_literals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 978, in _get_dis_func
    return create_default_dis_func(
        self,
    ...<2 lines>...
        overrides=overrides if overrides is not None else "from_converter",
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/disambiguators.py", line 63, in create_default_dis_func
    getattr(converter.get_structure_hook(c), "overrides", {}) for c in classes
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 592, in get_structure_hook
    self._structure_func.dispatch(type)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 133, in dispatch_without_caching
    res = self._function_dispatch.dispatch(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 76, in dispatch
    return handler(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 1296, in gen_structure_attrs_fromdict
    return make_dict_structure_fn(
        cl,
    ...<4 lines>...
        **attrib_overrides,
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/gen/__init__.py", line 747, in make_dict_structure_fn
    return make_dict_structure_fn_from_attrs(
        attrs,
    ...<9 lines>...
        **kwargs,
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/gen/__init__.py", line 388, in make_dict_structure_fn_from_attrs
    handler = find_structure_handler(
        a, t, converter, _cattrs_prefer_attrib_converters
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/gen/_shared.py", line 58, in find_structure_handler
    handler = c.get_structure_hook(type, cache_result=False)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 594, in get_structure_hook
    else self._structure_func.dispatch_without_caching(type)
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 133, in dispatch_without_caching
    res = self._function_dispatch.dispatch(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 75, in dispatch
    return handler(typ, self._converter)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/cols.py", line 113, in list_structure_factory
    handler = converter.get_structure_hook(elem_type)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 592, in get_structure_hook
    self._structure_func.dispatch(type)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 133, in dispatch_without_caching
    res = self._function_dispatch.dispatch(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 76, in dispatch
    return handler(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 670, in _gen_attrs_union_structure
    dis_fn = self._get_dis_func(cl, use_literals=use_literals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 978, in _get_dis_func
    return create_default_dis_func(
        self,
    ...<2 lines>...
        overrides=overrides if overrides is not None else "from_converter",
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/disambiguators.py", line 63, in create_default_dis_func
    getattr(converter.get_structure_hook(c), "overrides", {}) for c in classes
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 592, in get_structure_hook
    self._structure_func.dispatch(type)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 133, in dispatch_without_caching
    res = self._function_dispatch.dispatch(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 76, in dispatch
    return handler(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 1296, in gen_structure_attrs_fromdict
    return make_dict_structure_fn(
        cl,
    ...<4 lines>...
        **attrib_overrides,
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/gen/__init__.py", line 747, in make_dict_structure_fn
    return make_dict_structure_fn_from_attrs(
        attrs,
    ...<9 lines>...
        **kwargs,
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/gen/__init__.py", line 388, in make_dict_structure_fn_from_attrs
    handler = find_structure_handler(
        a, t, converter, _cattrs_prefer_attrib_converters
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/gen/_shared.py", line 58, in find_structure_handler
    handler = c.get_structure_hook(type, cache_result=False)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 594, in get_structure_hook
    else self._structure_func.dispatch_without_caching(type)
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 133, in dispatch_without_caching
    res = self._function_dispatch.dispatch(typ)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 75, in dispatch
    return handler(typ, self._converter)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/cols.py", line 113, in list_structure_factory
    handler = converter.get_structure_hook(elem_type)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 592, in get_structure_hook
    self._structure_func.dispatch(type)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/dispatch.py", line 134, in dispatch_without_caching
    return res if res is not None else self._fallback_factory(typ)
                                       ~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/converters.py", line 1050, in <lambda>
    structure_fallback_factory: HookFactory[StructureHook] = lambda t: raise_error(
                                                                       ~~~~~~~~~~~^
        None, t
        ^^^^^^^
    ),
    ^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/cattrs/fns.py", line 22, in raise_error
    raise StructureHandlerNotFoundError(msg, type_=cl)
cattrs.errors.StructureHandlerNotFoundError: Unsupported type: 'Attribute'. Register a structure hook for it.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx/cmd/build.py", line 496, in build_main
    app = Sphinx(
        srcdir=args.sourcedir,
    ...<14 lines>...
        exception_on_warning=args.exception_on_warning,
    )
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx/application.py", line 295, in __init__
    self._init_builder()
    ~~~~~~~~~~~~~~~~~~^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx/application.py", line 369, in _init_builder
    self.events.emit('builder-inited')
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyodide/envs/5610/lib/python3.13/site-packages/sphinx/events.py", line 415, in emit
    raise ExtensionError(
    ...<4 lines>...
    ) from exc
sphinx.errors.ExtensionError: Handler <function analyze at 0x7b557df662a0> for event 'builder-inited' threw an exception (exception: Unsupported type: 'Attribute'. Register a structure hook for it.)

Extension error (sphinx_js):
Handler <function analyze at 0x7b557df662a0> for event 'builder-inited' threw an exception (exception: Unsupported type: 'Attribute'. Register a structure hook for it.)

</p>
</details> 