### PR TITLE
Fix: callPromising should not treat async error as fatal

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -34,6 +34,9 @@ myst:
   {pr}`5597`
 - {{ Fix }} Add the current working directory to the path instead of `$HOME`.
   {pr}`5630`
+- {{ Fix }} Fixed a fatal error when stack switching is enabled on a function
+  that raises an asynchronous error.
+  {pr}`5678`
 
 - {{ Enhancement }} `pyodide.loadPackage` now prints the output to the `stdout` and `stderr`
   streams that are passed to `loadPyodide()` or by `pyodide.setStdout()` and `pyodide.setStderr()`.

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -833,7 +833,14 @@ _pyproxy_apply_promising(JsVal suspender,
   JsVal res =
     _pyproxy_apply(callable, jsargs, numposargs, jskwnames, numkwargs);
   *exc = PyErr_GetRaisedException();
-  return res;
+  // In case the result is a thenable, in callPromisingKwargs we only want to
+  // await the stack switch not the thenable that Python returned. So we wrap
+  // the result in a one-entry list. We'll unwrap it in callPromisingKwargs
+  // after awaiting the callable. If there was a synchronous error, we'll wrap
+  // the "null" in a list anyways. This simplifies the code a bit.
+  JsVal wrap = JsvArray_New();
+  JsvArray_Push(wrap, res);
+  return wrap;
 }
 
 EMSCRIPTEN_KEEPALIVE bool

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -582,7 +582,12 @@ async function callPyObjectKwargsPromising(
     // promisingApply clears the error flag and saves any error into excStatus.
     // This ensures that tasks that are run between when promisingApply resolves
     // and when this task resumes here won't incorrectly observe the error flag.
-    // See test_stack_switching.test_throw_from_switcher for a detailed explanation.
+    // See test_stack_switching.test_throw_from_switcher for a detailed
+    // explanation.
+    //
+    // The result of promisingApply() is wrapped in a one element list
+    // (regardless of whether there was an error or not) to ensure that we only
+    // await the stack switches and not a thenable result.
     result = await Module.promisingApply(
       ptrobj,
       jsargs,
@@ -595,6 +600,8 @@ async function callPyObjectKwargsPromising(
   } catch (e) {
     API.fatal_error(e);
   }
+  // Unwrap result
+  result = result[0];
   if (result === null) {
     _PyErr_SetRaisedException(HEAPU32[exc / 4]);
     try {

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -720,10 +720,12 @@ def test_can_run_sync(selenium):
         assert idx == i
         assert res == expected
 
+
 @requires_jspi
 def test_async_promising_sync_error(selenium):
     import pytest
-    with pytest.raises(selenium.JavascriptException, match='division by zero'):
+
+    with pytest.raises(selenium.JavascriptException, match="division by zero"):
         selenium.run_js(
             """
             const test = pyodide.runPython(`
@@ -748,7 +750,8 @@ def test_async_promising_sync_error(selenium):
 @requires_jspi
 def test_async_promising_async_error(selenium):
     import pytest
-    with pytest.raises(selenium.JavascriptException, match='division by zero'):
+
+    with pytest.raises(selenium.JavascriptException, match="division by zero"):
         selenium.run_js(
             """
             const test = pyodide.runPython(`

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -719,3 +719,52 @@ def test_can_run_sync(selenium):
     for idx, [i, res, expected] in enumerate(results):
         assert idx == i
         assert res == expected
+
+@requires_jspi
+def test_async_promising_sync_error(selenium):
+    import pytest
+    with pytest.raises(selenium.JavascriptException, match='division by zero'):
+        selenium.run_js(
+            """
+            const test = pyodide.runPython(`
+                def test():
+                    1/0
+
+                test
+            `)
+
+            try {
+                await test.callPromising();
+            } finally {
+                test.destroy();
+            }
+            """
+        )
+    # In bad cases, the previous exception was a fatal error but we didn't
+    # notice. Check that no fatal error occurred by running Python.
+    selenium.run("")
+
+
+@requires_jspi
+def test_async_promising_async_error(selenium):
+    import pytest
+    with pytest.raises(selenium.JavascriptException, match='division by zero'):
+        selenium.run_js(
+            """
+            const test = pyodide.runPython(`
+                async def test():
+                    1/0
+
+                test
+            `)
+
+            try {
+                await test.callPromising();
+            } finally {
+                test.destroy();
+            }
+            """
+        )
+    # In bad cases, the previous exception was a fatal error but we didn't
+    # notice. Check that no fatal error occurred by running Python.
+    selenium.run("")


### PR DESCRIPTION
There is a problem here with Promise flattening: if the return value of the function is a thenable, we accidentally await both the promise from stack switching and the enclosed thenable. This raises a user error out and we catch it and treat it as a fatal error.

To avoid this problem, we wrap the result in a one element list to prevent the promises from being flattened.

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
