### PR TITLE
Improve the error message when a dynamic library is not found

### DIFF
--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -280,7 +280,10 @@ If you updated the Pyodide version, make sure you also updated the 'indexURL' pa
   }
   // Disable further loading of Emscripten file_packager stuff.
   Module.locateFile = (path: string) => {
-    throw new Error("Didn't expect to load any more file_packager files!");
+    if (path.endsWith(".so")) {
+      throw new Error(`Failed to find dynamic library "${path}"`)
+    }
+    throw new Error(`Unexpected call to locateFile("${path}")`);
   };
 
   let snapshotConfig: SnapshotConfig | undefined = undefined;


### PR DESCRIPTION
Prior to this, if we dlopen a dynamic library a.so which depends on b.so and we find a.so but not b.so, the error message looks like:
```
Could not load dynamic lib: a.so
Error: Didn't expect to load any more file_packager files!
```
After this change:
```
Could not load dynamic lib: a.so
Error: Failed to find dynamic library b.so
```
So the error message will mention `b.so` now.
