### PR TITLE
Add tags to the core packages

### DIFF
--- a/packages/Jinja2/meta.yaml
+++ b/packages/Jinja2/meta.yaml
@@ -2,6 +2,8 @@ package:
   name: Jinja2
   version: 3.1.6
   tag:
+    # Remove tag after removing Jinja2 from the test suite
+    - pyodide.test
     - core
     - min-scipy-stack
   top-level:

--- a/packages/MarkupSafe/meta.yaml
+++ b/packages/MarkupSafe/meta.yaml
@@ -1,6 +1,10 @@
 package:
   name: MarkupSafe
   version: 3.0.2
+  tag:
+    # Remove tag after removing MarkupSafe from the test suite
+    - pyodide.test
+    - core
   top-level:
     - markupsafe
 source:

--- a/packages/atomicwrites/meta.yaml
+++ b/packages/atomicwrites/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: atomicwrites
   version: 1.4.1
+  tag:
+    - core
+    - pytest
   top-level:
     - atomicwrites
 source:

--- a/packages/attrs/meta.yaml
+++ b/packages/attrs/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: attrs
   version: 25.2.0
+  tag:
+    - core
+    - pytest
   top-level:
     - attr
     - attrs

--- a/packages/boost-cpp/meta.yaml
+++ b/packages/boost-cpp/meta.yaml
@@ -2,6 +2,7 @@ package:
   name: boost-cpp
   version: 1.84.0
   tag:
+    - core
     - library
     - static_library
 source:

--- a/packages/cffi/meta.yaml
+++ b/packages/cffi/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: cffi
   version: 1.17.1
+  tag:
+    - core
+    - cross_build
   top-level:
     - cffi
 requirements:

--- a/packages/coverage/meta.yaml
+++ b/packages/coverage/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: coverage
   version: 7.6.12
+  tag:
+    - core
+    - pytest
   top-level:
     - coverage
 source:

--- a/packages/exceptiongroup/meta.yaml
+++ b/packages/exceptiongroup/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: exceptiongroup
   version: 1.2.2
+  tag:
+    - core
+    - pytest
   top-level:
     - exceptiongroup
 source:

--- a/packages/iniconfig/meta.yaml
+++ b/packages/iniconfig/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: iniconfig
   version: 2.0.0
+  tag:
+    - core
+    - pytest
   top-level:
     - iniconfig
 source:

--- a/packages/libf2c/meta.yaml
+++ b/packages/libf2c/meta.yaml
@@ -8,6 +8,7 @@ package:
   name: libf2c
   version: CLAPACK-3.2.1
   tag:
+    - core
     - library
     - static_library
 source:

--- a/packages/liblzma/meta.yaml
+++ b/packages/liblzma/meta.yaml
@@ -2,6 +2,7 @@ package:
   name: liblzma
   version: 5.2.2
   tag:
+    - always
     - library
     - static_library
 source:

--- a/packages/more-itertools/meta.yaml
+++ b/packages/more-itertools/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: more-itertools
   version: 10.6.0
+  tag:
+    - core
+    - pytest
   top-level:
     - more_itertools
 source:

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -2,7 +2,6 @@ package:
   name: numpy
   version: 2.2.5
   tag:
-    - core
     - cross-build
     - min-scipy-stack
   top-level:

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -2,6 +2,8 @@ package:
   name: numpy
   version: 2.2.5
   tag:
+    - core
+    - cross-build
     - min-scipy-stack
   top-level:
     - numpy

--- a/packages/openblas/meta.yaml
+++ b/packages/openblas/meta.yaml
@@ -2,6 +2,7 @@ package:
   name: openblas
   version: 0.3.26
   tag:
+    - core
     - library
     - shared_library
 source:

--- a/packages/openssl/meta.yaml
+++ b/packages/openssl/meta.yaml
@@ -2,6 +2,7 @@ package:
   name: openssl
   version: 1.1.1w
   tag:
+    - core
     - library
     - shared_library
 source:

--- a/packages/packaging/meta.yaml
+++ b/packages/packaging/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: packaging
   version: "24.2"
+  tag:
+    - core
   top-level:
     - packaging
 source:

--- a/packages/pluggy/meta.yaml
+++ b/packages/pluggy/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: pluggy
   version: 1.5.0
+  tag:
+    - core
+    - pytest
   top-level:
     - pluggy
 source:

--- a/packages/py/meta.yaml
+++ b/packages/py/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: py
   version: 1.11.0
+  tag:
+    - core
+    - pytest
   top-level:
     - py
 source:

--- a/packages/pycparser/meta.yaml
+++ b/packages/pycparser/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pycparser
   version: "2.22"
+  tag:
+    - core
   top-level:
     - pycparser
 source:

--- a/packages/pyparsing/meta.yaml
+++ b/packages/pyparsing/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: pyparsing
   version: 3.2.1
+  tag:
+    - core
+    - pytest
   top-level:
     - pyparsing
 source:

--- a/packages/pytest-asyncio/meta.yaml
+++ b/packages/pytest-asyncio/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 0.25.3
   tag:
     - core
+    - pytest
     - min-scipy-stack
   top-level:
     - pytest_asyncio

--- a/packages/pytest/meta.yaml
+++ b/packages/pytest/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 8.3.5
   tag:
     - core
+    - pytest
     - min-scipy-stack
   top-level:
     - _pytest

--- a/packages/pytz/meta.yaml
+++ b/packages/pytz/meta.yaml
@@ -2,6 +2,8 @@ package:
   name: pytz
   version: "2025.1"
   tag:
+    # Remove tag after removing pytz from the test suite
+    - pyodide.test
     - core
     - min-scipy-stack
   top-level:

--- a/packages/regex/meta.yaml
+++ b/packages/regex/meta.yaml
@@ -2,6 +2,8 @@ package:
   name: regex
   version: 2024.11.6
   tag:
+    # Remove tag after removing regex from the test suite
+    - pyodide.test
     - core
     - min-scipy-stack
   top-level:

--- a/packages/rust-abi-test/meta.yaml
+++ b/packages/rust-abi-test/meta.yaml
@@ -2,7 +2,9 @@ package:
   name: rust-abi-test
   version: "1.0"
   tag:
+    - core
     - rust
+    - pyodide.test
 source:
   path: src
 requirements:

--- a/packages/rust-panic-test/meta.yaml
+++ b/packages/rust-panic-test/meta.yaml
@@ -3,6 +3,8 @@ package:
   version: "1.0"
   tag:
     - rust
+    - core
+    - pyodide.test
 source:
   path: src
 requirements:

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -4,6 +4,8 @@ package:
   pinned: true
   tag:
     - min-scipy-stack
+    - core
+    - cross-build
   top-level:
     - scipy
 

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -4,7 +4,6 @@ package:
   pinned: true
   tag:
     - min-scipy-stack
-    - core
     - cross-build
   top-level:
     - scipy

--- a/packages/setuptools/meta.yaml
+++ b/packages/setuptools/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: setuptools
   version: 76.0.0
+  tag:
+    - core
+    - pytest
   top-level:
     - _distutils_hack
     - pkg_resources

--- a/packages/sharedlib-test/meta.yaml
+++ b/packages/sharedlib-test/meta.yaml
@@ -2,6 +2,7 @@ package:
   name: sharedlib-test
   version: "1.0"
   tag:
+    - core
     - pyodide.test
     - library
     - shared_library

--- a/packages/six/meta.yaml
+++ b/packages/six/meta.yaml
@@ -1,6 +1,9 @@
 package:
   name: six
   version: 1.17.0
+  tag:
+    - core
+    - pytest
   top-level:
     - six
 source:

--- a/packages/tblib/meta.yaml
+++ b/packages/tblib/meta.yaml
@@ -4,8 +4,8 @@ package:
   top-level:
     - tblib
   tag:
-    - always
     - core
+    - pytest
     - min-scipy-stack
 source:
   url: https://files.pythonhosted.org/packages/9b/87/ce70db7cae60e67851eb94e1a2127d4abb573d3866d2efd302ceb0d4d2a5/tblib-3.0.0-py3-none-any.whl


### PR DESCRIPTION
Splitted out from #4987

This PR adds some informational tags to the core packages, which will remain in this repository after unvendoring recipes.

- core: core packages
  - pytest: packages that are used in pytest. We need these packages to make @run_in_pyodide work.
  - cross-build: packages that are included in xbuildenv
  - pyodide.test: packages that are used in our core test suite