### PR TITLE
Use pytest-pyodide 0.58.6

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -91,6 +91,7 @@ def set_configs():
         });
         """,
     )
+    pytest_pyodide_config.add_node_extra_globals(["URL", "Headers"])
 
 
 set_configs()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ pytest-asyncio
 pytest-cov
 pytest-httpserver
 pytest-benchmark
-pytest-pyodide==0.58.5
+pytest-pyodide==0.58.6
 setuptools; python_version >= '3.12'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ pytest-asyncio
 pytest-cov
 pytest-httpserver
 pytest-benchmark
-pytest-pyodide==0.58.3
+pytest-pyodide==0.58.5
 setuptools; python_version >= '3.12'

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -36,6 +36,9 @@ def test_find_imports():
         """
     )
     assert res == []
+    l: list[str] = []
+
+    l.update(["a"])
 
 
 def test_ffi_import_star():

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -36,9 +36,6 @@ def test_find_imports():
         """
     )
     assert res == []
-    l: list[str] = []
-
-    l.update(["a"])
 
 
 def test_ffi_import_star():


### PR DESCRIPTION
Brings in `add_node_extra_globals()`. Should unblock #5655. cc @dom96.