### PR TITLE
Rename zlib to libzlib

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -81,6 +81,8 @@ myst:
   `matplotlib.use("module://matplotlib_pyodide.wasm_backend")`.
   {pr}`5374` {pr}`5398`
 
+- Renamed `zlib` to `libzlib`
+
 ## Version 0.27.7
 
 _June 04, 2025_

--- a/packages/libzlib/meta.yaml
+++ b/packages/libzlib/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: zlib
+  name: libzlib
   version: 1.3.1
   tag:
     - library


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description
- reasoning for the change
    - zlib is shipped in distros as libz-dev. zlib could be confused with Python’s built-in zlib module. Renaming to libzlib disambiguates it as the C library. Related: #5180
<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation

Since #5180 is for renaming all static and shared libraries, please let me know if some more packages are needed to be renamed. I just wanted to onboard this project by this PR at first.   
