### PR TITLE
Enable WebGL2 (-sMAX_WEBGL_VERSION=2)

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -191,6 +191,7 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-lhtml5.js \
 	-lhtml5_webgl.js \
 	-lsdl.js \
+	-sMAX_WEBGL_VERSION=2  \
 	-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0
 
 EXPORTS=_main \

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -62,6 +62,10 @@ myst:
 
 - {{ Fix }} Fixed iPad + Safari issue started to happen since 0.27.1. {pr}`5695`
 
+- {{ Enhancement }} Enable WebGL 2 (-sMAX_WEBGL_VERSION=2).
+  WebGL 1 is still available but must be required explicitly
+  (for example, by using OpenGL ES 2.0)
+
 ### `python` CLI entrypoint
 
 - {{ Fix }} The `python` CLI now mounts the `/tmp` directory. In


### PR DESCRIPTION
### Description

By default, emscripten does not enable WebGL 2 (only WebGL 1 is available).
This PR add support for WebGL2, by setting -sMAX_WEBGL_VERSION=2

(WebGL 2 was finalised and first appeared in stable browsers in January 2017)

**Impacts**
See [doc for MAX_WEBGL_VERSION](https://emscripten.org/docs/tools_reference/settings_reference.html#max-webgl-version)

*Setting MAX_WEBGL_VERSION=2 implies that*
- WebGL 2 is now available (it was not available without this flag)
- WebGL 1 is *still available*, but WebGL 2 will be the default if no version is specified
- WebGL 1 can be required explicitly; for example, by using OpenGL ES 2.0 like in the example below: 


```cpp
SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES );
SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
```

### Related PR

This PR is related to [this pyodide-recipes PR](https://github.com/pyodide/pyodide-recipes/pull/116) which add the imgui_bundle package (and requires WebGL2 to work).


### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [X] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation

I don't think it will be required to add test and update the documentation. 

I'd be happy to discuss about this.
