### PR TITLE
CI Fix incorrect lockfile in dev release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,14 +790,14 @@ workflows:
 
       - build-pyodide-debug:
           requires:
-            - build-core-packages
+            - build-full-packages
           filters:
             tags:
               only: /.*/
 
       - build-test-pyc-packages:
           requires:
-            - build-core-packages
+            - build-full-packages
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,6 @@ jobs:
       - run:
           name: build pyodide debug
           command: |
-            cp -r dist dist-release
             rm dist/pyodide.asm.js
             source pyodide_env.sh
             ccache -z
@@ -223,12 +222,11 @@ jobs:
             npx prettier -w pyodide.js
             cd ..
             mv dist dist-debug
-            mv dist-release dist
 
       - persist_to_workspace:
           root: .
           paths:
-            - .
+            - ./dist-debug
 
   create-xbuild-env:
     <<: *defaults


### PR DESCRIPTION
Resolves #5713

There was a misconfiguration in the circle CI dependency tree. The `build-pyodide-debug` and `build-test-pyc-packages` job was outputting the lockfile from the core packages set, not the full packages set, and overrides the lockfile in the `deploy-dev` job.