### PR TITLE
PERF Use sentinel for faster Jsv_novalue

### DIFF
--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -45,17 +45,21 @@ Jsv_GetNoValue(void)
   return create_sentinel(NO_VALUE_SENTINEL);
 }
 
-__attribute__((import_module("sentinel"),
-               import_name("sentinel_get_value"))) int sentinel_get_value(JsVal);
+__attribute__((
+  import_module("sentinel"),
+  import_name("sentinel_get_value"))) int sentinel_get_value(JsVal);
 
-int JsvError_Check(JsVal x) {
+int
+JsvError_Check(JsVal x)
+{
   return sentinel_get_value(x) == ERROR_SENTINEL;
 }
 
-int JsvNoValue_Check(JsVal x) {
+int
+JsvNoValue_Check(JsVal x)
+{
   return sentinel_get_value(x) == NO_VALUE_SENTINEL;
 }
-
 
 EM_JS_NUM(int, jslib_init_js, (void), {
   JS_INIT_CONSTS();
@@ -78,7 +82,6 @@ jslib_init(void)
 finally:
   return -1;
 }
-
 
 // ==================== Conversions between JsRef and JsVal ====================
 

--- a/src/core/jslib.h
+++ b/src/core/jslib.h
@@ -37,7 +37,6 @@ extern JsRef Jsr_false;
 extern JsRef Jsr_novalue;
 extern JsRef Jsr_error;
 
-
 // ==================== JS_ERROR ====================
 
 #define JS_ERROR hiwire_get(Jsr_error)

--- a/src/core/sentinel.ts
+++ b/src/core/sentinel.ts
@@ -43,7 +43,7 @@ export async function getSentinelImport(): Promise<SentinelInstance> {
   }
   const error_marker = Symbol("error marker");
   return {
-    create_sentinel: (a: number) => ({[error_marker]: a}),
+    create_sentinel: (a: number) => ({ [error_marker]: a }),
     sentinel_get_value: (val: any): number => val?.[error_marker] ?? 0,
   };
 }

--- a/src/js/snapshot.ts
+++ b/src/js/snapshot.ts
@@ -175,7 +175,8 @@ API.serializeHiwireState = function (
     throw new Error(`Can't serialize object at index ${i}`);
   }
   const immortalKeys = [];
-  const shouldBeEndOfConstants = Module.__hiwire_immortal_get(NUM_STATIC_JS_REFS);
+  const shouldBeEndOfConstants =
+    Module.__hiwire_immortal_get(NUM_STATIC_JS_REFS);
   if (shouldBeEndOfConstants !== "end of constants") {
     throw new Error(
       `Internal error: expected end of constants object at index ${NUM_STATIC_JS_REFS}`,
@@ -275,7 +276,8 @@ export function syncUpSnapshotLoad1() {
   Module._jslib_init();
   // We expect everything after this in the immortal table to be interned strings.
   // We need to know where to start looking for the strings so that we serialized correctly.
-  const shouldBeEndOfConstants = Module.__hiwire_immortal_get(NUM_STATIC_JS_REFS);
+  const shouldBeEndOfConstants =
+    Module.__hiwire_immortal_get(NUM_STATIC_JS_REFS);
   if (shouldBeEndOfConstants !== "end of constants") {
     throw new Error(
       `Internal error: expected js_no_value object at index ${NUM_STATIC_JS_REFS}`,


### PR DESCRIPTION
This will speed up python2js a bit.
