### PR TITLE
Compare ABI version not Pyodide version

### DIFF
--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -3,6 +3,9 @@ const Hiwire = {};
 const Tests = {};
 API.tests = Tests;
 API.version = "0.28.0";
+// This version should be equal to the one in the Makefile.envs
+// TODO: Pass this value dynamically from outside.
+API.abiVersion = "2025_0";
 Module.hiwire = Hiwire;
 
 function getTypeTag(x) {

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -45,11 +45,11 @@ export async function initializePackageIndex(
     );
   }
 
-  if (lockfile.info.version !== API.version) {
+  if (lockfile.info.abi_version !== API.abiVersion) {
     throw new Error(
-      "Lock file version doesn't match Pyodide version.\n" +
-        `   lockfile version: ${lockfile.info.version}\n` +
-        `   pyodide  version: ${API.version}`,
+      "Lock file ABI version doesn't match Pyodide ABI version.\n" +
+        `   lockfile version: ${lockfile.info.abi_version}\n` +
+        `   pyodide  version: ${API.abiVersion}`,
     );
   }
 

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -349,6 +349,7 @@ export interface Module {
 
 type LockfileInfo = {
   arch: "wasm32" | "wasm64";
+  abi_version: string;
   platform: string;
   version: string;
   python: string;
@@ -506,6 +507,7 @@ export interface API {
   syncUpSnapshotLoad3(conf: SnapshotConfig): void;
   abortSignalAny: (signals: AbortSignal[]) => AbortSignal;
   version: string;
+  abiVersion: string;
   pyVersionTuple: [number, number, number];
   LiteralMap: any;
   sitePackages: string;


### PR DESCRIPTION
### Description

Updates the lockfile version check to compare the ABI version, not the Pyodide version. The prebuilt packages may have a different Pyodide version if they use alpha or nightly xbuildenv.

