### PR TITLE
FIX Buffer messages in PackageManager when the stream is not ready

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -17,7 +17,8 @@ myst:
 
 ## Unreleased
 
-- {{ Fix }} Pyodide now prints the package load messages / errors when `packages: [...]` is passed to `loadPyodide()`.
+- {{ Fix }} Fixed a bug which preloading packages through `packages: [...]` parameter of `loadPyodide()` did not work
+  when the `lockfileURL` was set to a custom URL.
   {pr}`5737`
 
 ## Version 0.28.0

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,7 +18,7 @@ myst:
 ## Unreleased
 
 - {{ Fix }} Pyodide now prints the package load messages / errors when `packages: [...]` is passed to `loadPyodide()`.
-  {pr}`5654`
+  {pr}`5737`
 
 ## Version 0.28.0
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,11 @@ myst:
 
 # Change Log
 
+## Unreleased
+
+- {{ Fix }} Pyodide now prints the package load messages / errors when `packages: [...]` is passed to `loadPyodide()`.
+  {pr}`5654`
+
 ## Version 0.28.0
 
 _July 4, 2025_

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -84,7 +84,7 @@ export async function initializePackageIndex(
   if (API.config.fullStdLib) {
     toLoad = [...toLoad, ...API.lockfile_unvendored_stdlibs];
   }
-  await loadPackage(toLoad);
+  await loadPackage(toLoad, { messageCallback() {} });
   // Have to wait for bootstrapFinalizedPromise before calling Python APIs
   await API.bootstrapFinalizedPromise;
   API.flushPackageManagerBuffers();

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -84,9 +84,11 @@ export async function initializePackageIndex(
   if (API.config.fullStdLib) {
     toLoad = [...toLoad, ...API.lockfile_unvendored_stdlibs];
   }
-  await loadPackage(toLoad, { messageCallback() {} });
+  await loadPackage(toLoad);
   // Have to wait for bootstrapFinalizedPromise before calling Python APIs
   await API.bootstrapFinalizedPromise;
+  API.flushPackageManagerBuffers();
+
   // Set up module_not_found_hook
   const importhook = API._pyodide._importhook;
   importhook.register_module_not_found_hook(
@@ -133,6 +135,15 @@ export class PackageManager {
   private stdout: (message: string) => void;
   private stderr: (message: string) => void;
 
+  /**
+   * Buffers for store stdout and stderr messages temporarily.
+   * These are used to store the messages that are printed before the
+   * stdout and stderr functions are set.
+   */
+  private streamReady: boolean = false;
+  private stdoutBuffer: string[] = [];
+  private stderrBuffer: string[] = [];
+
   private defaultChannel: string = DEFAULT_CHANNEL;
 
   constructor(api: PackageManagerAPI, pyodideModule: PackageManagerModule) {
@@ -155,6 +166,11 @@ export class PackageManager {
     }
 
     this.stdout = (msg: string) => {
+      if (!this.streamReady) {
+        this.stdoutBuffer.push(msg);
+        return;
+      }
+
       const sp = this.#module.stackSave();
       try {
         const msgPtr = this.#module.stringToUTF8OnStack(msg);
@@ -165,6 +181,11 @@ export class PackageManager {
     };
 
     this.stderr = (msg: string) => {
+      if (!this.streamReady) {
+        this.stderrBuffer.push(msg);
+        return;
+      }
+
       const sp = this.#module.stackSave();
       try {
         const msgPtr = this.#module.stringToUTF8OnStack(msg);
@@ -312,6 +333,10 @@ export class PackageManager {
 
       // We have to invalidate Python's import caches, or it won't
       // see the new files.
+
+      // Can't use invalidate_caches until bootstrap is finalized.
+      await this.#api.bootstrapFinalizedPromise;
+
       this.#api.importlib.invalidate_caches();
       return Array.from(loadedPackageData, filterPackageData);
     } finally {
@@ -564,6 +589,24 @@ export class PackageManager {
   }
 
   /**
+   * Flushes the stdout and stderr buffers, that were collected before the
+   * stdout and stderr functions were set.
+   */
+  public flushBuffers() {
+    this.streamReady = true;
+
+    for (const msg of this.stdoutBuffer) {
+      this.stdout(msg);
+    }
+    for (const msg of this.stderrBuffer) {
+      this.stderr(msg);
+    }
+
+    this.stdoutBuffer = [];
+    this.stderrBuffer = [];
+  }
+
+  /**
    * getLoadedPackageChannel returns the channel from which a package was loaded.
    * if the package is not loaded, it returns null.
    * @param pkg package name
@@ -666,6 +709,10 @@ if (typeof API !== "undefined" && typeof Module !== "undefined") {
   );
 
   API.lockfileBaseUrl = singletonPackageManager.installBaseUrl;
+
+  API.flushPackageManagerBuffers = singletonPackageManager.flushBuffers.bind(
+    singletonPackageManager,
+  );
 
   if (API.lockFilePromise) {
     API.packageIndexReady = initializePackageIndex(API.lockFilePromise);

--- a/src/js/test/unit/package-manager.test.ts
+++ b/src/js/test/unit/package-manager.test.ts
@@ -95,4 +95,28 @@ describe("getLoadedPackageChannel", () => {
     const notLoadedPackage = pm.getLoadedPackageChannel("notLoadedPackage");
     chai.assert.equal(notLoadedPackage, null);
   });
+
+  describe("streamReady and flushing buffers", () => {
+    it("Should flush stdout and stderr buffers when stream is ready", () => {
+      const mockApi = genMockAPI();
+      const mockMod = genMockModule();
+
+      const logStdoutSpy = sinon.spy(mockMod, "_print_stdout");
+      const logStderrSpy = sinon.spy(mockMod, "_print_stderr");
+
+      const pm = new PackageManager(mockApi, mockMod);
+      pm.logStdout("stdout message");
+      pm.logStderr("stderr message");
+
+      // not called yet, buffers should not be flushed
+      chai.assert.isFalse(logStdoutSpy.called);
+      chai.assert.isFalse(logStderrSpy.called);
+
+      pm.flushBuffers();
+
+      // now buffers should be flushed
+      chai.assert.isTrue(logStdoutSpy.calledOnce);
+      chai.assert.isTrue(logStderrSpy.calledOnce);
+    });
+  });
 });

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -466,6 +466,7 @@ export interface API {
   repodata_packages: Record<string, InternalPackageData>;
   repodata_info: LockfileInfo;
   lockfileBaseUrl: string;
+  flushPackageManagerBuffers: () => void;
   defaultLdLibraryPath: string[];
   sitepackages: string;
   loadBinaryFile: (


### PR DESCRIPTION
### Description

This fixes half of the bug in #5736. It does not fix the real error, but fixes the incorrect error message `TypeError: _emscripten_stack_get_current is not a function` being printed, and makes the stacktrace show the real error.

The problem was that, after #5621, the PackageManager uses the native APIs to print messages, which requires the bootstrap to finish to print messages. However, when the packages are preloaded by passing `packages` option in `loadPyodide`, the bootstrap doesn't finish until `bootstrapFinalizedPromise` is resolved.

This PR makes a temporary buffer that stores the streams, and flush it when the bootstrap is finalized. After this change, the reproducer in #5736 shows the real error message.

![image](https://github.com/user-attachments/assets/0e12f863-3c91-431b-a609-8d6c5dbcdcd6)


### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
