### PR TITLE
chore: add missing defaults to `to_js` overloads

### DIFF
--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1449,9 +1449,9 @@ def to_js(
     /,
     *,
     depth: int = -1,
-    pyproxies: JsProxy | None,
+    pyproxies: JsProxy | None = None,
     create_pyproxies: bool,
-    dict_converter: None,
+    dict_converter: None = None,
     default_converter: ToJsConverter | None = None,
     eager_converter: ToJsConverter | None = None,
 ) -> JsMap[Any, Any]: ...


### PR DESCRIPTION
`to_js` was missing some defaults in the overloads, meaning that that overload wouldn't be matched if the user didn't pass the value explicitly

For example, in 
```python
from typing import overload, Literal, reveal_type

@overload
def func(a: str) -> Literal[2]: ...
@overload
def func(a: None) -> Literal[1]: ...

def func(a: str | None = None) -> Literal[1, 2]:
    return 1 if a is None else 2

reveal_type(func())
```
mypy gives
```
main.py:11: error: All overload variants of "func" require at least one argument  [call-overload]
```
but for
```python
from typing import overload, Literal, reveal_type

@overload
def func(a: str) -> Literal[2]: ...
@overload
def func(a: None = None) -> Literal[1]: ...

def func(a: str | None = None) -> Literal[1, 2]:
    return 1 if a is None else 2

reveal_type(func())
```
it gives
```
main.py:11: note: Revealed type is "Literal[1]"
```

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
