### PR TITLE
CI Fix incorrect lockfile in xbuildenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,7 +767,7 @@ workflows:
 
       - create-xbuild-env:
           requires:
-            - build-core-packages
+            - build-full-packages
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
The xbuildenv should contain the lockfile from the prebuilt packages set, not one that built from this repository. This fixes it.

- Related issue: https://github.com/duckdb/duckdb/pull/18173#pullrequestreview-2996403853