### PR TITLE
Fix installBaseUrl calculation in Node.js when relative URL is passed.

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -21,6 +21,9 @@ myst:
   when the `lockfileURL` was set to a custom URL.
   {pr}`5737`
 
+- {{ Fix }} Fixed a bug in Node.js which providing a relative path to `lockFileURL` parameter of `loadPyodide()` did not work.
+  {pr}`5750`
+
 ## Version 0.28.0
 
 _July 4, 2025_

--- a/src/js/test/unit/package-manager.test.ts
+++ b/src/js/test/unit/package-manager.test.ts
@@ -2,6 +2,7 @@ import * as chai from "chai";
 import sinon from "sinon";
 import { PackageManager, toStringArray } from "../../load-package.ts";
 import { genMockAPI, genMockModule } from "./test-helper.ts";
+import { calculateInstallBaseUrl } from "../../load-package.ts";
 
 describe("PackageManager", () => {
   it("should initialize with API and Module", () => {
@@ -118,5 +119,113 @@ describe("getLoadedPackageChannel", () => {
       chai.assert.isTrue(logStdoutSpy.calledOnce);
       chai.assert.isTrue(logStderrSpy.calledOnce);
     });
+  });
+});
+
+describe("calculateInstallBaseUrl", () => {
+  let originalLocation: any;
+
+  beforeEach(() => {
+    // Store original location
+    originalLocation = globalThis.location;
+  });
+
+  afterEach(() => {
+    // Restore original location
+    if (originalLocation) {
+      globalThis.location = originalLocation;
+    } else {
+      delete (globalThis as any).location;
+    }
+  });
+
+  it("Should extract base URL from absolute HTTP URL", () => {
+    const result = calculateInstallBaseUrl(
+      "https://cdn.example.com/pyodide/pyodide-lock.json",
+    );
+    chai.assert.equal(result, "https://cdn.example.com/pyodide/");
+  });
+
+  it("Should extract base URL from file URL", () => {
+    const result = calculateInstallBaseUrl(
+      "file:///tmp/pyodide/pyodide-lock.json",
+    );
+    chai.assert.equal(result, "file:///tmp/pyodide/");
+  });
+
+  it("Should extract base URL from relative URL with path", () => {
+    const result = calculateInstallBaseUrl("./pyodide/pyodide-lock.json");
+    chai.assert.equal(result, "./pyodide/");
+  });
+
+  it("Should extract base URL from relative URL with parent directory", () => {
+    const result = calculateInstallBaseUrl("../pyodide/pyodide-lock.json");
+    chai.assert.equal(result, "../pyodide/");
+  });
+
+  it("Should handle URL with no path component", () => {
+    const result = calculateInstallBaseUrl("pyodide-lock.json");
+    chai.assert.equal(result, ".");
+  });
+
+  it("Should handle empty string", () => {
+    const result = calculateInstallBaseUrl("");
+    chai.assert.equal(result, ".");
+  });
+
+  it("Should fallback to location when URL has no slash", () => {
+    // Mock browser location
+    (globalThis as any).location = {
+      toString: () => "https://example.com/app/",
+    };
+
+    const result = calculateInstallBaseUrl("pyodide-lock.json");
+    chai.assert.equal(result, "https://example.com/app/");
+  });
+
+  it("Should fallback to location when URL is empty", () => {
+    // Mock browser location
+    (globalThis as any).location = {
+      toString: () => "https://example.com/app/",
+    };
+
+    const result = calculateInstallBaseUrl("");
+    chai.assert.equal(result, "https://example.com/app/");
+  });
+
+  it("Should fallback to '.' when no location available", () => {
+    // Remove location to simulate environment without location
+    delete (globalThis as any).location;
+
+    const result = calculateInstallBaseUrl("pyodide-lock.json");
+    chai.assert.equal(result, ".");
+  });
+
+  it("Should handle URL with query parameters", () => {
+    const result = calculateInstallBaseUrl(
+      "https://cdn.example.com/pyodide/pyodide-lock.json?v=1.0",
+    );
+    chai.assert.equal(result, "https://cdn.example.com/pyodide/");
+  });
+
+  it("Should handle URL with hash fragment", () => {
+    const result = calculateInstallBaseUrl(
+      "https://cdn.example.com/pyodide/pyodide-lock.json#section",
+    );
+    chai.assert.equal(result, "https://cdn.example.com/pyodide/");
+  });
+
+  it("Should handle URL with both query parameters and hash", () => {
+    const result = calculateInstallBaseUrl(
+      "https://cdn.example.com/pyodide/pyodide-lock.json?v=1.0#section",
+    );
+    chai.assert.equal(result, "https://cdn.example.com/pyodide/");
+  });
+
+  it("Should handle URL with username and password", () => {
+    const result = calculateInstallBaseUrl(
+      "https://user:pass@cdn.example.com/pyodide/pyodide-lock.json",
+    );
+    chai.assert.equal(result, "https://user:pass@cdn.example.com/pyodide/");
   });
 });


### PR DESCRIPTION
### Description

This fixes a bug in the installBaseURL calculation in Node.js.

When a path such as

```js
loadPyodide({
  lockfileURL: "my-lockfile.json",
})
```

is passed, the installBaseURL is calculated to undefined in Node, which resulted in an error in package loading. This PR changes it to output cwd (`.`) instead.

### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
