### PR TITLE
Manual patch for incorrect xbuildenv file in 0.28.0

### DIFF
--- a/pyodide-cross-build-environments.json
+++ b/pyodide-cross-build-environments.json
@@ -3,7 +3,7 @@
     "0.28.0": {
       "version": "0.28.0",
       "url": "https://github.com/pyodide/pyodide/releases/download/0.28.0/xbuildenv-0.28.0.tar.bz2",
-      "sha256": "f962ac1fdb397cdb26e743f672415ee74bc4af2d1e9f55a931146530d07b5c52",
+      "sha256": "4b0bf238554ff78ac07436c9d07d71633a4ba7a813b8a2f5f2f5d191a08d939d",
       "python_version": "3.13.2",
       "emscripten_version": "4.0.9",
       "min_pyodide_build_version": "0.26.0"


### PR DESCRIPTION
I fixed the incorret xbuildenv in 0.28.0 releases. This updates the sha256 sum in the metadata file. We are not using this sha256sum yet, but fixing it for the future validation.