### PR TITLE
Optimize import test speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ Pyodide also has a large number of small donors. If you’re interested in suppo
 
 Pyodide uses the [Mozilla Public License Version
 2.0](https://choosealicense.com/licenses/mpl-2.0/).
+
+## Running tests in parallel
+
+To speed up test execution, you can use pytest-xdist:
+
+```
+pytest -n auto
+```
+
+This will run tests in parallel using all available CPU cores.

--- a/conftest.py
+++ b/conftest.py
@@ -331,9 +331,11 @@ def strip_assertions_stderr(messages: Sequence[str]) -> list[str]:
 def selenium_standalone(request):
     """Reuse the Selenium session and refresh the page between tests."""
     from pytest_pyodide.fixtures import selenium_standalone as orig_fixture
+
     selenium = orig_fixture(request)
     yield selenium
     # Do not quit the session here; let the session fixture handle cleanup.
+
 
 @pytest.fixture(autouse=True)
 def refresh_selenium_standalone(selenium_standalone):

--- a/conftest.py
+++ b/conftest.py
@@ -327,17 +327,21 @@ def strip_assertions_stderr(messages: Sequence[str]) -> list[str]:
     return res
 
 
-@pytest.fixture(scope="session")
-def selenium_standalone(request):
-    """Reuse the Selenium session and refresh the page between tests."""
+try:
     from pytest_pyodide.fixtures import selenium_standalone as orig_fixture
 
-    selenium = orig_fixture(request)
-    yield selenium
-    # Do not quit the session here; let the session fixture handle cleanup.
+    @pytest.fixture(scope="session")
+    def selenium_standalone(request):
+        """Reuse the Selenium session and refresh the page between tests."""
+        selenium = orig_fixture(request)
+        yield selenium
+        # Do not quit the session here; let the session fixture handle cleanup.
 
+    @pytest.fixture(autouse=True)
+    def refresh_selenium_standalone(selenium_standalone):
+        """Refresh the page between tests to simulate a clean environment."""
+        selenium_standalone.browser.refresh()
 
-@pytest.fixture(autouse=True)
-def refresh_selenium_standalone(selenium_standalone):
-    """Refresh the page between tests to simulate a clean environment."""
-    selenium_standalone.browser.refresh()
+except ImportError:
+    # pytest_pyodide is not available; do not override the fixture.
+    pass

--- a/conftest.py
+++ b/conftest.py
@@ -325,3 +325,17 @@ def strip_assertions_stderr(messages: Sequence[str]) -> list[str]:
             continue
         res.append(msg)
     return res
+
+
+@pytest.fixture(scope="session")
+def selenium_standalone(request):
+    """Reuse the Selenium session and refresh the page between tests."""
+    from pytest_pyodide.fixtures import selenium_standalone as orig_fixture
+    selenium = orig_fixture(request)
+    yield selenium
+    # Do not quit the session here; let the session fixture handle cleanup.
+
+@pytest.fixture(autouse=True)
+def refresh_selenium_standalone(selenium_standalone):
+    """Refresh the page between tests to simulate a clean environment."""
+    selenium_standalone.browser.refresh()

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -28,7 +28,7 @@ myst:
   - Adding `pytest-xdist` for parallel test execution.
   - Reusing Selenium session and refreshing the page between tests to reduce overhead.
   - Updating documentation for parallel test running.
-  ([#5772](https://github.com/pyodide/pyodide/issues/5772))
+    ([#5772](https://github.com/pyodide/pyodide/issues/5772))
 
 ## Version 0.28.0
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -24,6 +24,12 @@ myst:
 - {{ Fix }} Fixed a bug in Node.js which providing a relative path to `lockFileURL` parameter of `loadPyodide()` did not work.
   {pr}`5750`
 
+- {{ Enhancement }} Optimize package import test speed by:
+  - Adding `pytest-xdist` for parallel test execution.
+  - Reusing Selenium session and refreshing the page between tests to reduce overhead.
+  - Updating documentation for parallel test running.
+  ([#5772](https://github.com/pyodide/pyodide/issues/5772))
+
 ## Version 0.28.0
 
 _July 4, 2025_
@@ -2130,7 +2136,7 @@ _April 9th, 2022_
   throws something else.
   {pr}`2294`
 
-### pyodide_build
+### pyodide-build
 
 - {{Enhancement}} Pyodide now uses Python wheel files to distribute packages
   rather than the emscripten `file_packager.py` format.

--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,4 @@ dependencies:
   - wget
   - patch # only needed on MacOS
   - sed # only needed on MacOS
+  - pytest-xdist

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pytest-httpserver
 pytest-benchmark
 pytest-pyodide==0.58.6
 setuptools; python_version >= '3.12'
+pytest-xdist


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

This PR optimizes the speed of package import tests:

- **Parallelizes test execution** using `pytest-xdist`, allowing tests to run concurrently and significantly reducing total test time.
- **Optimizes the Selenium fixture** by overriding `selenium_standalone` to reuse the browser session and refresh the page between tests, instead of creating a new session for each test. This reduces the overhead associated with Selenium-based tests.
- **Updates documentation** in the README to explain how to run tests in parallel.

These changes should make the test suite much faster, especially for the package import tests that previously required a new Selenium session for each test.

Closes #5772

### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests (Not needed; this PR only optimizes test infrastructure and does not change test logic)
- [x] Add new / update outdated documentation