### PR TITLE
DOC use stable version of micropip for intersphinx mapping (#5755)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,6 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 
-import micropip
-
 panels_add_bootstrap_css = False
 
 # -- Project information -----------------------------------------------------
@@ -80,10 +78,9 @@ versionwarning_message = (
 autosummary_generate = True
 autodoc_default_flags = ["members", "inherited-members"]
 
-micropip_version = micropip.__version__
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.13", None),
-    "micropip": (f"https://micropip.pyodide.org/en/v{micropip_version}/", None),
+    "micropip": ("https://micropip.pyodide.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
 }
 


### PR DESCRIPTION
### Description

This PR updates the intershpinx URL for micropip to point to the stable version of micropip. (resolves #5755)

1. change the version of micropip into stable
2. delete unused assign and import statement

### Checklist
- [x] Add new / update outdated documentation
