### PR TITLE
DOC remove unused micropip dependency

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -18,8 +18,6 @@ sphinx-design>=0.3.0
 pydantic
 # TODO: separate document for pyodide-build?
 -e ./pyodide-build
-# Version should be consistent with packages/micropip/meta.yaml
-micropip==0.7.1
 jinja2>=3.0
 ruamel.yaml
 sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@781dc61870a802222051bcc8f6b2a592cd5eec7b


### PR DESCRIPTION
### Description
This PR is follow-up of #5781
I also remove the unused micropip dependency in [requirements-doc](https://github.com/pyodide/pyodide/blob/main/docs/requirements-doc.txt).


