### PR TITLE
Don't print traceback for cancelled futures in webloop

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -93,6 +93,8 @@ _July 4, 2025_
 
 - {{ Enhancement }} Update types to include `FS.unmount`. {pr}`5788`
 
+- {{ Fix }} Fixed cancelled futures causing a traceback to be printed. {pr}`5784`
+
 ### `python` CLI entrypoint
 
 - {{ Fix }} The `python` CLI now mounts the `/tmp` directory. In

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -359,6 +359,7 @@ class WebLoop(asyncio.AbstractEventLoop):
         if (
             fut
             and getattr(fut, "_num_done_callbacks", None) == 1
+            and not fut.cancelled()
             and (exc := fut.exception())
         ):
             # Only callback is this one, let's say it's an unhandled exception

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -58,6 +58,7 @@ def test_cancel_unhandled(selenium):
     @run_in_pyodide
     async def test(selenium):
         import asyncio
+
         loop = asyncio.get_running_loop()
 
         async def f():

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -70,7 +70,7 @@ def test_cancel_unhandled(selenium):
         await asyncio.sleep(2)
 
     test(selenium)
-    assert "Some traceback string" not in selenium.logs
+    assert "CancelledError" not in selenium.logs
 
 
 def test_return_result(selenium):

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -54,6 +54,23 @@ def test_cancel_handle(selenium_standalone):
     )
 
 
+def test_cancel_unhandled(selenium):
+    selenium.run_async(
+        """
+        import asyncio
+        loop = asyncio.get_running_loop()
+
+        async def f():
+            await asyncio.sleep(1)
+
+        t = loop.create_task(f())
+        print("done:", t.done())
+        print("cancel:", t.cancel())
+        await asyncio.sleep(2)
+        """
+    )
+
+
 def test_return_result(selenium):
     # test return result
     run_with_resolve(

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -55,8 +55,8 @@ def test_cancel_handle(selenium_standalone):
 
 
 def test_cancel_unhandled(selenium):
-    selenium.run_async(
-        """
+    @run_in_pyodide
+    async def test(selenium):
         import asyncio
         loop = asyncio.get_running_loop()
 
@@ -67,8 +67,9 @@ def test_cancel_unhandled(selenium):
         print("done:", t.done())
         print("cancel:", t.cancel())
         await asyncio.sleep(2)
-        """
-    )
+
+    test(selenium)
+    assert "Some traceback string" not in selenium.logs
 
 
 def test_return_result(selenium):


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Fixes #5782.

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklist

I think this doesn't need a CHANGELOG entry or documentation changes, and I'm not really sure how to test it.
