### PR TITLE
Use selenium manager in dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
     # Note: when updating the docker image version,
     #       make sure there are no extra old versions lying around.
     #       (e.g. `rg -F --hidden <old_tag>`)
-    - image: zsaladin/pyodide-selenium-manager:dev4
+    - image: pyodide/pyodide-env:20250311-chrome134-firefox136-py313
   environment:
     EMSDK_NUM_CORES: 3
     EMCC_CORES: 3


### PR DESCRIPTION
### Description

- resolve #5500 
- https://docs.docker.com/build/building/multi-stage/
- [Multi-stage builds](https://docs.docker.com/build/building/multi-stage/), which is useful for separating unnecessary layers from the main image, is used for downloading browsers and drivers
- [Installing chrome using apt](https://github.com/pyodide/pyodide/blob/9fa7137a88d71a16a51bae13c91381cc5e477dfb/Dockerfile#L124) installed dependencies of chrome whereas selenium manager doesn't, so dependency installation needs to be added([link](https://www.selenium.dev/documentation/selenium_manager/#browser-dependencies)).
