### PR TITLE
Add `FS.unmount` to type definitions

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -78,6 +78,8 @@ myst:
   and assign it to JavaScript properties via `pyodide.ffi.jsnull`.
   {pr}`5719`
 
+- {{ Enhancement }} Update types to include `FS.unmount`. {pr}`5788`
+
 ### `python` CLI entrypoint
 
 - {{ Fix }} The `python` CLI now mounts the `/tmp` directory. In

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -258,6 +258,7 @@ export interface FSType {
   utime: (path: string, atime: number, mtime: number) => void;
   rmdir: (path: string) => void;
   mount: (type: any, opts: any, mountpoint: string) => any;
+  unmount: (mountpoint: string) => any;
   write: (
     stream: FSStream,
     buffer: any,


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Add `FS.unmount` to type definitions. I am using it (successfully) in a TypeScript project to unmount the NATIVEFS once I'm done with it.

### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
