### PR TITLE
TST Remove pyodide-build directory from default testpath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,14 +133,11 @@ addopts = '''
 --ignore-glob="**/dist/"
 --ignore-glob="src/py/_pyodide/jsbind.py"
 --ignore-glob="packages/**/extras/"
---ignore-glob="packages/aiohttp/aiohttp_patch.py"
---ignore-glob="packages/openai/helper_test_openai.py"
 --ignore-glob="packages/scipy/cmdline_test_file.py"
 --tb=short
 --dist-dir=dist'''
 testpaths = [
-    "src",
-    "pyodide-build",
+    "src/tests",
     "packages",
 ]
 asyncio_mode = "strict"


### PR DESCRIPTION
This was annoying, as running `pytest` without passing any argument would grep tests from pyodide-build directory. New contributors were confused about the test failures.
