### PR TITLE
fix(test): strip ANSI color codes in test_fatal_error

### DIFF
--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1035,6 +1035,8 @@ def test_fatal_error(selenium_standalone):
     import re
 
     def strip_stack_trace(x):
+        # Remove ANSI color codes
+        x = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', x)
         x = re.sub("\n.*site-packages.*", "", x)
         x = re.sub("/lib/python.*/", "", x)
         x = re.sub("/lib/python.*/", "", x)

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1036,7 +1036,7 @@ def test_fatal_error(selenium_standalone):
 
     def strip_stack_trace(x):
         # Remove ANSI color codes
-        x = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', x)
+        x = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", x)
         x = re.sub("\n.*site-packages.*", "", x)
         x = re.sub("/lib/python.*/", "", x)
         x = re.sub("/lib/python.*/", "", x)


### PR DESCRIPTION
### Description

This PR fixes the `test_fatal_error` test case which was failing due to the presence of ANSI escape codes in the error message.

The original test assumed that the output would be plain text, but in some environments (such as Linux terminals), the output includes ANSI color codes. This led to false failures in the test. I modified the test to strip ANSI sequences from the error output before performing the assertion.

This change improves test reliability across platforms with different terminal behaviors.

No related issue was opened prior to this PR.

### Checklist

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation

