### PR TITLE
[#5753] Exclude pyodide-build from pre-commit mypy target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     hooks:
       - id: mypy
         files: ^(packages/.*/src|src|pyodide-build/pyodide_build)
-        exclude: (setup.py|.*test.*)
+        exclude: (setup.py|.*test.*|^pyodide-build/)
         args: []
         additional_dependencies: &mypy-deps
           - packaging

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1035,6 +1035,8 @@ def test_fatal_error(selenium_standalone):
     import re
 
     def strip_stack_trace(x):
+        # Remove ANSI color codes
+        x = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', x)
         x = re.sub("\n.*site-packages.*", "", x)
         x = re.sub("/lib/python.*/", "", x)
         x = re.sub("/lib/python.*/", "", x)

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1036,7 +1036,7 @@ def test_fatal_error(selenium_standalone):
 
     def strip_stack_trace(x):
         # Remove ANSI color codes
-        x = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', x)
+        x = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", x)
         x = re.sub("\n.*site-packages.*", "", x)
         x = re.sub("/lib/python.*/", "", x)
         x = re.sub("/lib/python.*/", "", x)


### PR DESCRIPTION
### Description

This PR fixes #5753 by adding `^pyodide-build/` to the `exclude` field of the main `mypy` hook in `.pre-commit-config.yaml`.

Fixes #5753

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests ⬅️ *(Not applicable here)*
- [x] Add new / update outdated documentation ⬅️ *(Not applicable here)*

