### PR TITLE
[#5753] Exclude pyodide-build from mypy pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
     hooks:
       - id: mypy
         files: ^(packages/.*/src|src|pyodide-build/pyodide_build)
-        exclude: (setup.py|.*test.*)
+        exclude: (setup.py|.*test.*|^pyodide-build/)
         args: []
         additional_dependencies: &mypy-deps
           - packaging


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

This PR fixes #5753 by excluding the pyodide-build/ directory from the mypy check in the .pre-commit-config.yaml file.

The pyodide-build directory is a Git submodule with its own pre-commit configuration and dependencies. Running mypy on it from the main repository leads to redundant linting and false positives due to missing dependencies.

To address this, I added ^pyodide-build/ to the exclude field of the main mypy hook.

This PR replaces a previous one that unintentionally included unrelated commits.

Fixes #5753


### Checklist

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests ⬅️ *(Not applicable here)*
- [x] Add new / update outdated documentation ⬅️ *(Not applicable here)*