### PR TITLE
Resolve paths in python_cli_entry argv on Windows

### DIFF
--- a/src/templates/python_cli_entry.mjs
+++ b/src/templates/python_cli_entry.mjs
@@ -19,7 +19,23 @@ const thisProgramFlag = "--this-program=";
 const thisProgramIndex = process.argv.findIndex((x) =>
   x.startsWith(thisProgramFlag),
 );
-const args = process.argv.slice(thisProgramIndex + 1);
+const args = process.argv.slice(thisProgramIndex + 1).map(
+  arg => {
+    if (process.platform !== "win32") {
+      return arg;
+    }
+
+    // We replace Windows-style paths with Unix-style paths as that is how
+    // our Windows filesystem is mapped in emscripten.
+    if (arg.startsWith("\"C:\\")) {
+      return arg.slice(3).replaceAll("\\", "/");
+    } else if (arg.startsWith("C:\\")) {
+      return arg.slice(2).replaceAll("\\", "/");
+    } else {
+      return arg;
+    }
+  }
+);
 const _sysExecutable = process.argv[thisProgramIndex].slice(
   thisProgramFlag.length,
 );


### PR DESCRIPTION
### Description

This is a change that gets us one step closer to being able to create a working Pyodide venv on Windows. 

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation

### Test Plan

```
uv venv -p .\python.bat -v
DEBUG uv 0.8.3 (7e78f54e7 2025-07-24)
DEBUG Using Python request `.\python.bat` from explicit request
DEBUG Checking for Python interpreter at path `.\python.bat`
Using CPython 3.13.2 interpreter at: .
Creating virtual environment at: .venv
error: Failed to create virtual environment
  Caused by: cannot make an empty path absolute
```