### PR TITLE
Remove redundant setup.py file in src/py

### DIFF
--- a/src/py/setup.py
+++ b/src/py/setup.py
@@ -1,5 +1,0 @@
-# Needed for editable install
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup()


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

  The setup.py under the [src/py](https://github.com/pyodide/pyodide/blob/main/src/py/setup.py) directory was needed when we first adopted the pyproject.toml file, and there was an issue with the editable install.<#5756> 
Deleted the setup.py under the [src/py].
### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->


- [ X] Add / update tests

