### PR TITLE
Fix test_relaxed_call for Python 3.13 TypeError message format

### DIFF
--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -283,7 +283,6 @@ def test_relaxed_call():
     with pytest.raises(TypeError, match=r"missing .* argument: 'a'"):
         relaxed_call(f4, a=2, b=7)
 
-
     def f5(a, *args, b=7, **kwargs):
         return [a, args, b, kwargs]
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -278,10 +278,7 @@ def test_relaxed_call():
     def f4(a, /, *args, b=7):
         return [a, args, b]
 
-    with pytest.raises(
-        TypeError,
-        match=r"missing .* argument: 'a'"
-    ):
+    with pytest.raises(TypeError, match=r"missing .* argument: 'a'"):
         relaxed_call(f4, a=2, b=7)
 
     def f5(a, *args, b=7, **kwargs):
@@ -341,12 +338,8 @@ def test_relaxed_wrap():
     def f4(a, /, *args, b=7):
         return [a, args, b]
 
-    with pytest.raises(
-        TypeError,
-        match=r"missing .* argument: 'a'"
-    ):
+    with pytest.raises(TypeError, match=r"missing .* argument: 'a'"):
         f4(a=2, b=7)
-
 
     @relaxed_wrap
     def f5(a, *args, b=7, **kwargs):

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -278,8 +278,11 @@ def test_relaxed_call():
     def f4(a, /, *args, b=7):
         return [a, args, b]
 
+    # Since Python 3.13.3, the TypeError message for missing positional-only arguments has changed.
+    # See: https://github.com/python/cpython/pull/130192
     with pytest.raises(TypeError, match=r"missing .* argument: 'a'"):
         relaxed_call(f4, a=2, b=7)
+
 
     def f5(a, *args, b=7, **kwargs):
         return [a, args, b, kwargs]

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -280,7 +280,7 @@ def test_relaxed_call():
 
     with pytest.raises(
         TypeError,
-        match=r"missing a required positional-only argument: 'a'",
+        match=r"missing .* argument: 'a'"
     ):
         relaxed_call(f4, a=2, b=7)
 
@@ -343,7 +343,7 @@ def test_relaxed_wrap():
 
     with pytest.raises(
         TypeError,
-        match=r"missing a required positional[- ]only argument: 'a'",
+        match=r"missing .* argument: 'a'"
     ):
         f4(a=2, b=7)
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -280,9 +280,7 @@ def test_relaxed_call():
 
     with pytest.raises(
         TypeError,
-        match=re.escape(
-            "test_relaxed_call.<locals>.f4() missing 1 required positional argument: 'a'"
-        ),
+        match=r"missing a required positional-only argument: 'a'",
     ):
         relaxed_call(f4, a=2, b=7)
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -343,11 +343,10 @@ def test_relaxed_wrap():
 
     with pytest.raises(
         TypeError,
-        match=re.escape(
-            "test_relaxed_wrap.<locals>.f4() missing 1 required positional argument: 'a'"
-        ),
+        match=r"missing a required positional[- ]only argument: 'a'",
     ):
         f4(a=2, b=7)
+
 
     @relaxed_wrap
     def f5(a, *args, b=7, **kwargs):


### PR DESCRIPTION

### Description

This PR fixes the `test_relaxed_call` and `test_relaxed_wrap` tests, which were failing on Python 3.13 due to changes in the `TypeError` message format.

In Python 3.13, when a required positional-only argument is missing, the error message no longer includes the function name. However, the original tests used a regex that expected the full function name, which caused them to fail.

I updated the regex patterns in both tests to match the new, simplified message format. After the changes, both tests pass locally on Python 3.13.


- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [V ] Add / update tests
- [ ] Add new / update outdated documentation

<img width="1430" height="92" alt="image" src="https://github.com/user-attachments/assets/d71d8785-5d29-43bf-b464-59a8afa3959c" />

<img width="1336" height="82" alt="image" src="https://github.com/user-attachments/assets/4604908e-1e37-49e4-8bf2-63cbcfc46ad2" />

