### PR TITLE
Fix cdnURL in Node

### DIFF
--- a/src/js/common/path.ts
+++ b/src/js/common/path.ts
@@ -1,0 +1,13 @@
+/**
+ * @hidden 
+ */
+export function withTrailingSlash<T extends string | undefined>(path: T): T {
+  if (path === undefined) {
+    return path;
+  }
+
+  if (path.endsWith("/")) {
+    return path;
+  }
+  return path + "/" as T;
+}

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -116,7 +116,7 @@ export class PackageManager {
    *
    * exported for testing purposes.
    */
-  public cdnURL: string = "";
+  public cdnURL: string;
 
   /**
    * The set of loaded packages.
@@ -157,7 +157,7 @@ export class PackageManager {
       // back to cdnURL
       this.installBaseUrl =
         this.#api.config.packageCacheDir ?? this.#api.config.packageBaseUrl;
-      this.cdnURL = this.#api.config.cdnUrl;
+      this.cdnURL = `https://cdn.jsdelivr.net/pyodide/v${this.#api.version}/full/`;
     } else {
       // use packageBaseUrl as the base URL for the packages
       this.installBaseUrl = this.#api.config.packageBaseUrl;

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -113,8 +113,10 @@ export class PackageManager {
    * Only used in Node. If we can't find a package in node_modules, we'll use this
    * to fetch the package from the cdn (and we'll store it into node_modules so
    * subsequent loads don't require a web request).
+   *
+   * exported for testing purposes.
    */
-  private cdnURL: string = "";
+  public cdnURL: string = "";
 
   /**
    * The set of loaded packages.
@@ -154,7 +156,7 @@ export class PackageManager {
       // In node, we'll try first to load from the packageCacheDir and then fall
       // back to cdnURL
       this.installBaseUrl =
-        this.#api.config.packageCacheDir ?? API.config.packageBaseUrl;
+        this.#api.config.packageCacheDir ?? this.#api.config.packageBaseUrl;
       this.cdnURL = this.#api.config.cdnUrl;
     } else {
       // use packageBaseUrl as the base URL for the packages
@@ -713,4 +715,6 @@ if (typeof API !== "undefined" && typeof Module !== "undefined") {
   if (API.lockFilePromise) {
     API.packageIndexReady = initializePackageIndex(API.lockFilePromise);
   }
+
+  API.packageManager = singletonPackageManager;
 }

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -23,6 +23,7 @@ import type {
 } from "./types";
 import type { EmscriptenSettings } from "./emscripten-settings";
 import type { SnapshotConfig } from "./snapshot";
+import { withTrailingSlash } from "./common/path";
 export type { PyodideAPI, TypedArray };
 export type { LockfileInfo, LockfilePackage, Lockfile } from "./types";
 
@@ -257,10 +258,7 @@ export async function loadPyodide(
 
   // Relative paths cause havoc.
   let indexURL = options.indexURL || (await calculateDirname());
-  indexURL = resolvePath(indexURL);
-  if (!indexURL.endsWith("/")) {
-    indexURL += "/";
-  }
+  indexURL = withTrailingSlash(resolvePath(indexURL));
   const options_ = options as ConfigType;
   if (!options.lockFileContents) {
     const lockFileURL = options.lockFileURL ?? indexURL + "pyodide-lock.json";
@@ -271,17 +269,15 @@ export async function loadPyodide(
   }
   options_.indexURL = indexURL;
   // cdnUrl only for node.
-  options_.cdnUrl =
-    options_.packageBaseUrl ??
-    `https://cdn.jsdelivr.net/pyodide/v${version}/full/`;
+  options_.cdnUrl = `https://cdn.jsdelivr.net/pyodide/v${version}/full/`;
 
-  if (options.packageCacheDir) {
-    let packageCacheDir = resolvePath(options.packageCacheDir);
-    if (!packageCacheDir.endsWith("/")) {
-      packageCacheDir += "/";
-    }
-    options.packageCacheDir = packageCacheDir;
+  if (options_.packageCacheDir) {
+    options_.packageCacheDir = withTrailingSlash(
+      resolvePath(options_.packageCacheDir),
+    );
   }
+
+  options_.packageBaseUrl = withTrailingSlash(options_.packageBaseUrl);
 
   const default_config = {
     fullStdLib: false,

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -74,7 +74,6 @@ export type ConfigType = {
   checkAPIVersion: boolean;
   BUILD_ID: string;
   packageBaseUrl?: string;
-  cdnUrl: string;
 };
 
 /**
@@ -268,8 +267,6 @@ export async function loadPyodide(
     options_.packageBaseUrl ??= calculateInstallBaseUrl(lockFileURL);
   }
   options_.indexURL = indexURL;
-  // cdnUrl only for node.
-  options_.cdnUrl = `https://cdn.jsdelivr.net/pyodide/v${version}/full/`;
 
   if (options_.packageCacheDir) {
     options_.packageCacheDir = withTrailingSlash(

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -5,6 +5,7 @@ import { type ConfigType } from "./pyodide";
 import { type InFuncType } from "./streams";
 import { SnapshotConfig } from "./snapshot";
 import { ResolvablePromise } from "./common/resolveable";
+import { PackageManager } from "./load-package";
 
 /**
  * @docgroup pyodide.ffi
@@ -522,6 +523,7 @@ export interface API {
   lockfile: Lockfile;
   lockfile_info: LockfileInfo;
   lockfile_packages: Record<string, LockfilePackage>;
+  packageManager: PackageManager;
   flushPackageManagerBuffers: () => void;
   defaultLdLibraryPath: string[];
   sitepackages: string;

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -579,8 +579,9 @@ export type PackageManagerAPI = Pick<
   | "bootstrapFinalizedPromise"
   | "sitepackages"
   | "defaultLdLibraryPath"
+  | "version"
 > & {
-  config: Pick<ConfigType, "packageCacheDir" | "packageBaseUrl" | "cdnUrl">;
+  config: Pick<ConfigType, "packageCacheDir" | "packageBaseUrl">;
 };
 /**
  * @hidden


### PR DESCRIPTION
### Description

Resolve #5821

There was some regression introduced in #5764.

Previously, loading Pyodide in Node without passing any options would set

- indexURL: dist directory
- packageBaseURL: dist directory
- cdnURL: dist directory ==> incorrect

This ensures the CDN URL is always set to the same value.

### Checklist

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
