### PR TITLE
chore: standardize requirements files formatting and add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+      - id: requirements-txt-fixer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.9.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,13 +93,5 @@ repos:
         additional_dependencies: ["@biomejs/biome@2.1.1"]
         types_or: [javascript, ts]
 
-  - repo: local
-    hooks:
-      - id: requirements-spacing
-        name: Fix requirements.txt spacing around operators
-        entry: sed -i 's/ \([<>=!~]\)/\1/g; s/\([<>=!~]\) /\1/g'
-        language: system
-        files: requirements.*\.txt$
-
 ci:
   autoupdate_schedule: "quarterly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,5 +93,13 @@ repos:
         additional_dependencies: ["@biomejs/biome@2.1.1"]
         types_or: [javascript, ts]
 
+  - repo: local
+    hooks:
+      - id: requirements-spacing
+        name: Fix requirements.txt spacing around operators
+        entry: sed -i 's/ \([<>=!~]\)/\1/g; s/\([<>=!~]\) /\1/g'
+        language: system
+        files: requirements.*\.txt$
+
 ci:
   autoupdate_schedule: "quarterly"

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,25 +1,25 @@
+# TODO: separate document for pyodide-build?
+-e ./pyodide-build
 autodocsumm
+# In 25.1.0, we get the error "cattrs.errors.StructureHandlerNotFoundError: Unsupported type: 'Attribute'. Register a structure hook for it."
+cattrs<25.1.0
+click<8.2
 docutils>=0.21.2
+jinja2>=3.0
 myst-parser>=4.0
 packaging   # required by micropip at import time
+pydantic
+ruamel.yaml
 # 8.2.0 has build issue: https://github.com/pyodide/pyodide/issues/5443
 sphinx>=5.3.0,<8.2.0
 sphinx-argparse-cli>=1.6.0
-sphinx_book_theme
-sphinx-issues
+sphinx-autodoc-typehints>=1.21.7
 # Use my branch of sphinx-click with fix for warnings:
 # CRITICAL: Unexpected section title or transition
 # https://github.com/click-contrib/sphinx-click/pull/137
 # https://github.com/click-contrib/sphinx-click/pull/138
 sphinx-click @ git+https://github.com/hoodmane/sphinx-click@271ebdb3e5855f2901f5dd4390f26381a353224e
-click < 8.2
-sphinx-autodoc-typehints>=1.21.7
 sphinx-design>=0.3.0
-pydantic
-# TODO: separate document for pyodide-build?
--e ./pyodide-build
-jinja2>=3.0
-ruamel.yaml
+sphinx-issues
 sphinx-js @ git+https://github.com/pyodide/sphinx-js-fork@781dc61870a802222051bcc8f6b2a592cd5eec7b
-# In 25.1.0, we get the error "cattrs.errors.StructureHandlerNotFoundError: Unsupported type: 'Attribute'. Register a structure hook for it."
-cattrs < 25.1.0
+sphinx_book_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
 argcomplete
-# lint
-pre-commit
 # testing
 build~=1.2.0
-sphinx-click
-click < 8.2
+click<8.2
 hypothesis
 mypy==1.11.0
+# lint
+pre-commit
 # (FIXME: 2024/01/28) The latest pytest-asyncio 0.23.3 is not compatible with pytest 8.0.0
 pytest<8.0.0
 pytest-asyncio
+pytest-benchmark
 pytest-cov
 pytest-httpserver
-pytest-benchmark
 pytest-pyodide==0.58.6
-setuptools; python_version >= '3.12'
+setuptools; python_version>='3.12'
+sphinx-click


### PR DESCRIPTION
### Description

This PR addresses formatting inconsistencies in requirements files and adds pre-commit hooks to maintain consistent formatting.

**Changes made:**
- Fixed spacing around version operators in all requirements files (e.g., `click < 8.2` → `click<8.2`, `python_version >= '3.12'` → `python_version>='3.12'`)
- Added `requirements-txt-fixer` hook for general requirements file formatting (removes duplicates, sorts dependencies, cleans up blank lines, etc.)
- Added custom `requirements-spacing` hook specifically for fixing spacing around version operators

**Reasoning:**
- Improves consistency across the codebase
- Prevents future formatting inconsistencies through automation

**Note on pre-commit hooks:**
I added both a standard hook (`requirements-txt-fixer`) and a custom hook for spacing. If you think this is excessive or if the standard hook conflicts with the project's grouping/commenting strategy in requirements files, I'm happy to remove either hook and keep only the manual formatting fixes.