### PR TITLE
Fix minor bug in snapshot serialization error handling

### DIFF
--- a/src/js/snapshot.ts
+++ b/src/js/snapshot.ts
@@ -153,7 +153,7 @@ API.serializeHiwireState = function (
     let path;
     try {
       path = value[getAccessorList];
-    } catch(e) {}
+    } catch (e) {}
     if (path) {
       hiwireKeys.push({ path });
       continue;

--- a/src/js/snapshot.ts
+++ b/src/js/snapshot.ts
@@ -150,7 +150,10 @@ API.serializeHiwireState = function (
       hiwireKeys.push(value);
       continue;
     }
-    const path = value[getAccessorList];
+    let path;
+    try {
+      path = value[getAccessorList];
+    } catch(e) {}
     if (path) {
       hiwireKeys.push({ path });
       continue;

--- a/src/tests/test_snapshots.py
+++ b/src/tests/test_snapshots.py
@@ -195,7 +195,7 @@ def test_snapshot_serializer1(selenium_standalone_noload):
     )
 
 
-def test_snapshot_serializer_not_serializable(selenium_standalone_noload):
+def test_snapshot_serializer_not_serializable1(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     match = "Serializer returned result that cannot be JSON.stringify'd at index"
     with pytest.raises(selenium.JavascriptException, match=match):
@@ -208,6 +208,23 @@ def test_snapshot_serializer_not_serializable(selenium_standalone_noload):
                 a = run_js("(o = {}, o.o = o)")
             `);
             const snapshot = py1.makeMemorySnapshot({serializer: (obj) => obj});
+            """
+        )
+
+
+def test_snapshot_serializer_not_serializable2(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+    match = "Comes from user serializer"
+    with pytest.raises(selenium.JavascriptException, match=match):
+        selenium.run_js(
+            """
+            const py1 = await loadPyodide({_makeSnapshot: true});
+            py1.runPython(`
+                from pyodide.code import run_js
+
+                a = run_js("(p = Proxy.revocable({}, {}), p.revoke(), p.proxy)")
+            `);
+            const snapshot = py1.makeMemorySnapshot({serializer: (obj) => {throw new Error("Comes from user serializer")}});
             """
         )
 


### PR DESCRIPTION
Trying to perform a lookup on the object can throw, so we need a try/catch here.