### PR TITLE
Bump node.js 24.7 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN if [ $CHROME_VERSION = "latest" ]; then SE_CHROME_VERSION="stable"; \
   && mv $(dirname ${SE_CHROME_DRIVER_PATH}) /opt/chromedriver
 
 
-FROM node:20.11-bookworm-slim AS node-image
+FROM node:24.7-bookworm-slim AS node-image
 FROM python:3.13.2-slim-bookworm
 
 RUN apt-get update \


### PR DESCRIPTION
### Description

https://github.com/pyodide/pyodide/pull/5869#discussion_r2313728072

To use glob pattern in builtin Node.js test runner, it should be upgraded.
