### PR TITLE
Make all args in ToJsConverter protocol position only

### DIFF
--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1422,10 +1422,10 @@ class ToJsConverter(Protocol):
 
     def __call__(
         self,
-        /,
         value: Any,
         converter: Callable[[Any], JsProxy],
         cache: Callable[[Any, JsProxy], None],
+        /,
     ) -> JsProxy: ...
 
 


### PR DESCRIPTION
Otherwise, we're demanding that the user names their arguments exactly these things. We only call it positionally.
### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
