### PR TITLE
add: replace spawn_web_server with pytest-httpserver

### DIFF
--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -5,8 +5,6 @@ from pathlib import Path
 
 import pytest
 from pytest_pyodide import run_in_pyodide
-from pytest_pyodide.fixture import selenium_common
-from pytest_pyodide.utils import parse_driver_timeout, set_webdriver_script_timeout
 
 from conftest import DIST_PATH, only_node
 

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 from pytest_pyodide import run_in_pyodide
-from pytest_pyodide.server import spawn_web_server
+from pytest_pyodide.fixture import selenium_common
+from pytest_pyodide.utils import parse_driver_timeout, set_webdriver_script_timeout
 
 from conftest import DIST_PATH, only_node
 
@@ -744,7 +745,9 @@ def test_custom_lockfile_from_indexedDB(selenium_standalone_noload):
     )
 
 
-def test_custom_lockfile_different_dir(selenium_standalone_noload, tmp_path):
+def test_custom_lockfile_different_dir(
+    selenium_standalone_noload, tmp_path, httpserver
+):
     selenium = selenium_standalone_noload
 
     orig_lockfile = DIST_PATH / "pyodide-lock.json"
@@ -768,24 +771,38 @@ def test_custom_lockfile_different_dir(selenium_standalone_noload, tmp_path):
         }
     }
 
-    custom_lockfile_path = tmp_path / "custom-lockfile.json"
-    custom_lockfile_path.write_text(json.dumps(lockfile_content))
-    shutil.copy(test_file_path, tmp_path / test_file_name)
+    custom_lockfile_content = json.dumps(lockfile_content)
+    test_file_data = test_file_path.read_bytes()
 
-    with spawn_web_server(tmp_path) as web_server:
-        url, port, _ = web_server
+    # Setup httpserver to serve lockfile and wheel file
+    httpserver.expect_oneshot_request(f"/{custom_lockfile_name}").respond_with_data(
+        custom_lockfile_content.encode(),
+        content_type="application/json",
+        headers={"Access-Control-Allow-Origin": "*"},
+        status=200,
+    )
+    httpserver.expect_oneshot_request(f"/{test_file_name}").respond_with_data(
+        test_file_data,
+        content_type="application/zip",
+        headers={"Access-Control-Allow-Origin": "*"},
+        status=200,
+    )
 
-        if selenium.browser == "node":
-            lockfile_url = f"{custom_lockfile_path.resolve()}"
-        else:
-            lockfile_url = f"http://{url}:{port}/{custom_lockfile_name}"
-        selenium.run_js(
-            f"""
-            let pyodide = await loadPyodide({{fullStdLib: false, lockFileURL: {lockfile_url!r} }});
-            await pyodide.loadPackage("dummy_pkg", {{ checkIntegrity: false }});
-            return pyodide.runPython("import dummy_pkg")
-            """
-        )
+    if selenium.browser == "node":
+        lockfile_url = f"{(tmp_path / custom_lockfile_name).resolve()}"
+        # For node, we still need to write the file locally
+        (tmp_path / custom_lockfile_name).write_text(custom_lockfile_content)
+        shutil.copy(test_file_path, tmp_path / test_file_name)
+    else:
+        lockfile_url = httpserver.url_for(f"/{custom_lockfile_name}")
+
+    selenium.run_js(
+        f"""
+        let pyodide = await loadPyodide({{fullStdLib: false, lockFileURL: {lockfile_url!r} }});
+        await pyodide.loadPackage("dummy_pkg", {{ checkIntegrity: false }});
+        return pyodide.runPython("import dummy_pkg")
+        """
+    )
 
 
 def test_lock_file_contents_error(selenium_standalone_noload):
@@ -834,7 +851,9 @@ def test_lock_file_contents_relative_file_name(selenium_standalone_noload, tmp_p
     assert message in selenium.logs
 
 
-def test_lockfilecontents_package_base_url(selenium_standalone_noload, tmp_path):
+def test_lockfilecontents_package_base_url(
+    selenium_standalone_noload, tmp_path, httpserver
+):
     selenium = selenium_standalone_noload
     orig_lockfile = DIST_PATH / "pyodide-lock.json"
     test_file_name = "dummy_pkg-0.1.0-py3-none-any.whl"
@@ -855,26 +874,35 @@ def test_lockfilecontents_package_base_url(selenium_standalone_noload, tmp_path)
         }
     }
     lockfile_content_json = json.dumps(lockfile_content)
+    test_file_data = test_file_path.read_bytes()
 
-    shutil.copy(test_file_path, tmp_path / test_file_name)
+    # Setup httpserver to serve the wheel file
+    httpserver.expect_oneshot_request(f"/{test_file_name}").respond_with_data(
+        test_file_data,
+        content_type="application/zip",
+        headers={"Access-Control-Allow-Origin": "*"},
+        status=200,
+    )
 
-    with spawn_web_server(tmp_path) as web_server:
-        url, port, _ = web_server
+    if selenium.browser == "node":
+        base_url = str(tmp_path)
+        # For node, we still need to copy the file locally
+        shutil.copy(test_file_path, tmp_path / test_file_name)
+    else:
+        base_url = f"http://{httpserver.host}:{httpserver.port}"
 
-        if selenium.browser == "node":
-            base_url = str(tmp_path)
-        else:
-            base_url = f"http://{url}:{port}/"
-        selenium.run_js(
-            f"""
-            let pyodide = await loadPyodide({{fullStdLib: false, lockFileContents: {lockfile_content_json!r}, packageBaseUrl: {base_url!r} }});
-            await pyodide.loadPackage("dummy_pkg", {{ checkIntegrity: false }});
-            return pyodide.runPython("import dummy_pkg")
-            """
-        )
+    selenium.run_js(
+        f"""
+        let pyodide = await loadPyodide({{fullStdLib: false, lockFileContents: {lockfile_content_json!r}, packageBaseUrl: {base_url!r} }});
+        await pyodide.loadPackage("dummy_pkg", {{ checkIntegrity: false }});
+        return pyodide.runPython("import dummy_pkg")
+        """
+    )
 
 
-def test_lockfilecontents_absolute_file_name(selenium_standalone_noload, tmp_path):
+def test_lockfilecontents_absolute_file_name(
+    selenium_standalone_noload, tmp_path, httpserver
+):
     selenium = selenium_standalone_noload
     orig_lockfile = DIST_PATH / "pyodide-lock.json"
     test_file_name = "dummy_pkg-0.1.0-py3-none-any.whl"
@@ -891,28 +919,36 @@ def test_lockfilecontents_absolute_file_name(selenium_standalone_noload, tmp_pat
         "imports": [],
     }
 
-    shutil.copy(test_file_path, tmp_path / test_file_name)
+    test_file_data = test_file_path.read_bytes()
 
-    with spawn_web_server(tmp_path) as web_server:
-        url, port, _ = web_server
+    # Setup httpserver to serve the wheel file
+    httpserver.expect_oneshot_request(f"/{test_file_name}").respond_with_data(
+        test_file_data,
+        content_type="application/zip",
+        headers={"Access-Control-Allow-Origin": "*"},
+        status=200,
+    )
 
-        if selenium.browser == "node":
-            base_url = str(tmp_path / test_file_name)
-        else:
-            base_url = f"http://{url}:{port}/{test_file_name}"
-        dummy_pkg["file_name"] = base_url
+    if selenium.browser == "node":
+        base_url = str(tmp_path / test_file_name)
+        # For node, we still need to copy the file locally
+        shutil.copy(test_file_path, tmp_path / test_file_name)
+    else:
+        base_url = httpserver.url_for(f"/{test_file_name}")
 
-        lockfile_content = json.loads(orig_lockfile.read_text())
-        lockfile_content["packages"] = {"dummy-pkg": dummy_pkg}
-        lockfile_content_json = json.dumps(lockfile_content)
+    dummy_pkg["file_name"] = base_url
 
-        selenium.run_js(
-            f"""
-            let pyodide = await loadPyodide({{fullStdLib: false, lockFileContents: {lockfile_content_json!r} }});
-            await pyodide.loadPackage("dummy_pkg", {{ checkIntegrity: false }});
-            return pyodide.runPython("import dummy_pkg")
-            """
-        )
+    lockfile_content = json.loads(orig_lockfile.read_text())
+    lockfile_content["packages"] = {"dummy-pkg": dummy_pkg}
+    lockfile_content_json = json.dumps(lockfile_content)
+
+    selenium.run_js(
+        f"""
+        let pyodide = await loadPyodide({{fullStdLib: false, lockFileContents: {lockfile_content_json!r} }});
+        await pyodide.loadPackage("dummy_pkg", {{ checkIntegrity: false }});
+        return pyodide.runPython("import dummy_pkg")
+        """
+    )
 
 
 @pytest.mark.parametrize(

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import pytest
 from pytest_pyodide import run_in_pyodide
-from pytest_pyodide.server import spawn_web_server
 
 from conftest import DIST_PATH, PYODIDE_ROOT, strip_assertions_stderr
 from pyodide.code import CodeRunner, eval_code, find_imports, should_quiet  # noqa: E402
@@ -1732,7 +1731,7 @@ def test_csp(selenium_standalone_noload):
 
 
 @pytest.mark.xfail_browsers(node="static import test is browser-only")
-def test_static_import(selenium_standalone_noload, tmp_path):
+def test_static_import(selenium_standalone_noload, tmp_path, httpserver):
     selenium = selenium_standalone_noload
 
     # copy dist to tmp_path to perform file changes safely
@@ -1751,21 +1750,71 @@ def test_static_import(selenium_standalone_noload, tmp_path):
         PYODIDE_ROOT / "src/templates/module_static_import_test.html"
     ).read_text()
     test_html = test_html.replace("./pyodide.asm.js", f"./{hiding_dir}/pyodide.asm.js")
-    (tmp_path / "module_static_import_test.html").write_text(test_html)
+    test_html_content = test_html.encode()
 
-    with spawn_web_server(tmp_path) as web_server:
-        server_hostname, server_port, _ = web_server
-        base_url = f"http://{server_hostname}:{server_port}/"
-        selenium.goto(f"{base_url}/module_static_import_test.html")
-        selenium.javascript_setup()
-        selenium.load_pyodide()
-        selenium.run_js(
-            """
-            pyodide.runPython(`
-                print('Static import works')
-            `);
-            """
-        )
+    # Setup httpserver to serve all necessary files
+    httpserver.expect_oneshot_request(
+        "/module_static_import_test.html"
+    ).respond_with_data(
+        test_html_content,
+        content_type="text/html",
+        headers={"Access-Control-Allow-Origin": "*"},
+        status=200,
+    )
+
+    # Serve the moved pyodide.asm.js file
+    pyodide_asm_data = (tmp_path / hiding_dir / "pyodide.asm.js").read_bytes()
+    httpserver.expect_oneshot_request(
+        f"/{hiding_dir}/pyodide.asm.js"
+    ).respond_with_data(
+        pyodide_asm_data,
+        content_type="application/javascript",
+        headers={"Access-Control-Allow-Origin": "*"},
+        status=200,
+    )
+
+    # Serve other necessary pyodide files
+    for file_name in [
+        "pyodide.js",
+        "pyodide.mjs",
+        "pyodide-lock.json",
+        "python_stdlib.zip",
+        "pyodide.asm.wasm",
+    ]:
+        file_path = tmp_path / file_name
+        if file_path.exists():
+            file_data = file_path.read_bytes()
+            content_type = (
+                "application/javascript"
+                if file_name.endswith((".js", ".mjs"))
+                else (
+                    "application/json"
+                    if file_name.endswith(".json")
+                    else "application/zip"
+                    if file_name.endswith(".zip")
+                    else "application/wasm"
+                    if file_name.endswith(".wasm")
+                    else "application/octet-stream"
+                )
+            )
+            httpserver.expect_request(f"/{file_name}").respond_with_data(
+                file_data,
+                content_type=content_type,
+                headers={"Access-Control-Allow-Origin": "*"},
+                status=200,
+            )
+
+    url = httpserver.url_for("/module_static_import_test.html")
+    selenium.goto(url)
+    selenium.javascript_setup()
+    selenium.load_pyodide()
+    selenium.run_js(
+        """
+        pyodide.runPython(`
+            print('Static import works')
+        `);
+        """
+    )
 
 
 def test_python_error(selenium):


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description
This pull request refactors several test cases to use the `httpserver` fixture instead of the custom `spawn_web_server` function.

I replaces `spawn_web_server` into `httpserver` one, in 
- `test_load_relative_url`, `test_custom_lockfile_different_dir`, `test_lockfilecontents_package_base_url`, and `test_lockfilecontents_absolute_file_name` (in `test_package_loading.py`)
- `test_static_import` ( in `test_pyodide.py`)

(resolves #5860)


<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation

