### PR TITLE
Add get_debug/set_debug methods to WebLoop for asyncio compatibility

### DIFF
--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 import inspect
+import os
 import sys
 import time
 import traceback
@@ -209,9 +210,17 @@ class WebLoop(asyncio.AbstractEventLoop):
         self._no_in_progress_handler = None
         self._keyboard_interrupt_handler = None
         self._system_exit_handler = None
+        # Debug mode is currently no-op (actual asyncio debug features not implemented)
+        self._debug = sys.flags.dev_mode or (not sys.flags.ignore_environment and
+                                             bool(os.environ.get('PYTHONASYNCIODEBUG')))
 
     def get_debug(self):
-        return False
+        """Return the debug mode of the event loop."""
+        return self._debug
+    
+    def set_debug(self, enabled: bool) -> None:
+        """Set the debug mode of the event loop."""
+        self._debug = enabled
 
     #
     # Lifecycle methods: We ignore all lifecycle management

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -211,13 +211,15 @@ class WebLoop(asyncio.AbstractEventLoop):
         self._keyboard_interrupt_handler = None
         self._system_exit_handler = None
         # Debug mode is currently no-op (actual asyncio debug features not implemented)
-        self._debug = sys.flags.dev_mode or (not sys.flags.ignore_environment and
-                                             bool(os.environ.get('PYTHONASYNCIODEBUG')))
+        self._debug = sys.flags.dev_mode or (
+            not sys.flags.ignore_environment
+            and bool(os.environ.get("PYTHONASYNCIODEBUG"))
+        )
 
     def get_debug(self):
         """Return the debug mode of the event loop."""
         return self._debug
-    
+
     def set_debug(self, enabled: bool) -> None:
         """Set the debug mode of the event loop."""
         self._debug = enabled


### PR DESCRIPTION
### Description
Related to https://github.com/pyodide/pyodide/issues/5859
This is part of splitting [#5885](https://github.com/pyodide/pyodide/pull/5885) into focused PR
- Implements `get_debug()` and `set_debug()` methods in WebLoop to maintain API compatibility with standard asyncio event loops.
- Added `_debug` flag initialization following CPython's pattern from [asyncio/coroutines.py](https://github.com/python/cpython/blob/703da5e81db012713228414b02b39d3240dc1d02/Lib/asyncio/coroutines.py#L11-L13)
- Debug mode is currently **no-op** (actual asyncio debug features like slow callback logging are not implemented)
- Only provides the API interface for compatibility with existing asyncio code
