### PR TITLE
Minor internal improvement to JsArray methods

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2133,7 +2133,7 @@ JsArray_index_js,
       return i;
     }
   }
-  return -1;
+  return -2;
 })
 // clang-format on
 
@@ -2183,7 +2183,7 @@ JsArray_index_helper(PyObject* self,
     goto error;
   } else {
     int result = JsArray_index_js(JsProxy_VAL(self), jsvalue, start, stop);
-    if (result == -1) {
+    if (result == -2) {
       goto error;
     }
     return result;


### PR DESCRIPTION
If a JS exception is for some reason raised in `JsArray_index_js`, we return -1, but we also return -1 if we just didn't find the index. We then unconditionally write over the JS error. This changes it to return -2 so that we can propagate a JS error.