### PR TITLE
refactor(types): split Module into EmscriptenModule, PythonModule, and PyodideModule #5786

### DIFF
--- a/src/js/emscripten-settings.ts
+++ b/src/js/emscripten-settings.ts
@@ -3,7 +3,7 @@
 import { ConfigType } from "./pyodide";
 import { initializeNativeFS } from "./nativefs";
 import { loadBinaryFile, getBinaryResponse } from "./compat";
-import { API, PreRunFunc, type Module, type FSType } from "./types";
+import { API, PreRunFunc, type PyodideModule, type FSType } from "./types";
 import { getSentinelImport } from "generated/sentinel";
 
 /**
@@ -122,7 +122,7 @@ function callFsInitHook(
   ];
 }
 
-function computeVersionTuple(Module: Module): [number, number, number] {
+function computeVersionTuple(Module: PyodideModule): [number, number, number] {
   const versionInt = Module.HEAPU32[Module._Py_Version >>> 2];
   const major = (versionInt >>> 24) & 0xff;
   const minor = (versionInt >>> 16) & 0xff;
@@ -144,7 +144,7 @@ function computeVersionTuple(Module: Module): [number, number, number] {
  */
 function installStdlib(stdlibURL: string): PreRunFunc {
   const stdlibPromise: Promise<Uint8Array> = loadBinaryFile(stdlibURL);
-  return async (Module: Module) => {
+  return async (Module: PyodideModule) => {
     Module.API.pyVersionTuple = computeVersionTuple(Module);
     const [pymajor, pyminor] = Module.API.pyVersionTuple;
     Module.FS.mkdirTree("/lib");

--- a/src/js/nativefs.ts
+++ b/src/js/nativefs.ts
@@ -1,9 +1,9 @@
-import { Module } from "./types";
+import { PyodideModule } from "./types";
 
 /**
  * @private
  */
-async function syncfs(m: Module, direction: boolean): Promise<void> {
+async function syncfs(m: PyodideModule, direction: boolean): Promise<void> {
   return new Promise((resolve, reject) => {
     m.FS.syncfs(direction, (err: any) => {
       if (err) {
@@ -18,21 +18,21 @@ async function syncfs(m: Module, direction: boolean): Promise<void> {
 /**
  * @private
  */
-export async function syncLocalToRemote(m: Module): Promise<void> {
+export async function syncLocalToRemote(m: PyodideModule): Promise<void> {
   return await syncfs(m, false);
 }
 
 /**
  * @private
  */
-export async function syncRemoteToLocal(m: Module): Promise<void> {
+export async function syncRemoteToLocal(m: PyodideModule): Promise<void> {
   return await syncfs(m, true);
 }
 
 /**
  * @private
  */
-export function initializeNativeFS(module: Module) {
+export function initializeNativeFS(module: PyodideModule) {
   const FS = module.FS;
   const MEMFS = module.FS.filesystems.MEMFS;
   const PATH = module.PATH;

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -16,7 +16,7 @@ import { version as version_ } from "./version";
 import type { PyodideAPI } from "./api.js";
 import type {
   TypedArray,
-  Module,
+  PyodideModule,
   PackageData,
   FSType,
   Lockfile,
@@ -40,7 +40,7 @@ export const version: string = version_;
 
 declare function _createPyodideModule(
   settings: EmscriptenSettings,
-): Promise<Module>;
+): Promise<PyodideModule>;
 
 // BUILD_ID is generated from hashing together pyodide.asm.js and
 // pyodide.asm.wasm in esbuild.config.outer.mjs

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -21,7 +21,7 @@ export type TypedArray =
   | Float64Array;
 
 declare global {
-  export var Module: Module;
+  export var Module: PyodideModule;
   export var API: API;
 }
 
@@ -263,7 +263,7 @@ interface PyodideFSType {
 export type FSType = Omit<typeof FS, "lookupPath"> & PyodideFSType;
 
 /** @hidden */
-export type PreRunFunc = (Module: Module) => void;
+export type PreRunFunc = (Module: PyodideModule) => void;
 
 type DSO = any;
 
@@ -279,8 +279,7 @@ export interface LDSO {
  * between Module and ModuleType?
  * @hidden
  */
-export interface Module {
-  API: API;
+export interface EmscriptenModule {
   locateFile: (file: string) => string;
   exited?: { toThrow: any };
   ENV: { [key: string]: string };
@@ -298,6 +297,32 @@ export interface Module {
   ERRNO_CODES: { [k: string]: number };
   stringToNewUTF8(x: string): number;
   stringToUTF8OnStack: (str: string) => number;
+  HEAP8: Uint8Array;
+  HEAPU32: Uint32Array;
+  exitCode: number | undefined;
+  ExitStatus: { new (exitCode: number): Error };
+  _free: (ptr: number) => void;
+  stackSave: () => number;
+  stackRestore: (ptr: number) => void;
+  _emscripten_dlopen_promise(lib: number, flags: number): number;
+  _dlerror(): number;
+  UTF8ToString: (
+    ptr: number,
+    maxBytesToRead: number,
+    ignoreNul?: boolean,
+  ) => string;
+}
+
+export interface PythonModule extends EmscriptenModule{
+  _Py_EMSCRIPTEN_SIGNAL_HANDLING: number;
+  Py_EmscriptenSignalBuffer: TypedArray;
+  _Py_Version: number;
+  _print_stdout: (ptr: number) => void;
+  _print_stderr: (ptr: number) => void;
+}
+
+export interface PyodideModule extends PythonModule {
+  API: API;
   _compat_to_string_repr: number;
   _compat_null_to_none: number;
   js2python_convert: (
@@ -312,10 +337,6 @@ export interface Module {
     },
   ) => any;
   _PropagatePythonError: typeof Error;
-  _Py_EMSCRIPTEN_SIGNAL_HANDLING: number;
-  Py_EmscriptenSignalBuffer: TypedArray;
-  HEAP8: Uint8Array;
-  HEAPU32: Uint32Array;
   __hiwire_get(a: number): any;
   __hiwire_set(a: number, b: any): void;
   __hiwire_immortal_add(a: any): void;
@@ -323,26 +344,14 @@ export interface Module {
   _init_pyodide_proxy(): number;
   getExceptionMessage(e: number): [string, string];
   handle_js_error(e: any): void;
-  exitCode: number | undefined;
-  ExitStatus: { new (exitCode: number): Error };
-  _Py_Version: number;
-  _print_stdout: (ptr: number) => void;
-  _print_stderr: (ptr: number) => void;
-  _free: (ptr: number) => void;
-  stackSave: () => number;
-  stackRestore: (ptr: number) => void;
   promiseMap: {
     free(id: number): void;
   };
-  _emscripten_dlopen_promise(lib: number, flags: number): number;
   getPromise(p: number): Promise<any>;
-  _dlerror(): number;
-  UTF8ToString: (
-    ptr: number,
-    maxBytesToRead: number,
-    ignoreNul?: boolean,
-  ) => string;
 }
+
+/** @deprecated Use PyodideModule instead. */
+export type Module = PyodideModule;
 
 /**
  * The lockfile platform info. The ``abi_version`` field is used to check if the
@@ -579,7 +588,7 @@ export type PackageManagerAPI = Pick<
  * @hidden
  */
 export type PackageManagerModule = Pick<
-  Module,
+  PyodideModule,
   | "PATH"
   | "LDSO"
   | "stringToNewUTF8"

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -313,7 +313,7 @@ export interface EmscriptenModule {
   ) => string;
 }
 
-export interface PythonModule extends EmscriptenModule{
+export interface PythonModule extends EmscriptenModule {
   _Py_EMSCRIPTEN_SIGNAL_HANDLING: number;
   Py_EmscriptenSignalBuffer: TypedArray;
   _Py_Version: number;
@@ -349,9 +349,6 @@ export interface PyodideModule extends PythonModule {
   };
   getPromise(p: number): Promise<any>;
 }
-
-/** @deprecated Use PyodideModule instead. */
-export type Module = PyodideModule;
 
 /**
  * The lockfile platform info. The ``abi_version`` field is used to check if the


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Related to issue #5786

This PR splits the existing `Module` interface definition into three layered interfaces:

- `EmscriptenModule`
- `PythonModule` extends `EmscriptenModule`
- `PyodideModule` extends `PythonModule`

The changes are made in `src/js/type.ts`, where the interface definitions are updated. 
This makes it clearer which APIs come from Emscripten, CPython, or Pyodide itself.

Out of scope for this PR, but worth considering: utilizing the Emscripten Module type definition from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).

Happy to iterate on feedback.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
