### PR TITLE
Implement missing no-op methods in WebLoop

### DIFF
--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -301,6 +301,13 @@ class WebLoop(asyncio.AbstractEventLoop):
                     }
                 )
 
+    async def shutdown_default_executor(self):
+        """Schedule the shutdown of the default executor.
+
+        This is a no-op since WebLoop doesn't use thread executors.
+        """
+        pass
+
     #
     # Lifecycle methods: We ignore all lifecycle management
     #
@@ -362,9 +369,24 @@ class WebLoop(asyncio.AbstractEventLoop):
             return run_sync(future)
         return asyncio.ensure_future(future)
 
+    def stop(self):
+        """Stop the event loop as soon as reasonable.
+
+        This is a no-op in WebLoop since it runs forever on the browser event loop.
+        """
+        pass
+
     #
     # Scheduling methods: use browser.setTimeout to schedule tasks on the browser event loop.
     #
+
+    def _timer_handle_cancelled(self, handle):
+        """Notification that a TimerHandle has been cancelled.
+
+        This is a no-op since we use browser setTimeout which handles
+        cancellation automatically.
+        """
+        pass
 
     def call_soon(  # type: ignore[override]
         self,
@@ -491,6 +513,14 @@ class WebLoop(asyncio.AbstractEventLoop):
         except BaseException as e:
             fut.set_exception(e)
         return fut
+
+    def set_default_executor(self, executor):
+        """Set the default executor.
+
+        This is a no-op since WebLoop doesn't use thread executors.
+        All functions are executed in the main thread via run_in_executor.
+        """
+        pass
 
     def create_future(self) -> asyncio.Future[Any]:
         """Create a Future object attached to the loop."""


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description
Related to https://github.com/pyodide/pyodide/issues/5859
This PR implements missing no-op methods in WebLoop to properly complete the AbstractEventLoop interface implementation.
- **`stop()`**: No-op implementation since WebLoop runs forever on the browser event loop
- **`_timer_handle_cancelled()`**: No-op implementation since browser setTimeout handles cancellation automatically
- **`shutdown_default_executor()`**: No-op implementation since WebLoop doesn't use thread executors
- **`set_default_executor()`**: No-op implementation since executors are not utilized in browser environment
