### PR TITLE
Fix @types/emscripten dependency

### DIFF
--- a/src/js/package.json
+++ b/src/js/package.json
@@ -17,6 +17,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@types/emscripten": "^1.40.1",
+    "ws": "^8.5.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.1.1",
@@ -115,9 +116,6 @@
         "DOM"
       ]
     }
-  },
-  "dependencies": {
-    "ws": "^8.5.0"
   },
   "types": "./pyodide.d.ts",
   "engines": {

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -15,10 +15,12 @@
     "url": "https://github.com/pyodide/pyodide/issues"
   },
   "license": "MPL-2.0",
+  "dependencies": {
+    "@types/emscripten": "^1.40.1",
+  },
   "devDependencies": {
     "@biomejs/biome": "2.1.1",
     "@types/assert": "^1.5.6",
-    "@types/emscripten": "^1.40.1",
     "@types/expect": "^24.3.0",
     "@types/node": "^20.8.4",
     "@types/ws": "^8.5.3",


### PR DESCRIPTION
Change @types/emscripten from `devDependencies` to `dependencies`.

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

See the discussion [here](https://github.com/pyodide/pyodide/pull/5863#issuecomment-3327355700) for context. Basically it fixes the TypeScript definition for the file system.