### PR TITLE
refactor: Rewrite tests to use @run_in_pyodide (WIP)

### DIFF
--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -141,25 +141,32 @@ def test_import_js(selenium):
     assert "window" in result
 
 
+@run_in_pyodide
 def test_globals_get_multiple(selenium):
     """See #1151"""
-    selenium.run_js(
+    from pyodide.code import run_js
+
+    v = 0.123  # noqa: F841
+    run_js(
         """
-        pyodide.runPython("v = 0.123");
         pyodide.globals.get('v')
         pyodide.globals.get('v')
         """
     )
 
 
+@run_in_pyodide(packages=["distutils"])
 def test_version_info(selenium):
     from distutils.version import LooseVersion
 
-    version_py_str = selenium.run("import pyodide; pyodide.__version__")
+    import pyodide
+    from pyodide.code import run_js
+
+    version_py_str = pyodide.__version__
     version_py = LooseVersion(version_py_str)
     assert version_py > LooseVersion("0.0.1")
 
-    version_js_str = selenium.run_js("return pyodide.version;")
+    version_js_str = run_js("pyodide.version")
     assert version_py_str == version_js_str
 
 


### PR DESCRIPTION
## Summary
This PR is part of ongoing work to refactor tests to use `@run_in_pyodide` decorator as outlined in #2444. This follows the patterns established in PRs #5845, #5796, and #5867.

## Progress
**Completed:**
- ✅ test_python.py: 2→0 violations (100%)
- ✅ test_asyncio.py: 8→0 violations (100%)
- 🔄 test_jsproxy.py: 36→21 violations (42% - partial)

**Overall:** 25/265 violations fixed (9.4%)

**Remaining Work:**
- Complete test_jsproxy.py (21 violations)
- Refactor test_typeconversions.py (24 violations)
- Refactor remaining files (~219 violations)

## Key Transformations
Following maintainer guidance from PRs #5845, #5796, #5867:

1. ✅ Add `@run_in_pyodide` decorator to test functions
2. ✅ Move Python code out of JS strings into function body
3. ✅ Replace `selenium.run_js()` with `run_js()` from `pyodide.code`
4. ✅ Use `from js import <object>` to access JS objects
5. ✅ Eliminate manual proxy cleanup (`toJs()`, `destroy()`)
6. ✅ Replace `self` assignments in JS with function parameters

## Benefits
- Better IDE/formatter support for Python code
- Clearer error messages and stack traces
- Potential pytest rewrite hook support
- More maintainable and readable tests
- Follows modern Pyodide testing patterns

## Testing
- Pre-commit checks: ✅ Passed
- ast-grep violations reduced from 265 to 240

## Notes
This is a **draft PR** to get early feedback on the approach. Will continue refactoring the remaining files once the pattern is confirmed to be correct.

Related: #2444

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>