### PR TITLE
docs: update macOS Homebrew build instructions

### DIFF
--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -152,7 +152,7 @@ Then install the required Python version and other build dependencies in a separ
 
 To build on macOS with Homebrew, you need:
 
-- System command line tools: 
+- System command line tools:
   `xcode-select --install`
 - [Homebrew](https://brew.sh/) for installing dependencies
 - Pyodide requires CMake3 but Homebrew installs CMake4.

--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -133,7 +133,7 @@ Then install the required Python version and other build dependencies in a separ
     conda activate pyodide-env
 
 ```
-```{tab-item} MacOS with conda
+```{tab-item} macOS with conda
 
 You would need,
 - System libraries in the root directory:
@@ -148,20 +148,22 @@ Then install the required Python version and other build dependencies in a separ
 
 ```
 
-```{tab-item} MacOS with Homebrew
+```{tab-item} macOS with Homebrew
 
-To build on MacOS with Homebrew, you need:
+To build on macOS with Homebrew, you need:
 
-- System command line tools
+- System command line tools: 
   `xcode-select --install`
 - [Homebrew](https://brew.sh/) for installing dependencies
-- `brew install coreutils autoconf automake libtool libffi ccache`
 - Pyodide requires CMake3 but Homebrew installs CMake4.
   Use pip for cmake `pip install cmake==3.31`
+- `brew install coreutils cmake autoconf automake libtool libffi ccache wget rustup-init`
+- Initialize Rust (needed for building test-rust-* packages): `rustup-init`
 - Install the GNU patch and
   GNU sed (`brew install gpatch gnu-sed`)
   and [re-defining them temporarily as `patch` and
   `sed`](https://formulae.brew.sh/formula/gnu-sed).
+
 ```
 ````
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

This PR updates the **macOS with Homebrew** build instructions in the documentation.  
- Added missing dependencies: `wget` and `rustup-init`  
- Added a step to initialize Rust (`rustup-init`) since it is required for building `test-rust-*` packages  
- Kept consistency with other platform instructions while clarifying Homebrew-specific setup  
- Fixed capitalization: MacOS → macOS for consistency with Apple naming

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [X] Add new / update outdated documentation
