### PR TITLE
When failed to compute indexURL, mention the fix

### DIFF
--- a/src/js/compat.ts
+++ b/src/js/compat.ts
@@ -309,7 +309,7 @@ export async function calculateDirname(): Promise<string> {
   const indexOfLastSlash = fileName.lastIndexOf(pathSep);
   if (indexOfLastSlash === -1) {
     throw new Error(
-      "Could not extract indexURL path from pyodide module location",
+      "Could not extract indexURL path from pyodide module location. Please pass the indexURL explicitly to loadPyodide.",
     );
   }
   return fileName.slice(0, indexOfLastSlash);


### PR DESCRIPTION
Which is to pass indexURL explicitly to loadPyodide. This still is a bit unclear but it is at least an improvement over the current situation.