### PR TITLE
Fix the error `make -C packages` in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,11 +86,9 @@ RUN npm install -g \
 # Normally, it is a bad idea to install rustup and cargo in
 # system directories (it should not be shared between users),
 # but this docker image is only for building packages, so I hope it is ok.
-# Setting RUSTUP_UPDATE_ROOT gives us a beta rustup.
-# TODO: Remove when Rustup 1.28.0 is released.
+ENV RUSTUP_HOME=/usr
+ENV CARGO_HOME=/usr
 RUN wget -q -O  -  https://sh.rustup.rs | \
-  RUSTUP_UPDATE_ROOT=https://dev-static.rust-lang.org/rustup \
-  RUSTUP_HOME=/usr CARGO_HOME=/usr \
   sh -s -- -y --profile minimal --no-modify-path
 
 COPY --from=selenium-manager-image /opt/firefox /opt/firefox


### PR DESCRIPTION
### Description

Export environment variables, `RUSTUP_HOME` and `CARGO_HOME` rather than specify them temporarily to fix the error below on running `make -C pakacges` in docker container.

```
root@8396dadc3681:/src/pyodide# make -C packages 
make: Entering directory '/src/pyodide/packages'
pyodide build-recipes "tag:pytest,tag:pyodide.test" \
        --install \
        --metadata-files \
        --n-jobs ${PYODIDE_JOBS:-4} \
        --log-dir=./build-logs \
        --compression-level "6"
info: syncing channel updates for 'nightly-2025-02-01-x86_64-unknown-linux-gnu'

  nightly-2025-02-01-x86_64-unknown-linux-gnu unchanged - rustc 1.86.0-nightly (854f22563 2025-01-31)

error: rustup is not installed at '/root/.cargo'
ERROR: command failed rustup toolchain install nightly-2025-02-01                     
make: *** [Makefile:15: all] Error 1
make: Leaving directory '/src/pyodide/packages'
```

And remove `RUSTUP_UPDATE_ROOT` as well by following `TODO` instruction
The installed version of rustup is higher than `1.28.0`

```
root@a38716856c84:/src# rustup --version
rustup 1.28.2 (e4f3ad6f8 2025-04-28)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.90.0 (1159e78c4 2025-09-14)`
```