### PR TITLE
Adjust timing in test_two_way_transfer to reduce flakiness

### DIFF
--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -292,7 +292,7 @@ def test_two_way_transfer(selenium):
                     l.append([n, i])
         `);
         f = pyodide.globals.get("f");
-        await Promise.all([f.callPromising("a", 15), f.callPromising("b", 25)])
+        await Promise.all([f.callPromising("a", 15), f.callPromising("b", 21)])
         f.destroy();
         const l = pyodide.globals.get("l");
         const res = l.toJs();
@@ -304,8 +304,8 @@ def test_two_way_transfer(selenium):
         ["a", 0],
         ["b", 0],
         ["a", 1],
-        ["a", 2],
         ["b", 1],
+        ["a", 2],
         ["a", 3],
         ["b", 2],
         ["a", 4],


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

test_two_way_transfer was occasionally failing because `15ms` and `25ms` share a common multiple (`75ms`), which makes the execution order of the two tasks nondeterministic.
Replaced them with `15` and `21ms` to avoid synchronized wake-ups and make the test more stable.

15 -> 15 30 45 60 75
21 -> 21 42 63 84 105


