### PR TITLE
Add @types/emscripten to package-lock.json

### DIFF
--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.29.0-dev.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@types/emscripten": "^1.40.1",
         "ws": "^8.5.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.1.1",
         "@playwright/test": "^1.55.1",
         "@types/assert": "^1.5.6",
-        "@types/emscripten": "^1.40.1",
         "@types/expect": "^24.3.0",
         "@types/node": "^20.8.4",
         "@types/ws": "^8.5.3",
@@ -1343,8 +1343,7 @@
     "node_modules/@types/emscripten": {
       "version": "1.40.1",
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.40.1.tgz",
-      "integrity": "sha512-sr53lnYkQNhjHNN0oJDdUm5564biioI5DuOpycufDVK7D3y+GR3oUswe2rlwY1nPNyusHbrJ9WoTyIHl4/Bpwg==",
-      "dev": true
+      "integrity": "sha512-sr53lnYkQNhjHNN0oJDdUm5564biioI5DuOpycufDVK7D3y+GR3oUswe2rlwY1nPNyusHbrJ9WoTyIHl4/Bpwg=="
     },
     "node_modules/@types/eslint": {
       "version": "7.29.0",


### PR DESCRIPTION
### Description

Recently `@types/emscripten` is moved to dependecies in #5910.
However, it seems like the same modification is needed in `package-lock.json` as well.
