### PR TITLE
Change `scheduleCallbackImmediate()` threshold to 0

### DIFF
--- a/src/js/scheduler.ts
+++ b/src/js/scheduler.ts
@@ -93,8 +93,8 @@ function scheduleCallbackImmediate(callback: () => void) {
  * @hidden
  */
 export function scheduleCallback(callback: () => void, timeout: number = 0) {
-  if (timeout <= 2) {
-    // for a very short delay (0, 1), use immediate callback
+  if (timeout === 0) {
+    // for 0 delay, use immediate callback
     scheduleCallbackImmediate(callback);
   } else {
     setTimeout(callback, timeout);


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

As I mentioned [here](https://github.com/pyodide/pyodide/issues/5925#issuecomment-3382000524), if there’s no more clamping when `asyncio.sleep(0.001 ~ 0.003)` is called repeatedly, we can call `scheduleCallbackImmediate()` only when the delay is 0 to improve scheduling accuracy.
