### PR TITLE
Add explicit url for redefining `patch` on mac

### DIFF
--- a/docs/development/building-from-sources.md
+++ b/docs/development/building-from-sources.md
@@ -161,8 +161,8 @@ To build on macOS with Homebrew, you need:
 - Initialize Rust (needed for building test-rust-* packages): `rustup-init`
 - Install the GNU patch and
   GNU sed (`brew install gpatch gnu-sed`)
-  and [re-defining them temporarily as `patch` and
-  `sed`](https://formulae.brew.sh/formula/gnu-sed).
+  and re-defining them temporarily as [`patch`](https://formulae.brew.sh/formula/gpatch) and
+  [`sed`](https://formulae.brew.sh/formula/gnu-sed).
 
 ```
 ````


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Add explicit url for redefining `patch` on mac so it will be harded to overlook the PATH prefix that should be used.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
