### PR TITLE
Fix MessageChannel to process task snapshots instead of draining queue

### DIFF
--- a/src/js/scheduler.ts
+++ b/src/js/scheduler.ts
@@ -52,8 +52,9 @@ function ensureSharedChannel() {
   sharedChannel = new MessageChannel();
 
   sharedChannel.port1.onmessage = () => {
-    // Drain the queue: process as many scheduled tasks as are currently queued.
-    while (taskQueue.length) {
+    // Process tasks that were queued when this message arrived
+    const count = taskQueue.length;
+    for (let i = 0; i < count; i++) {
       const handle = taskQueue.shift()!;
       const task = tasks[handle];
       if (!task) continue;


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description
- Changed MessageChannel event handler from `while` loop to `for` loop with snapshot count
- Now processes only tasks that were queued when the message arrived
