### PR TITLE
Revert "Remove _zoneinfo cpython patch (#5945)"

### DIFF
--- a/cpython/patches/0004-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
+++ b/cpython/patches/0004-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
@@ -1,0 +1,29 @@
+From 198ad7882105abb53e3b57c1aa44a73ad96c7bd3 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Thu, 25 Jul 2024 14:28:57 +0200
+Subject: [PATCH 04/10] Warn if ZoneInfo is imported without tzdata
+
+---
+ Lib/zoneinfo/_common.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/Lib/zoneinfo/_common.py b/Lib/zoneinfo/_common.py
+index 98cdfe37ca6..35d19eae9f0 100644
+--- a/Lib/zoneinfo/_common.py
++++ b/Lib/zoneinfo/_common.py
+@@ -11,6 +11,12 @@ def load_tzdata(key):
+     try:
+         return resources.files(package_name).joinpath(resource_name).open("rb")
+     except (ImportError, FileNotFoundError, UnicodeEncodeError):
++        import sys
++        if "tzdata" not in sys.modules:
++            raise ZoneInfoNotFoundError(
++                f"No time zone found with key {key}. \n"
++                " On Pyodide you must do pyodide.loadPackage('tzdata')"
++                " package before you use zoneinfo.")
+         # There are three types of exception that can be raised that all amount
+         # to "we cannot find this key":
+         #
+-- 
+2.34.1
+

--- a/cpython/patches/0005-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
+++ b/cpython/patches/0005-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
@@ -1,7 +1,7 @@
 From 76360edbea0808455523e42f024894215b483ebd Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:41:37 +0200
-Subject: [PATCH 04/09] Add call to `JsProxy_GetMethod` to help remove
+Subject: [PATCH 05/10] Add call to `JsProxy_GetMethod` to help remove
  temporary
 
 `_PyObject_GetMethod` is a special attribute lookup function that won't call the

--- a/cpython/patches/0006-Make-from-x-import-aware-of-jsproxy-modules.patch
+++ b/cpython/patches/0006-Make-from-x-import-aware-of-jsproxy-modules.patch
@@ -1,7 +1,7 @@
 From 01a53bd90d3e11992489989a2db45e41bd9b1947 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 22 Feb 2025 13:18:18 +0100
-Subject: [PATCH 05/09] Make `from x import *` aware of jsproxy modules
+Subject: [PATCH 06/10] Make `from x import *` aware of jsproxy modules
 
 ---
  Python/intrinsics.c | 8 ++++++++

--- a/cpython/patches/0007-Use-wasm-gc-based-call-adaptor-if-available.patch
+++ b/cpython/patches/0007-Use-wasm-gc-based-call-adaptor-if-available.patch
@@ -1,7 +1,7 @@
 From ebcde519cfa69f0a514555e46436379789f6d1bb Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Tue, 11 Mar 2025 14:31:31 +0100
-Subject: [PATCH 06/09] Use wasm-gc based call adaptor if available
+Subject: [PATCH 07/10] Use wasm-gc based call adaptor if available
 
 Part of the ongoing quest to support JSPI. The JSPI spec removed its dependence on
 JS type reflection, and now the plan is for runtimes to ship JSPI while keeping

--- a/cpython/patches/0008-Fix-Emscripten-call-trampoline-compatibility-with-Em.patch
+++ b/cpython/patches/0008-Fix-Emscripten-call-trampoline-compatibility-with-Em.patch
@@ -1,7 +1,7 @@
 From 62c9c54822dd8e313d1a2ea4ffaba13c6623ed92 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Mon, 31 Mar 2025 12:09:50 +0200
-Subject: [PATCH 07/09] Fix Emscripten call trampoline compatibility with
+Subject: [PATCH 08/10] Fix Emscripten call trampoline compatibility with
  Emscripten 4.0.3 and 4.0.4
 
 See upstream issue:

--- a/cpython/patches/0009-Fix-iPad-detection-in-wasm-gc.patch
+++ b/cpython/patches/0009-Fix-iPad-detection-in-wasm-gc.patch
@@ -1,7 +1,7 @@
 From 6f119c924bb218b3cddc9c0683ac2efc56ebf463 Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Wed, 11 Jun 2025 08:54:37 +0200
-Subject: [PATCH 08/09] Fix iPad detection in wasm-gc
+Subject: [PATCH 09/10] Fix iPad detection in wasm-gc
 
 Fixes iPad detection logic in wasm-gc, which was malfunctioning in recent iPadOS + safari.
 ---

--- a/cpython/patches/0010-Teach-json-encoder.py-to-encode-jsnull.patch
+++ b/cpython/patches/0010-Teach-json-encoder.py-to-encode-jsnull.patch
@@ -1,7 +1,7 @@
 From 7cf6863176a7b3b62980e25652102532582ae49e Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 9 Jul 2025 17:00:12 +0200
-Subject: [PATCH 09/09] Teach json encoder.py to encode jsnull
+Subject: [PATCH 10/10] Teach json encoder.py to encode jsnull
 
 ---
  Lib/json/encoder.py | 9 +++++++++

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -36,10 +36,6 @@ myst:
   relevant `this`. See {issue}`5929`.
   {pr}`5937`
 
-- {{ Fix }} Removed redundant `_zoneinfo` cpython patch that modified error messages
-  for missing tzdata. The standard Python documentation already covers this requirement.
-  {pr}`5945`
-
 ### Packages
 
 - {{ Enhancement }} New packages added:


### PR DESCRIPTION
This reverts commit 099d4f324f537f6bb1c9198f946cfe793b245f5a.

It doesn't make a whole lot of sense to me to delete this behavior from Pyodide while at the same time trying to add it to the main branch of Python. I am open to replacing this patch with the upstreamed patch though.