### PR TITLE
Bump packages set to 0.29-20251018

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -15,7 +15,7 @@ export RUST_EMSCRIPTEN_TARGET_URL ?= https://github.com/pyodide/rust-emscripten-
 export RUSTFLAGS = -C link-arg=-sSIDE_MODULE=2 -Z link-native-libraries=yes -Z emscripten-wasm-eh
 
 # URL to the prebuilt packages
-export PYODIDE_PREBUILT_PACKAGES_BASE=https://github.com/pyodide/pyodide-recipes/releases/download/0.29-20251005
+export PYODIDE_PREBUILT_PACKAGES_BASE=https://github.com/pyodide/pyodide-recipes/releases/download/0.29-20251018
 export PYODIDE_PREBUILT_PACKAGES_URL=$(PYODIDE_PREBUILT_PACKAGES_BASE)/packages.tar.gz
 export PYODIDE_PREBUILT_PACKAGES_LOCKFILE=$(PYODIDE_PREBUILT_PACKAGES_BASE)/pyodide-lock.json
 export ENABLE_PREBUILT_PACKAGES ?= 0

--- a/packages/micropip/meta.yaml
+++ b/packages/micropip/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: micropip
-  version: 0.10.1
+  version: 0.11.0
   tag:
     - always
   top-level:
     - micropip
 
 source:
-  sha256: 126a501fecb40fc87f7edb67974a45f32db87e8ff3d932452aefbbcde27e53f5
-  url: https://files.pythonhosted.org/packages/py3/m/micropip/micropip-0.10.1-py3-none-any.whl
+  sha256: 467568ffe26c3aa5b53bad7a4722ebd91b0427cfd664efbe1b571530ded4a84b
+  url: https://files.pythonhosted.org/packages/py3/m/micropip/micropip-0.11.0-py3-none-any.whl
 
 about:
   home: https://github.com/pyodide/micropip


### PR DESCRIPTION
Includes micropip update and re-enabling pygame-ce