### PR TITLE
Fix console-v2 to remember terminal history after refresh

### DIFF
--- a/src/templates/console-v2.html
+++ b/src/templates/console-v2.html
@@ -188,13 +188,29 @@ of the stable console.
         const history = [];
         let historyIndex = null; // null means not navigating history
 
+        // Load history from localStorage
+        try {
+          const savedHistory = localStorage.getItem("0_commands");
+          if (savedHistory) {
+            const parsed = JSON.parse(savedHistory);
+            if (Array.isArray(parsed)) {
+              history.push(...parsed);
+            }
+          }
+        } catch (e) {
+          console.error("Failed to load history from localStorage:", e);
+        }
+
         term.write(prompt);
 
         function addToHistory(command) {
           const trimmed = command.trimEnd();
           if (!trimmed) return;
           const last = history[history.length - 1];
-          if (last !== trimmed) history.push(trimmed);
+          if (last !== trimmed) {
+            history.push(trimmed);
+            localStorage.setItem("0_commands", JSON.stringify(history));
+          }
         }
 
         function refreshLine() {


### PR DESCRIPTION
### Description
This PR fixes the `console-v2.html` to remember terminal history, with saving the history data into localStorage. (resolves #5961)

Now, we can access the same terminal history, in both `console.html` and `console-v2.html`, because `console-v2.html` saves the terminal history data with key `0_commands` used by `console.html`.

We can maybe rename it more descriptive, after console-v2 becomes default.



