### PR TITLE
Load packages without using Python

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -56,6 +56,7 @@ def set_configs():
         pyodide._api.importlib.invalidate_caches;
         pyodide._api.package_loader.get_install_dir;
         pyodide._api.package_loader.unpack_buffer;
+        pyodide._api.package_loader.install_files;
         pyodide._api.package_loader.get_dynlibs;
         pyodide._api.pyodide_code.eval_code;
         pyodide._api.pyodide_code.eval_code_async;

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -841,5 +841,6 @@ API.finalizeBootstrap = function (
   pyodide.pyodide_py = API.pyodide_py;
   pyodide.globals = API.globals;
   bootstrapFinalized!();
+  API.bootstrapFinalized = true;
   return pyodide;
 };

--- a/src/js/installer.ts
+++ b/src/js/installer.ts
@@ -1,6 +1,14 @@
 import { DynlibLoader } from "./dynload";
-import { uriToPackageData } from "./packaging-utils";
-import { PackageManagerAPI, PackageManagerModule } from "./types";
+import {
+  PackageManagerAPI,
+  PackageManagerModule,
+  PyodideModule,
+} from "./types";
+import { ZipReader, Uint8ArrayReader } from "@zip.js/zip.js";
+
+function canonicalizePackageName(name: string): string {
+  return name.replaceAll(/[-_.]+/g, "-").toLowerCase();
+}
 
 /**
  * The Installer class is responsible for installing packages into the Pyodide filesystem.
@@ -13,33 +21,109 @@ import { PackageManagerAPI, PackageManagerModule } from "./types";
  */
 export class Installer {
   #api: PackageManagerAPI;
+  #fs: PyodideModule["FS"];
   #dynlibLoader: DynlibLoader;
 
   constructor(api: PackageManagerAPI, pyodideModule: PackageManagerModule) {
     this.#api = api;
+    this.#fs = pyodideModule.FS;
     this.#dynlibLoader = new DynlibLoader(api, pyodideModule);
+  }
+
+  async installTar(
+    buffer: Uint8Array,
+    filename: string,
+    installDir: string,
+    metadata?: [string, string][],
+  ) {
+    await this.#api.bootstrapFinalizedPromise;
+    const dynlibs = this.#api.package_loader.unpack_buffer.callKwargs({
+      buffer,
+      filename,
+      extract_dir: installDir,
+      metadata,
+      calculate_dynlibs: true,
+    });
+    await this.#dynlibLoader.loadDynlibsFromPackage(
+      { file_name: filename },
+      dynlibs,
+    );
+  }
+
+  async installDataFiles(dataDir: string): Promise<void> {
+    await this.#api.bootstrapFinalizedPromise;
+    this.#api.package_loader.install_files(dataDir, this.#api.sys.prefix);
+  }
+
+  async unpackZip(
+    buffer: Uint8Array,
+    installDir: string,
+  ): Promise<{
+    dynlibs: string[];
+    metadataDir: string | undefined;
+    dataFilesDir: string | undefined;
+  }> {
+    const reader = new ZipReader(new Uint8ArrayReader(buffer));
+    const dynlibs = [];
+    let metadataDir;
+    let dataFilesDir;
+    for await (const entry of reader.getEntriesGenerator()) {
+      const path = installDir + "/" + entry.filename;
+      if (entry.directory) {
+        this.#fs.mkdirTree(path);
+        continue;
+      }
+      const dirname = Module.PATH.dirname(path);
+      this.#fs.mkdirTree(dirname);
+      const buf = await entry.arrayBuffer();
+      this.#fs.writeFile(path, new Uint8Array(buf), { canOwn: true });
+      if (entry.filename.endsWith(".so")) {
+        dynlibs.push(path);
+      }
+      const start = entry.filename.split("/", 1)[0];
+      if (start.endsWith(".dist-info")) {
+        metadataDir = start;
+      }
+      if (start.endsWith(".data")) {
+        dataFilesDir = start;
+      }
+    }
+    return { dynlibs, dataFilesDir, metadataDir };
   }
 
   async install(
     buffer: Uint8Array,
     filename: string,
     installDir: string,
-    metadata?: ReadonlyMap<string, string>,
+    metadata?: [string, string][],
+    postBootstrapPromises?: Promise<void>[] | undefined,
   ) {
-    const dynlibs: string[] = this.#api.package_loader.unpack_buffer.callKwargs(
-      {
-        buffer,
-        filename,
-        extract_dir: installDir,
-        metadata,
-        calculate_dynlibs: true,
-      },
+    async function maybeDefer(p: Promise<void>) {
+      if (postBootstrapPromises) {
+        postBootstrapPromises.push(p);
+      } else {
+        await p;
+      }
+    }
+
+    if (filename.endsWith(".tar")) {
+      const promise = this.installTar(buffer, filename, installDir, metadata);
+      await maybeDefer(promise);
+      return;
+    }
+    const { dynlibs, dataFilesDir, metadataDir } = await this.unpackZip(
+      buffer,
+      installDir,
     );
 
-    DEBUG &&
-      console.debug(
-        `Found ${dynlibs.length} dynamic libraries inside ${filename}`,
+    for (const [key, value] of metadata ?? []) {
+      this.#fs.writeFile(`${installDir}/${metadataDir}/${key}`, value);
+    }
+    if (dataFilesDir) {
+      await maybeDefer(
+        this.installDataFiles(`${installDir}/${dataFilesDir}/data`),
       );
+    }
 
     await this.#dynlibLoader.loadDynlibsFromPackage(
       { file_name: filename },

--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@types/emscripten": "^1.41.4",
+        "@zip.js/zip.js": "^2.8.8",
         "ws": "^8.5.0"
       },
       "devDependencies": {
@@ -1506,6 +1507,17 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.8.tgz",
+      "integrity": "sha512-v0KutehhSAuaoFAFGLp+V4+UiZ1mIxQ8vNOYMD7k9ZJaBbtQV49MYlg568oRLiuwWDg2Di58Iw3Q0ESNWR+5JA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -17,6 +17,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@types/emscripten": "^1.41.4",
+    "@zip.js/zip.js": "^2.8.8",
     "ws": "^8.5.0"
   },
   "devDependencies": {

--- a/src/js/test/unit/installer.test.ts
+++ b/src/js/test/unit/installer.test.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { Installer } from "../../installer.ts";
 import { genMockAPI, genMockModule } from "./test-helper.ts";
@@ -8,38 +7,5 @@ describe("Installer", () => {
     const mockApi = genMockAPI();
     const mockMod = genMockModule();
     const _ = new Installer(mockApi, mockMod);
-  });
-
-  it("should call package_loader.unpack_buffer.callKwargs", async (t) => {
-    // @ts-ignore
-    globalThis.DEBUG = false;
-
-    const mockApi = genMockAPI();
-    const mockMod = genMockModule();
-    const installer = new Installer(mockApi, mockMod);
-
-    const unpackBufferSpy = t.mock.method(
-      mockApi.package_loader.unpack_buffer,
-      "callKwargs",
-      () => [],
-    );
-
-    const metadata = new Map<string, string>();
-    metadata.set("key", "value");
-    await installer.install(
-      new Uint8Array(),
-      "filename",
-      "installDir",
-      metadata,
-    );
-
-    assert.equal(unpackBufferSpy.mock.callCount(), 1);
-    assert.deepEqual(unpackBufferSpy.mock.calls[0].arguments[0], {
-      buffer: new Uint8Array(),
-      filename: "filename",
-      extract_dir: "installDir",
-      metadata,
-      calculate_dynlibs: true,
-    });
   });
 });

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -462,6 +462,7 @@ export interface API {
   config: PyodideConfigWithDefaults;
   packageIndexReady: Promise<void>;
   bootstrapFinalizedPromise: Promise<void>;
+  bootstrapFinalized: boolean;
   typedArrayAsUint8Array: (buffer: TypedArray | ArrayBuffer) => Uint8Array;
   initializeStreams: (
     stdin?: InFuncType | undefined,
@@ -524,7 +525,7 @@ export interface API {
     buffer: Uint8Array,
     filename: string,
     installDir: string,
-    metadata?: ReadonlyMap<string, string>,
+    metadata: [string, string][],
   ) => Promise<void>;
   _Comlink: any;
 
@@ -557,18 +558,22 @@ export interface API {
 export type PackageManagerAPI = Pick<
   API,
   | "importlib"
+  | "sys"
   | "package_loader"
   | "lockfile_packages"
   | "bootstrapFinalizedPromise"
+  | "bootstrapFinalized"
   | "sitepackages"
   | "defaultLdLibraryPath"
   | "version"
+  | "public_api"
 > & {
   config: Pick<
     PyodideConfigWithDefaults,
     "packageCacheDir" | "packageBaseUrl" | "cdnUrl"
   >;
 };
+
 /**
  * @hidden
  */
@@ -587,4 +592,5 @@ export type PackageManagerModule = Pick<
   | "promiseMap"
   | "_dlerror"
   | "UTF8ToString"
+  | "FS"
 >;

--- a/src/py/pyodide/_package_loader.py
+++ b/src/py/pyodide/_package_loader.py
@@ -194,7 +194,7 @@ def unpack_buffer(
     format: str | None = None,
     extract_dir: str | None = None,
     calculate_dynlibs: bool = False,
-    metadata: dict[str, str] | None = None,
+    metadata: list[tuple[str, str]] | None = None,
 ) -> JsArray[str] | None:
     """Used to install a package either into sitepackages or into the standard
     library.
@@ -233,7 +233,7 @@ def unpack_buffer(
         locations of the .so files.
 
     metadata
-        A dictionary of metadata to be stored in the package's dist-info directory.
+        A list of metadata tuples to be stored in the package's dist-info directory.
         The keys are the names of the metadata files and the values are the contents
         of the files.
 
@@ -296,7 +296,7 @@ def set_wheel_metadata(
     filename: str,
     archive: ZipFile,
     target_dir: Path,
-    metadata: dict[str, str],
+    metadata: list[tuple[str, str]],
 ) -> None:
     """Record the metadata of a wheel into the target directory.
 
@@ -329,7 +329,7 @@ def set_wheel_metadata(
     wheel_name = parse_wheel_name(filename)[0]
     dist_info_name = wheel_dist_info_dir(archive, wheel_name)
     dist_info = target_dir / dist_info_name
-    for key, value in metadata.items():
+    for key, value in metadata:
         (dist_info / key).write_text(value)
 
 

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -1386,3 +1386,22 @@ def test_package_manager_urls_browsers(selenium_standalone_noload, httpserver):
         assert(() => pyodide._api.packageManager.installBaseUrl === '{with_slash(base_url)}');
         """
     )
+
+
+def test_load_packages_before_python_init(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+    selenium.run_js(
+        """
+        await loadPyodide({
+            packages: ['test-dummy'],
+            fsInit: (FS, { sitePackages }) => {
+                FS.writeFile(
+                    `${sitePackages}/example.pth`,
+                    'import dummy; print("Got", dummy.dummy());',
+                );
+            }
+        });
+        """
+    )
+    assert "Error processing" not in selenium.logs
+    assert "Got dummy" in selenium.logs


### PR DESCRIPTION
If we want to execute .pth files in packages, we need to load the packages before we initialize the Python interpreter. We also need this for taking memory snapshots with packages.

This switches to using zip.js to unpack the zip archives. We still install data files and unpack .tar archives with Python. To handle this, when preloading packages we pass in an empty `_postBootstrapPromises` list and push tasks we want deferred to after interpreter startup into this list.

Installing data files just requires Python to get `sys.prefix`. Unpacking tar files would require us to also get a JavaScript tar parser. Probably it would be better to convert tests packages to the zip format.

This adds about 100kb to `pyodide.asm.js`.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation
