### PR TITLE
Fix or xfail flaky tests

### DIFF
--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -372,7 +372,8 @@ def test_install_archive(selenium):
 
 
 @pytest.mark.requires_dynamic_linking
-def test_load_bad_so_file(selenium):
+def test_load_bad_so_file(selenium_standalone):
+    selenium = selenium_standalone
     # If we load a bad so file, it will raise with a message
     with pytest.raises(
         selenium.JavascriptException, match="Failed to load dynamic library /a.so"
@@ -386,7 +387,8 @@ def test_load_bad_so_file(selenium):
 
 
 @pytest.mark.requires_dynamic_linking
-def test_load_dlerror(selenium):
+def test_load_dlerror(selenium_standalone):
+    selenium = selenium_standalone
     so_file_with_link_error = (
         Path(__file__).parent / "test_data" / "dlerror_test" / "main_func.so"
     )

--- a/src/tests/test_snapshots.py
+++ b/src/tests/test_snapshots.py
@@ -274,6 +274,7 @@ def test_syncify_in_snapshot_load(selenium_standalone_noload):
     )
 
 
+@pytest.mark.xfail_browsers(safari="FIXME")
 def test_make_snapshot_fetch(selenium_standalone_noload):
     selenium = selenium_standalone_noload
     # It's okay for the fetch to succeed (node) or fail with TypeError: Failed to fetch ()


### PR DESCRIPTION
- `test_load_dlerror` was always failing in its first attempt because of the side effect of other tests.
- `test_make_snapshot_fetch` is failing in safari. not sure why.