### PR TITLE
feat: Add reverse-search in console-v2 with refactors

### DIFF
--- a/src/templates/console-v2.html
+++ b/src/templates/console-v2.html
@@ -134,7 +134,7 @@ of the stable console.
         }
 
         execute(data) {
-          this.context.transitionTo(new ReverseSearchState(this.context));
+          this.context.transitionTo("reverseSearch");
         }
       }
 
@@ -218,8 +218,7 @@ of the stable console.
       // ============================================================================
       class AcceptSearchCommand extends Command {
         async execute(data) {
-          this.context.state.acceptSearch();
-          this.context.transitionTo(new NormalInputState(this.context));
+          this.context.transitionTo("normal");
           this.context.term.write("\r\n");
           await this.context.executeCommand();
           this.context.buffer = "";
@@ -231,7 +230,7 @@ of the stable console.
       class CancelSearchCommand extends Command {
         execute(data) {
           this.context.state.cancelSearch();
-          this.context.transitionTo(new NormalInputState(this.context));
+          this.context.transitionTo("normal");
           this.context.term.write("^C\r\n" + this.context.prompt);
         }
       }
@@ -256,8 +255,7 @@ of the stable console.
 
       class ExitSearchKeepResultCommand extends Command {
         execute(data) {
-          this.context.state.acceptSearch();
-          this.context.transitionTo(new NormalInputState(this.context));
+          this.context.transitionTo("normal");
         }
       }
 
@@ -438,10 +436,6 @@ of the stable console.
           }
         }
 
-        acceptSearch() {
-          // Keep current buffer (already set from search)
-        }
-
         cancelSearch() {
           this.context.buffer = this.savedBuffer;
           this.context.cursorIndex = this.savedBuffer.length;
@@ -587,7 +581,12 @@ of the stable console.
           this.historyIndex = null;
 
           this.historyManager = new HistoryManager();
-          this.state = new NormalInputState(this);
+
+          this.states = {
+            normal: new NormalInputState(this),
+            reverseSearch: new ReverseSearchState(this),
+          };
+          this.state = this.states.normal;
 
           this.pyconsole.stdout_callback = (s) => this.term.write(s);
           this.pyconsole.stderr_callback = (s) =>
@@ -596,9 +595,9 @@ of the stable console.
           this.term.write(this.prompt);
         }
 
-        transitionTo(newState) {
+        transitionTo(stateName) {
           this.state.exit();
-          this.state = newState;
+          this.state = this.states[stateName];
           this.state.enter();
         }
 


### PR DESCRIPTION
### Description
This PR includes new feature "**reverse-search"**, and some of refactors. I refactored  the existing `console-v2` code with some of classes, because it seems a little messy when I started to add new feature. (resolves #5961)


**1. Refactor with some classes**
This new, refactored codes consists of couples of classes.
- **`Command`**:  Each Command means action from keystrokes (ctrl-c, ctrl-v, etc)
    - There are multiple Commands that extends `Command`.
    - `NormalStateCommands`, `ReverseSearchStateCommands`: Maps keystroke to each Command which certain `InputState` uses
- **`InputState`**
     - `NormalInputState`: Normal REPL state for pyodide console.
     - `ReverseSearchState`: State for reverse-search.
     
-  **`HistoryManager`:** Class for managing terminal history.
-  **`TerminalFactory`**: It makes the frontend part of console. It makes XTerm.js object with its config.
-  **`PyodideConsole`**: The main class for Pyodide console. It links XTerm.js frontend with Pyodide console backend.

**2. New feature reverse-search**
In new code, `ReverseSearchState`, `ReverseSearchStateCommands` makes reverse-search feature.
It supports:

- **`Ctrl+R`**: Enter the reverse-search, and find next one
- **`Ctrl+C`**, **`Ctrl+G`**: Cancel the reverse-search
-  **`Arrows(Up, Down, Left, Right)`**: Cancel the reverse-search with statement now focusing


<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

