### PR TITLE
fix: Add reverse-search in console-v2

### DIFF
--- a/src/templates/console-v2.html
+++ b/src/templates/console-v2.html
@@ -275,6 +275,13 @@ of the stable console.
           refreshLine();
         }
 
+        function applyReverseSearchSelection() {
+          if (reverseSearchIndex >= 0) {
+            buffer = history[reverseSearchIndex];
+            cursorIndex = buffer.length;
+          }
+        }
+
         function updateReverseSearchDisplay() {
           const searchPrompt = `(reverse-i-search)\`${reverseSearchQuery}': `;
           let displayText = "";
@@ -288,10 +295,7 @@ of the stable console.
         function reverseSearchAddChar(char) {
           reverseSearchQuery += char;
           reverseSearchIndex = searchHistory(reverseSearchQuery);
-          if (reverseSearchIndex >= 0) {
-            buffer = history[reverseSearchIndex];
-            cursorIndex = buffer.length;
-          }
+          applyReverseSearchSelection();
           updateReverseSearchDisplay();
         }
 
@@ -300,10 +304,7 @@ of the stable console.
             reverseSearchQuery = reverseSearchQuery.slice(0, -1);
             if (reverseSearchQuery) {
               reverseSearchIndex = searchHistory(reverseSearchQuery);
-              if (reverseSearchIndex >= 0) {
-                buffer = history[reverseSearchIndex];
-                cursorIndex = buffer.length;
-              }
+              applyReverseSearchSelection();
             } else {
               reverseSearchIndex = -1;
               buffer = "";
@@ -319,10 +320,7 @@ of the stable console.
               reverseSearchQuery,
               reverseSearchIndex - 1
             );
-            if (reverseSearchIndex >= 0) {
-              buffer = history[reverseSearchIndex];
-              cursorIndex = buffer.length;
-            }
+            applyReverseSearchSelection();
             updateReverseSearchDisplay();
           }
         }
@@ -419,7 +417,7 @@ of the stable console.
                 break;
               default:
                 // Add printable characters to search query
-                if (data && data.length === 1 && data >= " " && data <= "~") {
+                if (data && data.length === 1) {
                   reverseSearchAddChar(data);
                 }
             }
@@ -444,7 +442,7 @@ of the stable console.
               historyIndex = null;
               break;
             case "\u0012": // Ctrl-R - enter reverse search mode
-              if (prompt === ps1 && history.length > 0) {
+              if (prompt === ps1) {
                 enterReverseSearchMode();
               }
               break;


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description
This PR adds `reverse-search` in console-v2. (resolves #5961)

It supports: 

`Ctrl+R`: Enter the reverse-search, and find next one
`Ctrl+C`, `Ctrl+G`: Cancel the reverse-search
`Arrows`(Up, Down, Left, Right), `TAB`: Cancel the reverse-search with statement now focusing.

