### PR TITLE
refactor: console-v2 with some classes

### DIFF
--- a/src/templates/console-v2.html
+++ b/src/templates/console-v2.html
@@ -234,6 +234,7 @@ of the stable console.
           this.context.term.write(
             "\r\nKeyboardInterrupt\r\n" + this.context.prompt
           );
+          this.context.refreshLine();
         }
       }
 
@@ -241,7 +242,7 @@ of the stable console.
         execute(data) {
           this.context.state.cancelSearch();
           this.context.transitionTo("normal");
-          this.context.term.write("");
+          this.context.refreshLine();
         }
       }
 
@@ -267,6 +268,7 @@ of the stable console.
         execute(data) {
           this.context.transitionTo("normal");
           // Clear the search line and refresh with normal prompt
+          this.context.term.write("\r\x1b[K");
           this.context.refreshLine();
         }
       }
@@ -412,7 +414,6 @@ of the stable console.
 
         enter() {
           this.savedBuffer = this.context.buffer;
-          this.context.buffer = "";
           this.query = "";
           this.index = -1;
           this.context.cursorIndex = 0;
@@ -465,7 +466,7 @@ of the stable console.
 
         updateDisplay() {
           const searchPrompt = `(reverse-i-search)\`${this.query}': `;
-          let displayText = "";
+          let displayText = this.context.buffer;
           if (this.index >= 0) {
             displayText = this.context.history[this.index];
           }


### PR DESCRIPTION
### Description
This PR includes refactoring of console-v2. I refactored it with some of classes, because it seems a little messy when I started to add new feature (#5985). I made it as draft because it can be reviewed after #5985 is merged.

This new, refactored codes consists of couples of classes.
- **`Command`**:  Each Command means action from keystrokes (ctrl-c, ctrl-v, etc)
    - There are multiple Commands that extends `Command`.
    - `NormalStateCommands`, `ReverseSearchStateCommands`: Maps keystroke to each Command which certain `InputState` uses
- **`InputState`**
     - `NormalInputState`: Normal REPL state for pyodide console.
     - `ReverseSearchState`: State for reverse-search.
     
-  **`HistoryManager`:** Class for managing terminal history.
-  **`TerminalFactory`**: It makes the frontend part of console. It makes XTerm.js object with its config.
-  **`PyodideConsole`**: The main class for Pyodide console. It links XTerm.js frontend with Pyodide console backend.


It is still a little complicated because we are using a single file of `console-v2.html`, but I think it is quite better than before. 

Thanks for any reviews!



