### PR TITLE
docs(working-with-bundlers): Update code for viteStaticCopyPyodide to…

### DIFF
--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -68,7 +68,9 @@ export function viteStaticCopyPyodide() {
   return viteStaticCopy({
     targets: [
       {
-        src: [join(pyodideDir, "*")].concat(PYODIDE_EXCLUDE),
+        src: [join(pyodideDir, "*").replace(/\\/g, "/")].concat(
+          PYODIDE_EXCLUDE
+        ),
         dest: "assets",
       },
     ],
@@ -84,7 +86,7 @@ export default defineConfig({
 You can test your setup with this `index.html` file:
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Vite + Pyodide</title>


### PR DESCRIPTION
… resolve path with forward slashes on windows

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

FIXES #5988

This fixes a small issue when working with bundlers on windows (vite section) as `join` will give you the path without forward slashes. `vite-plugin-static-copy` cannot deal with that and won't find any files. Adding `.replace(/\\/g, "/")` resolves it. 

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation
