### PR TITLE
Fix iterator test in safari

### DIFF
--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1611,7 +1611,7 @@ def test_array_like_sequence_iteration_fail(selenium):
     from pyodide.ffi import JsException
 
     l = run_js("({[Symbol.iterator](){}, length: 5})")
-    match = "TypeError.*Symbol.iterator"
+    match = r"TypeError.*[Ii]terator"
     with pytest.raises(JsException, match=match):
         l + [1, 2, 3]
 


### PR DESCRIPTION
This was failing for a few weeks because of the different error message in safari.

```
E   AssertionError: Regex pattern did not match.
E    Regex: 'TypeError.*Symbol.iterator'
E    Input: 'TypeError: Iterator result interface is not an object.'
```