### PR TITLE
Handle EBADF error during fsync when the runtime exits

### DIFF
--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -16,6 +16,13 @@ function nodeFsync(fd: number): void {
     if (e?.code === "ENOTSUP" && (fd === 1 || fd === 2)) {
       return;
     }
+
+    // On windows, the stdin and stdout may be closed already when we try to fsync them.
+    // In that case, we get EBADF, so we just ignore that error.
+    if (e?.code === "EBADF" && (fd === 1 || fd === 2)) {
+      return;
+    }
+
     throw e;
   }
 }


### PR DESCRIPTION
Related: https://github.com/pyodide/pyodide-build/issues/263

I am getting this error when running `pyodide venv` in Windows. My guess is that the stdout stderr stream is closed before the runtime exits and fsync is called.

```
Error: EBADF: bad file descriptor, fsync
    at Object.fsyncSync (node:fs:1279:11)
    at nodeFsync (C:\Users\siha\Desktop\cf\pyodide\dist\pyodide.asm.js:38478:16)
    at Le.fsync (C:\Users\siha\Desktop\cf\pyodide\dist\pyodide.asm.js:38854:15)
    at Object.fsync (C:\Users\siha\Desktop\cf\pyodide\dist\pyodide.asm.js:38579:28)
    at Object.close (C:\Users\siha\Desktop\cf\pyodide\dist\pyodide.asm.js:38573:28)
    at Object.close (C:\Users\siha\Desktop\cf\pyodide\dist\pyodide.asm.js:5299:31)
    at Object.quit (C:\Users\siha\Desktop\cf\pyodide\dist\pyodide.asm.js:5645:16)
    at exitRuntime (C:\Users\siha\Desktop\cf\pyodide\dist\pyodide.asm.js:415:10)
    at exitJS (C:\Users\siha\Desktop\cf\pyodide\dist\pyodide.asm.js:8977:11)
    at pyodide.asm.wasm.Py_Exit (wasm://wasm/pyodide.asm.wasm-023c9e56:wasm-function[4382]:0x2ce997) {
  errno: -4083,
  code: 'EBADF',
  syscall: 'fsync',
  pyodide_fatal_error: true
```