### PR TITLE
Remove custom rust sysroot

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -7,12 +7,11 @@ export PYTHON_ARCHIVE_SHA256=b8d79530e3b7c96a5cb2d40d431ddb512af4a563e863728d871
 
 export SED ?= sed
 
-export RUST_TOOLCHAIN ?= nightly-2025-02-01
-export RUST_EMSCRIPTEN_TARGET_URL ?= https://github.com/pyodide/rust-emscripten-wasm-eh-sysroot/releases/download/emcc-${PYODIDE_EMSCRIPTEN_VERSION}_${RUST_TOOLCHAIN}/emcc-${PYODIDE_EMSCRIPTEN_VERSION}_${RUST_TOOLCHAIN}.tar.bz2
+export RUST_TOOLCHAIN ?= nightly-2025-12-10
 # I'm not really sure what this explicit -Z link-native-libraries=yes is for,
 # `rustc -Z help` shows that `link-native-libraries=yes` is the default. But it
 # seems to be necessary...
-export RUSTFLAGS = -C link-arg=-sSIDE_MODULE=2 -Z link-native-libraries=yes -Z emscripten-wasm-eh
+export RUSTFLAGS = -C link-arg=-sSIDE_MODULE=2 -Z link-native-libraries=yes
 
 # URL to the prebuilt packages
 export PYODIDE_PREBUILT_PACKAGES_BASE=https://github.com/pyodide/pyodide-recipes/releases/download/0.29-20251018


### PR DESCRIPTION
Since this commit `-Z emscripten-wasm-eh` is the default for the Rust compiler: https://github.com/rust-lang/rust/pull/147224/
This switches to a recent Rust nightly which includes this change. This means we don't need a custom sysroot anymore.

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add new / update outdated documentation
