### PR TITLE
Add timeout=None to WebLoop.shutdown_default_executor

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -46,6 +46,10 @@ myst:
   limited backwards incompatibility.
   {pr}`6022`
 
+- {{ Fix }} Added missing `timeout=None` parameter to
+  `pyodide.webloop.WebLoop.shutdown_default_executor()`.
+  {pr}`6050`
+
 ## Version 0.29.1
 
 - {{ Enhancement }} Improved support for Windows/MacOS platform in the `python` CLI entrypoint.

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -301,7 +301,7 @@ class WebLoop(asyncio.AbstractEventLoop):
                     }
                 )
 
-    async def shutdown_default_executor(self):
+    async def shutdown_default_executor(self, timeout=None):
         """Schedule the shutdown of the default executor.
 
         This is a no-op since WebLoop doesn't use thread executors.


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

`pytest-asyncio` fails in teardown without this change:

```
___________________ ERROR at teardown of test_zarr_pointwise ___________________

event_loop_policy = <pyodide.webloop.WebLoopPolicy object at 0xed5b40>
request = <SubRequest '_function_scoped_runner' for <Coroutine test_zarr_pointwise>>

    @pytest.fixture(
        scope=scope,
        name=f"_{scope}_scoped_runner",
    )
    def _scoped_runner(
        event_loop_policy,
        request: FixtureRequest,
    ) -> Iterator[Runner]:
        new_loop_policy = event_loop_policy
        debug_mode = _get_asyncio_debug(request.config)
        with _temporary_event_loop_policy(new_loop_policy):
            runner = Runner(debug=debug_mode).__enter__()
            try:
                yield runner
            except Exception as e:
                runner.__exit__(type(e), e, e.__traceback__)
            else:
                with warnings.catch_warnings():
                    warnings.filterwarnings(
                        "ignore", ".*BaseEventLoop.shutdown_asyncgens.*", RuntimeWarning
                    )
                    try:
>                       runner.__exit__(None, None, None)

.venv-pyodide/lib/python3.13/site-packages/pytest_asyncio/plugin.py:817: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/lib/python313.zip/asyncio/runners.py:62: in __exit__
    self.close()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <asyncio.runners.Runner object at 0x6fb3670>

    def close(self):
        """Shutdown and close event loop."""
        if self._state is not _State.INITIALIZED:
            return
        try:
            loop = self._loop
            _cancel_all_tasks(loop)
            loop.run_until_complete(loop.shutdown_asyncgens())
            loop.run_until_complete(
>               loop.shutdown_default_executor(constants.THREAD_JOIN_TIMEOUT))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E               TypeError: WebLoop.shutdown_default_executor() takes 1 positional argument but 2 were given

/lib/python313.zip/asyncio/runners.py:73: TypeError
```

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
