### PR TITLE
Add meta path finder to convert windows path to linux path

### DIFF
--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -816,9 +816,8 @@ API.finalizeBootstrap = function (
     importhook.register_js_finder();
     importhook.register_js_module("js", jsglobals);
     importhook.register_js_module("pyodide_js", pyodide);
+    importhook.register_windows_finder();
   }
-
-  importhook.register_windows_finder();
 
   // import pyodide_py. We want to ensure that as much stuff as possible is
   // already set up before importing pyodide_py to simplify development of

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -818,6 +818,8 @@ API.finalizeBootstrap = function (
     importhook.register_js_module("pyodide_js", pyodide);
   }
 
+  importhook.register_windows_finder();
+
   // import pyodide_py. We want to ensure that as much stuff as possible is
   // already set up before importing pyodide_py to simplify development of
   // pyodide_py code (Otherwise it's very hard to keep track of which things

--- a/src/py/_pyodide/_importhook.py
+++ b/src/py/_pyodide/_importhook.py
@@ -120,7 +120,7 @@ class JsLoader(Loader):
 WINDOWS_DRIVE_REGEX = re.compile(r"^[a-zA-Z]:")
 
 
-class WindowsToLinuxPathFinder(PathFinder):
+class WindowsToLinuxPathFinder:
     """
     A MetaPathFinder that converts Windows-style paths in sys.path to
     Linux-style paths for module searching.
@@ -152,7 +152,7 @@ class WindowsToLinuxPathFinder(PathFinder):
         if not converted_paths:
             return None
 
-        return super().find_spec(fullname, converted_paths, target)
+        return PathFinder.find_spec(fullname, converted_paths, target)
 
 
 jsfinder: JsFinder = JsFinder()
@@ -183,9 +183,12 @@ def register_windows_finder() -> None:
 
     This is called in `loadPyodide` in `pyodide.js` to allow Windows-style paths
     in sys.path to be converted to Linux-style paths for module searching.
+
+    Using class instead of instance to alleviate the need for instantiation
+    (https://docs.python.org/3/library/importlib.html#importlib.machinery.PathFinder)
     """
     for importer in sys.meta_path:
-        if isinstance(importer, WindowsToLinuxPathFinder):
+        if importer is WindowsToLinuxPathFinder:
             raise RuntimeError("WindowsToLinuxPathFinder already registered")
     sys.meta_path.append(WindowsToLinuxPathFinder)
 

--- a/src/py/_pyodide/_importhook.py
+++ b/src/py/_pyodide/_importhook.py
@@ -1,7 +1,8 @@
+import re
 import sys
 from collections.abc import Callable, Sequence
 from importlib.abc import Loader, MetaPathFinder
-from importlib.machinery import ModuleSpec
+from importlib.machinery import ModuleSpec, PathFinder
 from importlib.util import spec_from_loader
 from types import ModuleType
 from typing import Any
@@ -116,6 +117,44 @@ class JsLoader(Loader):
         return True
 
 
+WINDOWS_DRIVE_REGEX = re.compile(r"^[a-zA-Z]:")
+
+
+class WindowsToLinuxPathFinder(PathFinder):
+    """
+    A MetaPathFinder that converts Windows-style paths in sys.path to
+    Linux-style paths for module searching.
+
+    This is useful when running Pyodide CLI in a Windows environment where
+    users or system configurations might add Windows-style paths to sys.path.
+    """
+
+    @classmethod
+    def find_spec(
+        cls,
+        fullname: str,
+        path: Sequence[str] | None = None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
+        sys_path = path if path is not None else sys.path
+
+        converted_paths: list[str] = []
+        for p in sys_path:
+            # Convert only if it's a string and looks like a Windows absolute path
+            if not WINDOWS_DRIVE_REGEX.match(p):
+                continue
+
+            # Convert 'C:\path\to\dir' to '/path/to/dir'
+            # Sometimes the path may contain forward slashes, sometimes backslashes...
+            linux_path = p[2:].replace("//", "/").replace("\\", "/")
+            converted_paths.append(linux_path)
+
+        if not converted_paths:
+            return None
+
+        return super().find_spec(fullname, converted_paths, target)
+
+
 jsfinder: JsFinder = JsFinder()
 register_js_module = jsfinder.register_js_module
 unregister_js_module = jsfinder.unregister_js_module
@@ -137,6 +176,18 @@ def register_js_finder() -> None:
         if isinstance(importer, JsFinder):
             raise RuntimeError("JsFinder already registered")
     sys.meta_path.append(jsfinder)
+
+
+def register_windows_finder() -> None:
+    """A bootstrap function to register WindowsToLinuxPathFinder in sys.meta_path.
+
+    This is called in `loadPyodide` in `pyodide.js` to allow Windows-style paths
+    in sys.path to be converted to Linux-style paths for module searching.
+    """
+    for importer in sys.meta_path:
+        if isinstance(importer, WindowsToLinuxPathFinder):
+            raise RuntimeError("WindowsToLinuxPathFinder already registered")
+    sys.meta_path.append(WindowsToLinuxPathFinder)
 
 
 STDLIBS = sys.stdlib_module_names | {"test"}

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1617,6 +1617,10 @@ def test_windows_to_linux_path_finder_edge_cases(selenium):
     spec = WindowsToLinuxPathFinder.find_spec("test_module", None)
     assert spec is None
 
+    # zipimport path
+    spec = WindowsToLinuxPathFinder.find_spec("test_module", ["my_whl.whl"])
+    assert spec is None
+
 
 @run_in_pyodide
 def test_windows_to_linux_path_import(selenium_standalone):


### PR DESCRIPTION
This PR adds a new meta path finder which automatically converts Windows style path in `sys.path` to linux path.

For example, when a user have `C:\Users\cache` in sys.path, this finder searches `/Users/cache` directory instead.

This is in most cases useless, but useful when running Pyodide CLI in windows host environment, where users may set Windows path as sys.path. I found that this happens in uv (https://github.com/astral-sh/uv/pull/17459).