### PR TITLE
Fix openblas and scipy build

### DIFF
--- a/packages/libopenblas/meta.yaml
+++ b/packages/libopenblas/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: libopenblas
-  version: 0.3.26
+  version: 0.3.28
   tag:
     - core
     - library
     - shared_library
 source:
-  sha256: 4e6e4f5cb14c209262e33e6816d70221a2fe49eb69eaf0a06f065598ac602c68
-  url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.26/OpenBLAS-0.3.26.tar.gz
+  sha256: f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1
+  url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.28/OpenBLAS-0.3.28.tar.gz
   patches:
     - patches/0001-Add-Wno-return-type-flag.patch
     - patches/0002-Align-xerbla_array-signature-with-scipy-expectation.patch
@@ -32,7 +32,13 @@ build:
     sed -ri 's@int ([cz](dotc|dotu|ladiv))@void \1@g' lapack-netlib/SRC/*.c\
         lapack-netlib/SRC/DEPRECATED/*.c
 
+    # When TARGET=RISCV64_GENERIC, OpenBLAS adds `-march` and `-mabi` flags to the compiler.
+    # However, they are not supported by Emscripten, and started to cause build failures from recent Emscripten versions (>4.X).
+    sed -i 's@ifeq ($(CORE), RISCV64_GENERIC)@ifeq ($(CORE), NOT_RISCV64_GENERIC)@g' Makefile.riscv64
+    sed -i 's@ifeq ($(TARGET), RISCV64_GENERIC)@ifeq ($(TARGET), NOT_RISCV64_GENERIC)@g' Makefile.prebuild
+
     emmake make libs shared \
+        BINARY=32 \
         CC="emcc -msimd128" \
         HOSTCC=gcc \
         TARGET=RISCV64_GENERIC \
@@ -49,6 +55,9 @@ build:
 
     cp libopenblas.so dist
     emmake make install PREFIX=${WASM_LIBRARY_DIR}
+    # We need to copy the shared library again as the make install
+    # does not know we've modified the binary with libf2c symbols.
+    cp dist/libopenblas.so ${WASM_LIBRARY_DIR}/lib/libopenblas.so
 
 requirements:
   host:

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -41,6 +41,7 @@ source:
     - patches/0016-Make-sf_error_state_lib-a-static-library.patch
     - patches/0017-Remove-test-modules-that-fail-to-build.patch
     - patches/0018-Fix-lapack-larfg-function-signature.patch
+    - patches/0019-Explicitly-convert-return-value-of-SUPERLU_MALLOC.patch
 
 build:
   # NumPy 2.1 disabled visibility for symbols outside of extension modules

--- a/packages/scipy/patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
+++ b/packages/scipy/patches/0001-Fix-dstevr-in-special-lapack_defs.h.patch
@@ -1,7 +1,7 @@
 From 45a31145679c83f2719b6420f234d484b9459697 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 18 Mar 2022 16:25:39 -0700
-Subject: [PATCH 1/18] Fix dstevr in special/lapack_defs.h
+Subject: [PATCH 1/19] Fix dstevr in special/lapack_defs.h
 
 ---
  scipy/special/lapack_defs.h | 5 ++---

--- a/packages/scipy/patches/0002-int-to-string.patch
+++ b/packages/scipy/patches/0002-int-to-string.patch
@@ -1,7 +1,7 @@
 From d53ade3f03ba3557fd50fb38990d605f4ae7f8f1 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 25 Dec 2021 18:04:18 -0800
-Subject: [PATCH 2/18] int to string
+Subject: [PATCH 2/19] int to string
 
 f2c does not handle implicit casts of function arguments correctly. The msg
 argument of `xerrwv` is defined to be an `int *`, and then implicitly cast

--- a/packages/scipy/patches/0003-gemm_-no-const.patch
+++ b/packages/scipy/patches/0003-gemm_-no-const.patch
@@ -1,7 +1,7 @@
 From e528227dd37c8b0512381992c222789a114e3169 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 18 Dec 2021 11:41:15 -0800
-Subject: [PATCH 3/18] gemm_ no const
+Subject: [PATCH 3/19] gemm_ no const
 
 cgemm, dgemm, sgemm, and zgemm are declared with `const` in slu_cdefs.h, but
 other places don't have the cosnt causing compile errors.

--- a/packages/scipy/patches/0004-make-int-return-values.patch
+++ b/packages/scipy/patches/0004-make-int-return-values.patch
@@ -1,7 +1,7 @@
 From a86a2304fd925f815bbb0e0753e46a7b863e2de2 Mon Sep 17 00:00:00 2001
 From: Joe Marshall <joe.marshall@nottingham.ac.uk>
 Date: Wed, 6 Apr 2022 21:25:13 -0700
-Subject: [PATCH 4/18] make int return values
+Subject: [PATCH 4/19] make int return values
 
 The return values of f2c functions are insignificant in most cases, so often it
 is treated as returning void, when it really should return int (values are

--- a/packages/scipy/patches/0005-Fix-fitpack.patch
+++ b/packages/scipy/patches/0005-Fix-fitpack.patch
@@ -1,7 +1,7 @@
 From c784d3a1ee38da88943364de4ea847a3b9cd155f Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Tue, 30 Aug 2022 11:51:53 -0700
-Subject: [PATCH 5/18] Fix fitpack
+Subject: [PATCH 5/19] Fix fitpack
 
 ---
  scipy/interpolate/fitpack/dblint.f | 9 ++++-----

--- a/packages/scipy/patches/0006-Fix-gees-calls.patch
+++ b/packages/scipy/patches/0006-Fix-gees-calls.patch
@@ -1,7 +1,7 @@
 From 8addc1da35bc63df651946ef14c723797a431e0c Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Mon, 26 Jun 2023 20:12:25 -0700
-Subject: [PATCH 6/18] Fix gees calls
+Subject: [PATCH 6/19] Fix gees calls
 
 ---
  scipy/linalg/flapack_gen.pyf.src | 8 ++++----

--- a/packages/scipy/patches/0007-MAINT-linalg-Remove-id_dist-Fortran-files.patch
+++ b/packages/scipy/patches/0007-MAINT-linalg-Remove-id_dist-Fortran-files.patch
@@ -1,7 +1,7 @@
 From 12ba8a395ce04194074a24d362143c22e7ac54bd Mon Sep 17 00:00:00 2001
 From: Ilhan Polat <ilhanpolat@gmail.com>
 Date: Tue, 23 Apr 2024 09:26:38 +0200
-Subject: [PATCH 7/18] MAINT:linalg:Remove id_dist Fortran files
+Subject: [PATCH 7/19] MAINT:linalg:Remove id_dist Fortran files
 
 [skip ci]
 

--- a/packages/scipy/patches/0008-Mark-mvndst-functions-recursive.patch
+++ b/packages/scipy/patches/0008-Mark-mvndst-functions-recursive.patch
@@ -1,7 +1,7 @@
 From c11745d763407d9a2bb195a21e2a8afaf7635248 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 6 Jul 2024 22:38:55 +0200
-Subject: [PATCH 8/18] Mark mvndst functions recursive
+Subject: [PATCH 8/19] Mark mvndst functions recursive
 
 ---
  scipy/stats/mvndst.f | 8 ++++----

--- a/packages/scipy/patches/0009-Make-sreorth-recursive.patch
+++ b/packages/scipy/patches/0009-Make-sreorth-recursive.patch
@@ -1,7 +1,7 @@
 From e4d1a570fa8bd4c710e10400822f60232e6408eb Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 6 Jul 2024 22:33:51 +0200
-Subject: [PATCH 9/18] Make sreorth recursive
+Subject: [PATCH 9/19] Make sreorth recursive
 
 ---
  complex16/zreorth.F | 6 +++---

--- a/packages/scipy/patches/0010-Link-openblas-with-modules-that-require-f2c.patch
+++ b/packages/scipy/patches/0010-Link-openblas-with-modules-that-require-f2c.patch
@@ -1,7 +1,7 @@
 From ccbb0fa0884d567c6139eeed7dc2dc9f8db4db3a Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Sun, 28 Jul 2024 18:15:17 +0900
-Subject: [PATCH 10/18] Link openblas with modules that require f2c
+Subject: [PATCH 10/19] Link openblas with modules that require f2c
 
 Some fortran modules require symbols from f2c, which is provided by
 openblas.

--- a/packages/scipy/patches/0011-Remove-fpchec-inline-if-then-endif-constructs.patch
+++ b/packages/scipy/patches/0011-Remove-fpchec-inline-if-then-endif-constructs.patch
@@ -1,7 +1,7 @@
 From b43a231f8326d6953929030131c3fb6b2cb163bd Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Wed, 15 May 2024 21:29:02 +0530
-Subject: [PATCH 11/18] Remove fpchec inline if-then-endif constructs
+Subject: [PATCH 11/19] Remove fpchec inline if-then-endif constructs
 
 This PR removes the single-line if-then-endif constructs in fpchec.f
 that were causing syntactical errors when compiling with f2c, possibly

--- a/packages/scipy/patches/0012-Remove-chla_transtype.patch
+++ b/packages/scipy/patches/0012-Remove-chla_transtype.patch
@@ -1,7 +1,7 @@
 From 848c94e218e89d866978fbc883cbb2d919f56ce9 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 31 Jul 2024 10:29:47 +0200
-Subject: [PATCH 12/18] Remove chla_transtype
+Subject: [PATCH 12/19] Remove chla_transtype
 
 The signature should probably be `int chla_transtype(char* res, int *trans)`.
 This just deletes it entirely due to laziness.

--- a/packages/scipy/patches/0013-Set-wrapper-return-type-to-int.patch
+++ b/packages/scipy/patches/0013-Set-wrapper-return-type-to-int.patch
@@ -1,7 +1,7 @@
 From b5d05197de084ab3cab52241f163bae7519b6027 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 31 Jul 2024 11:48:12 +0200
-Subject: [PATCH 13/18] Set wrapper return type to int
+Subject: [PATCH 13/19] Set wrapper return type to int
 
 ---
  scipy/linalg/_generate_pyx.py | 2 +-

--- a/packages/scipy/patches/0014-Skip-svd_gesdd-test.patch
+++ b/packages/scipy/patches/0014-Skip-svd_gesdd-test.patch
@@ -1,7 +1,7 @@
 From 59d3efdf9e55958c6a3651e8eda2a9d6fe48e192 Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Fri, 9 Aug 2024 19:00:41 +0530
-Subject: [PATCH 14/18] Skip svd_gesdd test
+Subject: [PATCH 14/19] Skip svd_gesdd test
 
 This patch excludes a test for gesdd which was introduced in this PR:
 https://github.com/scipy/scipy/pull/20349. It is not useful for Pyodide

--- a/packages/scipy/patches/0015-Remove-f2py-generators.patch
+++ b/packages/scipy/patches/0015-Remove-f2py-generators.patch
@@ -1,7 +1,7 @@
 From 9b670bd5330bd7834d157a9ec3087a97b71d6516 Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Fri, 16 Aug 2024 22:59:26 +0530
-Subject: [PATCH 15/18] Remove f2py generators
+Subject: [PATCH 15/19] Remove f2py generators
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/packages/scipy/patches/0016-Make-sf_error_state_lib-a-static-library.patch
+++ b/packages/scipy/patches/0016-Make-sf_error_state_lib-a-static-library.patch
@@ -1,7 +1,7 @@
 From 9d93ca19f4ad0ca327964b6234316547d774b17f Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Sat, 17 Aug 2024 01:12:28 +0530
-Subject: [PATCH 16/18] Make `sf_error_state_lib` a static library
+Subject: [PATCH 16/19] Make `sf_error_state_lib` a static library
 
 wasm.ld does not support linkage with shared libraries. This patch
 changes `sf_error_state_lib` to a static one.

--- a/packages/scipy/patches/0017-Remove-test-modules-that-fail-to-build.patch
+++ b/packages/scipy/patches/0017-Remove-test-modules-that-fail-to-build.patch
@@ -1,7 +1,7 @@
 From e21f33695da3275ec81b5f94685f0e4ac92c9ad5 Mon Sep 17 00:00:00 2001
 From: Gyeongjae Choi <def6488@gmail.com>
 Date: Mon, 30 Oct 2023 14:35:04 +0000
-Subject: [PATCH 17/18] Remove test modules that fail to build
+Subject: [PATCH 17/19] Remove test modules that fail to build
 
 These are tests and they have both void vs int return value problems and implicit
 function argument cast problems. Not worth fixing for tests.

--- a/packages/scipy/patches/0018-Fix-lapack-larfg-function-signature.patch
+++ b/packages/scipy/patches/0018-Fix-lapack-larfg-function-signature.patch
@@ -1,7 +1,7 @@
 From 8b06e7fef50327f84140cb09a3d9237e18b38a35 Mon Sep 17 00:00:00 2001
 From: Agriya Khetarpal <74401230+agriyakhetarpal@users.noreply.github.com>
 Date: Thu, 5 Sep 2024 21:14:20 +0530
-Subject: [PATCH 18/18] Fix lapack larfg function signature
+Subject: [PATCH 18/19] Fix lapack larfg function signature
 
 This patch fixes the signature of the LAPACK routine larfg. Please
 see https://github.com/pyodide/pyodide/issues/3379 for more details.

--- a/packages/scipy/patches/0019-Explicitly-convert-return-value-of-SUPERLU_MALLOC.patch
+++ b/packages/scipy/patches/0019-Explicitly-convert-return-value-of-SUPERLU_MALLOC.patch
@@ -1,0 +1,76 @@
+From 6a800412b14b5ab905721abe9a509a5e4f44ecef Mon Sep 17 00:00:00 2001
+From: ryanking13 <def6488@gmail.com>
+Date: Tue, 20 Jan 2026 15:22:19 +0900
+Subject: [PATCH 19/19] Explicitly convert return value of SUPERLU_MALLOC
+
+Fixes incompatible pointer type errors like:
+
+```
+error: incompatible pointer types assigning to 'float *' from 'int *' [-Wincompatible-pointer-types]
+```
+
+Upstream PR:
+https://github.com/scipy/scipy/pull/24408
+
+---
+ scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsitrf.c | 2 +-
+ scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgsitrf.c | 2 +-
+ scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgsitrf.c | 2 +-
+ scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsitrf.c | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsitrf.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsitrf.c
+index 21fb2497b..ae2a3fd2e 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsitrf.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/cgsitrf.c
+@@ -299,7 +299,7 @@ cgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
+     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
+     amax = (float *) SUPERLU_MALLOC(panel_size * sizeof(float));
+     if (drop_rule & DROP_SECONDARY)
+-	swork2 = SUPERLU_MALLOC(n * sizeof(float));
++	swork2 = (float *) SUPERLU_MALLOC(n * sizeof(float));
+     else
+ 	swork2 = NULL;
+ 
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgsitrf.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgsitrf.c
+index b3c1ffc15..57f242361 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgsitrf.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/dgsitrf.c
+@@ -298,7 +298,7 @@ dgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
+     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
+     amax = (double *) SUPERLU_MALLOC(panel_size * sizeof(double));
+     if (drop_rule & DROP_SECONDARY)
+-	dwork2 = SUPERLU_MALLOC(n * sizeof(double));
++	dwork2 = (double *) SUPERLU_MALLOC(n * sizeof(double));
+     else
+ 	dwork2 = NULL;
+ 
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgsitrf.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgsitrf.c
+index cc143726f..5c9722c45 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgsitrf.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/sgsitrf.c
+@@ -298,7 +298,7 @@ sgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
+     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
+     amax = (float *) SUPERLU_MALLOC(panel_size * sizeof(float));
+     if (drop_rule & DROP_SECONDARY)
+-	swork2 = SUPERLU_MALLOC(n * sizeof(float));
++	swork2 = (float *) SUPERLU_MALLOC(n * sizeof(float));
+     else
+ 	swork2 = NULL;
+ 
+diff --git a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsitrf.c b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsitrf.c
+index 4658eaf4c..a60c8119b 100644
+--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsitrf.c
++++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/zgsitrf.c
+@@ -299,7 +299,7 @@ zgsitrf(superlu_options_t *options, SuperMatrix *A, int relax, int panel_size,
+     for (k = 0; k < n; k++) iswap[k] = perm_c[k];
+     amax = (double *) SUPERLU_MALLOC(panel_size * sizeof(double));
+     if (drop_rule & DROP_SECONDARY)
+-	dwork2 = SUPERLU_MALLOC(n * sizeof(double));
++	dwork2 = (double *) SUPERLU_MALLOC(n * sizeof(double));
+     else
+ 	dwork2 = NULL;
+ 
+-- 
+2.29.2.windows.2
+


### PR DESCRIPTION
Splitted out from https://github.com/pyodide/pyodide/pull/6002. These fixes are to fix openblas and scipy in newer emscripten, but I think they will work on the current version as well. Splitting out the PR to reduce the diff.