### PR TITLE
MAINT Move normalizeReservedWords to pre.js

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -396,41 +396,6 @@ finally:
   return result;
 }
 
-EM_JS(bool, isReservedWord, (int word), {
-  if (!Module.pythonReservedWords) {
-    Module.pythonReservedWords = new Set([
-      "False",  "await", "else",     "import", "pass",   "None",    "break",
-      "except", "in",    "raise",    "True",   "class",  "finally", "is",
-      "return", "and",   "continue", "for",    "lambda", "try",     "as",
-      "def",    "from",  "nonlocal", "while",  "assert", "del",     "global",
-      "not",    "with",  "async",    "elif",   "if",     "or",      "yield",
-    ]);
-  }
-  return Module.pythonReservedWords.has(word);
-})
-
-/**
- * action: a javascript string, one of get, set, or delete. For error reporting.
- * word: a javascript string, the property being accessed
- */
-EM_JS(int, normalizeReservedWords, (int word), {
-  // clang-format off
-  // 1. if word is not a reserved word followed by 0 or more underscores, return
-  //    it unchanged.
-  const noTrailing_ = word.replace(/_*$/, "");
-  if (!isReservedWord(noTrailing_)) {
-    return word;
-  }
-  // 2. If there is at least one trailing underscore, return the word with a
-  //    single underscore removed.
-  if (noTrailing_ !== word) {
-    return word.slice(0, -1);
-  }
-  // 3. If the word is exactly a reserved word, return it unchanged
-  return word;
-  // clang-format on
-});
-
 EM_JS_VAL(JsVal, JsProxy_GetAttr_js, (JsVal jsobj, const char* ptrkey), {
   const jskey = normalizeReservedWords(UTF8ToString(ptrkey));
   const result = jsobj[jskey];

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -110,3 +110,36 @@ function wasmFunctionType(wasm_func) {
   }
   return wasm_func.type();
 }
+
+// biome-ignore format: Keep list compact
+const pythonReservedWords = new Set(
+  [
+    "False",  "await", "else",     "import", "pass",   "None",    "break",
+    "except", "in",    "raise",    "True",   "class",  "finally", "is",
+    "return", "and",   "continue", "for",    "lambda", "try",     "as",
+    "def",    "from",  "nonlocal", "while",  "assert", "del",     "global",
+    "not",    "with",  "async",    "elif",   "if",     "or",      "yield",
+  ],
+);
+
+function isReservedWord(word) {
+  return pythonReservedWords.has(word);
+}
+
+function normalizeReservedWords(word) {
+  // clang-format off
+  // 1. if word is not a reserved word followed by 0 or more underscores, return
+  //    it unchanged.
+  const noTrailing_ = word.replace(/_*$/, "");
+  if (!isReservedWord(noTrailing_)) {
+    return word;
+  }
+  // 2. If there is at least one trailing underscore, return the word with a
+  //    single underscore removed.
+  if (noTrailing_ !== word) {
+    return word.slice(0, -1);
+  }
+  // 3. If the word is exactly a reserved word, return it unchanged
+  return word;
+  // clang-format on
+}


### PR DESCRIPTION
Seems like a more natural place for it and there are some bugs caused by using EM_JS functions like this with ASAN.
