### PR TITLE
Remove -Zlink-native-libs=yes from RUSTFLAGS

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -8,10 +8,7 @@ export PYTHON_ARCHIVE_SHA256=b8d79530e3b7c96a5cb2d40d431ddb512af4a563e863728d871
 export SED ?= sed
 
 export RUST_TOOLCHAIN ?= nightly-2025-12-10
-# I'm not really sure what this explicit -Z link-native-libraries=yes is for,
-# `rustc -Z help` shows that `link-native-libraries=yes` is the default. But it
-# seems to be necessary...
-export RUSTFLAGS = -C link-arg=-sSIDE_MODULE=2 -Z link-native-libraries=yes
+export RUSTFLAGS = -C link-arg=-sSIDE_MODULE=2
 
 # URL to the prebuilt packages
 export PYODIDE_PREBUILT_PACKAGES_BASE=https://github.com/pyodide/pyodide-recipes/releases/download/0.29-20260116


### PR DESCRIPTION
This will allow us to build with stable rust 1.93.0 when it is released