### PR TITLE
Use stable Rust 1.93.0

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -7,7 +7,7 @@ export PYTHON_ARCHIVE_SHA256=b8d79530e3b7c96a5cb2d40d431ddb512af4a563e863728d871
 
 export SED ?= sed
 
-export RUST_TOOLCHAIN ?= nightly-2025-12-10
+export RUST_TOOLCHAIN ?= 1.93.0
 export RUSTFLAGS = -C link-arg=-sSIDE_MODULE=2
 
 # URL to the prebuilt packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,6 @@ markers = [
 
 [tool._pyodide]
 
-[tool.pyodide.build]
-rust_toolchain = "nightly-2025-02-01"
-
 [tool.codespell]
 ignore-words = 'tools/codespell_ignore_words.txt'
 skip = 'benchmark/benchmarks/pystone_benchmarks/pystone.py,src/js/package-lock.json,tools/codespell_ignore_words.txt'


### PR DESCRIPTION
For the first time ever we can build with stable Rust.