### PR TITLE
fix(js/compat): handle browser-ambiguous runtime detection (#3893)

### DIFF
--- a/src/js/test/unit/compat.test.ts
+++ b/src/js/test/unit/compat.test.ts
@@ -4,7 +4,28 @@ import { describe, it } from "node:test";
 import * as os from "os";
 import * as path from "path";
 
-import { ensureDirNode, initNodeModules } from "../../compat";
+import {
+  ensureDirNode,
+  getLoadScriptForRuntimeEnv,
+  initNodeModules,
+} from "../../compat";
+import type { RuntimeEnv } from "../../environments";
+
+function makeRuntimeEnv(partial: Partial<RuntimeEnv> = {}): RuntimeEnv {
+  return {
+    IN_NODE: false,
+    IN_BUN: false,
+    IN_DENO: false,
+    IN_SAFARI: false,
+    IN_SHELL: false,
+    IN_NODE_COMMONJS: false,
+    IN_NODE_ESM: false,
+    IN_BROWSER: false,
+    IN_BROWSER_MAIN_THREAD: false,
+    IN_BROWSER_WEB_WORKER: false,
+    ...partial,
+  };
+}
 
 describe("ensureDirNode", () => {
   it("Should create the dir if it does not exist", async () => {
@@ -31,5 +52,35 @@ describe("ensureDirNode", () => {
     await ensureDirNode(baseDir);
 
     assert.ok(fs.existsSync(baseDir));
+  });
+});
+
+describe("getLoadScriptForRuntimeEnv", () => {
+  it("should not throw for browser-ambiguous runtime state", () => {
+    const env = makeRuntimeEnv({
+      // Some module-evaluation environments can set IN_BROWSER=true while
+      // browser thread probes are false at evaluation time.
+      IN_BROWSER: true,
+      IN_BROWSER_MAIN_THREAD: false,
+      IN_BROWSER_WEB_WORKER: false,
+    });
+    const getLoader = () => getLoadScriptForRuntimeEnv(env);
+    assert.doesNotThrow(getLoader);
+    assert.equal(typeof getLoader(), "function");
+  });
+
+  it("should not throw when process.browser shim disables IN_NODE", () => {
+    const env = makeRuntimeEnv({
+      IN_NODE: false,
+      IN_BROWSER: true,
+      IN_BROWSER_MAIN_THREAD: false,
+      IN_BROWSER_WEB_WORKER: false,
+    });
+    assert.doesNotThrow(() => getLoadScriptForRuntimeEnv(env));
+  });
+
+  it("should throw when no runtime branch matches", () => {
+    const env = makeRuntimeEnv();
+    assert.throws(() => getLoadScriptForRuntimeEnv(env));
   });
 });


### PR DESCRIPTION

### Description

This PR addresses `#3893` in the JS runtime selection path (`src/js/compat.ts`).

In this PR, I define a 'browser-ambiguous runtime state' as:

- `IN_BROWSER === true`
- `IN_BROWSER_MAIN_THREAD === false`
- `IN_BROWSER_WEB_WORKER === false`

In other words, the environment is classified as browser-like by broad detection, but it is not confidently identified as either browser main thread or web worker at module-evaluation time.

My understanding is that this can happen in Next.js-style server build/module-evaluation flows, where client-targeted code may still be evaluated in a server-side context.  

Previously, this state could trigger an eager `Cannot determine runtime environment` throw.  
This PR avoids that eager failure by keeping the browser fallback lazy in runtime selection.

### What changed

- `src/js/compat.ts`
  - Refactored runtime script-loader selection through `getLoadScriptForRuntimeEnv(...)`
  - For browser-ambiguous state, avoid eager throw and keep selection/load behavior lazy
  - Added a short comment clarifying why this branch exists
- `src/js/test/unit/compat.test.ts`
  - Added coverage for browser-ambiguous runtime selection
  - Kept explicit throw behavior for truly unmatched runtime state


This PR intentionally focuses on the 'JS/compat runtime detection' layer.  
I did not extend scope into Emscripten-level investigation in this PR. My reasoning is that Emscripten follow-up should be handled separately if we see additional reproducible signals in asm.js loading/initialization paths.

### Validation

Executed locally:

```bash
node tools/runtime_detect_stub.mjs
cd src/js
TEST_NODE=1 node --import tsx --experimental-wasm-stack-switching --test test/unit/compat.test.ts
```

Results:

<img width="744" height="267" alt="스크린샷 2026-02-15 오후 11 15 39" src="https://github.com/user-attachments/assets/077863df-efc8-498b-bdbc-863c6255b4cf" />

- `tools/runtime_detect_stub.mjs`: `All cases passed: 5/5`
- `test/unit/compat.test.ts`: `tests 5`, `pass 5`, `fail 0`


- `PRE_COMMIT_HOME=/tmp/pre-commit-cache python -m pre_commit run --all-files`: passed


### Checklist

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation