### PR TITLE
Export _Py_emscripten_signal_clock

### DIFF
--- a/cpython/patches/0001-Public-pymain_run_python.patch
+++ b/cpython/patches/0001-Public-pymain_run_python.patch
@@ -1,7 +1,7 @@
-From 6ebddb6b930268d54359eebc5454fd75b28f236c Mon Sep 17 00:00:00 2001
+From 407ccc1af945a48a81d990a8329b0c37dca4f32c Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sun, 17 Jul 2022 14:40:39 +0100
-Subject: [PATCH 01/07] Public pymain_run_python
+Subject: [PATCH 1/8] Public pymain_run_python
 
 Discussion here:
 https://discuss.python.org/t/unstable-api-for-pymain-run-python-run-python-cli-but-dont-finalize-interpreter/44675
@@ -10,10 +10,10 @@ https://discuss.python.org/t/unstable-api-for-pymain-run-python-run-python-cli-b
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Modules/main.c b/Modules/main.c
-index 3bf2241f283..54f2141fb8c 100644
+index 9b2ee103d52..db032ef8b26 100644
 --- a/Modules/main.c
 +++ b/Modules/main.c
-@@ -612,7 +612,7 @@ pymain_repl(PyConfig *config, int *exitcode)
+@@ -609,7 +609,7 @@ pymain_repl(PyConfig *config, int *exitcode)
  }
  
  

--- a/cpython/patches/0002-Fix-LONG_BIT-constant-to-be-always-32bit.patch
+++ b/cpython/patches/0002-Fix-LONG_BIT-constant-to-be-always-32bit.patch
@@ -1,7 +1,7 @@
-From 9c76fbcd5e3654541d5c6303e1ca180425ba158c Mon Sep 17 00:00:00 2001
+From 9d3e39fecd794c236e7f40c2eadd946820b55d9b Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 12 Jan 2024 00:52:57 +0900
-Subject: [PATCH 02/07] Fix LONG_BIT constant to be always 32bit
+Subject: [PATCH 2/8] Fix LONG_BIT constant to be always 32bit
 
 Starting from Emscripten 3.1.50, there is an issue where LONG_BIT is
 calculated to 64 for some reason. This is very strange because LONG_MAX
@@ -17,10 +17,10 @@ Related: https://github.com/emscripten-core/emscripten/pull/20752
  1 file changed, 1 insertion(+)
 
 diff --git a/Include/pyport.h b/Include/pyport.h
-index 2ba81a4be42..292583196b9 100644
+index 2c8567f2554..63624a26b44 100644
 --- a/Include/pyport.h
 +++ b/Include/pyport.h
-@@ -386,6 +386,7 @@ extern "C" {
+@@ -416,6 +416,7 @@ extern "C" {
  #define LONG_MIN (-LONG_MAX-1)
  #endif
  

--- a/cpython/patches/0003-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
+++ b/cpython/patches/0003-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
@@ -1,8 +1,7 @@
-From 76360edbea0808455523e42f024894215b483ebd Mon Sep 17 00:00:00 2001
+From a28e166e3c40ee5c2bd0c759e52e3522c7b9dc05 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:41:37 +0200
-Subject: [PATCH 03/07] Add call to `JsProxy_GetMethod` to help remove
- temporary
+Subject: [PATCH 3/8] Add call to `JsProxy_GetMethod` to help remove temporary
 
 `_PyObject_GetMethod` is a special attribute lookup function that won't call the
 `__get__` descriptor on a method to avoid creating a temporary PyMethodObject.
@@ -22,10 +21,10 @@ See the definition of `JsProxy_GetMethod` in `jsproxy.c` and particularly
  1 file changed, 17 insertions(+)
 
 diff --git a/Objects/object.c b/Objects/object.c
-index a80d20c182a..4d6f832fc19 100644
+index 8dc3ab9643c..49fb1da1073 100644
 --- a/Objects/object.c
 +++ b/Objects/object.c
-@@ -1524,6 +1524,18 @@ _PyObject_NextNotImplemented(PyObject *self)
+@@ -1562,6 +1562,18 @@ _PyObject_NextNotImplemented(PyObject *self)
  }
  
  
@@ -44,7 +43,7 @@ index a80d20c182a..4d6f832fc19 100644
  /* Specialized version of _PyObject_GenericGetAttrWithDict
     specifically for the LOAD_METHOD opcode.
  
-@@ -1548,6 +1560,11 @@ _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
+@@ -1586,6 +1598,11 @@ _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
          }
      }
  

--- a/cpython/patches/0004-Make-from-x-import-aware-of-jsproxy-modules.patch
+++ b/cpython/patches/0004-Make-from-x-import-aware-of-jsproxy-modules.patch
@@ -1,18 +1,18 @@
-From 01a53bd90d3e11992489989a2db45e41bd9b1947 Mon Sep 17 00:00:00 2001
+From 4878c95d8d7f9f8d60e512aacf3e59037e336227 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 22 Feb 2025 13:18:18 +0100
-Subject: [PATCH 04/07] Make `from x import *` aware of jsproxy modules
+Subject: [PATCH 4/8] Make `from x import *` aware of jsproxy modules
 
 ---
  Python/intrinsics.c | 8 ++++++++
  1 file changed, 8 insertions(+)
 
 diff --git a/Python/intrinsics.c b/Python/intrinsics.c
-index a6b2c108b67..c44e329b1c7 100644
+index ff44ba0ee64..2921e702ea6 100644
 --- a/Python/intrinsics.c
 +++ b/Python/intrinsics.c
-@@ -35,6 +35,11 @@ print_expr(PyThreadState* tstate, PyObject *value)
-     return PyObject_CallOneArg(hook, value);
+@@ -36,6 +36,11 @@ print_expr(PyThreadState* Py_UNUSED(ignored), PyObject *value)
+     return res;
  }
  
 +int __attribute__((weak))
@@ -23,7 +23,7 @@ index a6b2c108b67..c44e329b1c7 100644
  static int
  import_all_from(PyThreadState *tstate, PyObject *locals, PyObject *v)
  {
-@@ -45,6 +50,9 @@ import_all_from(PyThreadState *tstate, PyObject *locals, PyObject *v)
+@@ -46,6 +51,9 @@ import_all_from(PyThreadState *tstate, PyObject *locals, PyObject *v)
      if (PyObject_GetOptionalAttr(v, &_Py_ID(__all__), &all) < 0) {
          return -1; /* Unexpected error */
      }

--- a/cpython/patches/0005-Remove-JSPI-related-parts-in-emscripten_syscalls.c.patch
+++ b/cpython/patches/0005-Remove-JSPI-related-parts-in-emscripten_syscalls.c.patch
@@ -1,11 +1,10 @@
-From b41f4bcdd8adc76f742d434ee2adec8423d41589 Mon Sep 17 00:00:00 2001
+From 7774d54f58deb619b13b5220e17b6bc3377e9196 Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 30 Jan 2026 15:48:03 +0900
-Subject: [PATCH 05/07] Remove JSPI-related parts in emscripten_syscalls.c
+Subject: [PATCH 5/8] Remove JSPI-related parts in emscripten_syscalls.c
 
 These changes were to make CPython's WASM build work with pyrepl,
 but we don't use main in Pyodide, so we can remove these parts.
-
 ---
  Python/emscripten_syscalls.c | 244 -----------------------------------
  1 file changed, 244 deletions(-)
@@ -266,5 +265,5 @@ index b1236e6b123..e2deb7281b9 100644
  
  int syscall_ioctl_orig(int fd, int request, void* varargs)
 -- 
-2.29.2.windows.2
+2.34.1
 

--- a/cpython/patches/0006-Teach-json-encoder.py-to-encode-jsnull.patch
+++ b/cpython/patches/0006-Teach-json-encoder.py-to-encode-jsnull.patch
@@ -1,7 +1,7 @@
-From 7cf6863176a7b3b62980e25652102532582ae49e Mon Sep 17 00:00:00 2001
+From 77bcb5f2de330bc9ae13c7b50eb72cb4d52a7eef Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 9 Jul 2025 17:00:12 +0200
-Subject: [PATCH 06/07] Teach json encoder.py to encode jsnull
+Subject: [PATCH 6/8] Teach json encoder.py to encode jsnull
 
 ---
  Lib/json/encoder.py | 9 +++++++++
@@ -9,7 +9,7 @@ Subject: [PATCH 06/07] Teach json encoder.py to encode jsnull
  2 files changed, 14 insertions(+), 3 deletions(-)
 
 diff --git a/Lib/json/encoder.py b/Lib/json/encoder.py
-index bc446e0f377..c4515f9812f 100644
+index 5cf6d64f3ea..a75ea21baff 100644
 --- a/Lib/json/encoder.py
 +++ b/Lib/json/encoder.py
 @@ -33,6 +33,7 @@
@@ -20,7 +20,7 @@ index bc446e0f377..c4515f9812f 100644
  
  def py_encode_basestring(s):
      """Return a JSON representation of a Python string
-@@ -301,6 +302,8 @@ def _iterencode_list(lst, _current_indent_level):
+@@ -303,6 +304,8 @@ def _iterencode_list(lst, _current_indent_level):
                      yield buf + _encoder(value)
                  elif value is None:
                      yield buf + 'null'
@@ -29,7 +29,7 @@ index bc446e0f377..c4515f9812f 100644
                  elif value is True:
                      yield buf + 'true'
                  elif value is False:
-@@ -370,6 +373,8 @@ def _iterencode_dict(dct, _current_indent_level):
+@@ -372,6 +375,8 @@ def _iterencode_dict(dct, _current_indent_level):
                  key = 'false'
              elif key is None:
                  key = 'null'
@@ -38,7 +38,7 @@ index bc446e0f377..c4515f9812f 100644
              elif isinstance(key, int):
                  # see comment for int/float in _make_iterencode
                  key = _intstr(key)
-@@ -391,6 +396,8 @@ def _iterencode_dict(dct, _current_indent_level):
+@@ -393,6 +398,8 @@ def _iterencode_dict(dct, _current_indent_level):
                      yield _encoder(value)
                  elif value is None:
                      yield 'null'
@@ -47,7 +47,7 @@ index bc446e0f377..c4515f9812f 100644
                  elif value is True:
                      yield 'true'
                  elif value is False:
-@@ -426,6 +433,8 @@ def _iterencode(o, _current_indent_level):
+@@ -428,6 +435,8 @@ def _iterencode(o, _current_indent_level):
              yield _encoder(o)
          elif o is None:
              yield 'null'
@@ -57,7 +57,7 @@ index bc446e0f377..c4515f9812f 100644
              yield 'true'
          elif o is False:
 diff --git a/Modules/_json.c b/Modules/_json.c
-index 2f82a69a157..6104aea8832 100644
+index 2f82a69a157..83d1c3e2f62 100644
 --- a/Modules/_json.c
 +++ b/Modules/_json.c
 @@ -1398,11 +1398,13 @@ encoder_call(PyObject *op, PyObject *args, PyObject *kwds)
@@ -94,6 +94,5 @@ index 2f82a69a157..6104aea8832 100644
                         True and False are also 1 and 0.*/
          keystr = _encoded_const(key);
 -- 
-2.43.0
-
+2.34.1
 

--- a/cpython/patches/0007-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
+++ b/cpython/patches/0007-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
@@ -1,7 +1,7 @@
-From 198ad7882105abb53e3b57c1aa44a73ad96c7bd3 Mon Sep 17 00:00:00 2001
+From 2ced1c0454df340dac85d3f02331021fbd9ac7d0 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:28:57 +0200
-Subject: [PATCH 07/07] Warn if ZoneInfo is imported without tzdata
+Subject: [PATCH 7/8] Warn if ZoneInfo is imported without tzdata
 
 ---
  Lib/zoneinfo/_common.py | 6 ++++++
@@ -24,5 +24,6 @@ index 03cc42149f9..2767edb9c6a 100644
          # There are four types of exception that can be raised that all amount
          # to "we cannot find this key":
          #
---
-2.50.1 (Apple Git-155)
+-- 
+2.34.1
+

--- a/cpython/patches/0008-Export-_Py_emscripten_signal_clock.patch
+++ b/cpython/patches/0008-Export-_Py_emscripten_signal_clock.patch
@@ -1,0 +1,26 @@
+From 3416cd2d272444404c4842500957f72d62ce8346 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Fri, 20 Feb 2026 17:02:46 +0100
+Subject: [PATCH 8/8] Export _Py_emscripten_signal_clock
+
+Needed by signal handling in Cloudflare's JS runtime
+---
+ Python/emscripten_signal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Python/emscripten_signal.c b/Python/emscripten_signal.c
+index 561b5b73cd6..81fd8da9fba 100644
+--- a/Python/emscripten_signal.c
++++ b/Python/emscripten_signal.c
+@@ -39,7 +39,7 @@ _Py_CheckEmscriptenSignals(void)
+ }
+ 
+ #define PY_EMSCRIPTEN_SIGNAL_INTERVAL 50
+-int _Py_emscripten_signal_clock = PY_EMSCRIPTEN_SIGNAL_INTERVAL;
++EMSCRIPTEN_KEEPALIVE int _Py_emscripten_signal_clock = PY_EMSCRIPTEN_SIGNAL_INTERVAL;
+ 
+ void
+ _Py_CheckEmscriptenSignalsPeriodically(void)
+-- 
+2.34.1
+


### PR DESCRIPTION
Needed by signal handling in Cloudflare's JS runtime.