### PR TITLE
Remove AsyncioState from captured thread state

### DIFF
--- a/src/core/stack_switching/suspenders.c
+++ b/src/core/stack_switching/suspenders.c
@@ -62,6 +62,11 @@ EM_JS(JsVal, saveState, (void), {
   }
   const stackState = new StackState();
   const threadState = _captureThreadState();
+  // clang-format off
+  if (threadState === 0) {
+    return Module.error;
+  }
+  // clang-format on
   return {
     threadState,
     stackState,


### PR DESCRIPTION
This cleans up some sloppy changes from #5995. We don't use `AsyncioState` in `restoreThreadState()` anymore, so we don't need to store it. What we need to do is to set the event loop in the new tstate to be the same as the event loop in the old tstate.

This allows us to return PyThreadState* directly rather than our wrapper struct. It seems like we were leaking 8 bytes every time we stack switched before since the ThreadState* was never freed...