### PR TITLE
Fix wasm-gc call trampoline when RELOCATABLE isn't passed

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -155,7 +155,6 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-s ENVIRONMENT=web,webview,worker,node,shell \
 	-s MAIN_MODULE=1 \
 	-s MODULARIZE=1 \
-	-s RELOCATABLE=1 \
 	-s LZ4=1 \
 	-s EXPORT_NAME="'_createPyodideModule'" \
 	-s EXPORT_EXCEPTION_HANDLING_HELPERS \

--- a/cpython/patches/0001-Public-pymain_run_python.patch
+++ b/cpython/patches/0001-Public-pymain_run_python.patch
@@ -1,7 +1,7 @@
 From 407ccc1af945a48a81d990a8329b0c37dca4f32c Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sun, 17 Jul 2022 14:40:39 +0100
-Subject: [PATCH 1/8] Public pymain_run_python
+Subject: [PATCH 1/9] Public pymain_run_python
 
 Discussion here:
 https://discuss.python.org/t/unstable-api-for-pymain-run-python-run-python-cli-but-dont-finalize-interpreter/44675

--- a/cpython/patches/0002-Fix-LONG_BIT-constant-to-be-always-32bit.patch
+++ b/cpython/patches/0002-Fix-LONG_BIT-constant-to-be-always-32bit.patch
@@ -1,7 +1,7 @@
 From 9d3e39fecd794c236e7f40c2eadd946820b55d9b Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 12 Jan 2024 00:52:57 +0900
-Subject: [PATCH 2/8] Fix LONG_BIT constant to be always 32bit
+Subject: [PATCH 2/9] Fix LONG_BIT constant to be always 32bit
 
 Starting from Emscripten 3.1.50, there is an issue where LONG_BIT is
 calculated to 64 for some reason. This is very strange because LONG_MAX

--- a/cpython/patches/0003-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
+++ b/cpython/patches/0003-Add-call-to-JsProxy_GetMethod-to-help-remove-tempora.patch
@@ -1,7 +1,7 @@
 From a28e166e3c40ee5c2bd0c759e52e3522c7b9dc05 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:41:37 +0200
-Subject: [PATCH 3/8] Add call to `JsProxy_GetMethod` to help remove temporary
+Subject: [PATCH 3/9] Add call to `JsProxy_GetMethod` to help remove temporary
 
 `_PyObject_GetMethod` is a special attribute lookup function that won't call the
 `__get__` descriptor on a method to avoid creating a temporary PyMethodObject.

--- a/cpython/patches/0004-Make-from-x-import-aware-of-jsproxy-modules.patch
+++ b/cpython/patches/0004-Make-from-x-import-aware-of-jsproxy-modules.patch
@@ -1,7 +1,7 @@
 From 4878c95d8d7f9f8d60e512aacf3e59037e336227 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Sat, 22 Feb 2025 13:18:18 +0100
-Subject: [PATCH 4/8] Make `from x import *` aware of jsproxy modules
+Subject: [PATCH 4/9] Make `from x import *` aware of jsproxy modules
 
 ---
  Python/intrinsics.c | 8 ++++++++

--- a/cpython/patches/0005-Remove-JSPI-related-parts-in-emscripten_syscalls.c.patch
+++ b/cpython/patches/0005-Remove-JSPI-related-parts-in-emscripten_syscalls.c.patch
@@ -1,7 +1,7 @@
 From 7774d54f58deb619b13b5220e17b6bc3377e9196 Mon Sep 17 00:00:00 2001
 From: ryanking13 <def6488@gmail.com>
 Date: Fri, 30 Jan 2026 15:48:03 +0900
-Subject: [PATCH 5/8] Remove JSPI-related parts in emscripten_syscalls.c
+Subject: [PATCH 5/9] Remove JSPI-related parts in emscripten_syscalls.c
 
 These changes were to make CPython's WASM build work with pyrepl,
 but we don't use main in Pyodide, so we can remove these parts.

--- a/cpython/patches/0006-Teach-json-encoder.py-to-encode-jsnull.patch
+++ b/cpython/patches/0006-Teach-json-encoder.py-to-encode-jsnull.patch
@@ -1,7 +1,7 @@
 From 77bcb5f2de330bc9ae13c7b50eb72cb4d52a7eef Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Wed, 9 Jul 2025 17:00:12 +0200
-Subject: [PATCH 6/8] Teach json encoder.py to encode jsnull
+Subject: [PATCH 6/9] Teach json encoder.py to encode jsnull
 
 ---
  Lib/json/encoder.py | 9 +++++++++

--- a/cpython/patches/0007-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
+++ b/cpython/patches/0007-Warn-if-ZoneInfo-is-imported-without-tzdata.patch
@@ -1,7 +1,7 @@
 From 2ced1c0454df340dac85d3f02331021fbd9ac7d0 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Thu, 25 Jul 2024 14:28:57 +0200
-Subject: [PATCH 7/8] Warn if ZoneInfo is imported without tzdata
+Subject: [PATCH 7/9] Warn if ZoneInfo is imported without tzdata
 
 ---
  Lib/zoneinfo/_common.py | 6 ++++++

--- a/cpython/patches/0008-Export-_Py_emscripten_signal_clock.patch
+++ b/cpython/patches/0008-Export-_Py_emscripten_signal_clock.patch
@@ -1,7 +1,7 @@
 From 3416cd2d272444404c4842500957f72d62ce8346 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 20 Feb 2026 17:02:46 +0100
-Subject: [PATCH 8/8] Export _Py_emscripten_signal_clock
+Subject: [PATCH 8/9] Export _Py_emscripten_signal_clock
 
 Needed by signal handling in Cloudflare's JS runtime
 ---

--- a/cpython/patches/0009-Fix-Emscripten-trampoline-with-emcc-4.0.19.patch
+++ b/cpython/patches/0009-Fix-Emscripten-trampoline-with-emcc-4.0.19.patch
@@ -1,0 +1,216 @@
+From 3df042a1a7c3f3c30c984d3acdecd780cbaae4b4 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Fri, 20 Feb 2026 13:04:21 +0100
+Subject: [PATCH 9/9] Fix Emscripten trampoline with emcc >= 4.0.19
+
+This undoes a change made as a part of PR 137470. We add an `emscripten_trampoline`
+field in `pycore_runtime_structs.h` and initialize it from JS initialization code with
+the wasm-gc based trampoline if possible. Otherwise we fall back to the JS trampoline.
+---
+ .../internal/pycore_emscripten_trampoline.h   |  3 -
+ Include/internal/pycore_runtime_structs.h     | 10 ++
+ Python/emscripten_trampoline.c                | 97 +++++++++++++++----
+ configure                                     |  2 +-
+ configure.ac                                  |  2 +-
+ 5 files changed, 90 insertions(+), 24 deletions(-)
+
+diff --git a/Include/internal/pycore_emscripten_trampoline.h b/Include/internal/pycore_emscripten_trampoline.h
+index 16916f1a8eb..e37c53a64f4 100644
+--- a/Include/internal/pycore_emscripten_trampoline.h
++++ b/Include/internal/pycore_emscripten_trampoline.h
+@@ -27,9 +27,6 @@
+ 
+ #if defined(__EMSCRIPTEN__) && defined(PY_CALL_TRAMPOLINE)
+ 
+-void
+-_Py_EmscriptenTrampoline_Init(_PyRuntimeState *runtime);
+-
+ PyObject*
+ _PyEM_TrampolineCall(PyCFunctionWithKeywords func,
+                      PyObject* self,
+diff --git a/Include/internal/pycore_runtime_structs.h b/Include/internal/pycore_runtime_structs.h
+index c34d7e7edc0..78f236a51a1 100644
+--- a/Include/internal/pycore_runtime_structs.h
++++ b/Include/internal/pycore_runtime_structs.h
+@@ -279,6 +279,16 @@ struct pyruntimestate {
+     struct _types_runtime_state types;
+     struct _Py_time_runtime_state time;
+ 
++#if defined(__EMSCRIPTEN__) && defined(PY_CALL_TRAMPOLINE)
++    // Used in "Python/emscripten_trampoline.c" to choose between wasm-gc
++    // trampoline and JavaScript trampoline.
++    PyObject* (*emscripten_trampoline)(int* success,
++                                       PyCFunctionWithKeywords func,
++                                       PyObject* self,
++                                       PyObject* args,
++                                       PyObject* kw);
++#endif
++
+     /* All the objects that are shared by the runtime's interpreters. */
+     struct _Py_cached_objects cached_objects;
+     struct _Py_static_objects static_objects;
+diff --git a/Python/emscripten_trampoline.c b/Python/emscripten_trampoline.c
+index d61146504d0..1833311ca74 100644
+--- a/Python/emscripten_trampoline.c
++++ b/Python/emscripten_trampoline.c
+@@ -2,20 +2,59 @@
+ 
+ #include <emscripten.h>             // EM_JS, EM_JS_DEPS
+ #include <Python.h>
++#include "pycore_runtime.h"         // _PyRuntime
+ 
+-EM_JS(
+-PyObject*,
+-_PyEM_TrampolineCall_inner, (int* success,
+-                             PyCFunctionWithKeywords func,
+-                             PyObject *arg1,
+-                             PyObject *arg2,
+-                             PyObject *arg3), {
+-    // JavaScript fallback trampoline
++// We use the _PyRuntime.emscripten_trampoline field to store a function pointer
++// for a wasm-gc based trampoline if it works. Otherwise fall back to JS
++// trampoline. The JS trampoline breaks stack switching but every runtime that
++// supports stack switching also supports wasm-gc.
++//
++// We'd like to make the trampoline call into a direct call but currently we
++// need to import the wasmTable to compile trampolineModule. emcc >= 4.0.19
++// defines the table in WebAssembly and exports it so we won't have access to it
++// until after the main module is compiled.
++//
++// To fix this, one natural solution would be to pass a funcref to the
++// trampoline instead of a table index. Several PRs would be needed to fix
++// things in llvm and emscripten in order to make this possible.
++//
++// The performance costs of an extra call_indirect aren't that large anyways.
++// The JIT should notice that the target is always the same and turn into a
++// check
++//
++// if (call_target != expected) deoptimize;
++// direct_call(call_target, args);
++
++// Offset of emscripten_trampoline in _PyRuntimeState. There's a couple of
++// alternatives:
++//
++// 1. Just make emscripten_trampoline a real C global variable instead of a
++//    field of _PyRuntimeState. This would violate our rule against mutable
++//    globals.
++//
++// 2. #define a preprocessor constant equal to a hard coded number and make a
++//    _Static_assert(offsetof(_PyRuntimeState, emscripten_trampoline) == OURCONSTANT)
++//    This has the disadvantage that we have to update the hard coded constant
++//    when _PyRuntimeState changes
++//
++// So putting the mutable constant in _PyRuntime and using a immutable global to
++// record the offset so we can access it from JS is probably the best way.
++EMSCRIPTEN_KEEPALIVE const int _PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET = offsetof(_PyRuntimeState, emscripten_trampoline);
++
++typedef PyObject* (*TrampolineFunc)(int* success,
++                                    PyCFunctionWithKeywords func,
++                                    PyObject* self,
++                                    PyObject* args,
++                                    PyObject* kw);
++
++/**
++ * Backwards compatible trampoline works with all JS runtimes
++ */
++EM_JS(PyObject*, _PyEM_TrampolineCall_JS, (PyCFunctionWithKeywords func, PyObject *arg1, PyObject *arg2, PyObject *arg3), {
+     return wasmTable.get(func)(arg1, arg2, arg3);
+ }
+-// Try to replace the JS definition of _PyEM_TrampolineCall_inner with a wasm
+-// version.
+-(function () {
++// Try to compile wasm-gc trampoline if possible.
++function getPyEMTrampolinePtr() {
+     // Starting with iOS 18.3.1, WebKit on iOS has an issue with the garbage
+     // collector that breaks the call trampoline. See #130418 and
+     // https://bugs.webkit.org/show_bug.cgi?id=293113 for details.
+@@ -27,19 +66,32 @@ _PyEM_TrampolineCall_inner, (int* success,
+         (navigator.platform === 'MacIntel' && typeof navigator.maxTouchPoints !== 'undefined' && navigator.maxTouchPoints > 1)
+     );
+     if (isIOS) {
+-        return;
++        return 0;
+     }
++    let trampolineModule;
+     try {
+-        const trampolineModule = getWasmTrampolineModule();
+-        const trampolineInstance = new WebAssembly.Instance(trampolineModule, {
+-            env: { __indirect_function_table: wasmTable, memory: wasmMemory },
+-        });
+-        _PyEM_TrampolineCall_inner = trampolineInstance.exports.trampoline_call;
++        trampolineModule = getWasmTrampolineModule();
+     } catch (e) {
+         // Compilation error due to missing wasm-gc support, fall back to JS
+         // trampoline
++        return 0;
+     }
+-})();
++    const trampolineInstance = new WebAssembly.Instance(trampolineModule, {
++        env: { __indirect_function_table: wasmTable, memory: wasmMemory },
++    });
++    return addFunction(trampolineInstance.exports.trampoline_call);
++}
++// We have to be careful to work correctly with memory snapshots -- the value of
++// _PyRuntimeState.emscripten_trampoline needs to reflect whether wasm-gc is
++// available in the current runtime, not in the runtime the snapshot was taken
++// in. This writes the appropriate value to
++// _PyRuntimeState.emscripten_trampoline from JS startup code that runs every
++// time, whether we are restoring a snapshot or not.
++addOnPreRun(function setEmscriptenTrampoline() {
++    const ptr = getPyEMTrampolinePtr();
++    const offset = HEAP32[__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET / 4];
++    HEAP32[(__PyRuntime + offset) / 4] = ptr;
++});
+ );
+ 
+ PyObject*
+@@ -48,12 +100,19 @@ _PyEM_TrampolineCall(PyCFunctionWithKeywords func,
+                      PyObject* args,
+                      PyObject* kw)
+ {
++    TrampolineFunc trampoline = _PyRuntime.emscripten_trampoline;
++    if (trampoline == 0) {
++        return _PyEM_TrampolineCall_JS(func, self, args, kw);
++    }
+     int success = 1;
+-    PyObject *result = _PyEM_TrampolineCall_inner(&success, func, self, args, kw);
++    PyObject *result = trampoline(&success, func, self, args, kw);
+     if (!success) {
+         PyErr_SetString(PyExc_SystemError, "Handler takes too many arguments");
+     }
+     return result;
+ }
+ 
++#else
++// This is exported so we need to define it even when it isn't used
++__attribute__((used)) const int _PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET = 0;
+ #endif
+diff --git a/configure b/configure
+index 46eb0665bf4..fbacfcef923 100755
+--- a/configure
++++ b/configure
+@@ -9617,7 +9617,7 @@ fi
+ 
+         as_fn_append LINKFORSHARED " -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"
+     as_fn_append LINKFORSHARED " -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV,HEAPU32,TTY"
+-    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,_PyGILState_GetThisThreadState,__Py_DumpTraceback"
++    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,_PyGILState_GetThisThreadState,__Py_DumpTraceback,__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET"
+     as_fn_append LINKFORSHARED " -sSTACK_SIZE=5MB"
+         as_fn_append LINKFORSHARED " -sTEXTDECODER=2"
+ 
+diff --git a/configure.ac b/configure.ac
+index bd4446e9488..761a30178e0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2344,7 +2344,7 @@ AS_CASE([$ac_sys_system],
+     dnl Include file system support
+     AS_VAR_APPEND([LINKFORSHARED], [" -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"])
+     AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV,HEAPU32,TTY"])
+-    AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,_PyGILState_GetThisThreadState,__Py_DumpTraceback"])
++    AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,_PyGILState_GetThisThreadState,__Py_DumpTraceback,__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET"])
+     AS_VAR_APPEND([LINKFORSHARED], [" -sSTACK_SIZE=5MB"])
+     dnl Avoid bugs in JS fallback string decoding path
+     AS_VAR_APPEND([LINKFORSHARED], [" -sTEXTDECODER=2"])
+-- 
+2.34.1
+


### PR DESCRIPTION
In python/cpython#137470 we switched to using a direct import for the wasm-gc trampoline. Unfortunately it needs access to the function pointer table and since emcc 4.0.19, wasmTable is exported from the main module and so isn't available until after the main module is instantiated, too late for it to be used to define an import.

To fix, we switch back to using a function pointer. After tier-up it hopefully isn't any slower since we'll always be calling the same target.

Upstream PR: python/cpython#145038