### PR TITLE
Add emsdk patch to normalize library paths in loadDynamicLibrary

### DIFF
--- a/emsdk/patches/0005-dylink-Normalize-library-paths-to-prevent-duplicate-loading.patch
+++ b/emsdk/patches/0005-dylink-Normalize-library-paths-to-prevent-duplicate-loading.patch
@@ -1,0 +1,35 @@
+From 0661a9e674723851f6209699d8e73e32bea7e3bc Mon Sep 17 00:00:00 2001
+From: Pepijn de Vos <pepijndevos@gmail.com>
+Date: Fri, 6 Mar 2026 08:37:22 +0100
+Subject: [PATCH] [dylink] Normalize library paths to prevent duplicate loading
+
+When a shared library in a subdirectory references a dependency via
+$ORIGIN/.. rpath, findLibraryFS resolves it to a non-canonical path
+containing ".." (e.g. "sub/../lib.so"). Since loadDynamicLibrary uses
+the raw path as the LDSO key, this causes the same library to be loaded
+twice under different names, running constructors twice.
+
+Fix by normalizing libName with PATH.normalize() at the top of
+loadDynamicLibrary, matching what dlopenInternal already does.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ src/lib/libdylink.js | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/lib/libdylink.js b/src/lib/libdylink.js
+index 5cb86ee25..99ae83ff4 100644
+--- a/src/lib/libdylink.js
++++ b/src/lib/libdylink.js
+@@ -1103,6 +1103,8 @@ var LibraryDylink = {
+      * @param {Object=} localScope
+      */`,
+   $loadDynamicLibrary: function(libName, flags = {global: true, nodelete: true}, localScope, handle) {
++    // Avoid duplicate LDSO entries from non-canonical paths (e.g. "sub/../lib.so")
++    libName = PATH.normalize(libName);
+ #if DYLINK_DEBUG
+     dbg(`loadDynamicLibrary: ${libName} handle: ${handle}`);
+     dbg('existing:', Object.keys(LDSO.loadedLibsByName));
+-- 
+2.53.0
+


### PR DESCRIPTION
## Summary

When a shared library in a subdirectory references a dependency via `$ORIGIN/..` rpath, `findLibraryFS` resolves it to a non-canonical path containing `..` (e.g. `sub/../lib.so`). Since `loadDynamicLibrary` uses the raw path as the `LDSO.loadedLibsByName` key, this causes the same library to be loaded twice under different names, running `__wasm_call_ctors` twice.

This was discovered while building [KLayout](https://github.com/klayout/klayout) for Pyodide. KLayout has plugins in a `db_plugins/` subdirectory that depend on shared libraries in the parent directory via `-Wl,-rpath,$ORIGIN/..`. Patch 0003 added `findLibraryFS` for nested dependency resolution but the resolved path is not normalized before being used as the LDSO key.

## Fix

New emsdk patch (`0005`) that adds `libName = PATH.normalize(libName)` at the top of `loadDynamicLibrary`, matching what `dlopenInternal` already does.

Tested: patch applies cleanly against Emscripten 4.0.9 with patches 0001-0004 applied first.

Upstream Emscripten PR: https://github.com/emscripten-core/emscripten/pull/26399

🤖 Generated with [Claude Code](https://claude.com/claude-code)