### PR TITLE
Update ABI docs to use year for platform tag again

### DIFF
--- a/docs/development/abi.md
+++ b/docs/development/abi.md
@@ -16,8 +16,8 @@ the interpreter to avoid load-time or run-time errors.
 
 To balance ABI stability needs of package maintainers with flexibility to adopt
 new platform features and bug fixes, Pyodide adopts a new ABI for each feature
-release of Python. The platform tags take the form `pyodide_${PYTHON_MAJOR_MINOR}_${PATCH}_wasm32`
-(e.g., `pyodide_314_0_wasm32` for Python 3.14).
+release of Python. The platform tags take the form `pyodide_${YEAR}_${PATCH}_wasm32`
+(e.g., `pyodide_2026_0_wasm32` for Python 3.14).
 
 Each ABI version specifies the CPython version, Emscripten compiler version,
 linked libraries, and required compiler/linker flags needed to build compatible

--- a/docs/development/abi/314.md
+++ b/docs/development/abi/314.md
@@ -1,9 +1,9 @@
-# pyodide_314_0 (under development)
+# pyodide_2026_0 (under development)
 
 By default, all builds of the Pyodide runtime with Python 3.14 will use the
-`pyodide_314_0` ABI.
+`pyodide_2026_0` ABI.
 
-This section reflects the aspirational ABI for `pyodide_314_0`. This is all
+This section reflects the aspirational ABI for `pyodide_2026_0`. This is all
 subject to change without notice.
 
 ## ABI Specification
@@ -27,7 +27,7 @@ time and link time.
 
 ### Rust Toolchain
 
-Rust packages that target `pyodide_314_0` ABI should use the toolchain with
+Rust packages that target `pyodide_2026_0` ABI should use the toolchain with
 1.93.0 or later, to enable `emscripten-wasm-eh` feature. Unlike
 `pyodide_2025_0`, a custom sysroot is no longer required — the
 `-Z emscripten-wasm-eh` flag is expected to be stabilized in this toolchain
@@ -83,7 +83,7 @@ Emscripten was upgraded from **4.0.9** to **5.0.0**.
 ### Rust toolchain simplified
 
 In `pyodide_2025_0`, a Rust nightly was required with the unstable
-`-Z emscripten-wasm-eh` flag and a custom sysroot. In `pyodide_314_0`, Rust
+`-Z emscripten-wasm-eh` flag and a custom sysroot. In `pyodide_2026_0`, Rust
 1.93.0 or later is sufficient — no custom sysroot or nightly-only flags are
 needed.
 


### PR DESCRIPTION
Since we decided to use year and not Python version.