### PR TITLE
Add CF workers detection

### DIFF
--- a/src/js/environments.ts
+++ b/src/js/environments.ts
@@ -46,7 +46,7 @@ function getGlobalRuntimeEnv(): RuntimeEnv {
   const IN_SHELL = typeof read === "function" && typeof load === "function";
   const IN_WORKERD =
     typeof navigator === "object" &&
-    navigator.userAgent.includes("Cloudflare-Workers");
+    navigator.userAgent?.includes("Cloudflare-Workers");
   return calculateDerivedFlags({
     IN_BUN,
     IN_DENO,


### PR DESCRIPTION
Cloudflare workers is a browser-like environment but also support Node.js modules. Sometimes we need support a few features (e.g. setting user-agent when fetching) that are not supported in the browser but in Node.js in CF workers.