### PR TITLE
Calls API.on_fatal even when fatal error occurred previously.

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -70,6 +70,9 @@ myst:
   limited backwards incompatibility.
   {pr}`6022`
 
+- {{ Fix }} `API.on_fatal` is now called even when a fatal error has already occurred.
+  {pr}`6135`
+
 ## Version 0.29.3
 
 - {{ Enhancement }} Improved support for Windows platform in the `python` CLI entrypoint.

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -91,6 +91,11 @@ API.fatal_error = function (e: any): never {
   if (fatal_error_occurred) {
     console.error("Recursive call to fatal_error. Inner error was:");
     console.error(e);
+    try {
+      API.on_fatal?.(e);
+    } catch (e2) {
+      console.error(e2);
+    }
     // @ts-ignore
     return;
   }
@@ -142,9 +147,7 @@ API.fatal_error = function (e: any): never {
         },
       });
     }
-    if (API.on_fatal) {
-      API.on_fatal(e);
-    }
+    API.on_fatal?.(e);
   } catch (err2) {
     console.error("Another error occurred while handling the fatal error:");
     console.error(err2);


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

We want the on_fatal method to be called each time there is a fatal. Not just when it first occurs.

Follow up to what we patched in https://github.com/cloudflare/workerd/pull/6334.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] ~~Add / update tests~~
- [ ] ~~Add new / update outdated documentation~~
