### PR TITLE
Fix minor bugs in tools

### DIFF
--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -7,6 +7,7 @@ import itertools
 import pathlib
 import re
 import subprocess
+import sys
 from ast import Constant
 from collections import namedtuple
 from collections.abc import Callable
@@ -280,6 +281,4 @@ def main():
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(main())

--- a/tools/check_compressed_size.py
+++ b/tools/check_compressed_size.py
@@ -32,7 +32,7 @@ def check_size(file: str | Path) -> None:
 
     data = file.read_bytes()
     compressed_data_1 = gzip.compress(data, compresslevel=1)
-    compressed_data_6 = gzip.compress(data, compresslevel=9)
+    compressed_data_6 = gzip.compress(data, compresslevel=6)
     compressed_data_9 = gzip.compress(data, compresslevel=9)
 
     print(f"    Gzip compressed size (level 1): {kb(len(compressed_data_1))} KB")


### PR DESCRIPTION
## Summary

This PR fixes two minor bugs in the tools directory:

### Bug 1: `tools/check_compressed_size.py`

The `compressed_data_6` variable was incorrectly using `compresslevel=9` instead of `compresslevel=6`, causing the gzip compression size report for level 6 to show the same result as level 9.

**Before:**
```python
compressed_data_6 = gzip.compress(data, compresslevel=9)  # Wrong!
```

**After:**
```python
compressed_data_6 = gzip.compress(data, compresslevel=6)  # Correct
```

### Bug 2: `tools/bump_version.py`

The file uses `sys.exit()` in the `run()` function (line 174), but `sys` was only imported at the bottom of the file inside the `if __name__ == "__main__"` block. This would cause a `NameError` if the `run()` function is called before the main block executes.

**Fix:** Moved `import sys` to the top of the file with other imports.

## Test plan

- [x] Code syntax validated with `python3 -m py_compile` for both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)