### PR TITLE
TST Fix leaked proxy check to respect global markers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -261,9 +261,10 @@ def pytest_runtest_call(item):
         result = yield
         return result
 
-    trace_pyproxies = pytest.mark.skip_pyproxy_check.mark not in item.own_markers
+    all_markers = list(item.iter_markers())
+    trace_pyproxies = pytest.mark.skip_pyproxy_check.mark not in all_markers
     trace_hiwire_refs = (
-        trace_pyproxies and pytest.mark.skip_refcount_check.mark not in item.own_markers
+        trace_pyproxies and pytest.mark.skip_refcount_check.mark not in all_markers
     )
     yield from extra_checks_test_wrapper(
         browser, trace_hiwire_refs, trace_pyproxies, item


### PR DESCRIPTION
Splitted out from https://github.com/pyodide/pyodide/pull/6108/changes#r2945050318

A minor fix that allows `@pytest.mark.skip_pyproxy_check` and `@pytest.mark.skip_refcount_check` markers to be used in a module level.

pytest allows passing the markers to all the test function in the file using [`pytestmark`](https://docs.pytest.org/en/stable/reference/reference.html#globalvar-pytestmark) variable. However, before this change,

```
pytestmark = pytest.mark.skip_pyproxy_check
```

didn't work because our test config was checking the `own_markers` (which stores only the marker that directly decorates the test function), not the `pytestmark`.