### PR TITLE
DOCS: Fix rendering of FSType in docs

### DIFF
--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -234,7 +234,12 @@ declare global {
   namespace FS {
     let filesystems: Record<string, any>;
     function registerDevice<T>(dev: number, ops: FSStreamOpsGen<T>): void;
-    function createNode(parent: any, name: string, mode: number, dev: number): any;
+    function createNode(
+      parent: any,
+      name: string,
+      mode: number,
+      dev: number,
+    ): any;
     function createStream(stream: any, fd?: number): any;
   }
 }


### PR DESCRIPTION
Before:
<img width="394" height="69" alt="image" src="https://github.com/user-attachments/assets/8b896f19-6b41-475d-8006-925c0bfd78e4" />

After:
<img width="394" height="69" alt="image" src="https://github.com/user-attachments/assets/31e79c17-5900-450b-bf53-bf920baa23c2" />

Not that the type info is very useful after this fix but at least it isn't obviously buggy.