### PR TITLE
Add `getTerminalHandler()` method to setStdout and setStderr

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -75,6 +75,13 @@ myst:
   limited backwards incompatibility.
   {pr}`6022`
 
+- {{ Enhancement }} If `isatty` is set to true on `stdout` or `stderr` it is now
+  possible to set the window size by providing a stdout/stderr handler which
+  implements the `getTerminalSize()` method. In particular, the default `stdout`
+  and `stderr` in Node now define this handler. These terminal sizes are
+  reported by `os.get_terminal_size()` and `shutil.get_terminal_size()`.
+  {pr}`6157`
+
 ## Version 0.29.3
 
 _January 28, 2026_

--- a/src/js/streams.ts
+++ b/src/js/streams.ts
@@ -1,9 +1,13 @@
 import { RUNTIME_ENV } from "./environments.js";
 import "./constants";
 
-import type { FSStream, FSStreamOpsGen } from "./types";
-const fs: any = RUNTIME_ENV.IN_NODE ? require("node:fs") : undefined;
-const tty: any = RUNTIME_ENV.IN_NODE ? require("node:tty") : undefined;
+import type { FSStream, FSStreamOpsGen, TtyOps } from "./types";
+const fs: typeof import("node:fs") = RUNTIME_ENV.IN_NODE
+  ? require("node:fs")
+  : undefined;
+const tty: typeof import("node:tty") = RUNTIME_ENV.IN_NODE
+  ? require("node:tty")
+  : undefined;
 
 function nodeFsync(fd: number): void {
   try {
@@ -31,10 +35,29 @@ type Reader = {
   fsync?: () => void;
   read(buffer: Uint8Array): number;
 };
-type Writer = {
+
+/**
+ * A Writer to provide to :js:func:`~pyodide.setStdout` or
+ * :js:func:`~pyodide.setStderr`.
+ *
+ * ``Writer.write`` is called with a series of `Uint8Array` buffers containing
+ * bytes to write to the stream.
+ *
+ * ``isatty`` controls whether `isatty()` returns `true` or `false` for the
+ * stream. It defaults to `false`.
+ *
+ * If present, and `isatty` is `true`, `getTerminalSize()` controls the size of
+ * the terminal reported by the tiocgwinsz ioctl, which propagates to
+ * `os.get_terminal_size()`. If absent, the terminal size is reported as 24 rows
+ * by 80 columns.
+ *
+ * If provided, `fsync` is called when the stream is fsync'd.
+ */
+export type Writer = {
   isatty?: boolean;
   fsync?: () => void;
   write(buffer: Uint8Array): number;
+  getTerminalSize?: () => { rows: number; columns: number } | undefined;
 };
 
 type Stream = FSStream & {
@@ -154,7 +177,7 @@ function readWriteHelper(stream: Stream, cb: () => number, method: string) {
       // the handler set an errno, propagate it
       throw e;
     }
-    console.error("Error thrown in read:");
+    console.error(`Error thrown in ${method}:`);
     console.error(e);
     throw new FS.ErrnoError(cDefs.EIO);
   }
@@ -180,6 +203,18 @@ const prepareBuffer = (
 ): Uint8Array =>
   API.typedArrayAsUint8Array(buffer).subarray(offset, offset + length);
 
+type FSTty = {
+  ops: TtyOps<FSTty>;
+  devops: Reader & Writer;
+};
+
+const TTY_OPS = {
+  ioctl_tiocgwinsz(tty: FSTty): readonly [number, number] {
+    const { rows = 24, columns = 80 } = tty.devops.getTerminalSize?.() ?? {};
+    return [rows, columns];
+  },
+};
+
 const stream_ops: StreamOps = {
   open: function (stream) {
     const devops = DEVOPS[stream.node.rdev];
@@ -189,7 +224,8 @@ const stream_ops: StreamOps = {
     stream.devops = devops;
     stream.tty = stream.devops.isatty
       ? {
-          ops: {},
+          ops: TTY_OPS,
+          devops,
         }
       : undefined;
     stream.seekable = false;
@@ -273,7 +309,7 @@ API.initializeStreams = function (
  */
 function setDefaultStdin() {
   if (RUNTIME_ENV.IN_NODE) {
-    setStdin(new NodeReader(process.stdin.fd));
+    setStdin(new NodeReader(process.stdin));
   } else {
     setStdin({ stdin: () => prompt() });
   }
@@ -388,36 +424,67 @@ export function setStdin(
   refreshStreams();
 }
 
-type StdwriteOpts = {
-  batched?: (a: string) => void;
-  raw?: (a: number) => void;
-  isatty?: boolean;
+/**
+ * A batched handler to provide to :js:func:`~pyodide.setStdout` or
+ * :js:func:`~pyodide.setStderr`.
+ *
+ * The ``handler.batched()`` handler is called with a string whenever a newline
+ * character is written or stdout is flushed. In the former case, the received
+ * line will end with a newline, in the latter case it will not. Streams
+ * implemented with a batched handlers cannot be a tty.
+ */
+export type BatchedWriteHandler = {
+  batched: (a: string) => void;
 };
 
+/**
+ * A raw handler to provide to :js:func:`~pyodide.setStdout` or
+ * :js:func:`~pyodide.setStderr`.
+ *
+ * The ``handler.raw()`` function is called once with each byte written to the
+ * stream as an argument.
+ *
+ * ``isatty`` controls whether `isatty()` returns `true` or `false` for the
+ * stream. It defaults to `false`.
+ *
+ * If present, and `isatty` is `true`, `getTerminalSize()` controls the size of
+ * the terminal reported by the tiocgwinsz ioctl, which propagates to
+ * `os.get_terminal_size()`. If absent, the terminal size is reported as 24 rows
+ * by 80 columns.
+ */
+export type RawWriteHandler = {
+  raw: (a: number) => void;
+  isatty?: boolean;
+  getTerminalSize?: () => { rows: number; columns: number } | undefined;
+};
+
+type StdWriteOpts = BatchedWriteHandler | RawWriteHandler | Writer | {};
+type StdWriteOptsAll = Partial<BatchedWriteHandler & RawWriteHandler & Writer>;
+
 function _setStdwrite(
-  options: StdwriteOpts & Partial<Writer>,
+  options: StdWriteOpts,
   setOps: (ops: Writer) => void,
-  getDefaults: () => StdwriteOpts & Partial<Writer>,
+  getDefaults: () => StdWriteOpts,
 ) {
-  let { raw, isatty, batched, write } = options as StdwriteOpts &
-    Partial<Writer>;
-  let nset = +!!raw + +!!batched + +!!write;
-  if (nset === 0) {
-    options = getDefaults();
-    ({ raw, isatty, batched, write } = options);
-  }
-  if (nset > 1) {
-    throw new TypeError(
-      "At most one of 'raw', 'batched', and 'write' must be passed",
-    );
-  }
+  let opts = options as StdWriteOptsAll;
+  let { raw, isatty, batched, write } = opts;
   if (!raw && !write && isatty) {
     throw new TypeError(
       "Cannot set 'isatty' to true unless 'raw' or 'write' is provided",
     );
   }
+  let nset = +!!raw + +!!batched + +!!write;
+  if (nset > 1) {
+    throw new TypeError(
+      "At most one of 'raw', 'batched', and 'write' must be passed",
+    );
+  }
+  if (nset === 0) {
+    opts = getDefaults();
+    ({ raw, isatty, batched, write } = opts);
+  }
   if (raw) {
-    setOps(new CharacterCodeWriter(raw.bind(options), !!isatty));
+    setOps(new CharacterCodeWriter(options as RawWriteHandler));
   }
   if (batched) {
     setOps(new StringWriter(batched.bind(options)));
@@ -433,9 +500,9 @@ function _setStdwrite(
  * to tty.isatty(process.stdout.fd).
  * If in a browser, sets stdout to write to console.log and sets isatty(stdout) to false.
  */
-function _getStdoutDefaults(): StdwriteOpts & Partial<Writer> {
+function _getStdoutDefaults(): StdWriteOpts {
   if (RUNTIME_ENV.IN_NODE) {
-    return new NodeWriter(process.stdout.fd);
+    return new NodeWriter(process.stdout);
   } else {
     return { batched: (x) => console.log(x) };
   }
@@ -446,34 +513,20 @@ function _getStdoutDefaults(): StdwriteOpts & Partial<Writer> {
  * to tty.isatty(process.stdout.fd).
  * If in a browser, sets stdout to write to console.log and sets isatty(stdout) to false.
  */
-function _getStderrDefaults(): StdwriteOpts & Partial<Writer> {
+function _getStderrDefaults(): StdWriteOpts {
   if (RUNTIME_ENV.IN_NODE) {
-    return new NodeWriter(process.stderr.fd);
+    return new NodeWriter(process.stderr);
   } else {
     return { batched: (x) => console.warn(x) };
   }
 }
 
 /**
- * Sets the standard out handler. A batched handler, a raw handler, or a write
- * function can be provided. If no handler is provided, we restore the default
- * handler.
- *
- * The functions on the ``options`` argument will be called with ``options``
- * bound to ``this`` so passing an instance of a class as the ``options`` object
- * works as expected.
- *
- * @param options.batched A batched handler is called with a string whenever a
- * newline character is written or stdout is flushed. In the former
- * case, the received line will end with a newline, in the latter case it will
- * not.
- * @param options.raw A raw handler is called with the handler is called with a
- * `number` for each byte of the output to stdout.
- * @param options.write A write handler is called with a buffer that contains
- * the utf8 encoded binary data
- * @param options.isatty Should :py:func:`isatty(stdout) <os.isatty>` return
- * ``true`` or ``false``. Must be ``false`` if a batched handler is used.
- * (default ``false``).
+ * Sets the standard out handler. A :js:class:`BatchedWriteHandler`, a
+ * :js:class:`RawWriteHandler`, or a :js:class:`Writer` can be provided. See the
+ * documentation for these types for more information about how each works. If
+ * no handler is provided, we restore the default handler. Passing a `Writer`
+ * provides the most flexibility and the best performance.
  *
  * @example
  * async function main(){
@@ -490,29 +543,18 @@ function _getStderrDefaults(): StdwriteOpts & Partial<Writer> {
  * }
  * main();
  */
-export function setStdout(
-  options: {
-    batched?: (output: string) => void;
-    raw?: (charCode: number) => void;
-    write?: (buffer: Uint8Array) => number;
-    isatty?: boolean;
-  } = {},
-) {
+export function setStdout(options: StdWriteOpts = {}) {
   _setStdwrite(options, _setStdoutOps, _getStdoutDefaults);
 }
 
 /**
- * Sets the standard error handler. See the documentation for
- * :js:func:`pyodide.setStdout`.
+ * Sets the standard error handler. A :js:type:`BatchedWriteHandler`, a
+ * :js:type:`RawWriteHandler`, or a :js:type:`Writer` can be provided. See the
+ * documentation for these types for more information about how each works. If
+ * no handler is provided, we restore the default handler. Passing a `Writer`
+ * provides the most flexibility and the best performance.
  */
-export function setStderr(
-  options: {
-    batched?: (output: string) => void;
-    raw?: (charCode: number) => void;
-    write?: (buffer: Uint8Array) => number;
-    isatty?: boolean;
-  } = {},
-) {
+export function setStderr(options: StdWriteOpts = {}) {
   _setStdwrite(options, _setStderrOps, _getStderrDefaults);
 }
 
@@ -528,18 +570,20 @@ class ErrorReader {
   }
 }
 
-class NodeReader {
-  fd: number;
+type NodeReadStream = NodeJS.ReadStream & { fd: number };
+
+class NodeReader implements Reader {
+  stream: NodeReadStream;
   isatty: boolean;
 
-  constructor(fd: number) {
-    this.fd = fd;
-    this.isatty = tty.isatty(fd);
+  constructor(stream: NodeReadStream) {
+    this.stream = stream;
+    this.isatty = tty.isatty(stream.fd);
   }
 
   read(buffer: Uint8Array): number {
     try {
-      return fs.readSync(this.fd, buffer);
+      return fs.readSync(this.stream.fd, buffer);
     } catch (e) {
       // Platform differences: on Windows, reading EOF throws an exception,
       // but on other OSes, reading EOF returns 0. Uniformize behavior by
@@ -552,7 +596,7 @@ class NodeReader {
   }
 
   fsync() {
-    nodeFsync(this.fd);
+    nodeFsync(this.stream.fd);
   }
 }
 
@@ -658,24 +702,28 @@ class LegacyReader {
 
 // Writer implementations
 
-class CharacterCodeWriter {
-  out: (a: number) => void;
+class CharacterCodeWriter implements Writer {
+  options: RawWriteHandler;
   isatty: boolean;
 
-  constructor(out: (a: number) => void, isatty: boolean) {
-    this.out = out;
-    this.isatty = isatty;
+  constructor(options: RawWriteHandler) {
+    this.options = options;
+    this.isatty = !!options.isatty;
   }
 
   write(buffer: Uint8Array) {
     for (let i of buffer) {
-      this.out(i);
+      this.options.raw(i);
     }
     return buffer.length;
   }
+
+  getTerminalSize() {
+    return this.options.getTerminalSize?.();
+  }
 }
 
-class StringWriter {
+class StringWriter implements Writer {
   out: (a: string) => void;
   isatty: boolean = false;
   output: number[];
@@ -706,19 +754,25 @@ class StringWriter {
   }
 }
 
-class NodeWriter {
-  fd: number;
+type NodeWriteStream = NodeJS.WriteStream & { fd: number };
+
+class NodeWriter implements Writer {
+  stream: NodeWriteStream;
   isatty: boolean;
-  constructor(fd: number) {
-    this.fd = fd;
-    this.isatty = tty.isatty(fd);
+  constructor(stream: NodeWriteStream) {
+    this.stream = stream;
+    this.isatty = tty.isatty(stream.fd);
   }
 
   write(buffer: Uint8Array): number {
-    return fs.writeSync(this.fd, buffer);
+    return fs.writeSync(this.stream.fd, buffer);
   }
 
   fsync() {
-    nodeFsync(this.fd);
+    nodeFsync(this.stream.fd);
+  }
+
+  getTerminalSize() {
+    return this.stream;
   }
 }

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -192,10 +192,17 @@ export type FSNode = {
 };
 
 /** @hidden */
+export type TtyOps<T> = {
+  ioctl_tiocgwinsz(tty: T): readonly [number, number];
+};
+
+type FSTty = {
+  ops: TtyOps<FSTty>;
+} & Record<string, unknown>;
+
+/** @hidden */
 export type FSStream = {
-  tty?: {
-    ops: object;
-  };
+  tty: FSTty | undefined;
   seekable?: boolean;
   stream_ops: FSStreamOps;
   node: FSNode;

--- a/src/templates/python_cli_entry.mjs
+++ b/src/templates/python_cli_entry.mjs
@@ -219,20 +219,6 @@ async function main() {
     loop._no_in_progress_handler = handleExit
     loop._system_exit_handler = handleExit
     loop._keyboard_interrupt_handler = lambda: handleExit(130)
-
-    # Make shutil.get_terminal_size tell the terminal size accurately.
-    import shutil
-    from js.process import stdout
-    import os
-    def get_terminal_size(fallback=(80, 24)):
-        columns = getattr(stdout, "columns", None)
-        rows = getattr(stdout, "rows", None)
-        if columns is None:
-            columns = fallback[0]
-        if rows is None:
-            rows = fallback[1]
-        return os.terminal_size((columns, rows))
-    shutil.get_terminal_size = get_terminal_size
     `,
     { globals: sideGlobals },
   );

--- a/src/tests/test_streams.py
+++ b/src/tests/test_streams.py
@@ -1,7 +1,9 @@
+import subprocess
+
 import pytest
 from pytest_pyodide import run_in_pyodide
 
-from conftest import strip_assertions_stderr
+from conftest import DIST_PATH, strip_assertions_stderr
 
 
 @pytest.mark.skip_refcount_check
@@ -622,3 +624,67 @@ def test_node_eagain(selenium):
             pyodide.setStdin();
             """
         )
+
+
+@run_in_pyodide
+def test_get_terminal_size(selenium):
+    import shutil
+
+    from pyodide.code import run_js
+
+    run_js(
+        """
+        pyodide.setStdout({
+            isatty: true,
+            write(a) {},
+            getTerminalSize() {
+                return {rows: 80, columns: 150};
+            }
+        });
+        """
+    )
+    try:
+        assert (
+            str(shutil.get_terminal_size()) == "os.terminal_size(columns=150, lines=80)"
+        )
+    finally:
+        run_js(
+            """
+            pyodide.setStdout();
+            """
+        )
+
+
+@pytest.mark.xfail_browsers(chrome="Node only", firefox="Node only", safari="Node only")
+def test_get_terminal_size_node(tmp_path):
+    target_path = DIST_PATH / "pyodide.mjs"
+    script = (
+        """
+        import { loadPyodide } from "%s";
+        import * as tty from "node:tty";
+        import * as fs from "node:fs";
+
+        fs.closeSync(1);
+        fs.openSync("/dev/tty", 1);
+
+        globalThis.process = Object.assign({}, process, {stdout: new tty.WriteStream(1)});
+        process.stdout.fd = 1;
+        process.stdout.columns = 180;
+        process.stdout.rows = 50;
+
+        const pyodide = await loadPyodide();
+        pyodide.runPython(`
+            import shutil
+            import sys
+
+            print(shutil.get_terminal_size(), file=sys.stderr)
+        `);
+        """
+        % target_path
+    )
+    script_path = tmp_path / "script.mjs"
+    script_path.write_text(script)
+    res = subprocess.run(
+        ["node", script_path], text=True, check=True, capture_output=True
+    )
+    assert res.stderr.strip() == "os.terminal_size(columns=180, lines=50)"


### PR DESCRIPTION
This adds a new `getTerminalHandler()` method that can be passed to `setStdout` and `setStderr`. If the stream is a tty, this controls the reported window size. I also updated the `NodeWriter` to provide a `getTerminalSize()` method by default. This allows us to get rid of the monkeypatch for `shutil.get_terminal_size()` in `python_cli_entry.mjs`.
