### PR TITLE
Bundler documentation: fix vite config

### DIFF
--- a/docs/usage/working-with-bundlers.md
+++ b/docs/usage/working-with-bundlers.md
@@ -60,7 +60,7 @@ const PYODIDE_EXCLUDE = [
   "!**/*.{md,html}",
   "!**/*.d.ts",
   "!**/*.whl",
-  "!**/node_modules",
+  "!**/pyodide/node_modules",
 ];
 
 export function viteStaticCopyPyodide() {


### PR DESCRIPTION
Resolves #6162

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

* As per #6162, the current documentation for using pyodide in vite-based projects causes a build failure.
* In testing for one of my projects, I found that the contributed changes resolved the issue.
* I believe that these should work for other users with no new unintentionally-included files, however, I am not familiar enough with how `npm` (and other package managers) create their `node_modules` folders to be 100% confident that this will work for everyone.
* At the very least, [it does work for me](https://github.com/COMP1010UNSW/pyhtml-demo/commit/3631c89f9b256c2fec9da3747afccc39d1f4cfee), tested on fresh `node_modules` creations using `npm@11.11.0`, `pnpm@10.33.0` and `bun@1.3.11`.

### Checklist

I don't believe any of the changes apply since this PR exclusively changes documentation.

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged 

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [ ] Add new / update outdated documentation
 -->