### PR TITLE
Don't pass --experimental-wasm-stack-switching to Node >= 25

### DIFF
--- a/src/templates/python
+++ b/src/templates/python
@@ -21,7 +21,7 @@ if(major_version < 18) {
     process.exit(1);
 }
 
-if (major_version >= 20) {
+if (major_version >= 20 && major_version <= 24) {
     process.stdout.write("--experimental-wasm-stack-switching");
 }
 EOF


### PR DESCRIPTION
The stuff we need is on by default.