### PR TITLE
DOC hide connect parameter from useNodeSockFS

### DIFF
--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -613,9 +613,7 @@ export class PyodideAPI_ {
     /**
      * @hidden
      */
-    options?: {
-      connect?: ConnectFunc,
-    }
+    options?: { connect?: ConnectFunc },
   ) {
     if (!RUNTIME_ENV.IN_NODE) {
       throw new Error("useNodeSockFS only works in Node");


### PR DESCRIPTION
We don't want end users to use this parameter, at least for now.