### PR TITLE
Fix `python.bat` to not pass `--experimental-wasm-stack-switching` for Node >= 25

### DIFF
--- a/src/templates/python.bat
+++ b/src/templates/python.bat
@@ -90,7 +90,7 @@ REM Determine Node Flags based on Version
     echo "   process.exit(1);"
     echo "}"
     echo.
-    echo "if (major_version  >= 20) {"
+    echo "if (major_version  >= 20 ^&^& major_version ^<^= 24) {"
     echo "   process.stdout.write('--experimental-wasm-stack-switching');"
     echo "}"
 )> "%TEMP%\__node_check.js"


### PR DESCRIPTION

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

Follow-up to #6164, where this was missed for the Windows CLI entry point impl; cc @hoodmane
