### PR TITLE
CI Setup trusted publishing for npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,6 +396,13 @@ jobs:
       #       git checkout 164054a9c6fbd2176f386b6552ed8d079c6bcc04
       #       ./build.sh
 
+      # No need to setup NPM ID Token for dry run
+      # But doing this to know if the token is still valid
+      - run:
+          name: Set NPM ID Token
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+
       - run:
           name: test npm deploy (dry run)
           command: |
@@ -493,6 +500,11 @@ jobs:
               ${MAYBE_PRE_RELEASE} \
               "${CIRCLE_TAG}" \
               dist
+
+      - run:
+          name: Set NPM ID Token
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
 
       - run:
           name: Deploy to npm


### PR DESCRIPTION
Close https://github.com/pyodide/pyodide/issues/6055

npm now supports CircleCI for trusted publishing, so I set that up in our org (https://docs.npmjs.com/trusted-publishers)