### PR TITLE
DOC clarify package list lockfile behavior and nightly index usage

### DIFF
--- a/docs/usage/packages-in-pyodide.md
+++ b/docs/usage/packages-in-pyodide.md
@@ -8,6 +8,27 @@ Pyodide. These packages can be loaded with {js:func}`pyodide.loadPackage` or
 loading packages. Pure Python packages with wheels on PyPI can be loaded
 directly from PyPI with {py:func}`micropip.install`.
 
+The table below is generated from the lockfile configured for this Pyodide
+release. New package recipes merged in
+[`pyodide-recipes`](https://github.com/pyodide/pyodide-recipes) may appear in a
+later Pyodide release after the lockfile is updated.
+
+If you want to try packages from the latest recipe builds before they appear in
+this table, install from the Pyodide package indexes with
+{py:func}`micropip.install` and the `index_urls` argument:
+
+```py
+import micropip
+
+await micropip.install(
+    "your-package-name",
+    index_urls=[
+        "https://pypi.anaconda.org/pyodide-nightly/simple",
+        "https://pypi.org/simple",
+    ],
+)
+```
+
 ```{eval-rst}
 .. pyodide-package-list :: packages
 ```


### PR DESCRIPTION
## Summary

Update `docs/usage/packages-in-pyodide.md` to clarify package visibility timing:

- the package table is generated from the lockfile configured for the current release
- recipes merged in `pyodide-recipes` can appear in a later release
- users can test latest recipe builds before release with `micropip.install(..., index_urls=[...])`

## Why

This reduces confusion when a package exists in recipes but is not yet listed in the current release table.

## Validation

- built docs with `make -C docs html`
- verified output generated in `docs/_build/html`

Closes #6172