### PR TITLE
Expose PYEMSCRIPTEN_PLATFORM_VERSION to sysconfigvar

### DIFF
--- a/cpython/adjust_sysconfig.py
+++ b/cpython/adjust_sysconfig.py
@@ -49,6 +49,7 @@ def adjust_sysconfig(config_vars: dict[str, str]):
         LDCXXSHARED="c++",
     )
     config_vars["PYODIDE_ABI_VERSION"] = os.environ["PYODIDE_ABI_VERSION"]
+    config_vars["PYEMSCRIPTEN_PLATFORM_VERSION"] = os.environ["PYODIDE_ABI_VERSION"]
     for [key, val] in config_vars.items():
         if not isinstance(val, str):
             continue

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1379,7 +1379,12 @@ def test_abiVersion_variable(selenium):
         """
     )
 
-    assert lockfile_abi_version == py_abi_version == core_abi_version == pyemscripten_platform_version
+    assert (
+        lockfile_abi_version
+        == py_abi_version
+        == core_abi_version
+        == pyemscripten_platform_version
+    )
 
 
 @run_in_pyodide

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1371,8 +1371,15 @@ def test_abiVersion_variable(selenium):
         get_config_var("PYODIDE_ABI_VERSION")
         """
     )
+    pyemscripten_platform_version = selenium.run(
+        """
+        from sysconfig import get_config_var
 
-    assert lockfile_abi_version == py_abi_version == core_abi_version
+        get_config_var("PYEMSCRIPTEN_PLATFORM_VERSION")  # PEP 783
+        """
+    )
+
+    assert lockfile_abi_version == py_abi_version == core_abi_version == pyemscripten_platform_version
 
 
 @run_in_pyodide


### PR DESCRIPTION
Originally this was PYODIDE_ABI_VERSION but we renamed it to PYEMSCRIPTEN_PLATFORM_VERSION in PEP 783. We will leave PYODIDE_ABI_VERSION for backward compatibility