### PR TITLE
Update `pyodide-py` PyPI deployment workflow for Trusted Publishing

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -55,4 +55,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -3,34 +3,56 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+
+permissions: {}
+
 jobs:
   deploy-pyodide-py-pypi:
     runs-on: ubuntu-latest
-    environment: PyPi
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.11"
+          python-version: "3.x"
 
       - name: Install dependencies
-        run: python -m pip install build twine
+        run: python -m pip install build
 
-      - name: Build wheel
+      - name: Build sdist and wheel
         run: |
           cd src/py/
           python -m build .
 
-      - name: Check wheel
-        run: |
-          twine check src/py/dist/*
+      - name: Upload the distribution packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pyodide-py-distributions
+          path: src/py/dist/
+          if-no-files-found: error
+
+  publish-pyodide-py-pypi:
+    name: Publish pyodide-py to PyPI
+    needs: deploy-pyodide-py-pypi
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    environment:
+      name: PyPi
+      url: https://pypi.org/p/pyodide-py
+    permissions:
+      id-token: write # for OIDC trusted publishing
+
+    steps:
+      - name: Download pyodide-py Python distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pyodide-py-distributions
+          path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN_PYODIDE_PY }}
-          packages_dir: src/py/dist/
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -43,6 +43,7 @@ jobs:
     environment:
       name: PyPi
       url: https://pypi.org/p/pyodide-py
+      deployment: false
     permissions:
       id-token: write # for OIDC trusted publishing
 

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -55,7 +55,7 @@ Assume for concreteness that we are releasing version 0.20.0.
    git push upstream main 0.20.0
    ```
 5. Wait for CI to pass, the release to be created, and approve the package
-   repository deployments (for `pyodide-py` to PyPI, and so on) once they
+   repository deployments (for `pyodide-py` to PyPI and so on) once they
    are ready.
 6. Rename the `stable` branch to a release branch for the previous major
    version. For instance if last release was, `0.20.0`, the corresponding
@@ -158,7 +158,7 @@ Assume for concreteness that we are releasing version 0.27.2.
    git push upstream stable 0.27.2
    ```
 4. Wait for CI to pass and the release to be created, and approve the package
-   repository deployments (`pyodide-py` and so on) once they are ready.
+   repository deployments (for `pyodide-py` to PyPI and so on) once they are ready.
 
 ### Making an alpha release
 
@@ -167,9 +167,7 @@ Assume for concreteness that we are releasing 0.28.0a1.
 #### Preparation
 
 Any single maintainer can decide on their own to make an alpha release, it is
-not required to discuss it with other maintainers. The only approval needed
-is for the release deployments to the package repositories (for the `pyodide-py`
-package to PyPI, etc.) once they are ready.
+not required to discuss it with other maintainers.
 
 Name the first alpha release `x.x.xa1` and in subsequent alphas increment the
 final number. No preparation is necessary. Do not make any changes to the
@@ -194,7 +192,7 @@ changelog.
    git push upstream main
    ```
 5. Wait for CI to pass and the release to be created, and approve the package
-   repository deployments (`pyodide-py` and so on) once they are ready.
+   repository deployments (for `pyodide-py` to PyPI and so on) once they are ready.
 
 ## Fixing documentation for a released version
 

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -54,7 +54,9 @@ Assume for concreteness that we are releasing version 0.20.0.
    ```
    git push upstream main 0.20.0
    ```
-5. Wait for CI to pass and release to be created.
+5. Wait for CI to pass, the release to be created, and approve the package
+   repository deployments (for `pyodide-py` to PyPI, and so on) once they
+   are ready.
 6. Rename the `stable` branch to a release branch for the previous major
    version. For instance if last release was, `0.20.0`, the corresponding
    release branch would be `0.20.X`:
@@ -155,7 +157,8 @@ Assume for concreteness that we are releasing version 0.27.2.
    ```
    git push upstream stable 0.27.2
    ```
-4. Wait for CI to pass and the release to be created.
+4. Wait for CI to pass and the release to be created, and approve the package
+   repository deployments (`pyodide-py` and so on) once they are ready.
 
 ### Making an alpha release
 
@@ -164,7 +167,9 @@ Assume for concreteness that we are releasing 0.28.0a1.
 #### Preparation
 
 Any single maintainer can decide on their own to make an alpha release, it is
-not required to discuss it with other maintainers.
+not required to discuss it with other maintainers. The only approval needed
+is for the release deployments to the package repositories (for the `pyodide-py`
+package to PyPI, etc.) once they are ready.
 
 Name the first alpha release `x.x.xa1` and in subsequent alphas increment the
 final number. No preparation is necessary. Do not make any changes to the
@@ -188,7 +193,8 @@ changelog.
    git revert 0.28.0a1 -n && git commit -m "Back to development version"
    git push upstream main
    ```
-5. Wait for CI to pass and the release to be created.
+5. Wait for CI to pass and the release to be created, and approve the package
+   repository deployments (`pyodide-py` and so on) once they are ready.
 
 ## Fixing documentation for a released version
 

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -428,7 +428,6 @@ The desired version of CPython must be available at:
 
 | version | pr         |
 | ------- | ---------- |
-| 3.14    | {pr}`5995` |
 | 3.13    | {pr}`5498` |
 | 3.12    | {pr}`4435` |
 | 3.11    | {pr}`3252` |

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -434,6 +434,7 @@ The desired version of CPython must be available at:
 
 | version | pr         |
 | ------- | ---------- |
+| 3.14    | {pr}`5995` |
 | 3.13    | {pr}`5498` |
 | 3.12    | {pr}`4435` |
 | 3.11    | {pr}`3252` |

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -55,7 +55,7 @@ Assume for concreteness that we are releasing version 0.20.0.
    git push upstream main 0.20.0
    ```
 5. Wait for CI to pass, the release to be created, and approve the package
-   repository deployments (for `pyodide-py` to PyPI and so on) once they
+   repository deployments (for `pyodide-py` to PyPI, and so on) once they
    are ready.
 6. Rename the `stable` branch to a release branch for the previous major
    version. For instance if last release was, `0.20.0`, the corresponding
@@ -158,7 +158,7 @@ Assume for concreteness that we are releasing version 0.27.2.
    git push upstream stable 0.27.2
    ```
 4. Wait for CI to pass and the release to be created, and approve the package
-   repository deployments (for `pyodide-py` to PyPI and so on) once they are ready.
+   repository deployments (`pyodide-py` and so on) once they are ready.
 
 ### Making an alpha release
 
@@ -167,7 +167,9 @@ Assume for concreteness that we are releasing 0.28.0a1.
 #### Preparation
 
 Any single maintainer can decide on their own to make an alpha release, it is
-not required to discuss it with other maintainers.
+not required to discuss it with other maintainers. The only approval needed
+is for the release deployments to the package repositories (for the `pyodide-py`
+package to PyPI, etc.) once they are ready.
 
 Name the first alpha release `x.x.xa1` and in subsequent alphas increment the
 final number. No preparation is necessary. Do not make any changes to the
@@ -192,7 +194,7 @@ changelog.
    git push upstream main
    ```
 5. Wait for CI to pass and the release to be created, and approve the package
-   repository deployments (for `pyodide-py` to PyPI and so on) once they are ready.
+   repository deployments (`pyodide-py` and so on) once they are ready.
 
 ## Fixing documentation for a released version
 

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -54,9 +54,7 @@ Assume for concreteness that we are releasing version 0.20.0.
    ```
    git push upstream main 0.20.0
    ```
-5. Wait for CI to pass, the release to be created, and approve the package
-   repository deployments (for `pyodide-py` to PyPI, and so on) once they
-   are ready.
+5. Wait for CI to pass and release to be created.
 6. Rename the `stable` branch to a release branch for the previous major
    version. For instance if last release was, `0.20.0`, the corresponding
    release branch would be `0.20.X`:
@@ -157,8 +155,7 @@ Assume for concreteness that we are releasing version 0.27.2.
    ```
    git push upstream stable 0.27.2
    ```
-4. Wait for CI to pass and the release to be created, and approve the package
-   repository deployments (`pyodide-py` and so on) once they are ready.
+4. Wait for CI to pass and the release to be created.
 
 ### Making an alpha release
 
@@ -167,9 +164,7 @@ Assume for concreteness that we are releasing 0.28.0a1.
 #### Preparation
 
 Any single maintainer can decide on their own to make an alpha release, it is
-not required to discuss it with other maintainers. The only approval needed
-is for the release deployments to the package repositories (for the `pyodide-py`
-package to PyPI, etc.) once they are ready.
+not required to discuss it with other maintainers.
 
 Name the first alpha release `x.x.xa1` and in subsequent alphas increment the
 final number. No preparation is necessary. Do not make any changes to the
@@ -193,8 +188,7 @@ changelog.
    git revert 0.28.0a1 -n && git commit -m "Back to development version"
    git push upstream main
    ```
-5. Wait for CI to pass and the release to be created, and approve the package
-   repository deployments (`pyodide-py` and so on) once they are ready.
+5. Wait for CI to pass and the release to be created.
 
 ## Fixing documentation for a released version
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

Closes #6171. I have updated the workflow to include SHA pins, added the PyPi deployment, and separated the build and publish jobs. In parallel, I have set up a GitHub Trusted Publisher using this workflow filename in the `pyodide-py` PyPI settings. The PyPi environment has been locked down to require reviewer approval for deployments (self-reviews not allowed).

Also, I have deleted the PyPI and TestPyPI upload tokens from the repository before opening this PR (writing this from the PR description view). cc: @ryanking13, @hoodmane.