### PR TITLE
Patch Emscripten to get better error message for resolveGlobalSymbol failure

### DIFF
--- a/emsdk/patches/0001-Add-useful-error-when-symbol-resolution-fails.patch
+++ b/emsdk/patches/0001-Add-useful-error-when-symbol-resolution-fails.patch
@@ -1,4 +1,4 @@
-From 926d1b0bfb38f30ae066963fcdbc696fc5d6cb0d Mon Sep 17 00:00:00 2001
+From 94bc046c40b79eabbea4f83e39b6906587ae8baf Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 19 May 2023 12:19:00 -0700
 Subject: [PATCH 1/5] Add useful error when symbol resolution fails
@@ -7,6 +7,13 @@ Currently if symbol resolution fails, we get:
 ```js
 TypeError: Cannot read properties of undefined (reading 'apply')
 ```
+
+or 
+
+```js
+TypeError: Cannot read properties of undefined (reading 'value')
+```
+
 It is very hard for newcomers to Emscripten to recognize this as a
 symbol resolution error. Even for people experienced with this message,
 it has the annoyance that it doesn't give any hint as to which symbol
@@ -14,15 +21,26 @@ went missing.
 
 This adds a descriptive error message with the name of the missing
 symbol.
+
 ---
- src/lib/libdylink.js | 3 +++
- 1 file changed, 3 insertions(+)
+ src/lib/libdylink.js | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/src/lib/libdylink.js b/src/lib/libdylink.js
-index 5cb86ee25..a21db6019 100644
+index 5cb86ee25..348a78af9 100644
 --- a/src/lib/libdylink.js
 +++ b/src/lib/libdylink.js
-@@ -784,6 +784,9 @@ var LibraryDylink = {
+@@ -340,6 +340,9 @@ var LibraryDylink = {
+           entry.value = {{{ to64(0) }}};
+           continue;
+         }
++        else if (!value) {
++            throw new Error(`Dynamic linking error: undefined symbol '${symName}'`);
++        }
+ #if ASSERTIONS
+         assert(value, `undefined symbol '${symName}'. perhaps a side module was not linked in? if this global was expected to arrive from a system library, try to build the MAIN_MODULE with EMCC_FORCE_STDLIBS=1 in the environment`);
+ #endif
+@@ -784,6 +787,9 @@ var LibraryDylink = {
              var resolved;
              stubs[prop] = (...args) => {
                resolved ||= resolveSymbol(prop);


### PR DESCRIPTION
I don't really understand yet, but after we updated Emscripten to 5.0.3, some packages started to fail on resolving symbols in [resolveGlobalSymbol](https://github.com/emscripten-core/emscripten/blob/3b957d601a1d64622a8615f2921b92c913fd25aa/src/lib/libdylink.js#L122) function.

When this happens, people (including myself) get a mysterious error

```
TypeError: Cannot read properties of undefined (reading 'value')
```

which doesn't help debugging the issue at all.

So I updated our emsdk patch to show a better error message when this happens.

Related issues:

- https://github.com/pyodide/pyodide-recipes/pull/554
- https://github.com/onnx/onnx/pull/7847#issuecomment-4276212569