### PR TITLE
Fix sed script that strips c++ symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,14 @@ dist/pyodide.asm.mjs: \
 	fi
 
    # Strip out C++ symbols which all start __Z.
-   # There are 4821 of these and they have VERY VERY long names.
+   # There are ~3691 of these and they have VERY VERY long names.
+   # In the ES6 module format, these appear as:
+   #   1. Assignments: __ZSYM=Module["__ZSYM"]=wasmExports["_ZSYM"];
+   #   2. Variable declarations in a comma-separated var list: var ...,__ZSYM,...;
    # To show some stats on the symbols you can use the following:
-   # cat dist/pyodide.asm.mjs | grep -ohE 'var _{0,5}.' | sort | uniq -c | sort -nr | head -n 20
-	$(SED) -i -E 's/var __Z[^;]*;//g' dist/pyodide.asm.mjs
+   # cat dist/pyodide.asm.mjs | grep -ohE '__Z[A-Za-z0-9_]+' | sort -u | wc -l
+	$(SED) -i -E 's/__Z[A-Za-z0-9_]+=[^;]*;//g' dist/pyodide.asm.mjs
+	$(SED) -i -E 's/,__Z[A-Za-z0-9_]+//g' dist/pyodide.asm.mjs
 	@date +"[%F %T] done building pyodide.asm.mjs."
 
 env:


### PR DESCRIPTION
Resolve #6196 