### PR TITLE
Export __stack_low and __stack_high variables from main module

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -159,7 +159,7 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-s LZ4=1 \
 	-s EXPORT_NAME="'_createPyodideModule'" \
 	-s EXPORT_EXCEPTION_HANDLING_HELPERS \
-	-sEXPORTED_RUNTIME_METHODS='wasmTable,ERRNO_CODES,__stack_low,__stack_high' \
+	-sEXPORTED_RUNTIME_METHODS='wasmTable,ERRNO_CODES' \
 	-s USE_ZLIB \
 	-s USE_BZIP2 \
 	-s FORCE_FILESYSTEM=1 \
@@ -252,6 +252,9 @@ EXPORTS=_main \
    ,_PyUnicode_New \
    ,_emscripten_stack_get_current \
    ,_Py_Version \
+   \
+   ,___stack_low \
+   ,___stack_high \
 
 
 ifeq ($(DISABLE_DYLINK), 1)

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -159,7 +159,7 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-s LZ4=1 \
 	-s EXPORT_NAME="'_createPyodideModule'" \
 	-s EXPORT_EXCEPTION_HANDLING_HELPERS \
-	-sEXPORTED_RUNTIME_METHODS='wasmTable,ERRNO_CODES' \
+	-sEXPORTED_RUNTIME_METHODS='wasmTable,ERRNO_CODES,__stack_low,__stack_high' \
 	-s USE_ZLIB \
 	-s USE_BZIP2 \
 	-s FORCE_FILESYSTEM=1 \


### PR DESCRIPTION
While investigating #6197, I noticed that `__stack_low` and `__stack_high` symbols are disappeared from pyodide.asm.(m)js from 314.0.0a1.

I believe this is related to [Emscripten 4.0.19 change](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#4019---110425) that drops relocatable flag from main module. However, this was causing symbol resolution errors in some side modules that were using these symbols (I don't exactly understand when these symbols are useful in side modules though).

This re-exports these symbols from the main module to fix it.