### PR TITLE
Tidy up lockfile test

### DIFF
--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -2108,14 +2108,10 @@ def test_lockfile_api(selenium):
     from pyodide_js import lockfile
 
     lockfile_info = lockfile.info
-    lockfile_packages = lockfile.packages
 
     assert lockfile_info is not None
     assert lockfile_info.abi_version is not None
-    assert lockfile_info.version is not None
     assert lockfile_info.python is not None
-
-    assert lockfile_packages.micropip is not None
 
 
 def test_fs_init(selenium_standalone_noload):


### PR DESCRIPTION
I removed `version` field from lockfile. This PR cleans up the lockfile test that is failing because of that change.

This pr needs to be backported to 0.29.4 for release.