### PR TITLE
Fix Python->JS string corruption when strings are allocated at >2GB memory locations in WebAssembly memory

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -85,6 +85,10 @@ myst:
 - {{ Enhancement }} Made Pyodide compatible with wheels tagged `pyemscripten`.
   {pr}`6180`, {pr}`6203`
 
+- {{ Fix }} Fixed a bug where Python strings that contained codepoints above
+  0x00FF would be corrupted when read from JavaScript when they were located at
+  a WebAssembly memory address above 2GB. {pr}`6217`
+
 ## Version 0.29.3
 
 _January 28, 2026_

--- a/src/core/jsmemops.h
+++ b/src/core/jsmemops.h
@@ -1,24 +1,33 @@
 // Macros to access memory from JavaScript
+//
+// `addr` is a WASM byte pointer that arrives here as a signed JS Number (the
+// WASM JS API converts i32 → Number via signed ToInt32). For addresses with
+// the high bit set (i.e., heap > 2 GB, which Pyodide allows via
+// MAXIMUM_MEMORY=4GB), the value is negative. We must use *unsigned* right
+// shift `>>>` to convert byte address → element index, otherwise the
+// arithmetic shift sign-extends and produces a wildly wrong index. Emscripten
+// wraps the final array index in `>>>0`, which patches up the U8/I8 cases
+// (no shift), but cannot rescue a sign-extended intermediate.
 
 #define DEREF_U8(addr, offset) HEAPU8[addr + offset]
 #define DEREF_I8(addr, offset) HEAP8[addr + offset]
 
-#define DEREF_U16(addr, offset) HEAPU16[(addr >> 1) + offset]
-#define DEREF_I16(addr, offset) HEAP16[(addr >> 1) + offset]
+#define DEREF_U16(addr, offset) HEAPU16[(addr >>> 1) + offset]
+#define DEREF_I16(addr, offset) HEAP16[(addr >>> 1) + offset]
 
-#define DEREF_U32(addr, offset) HEAPU32[(addr >> 2) + offset]
-#define DEREF_I32(addr, offset) HEAP32[(addr >> 2) + offset]
+#define DEREF_U32(addr, offset) HEAPU32[(addr >>> 2) + offset]
+#define DEREF_I32(addr, offset) HEAP32[(addr >>> 2) + offset]
 
-#define DEREF_F32(addr, offset) HEAPF32[(addr >> 2) + offset]
-#define DEREF_F64(addr, offset) HEAPF64[(addr >> 3) + offset]
+#define DEREF_F32(addr, offset) HEAPF32[(addr >>> 2) + offset]
+#define DEREF_F64(addr, offset) HEAPF64[(addr >>> 3) + offset]
 
 #define ASSIGN_U8(addr, offset, value) DEREF_U8(addr, offset) = value
 #define ASSIGN_U16(addr, offset, value) DEREF_U16(addr, offset) = value
 #define ASSIGN_U32(addr, offset, value) DEREF_U32(addr, offset) = value
 #if WASM_BIGINT
 // We have HEAPU64 / HEAPI64 in this case.
-#define DEREF_U64(addr, offset) HEAPU64[(addr >> 3) + offset]
-#define DEREF_I64(addr, offset) HEAP64[(addr >> 3) + offset]
+#define DEREF_U64(addr, offset) HEAPU64[(addr >>> 3) + offset]
+#define DEREF_I64(addr, offset) HEAP64[(addr >>> 3) + offset]
 
 #define LOAD_U64(addr, offset) DEREF_U64(addr, offset)
 #define LOAD_I64(addr, offset) DEREF_I64(addr, offset)

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -142,6 +142,76 @@ def test_large_string_conversion(selenium):
     )("ab" * 20_000)
 
 
+@run_in_pyodide
+def test_string_conversion_above_2gb(selenium):
+    """Regression test for a Python str -> JS string conversion bug that
+    fired only when the str's data buffer was allocated above the 2 GB WASM
+    heap boundary.
+
+    The DEREF_U16/U32/etc macros in src/core/jsmemops.h must use unsigned
+    right shift (>>>) to convert byte address -> typed-array element index;
+    with signed >>, an address >= 0x80000000 (allowed by MAXIMUM_MEMORY=4GB)
+    arrives in JS as a negative Number, and the shift sign-extends to an
+    out-of-bounds index. The result is a JS string with correct .length but
+    every charCodeAt() is 0.
+
+    To trigger we (1) grow the heap past 2 GB and (2) fragment with small
+    varied allocations until a fresh str data buffer lands above the
+    boundary. UCS2 is forced by including a codepoint > U+00FF, which routes
+    the conversion through _python2js_ucs2 / DEREF_U16.
+    """
+    import gc
+
+    from pyodide.code import run_js
+
+    inspect = run_js(
+        """
+        (s) => {
+            let nulCount = 0;
+            for (let i = 0; i < s.length; i++) {
+                if (s.charCodeAt(i) === 0) nulCount++;
+            }
+            return [s.length, nulCount];
+        }
+        """
+    )
+
+    def check(label):
+        s = chr(0x0100) + "x" * 1023
+        assert s.count("\x00") == 0, "source str corrupted on Python side"
+        length, nul_count = inspect(s).to_py()
+        assert length == len(s)
+        assert nul_count == 0, (
+            f"{label}: Python str -> JS string corruption "
+            f"({nul_count}/{length} chars are U+0000); str buffer likely "
+            "lives above 2 GB and DEREF_U16 sign-extended the byte address"
+        )
+
+    check("baseline (heap < 2 GB)")
+
+    # Grow the heap past 2 GB.
+    ballast = []
+    for _ in range(21):
+        try:
+            ballast.append(bytes(100 * 1024 * 1024))
+        except MemoryError:
+            break
+    check("after 2 GB ballast")
+
+    # Fragment with small varied allocations until something lands above the
+    # boundary. In practice the bug fires within ~15k iterations.
+    small = []
+    try:
+        for i in range(20000):
+            small.append(bytes(1000 + (i % 4000)))
+            if i and i % 1000 == 0:
+                check(f"during small allocs i={i}")
+    finally:
+        del small
+        del ballast
+        gc.collect()
+
+
 @given(
     n=st.one_of(
         st.integers(),


### PR DESCRIPTION
### Description
I've discovered a bug where Python strings that contain a codepoint above 0x00FF and that are located at a memory address above 2GB, are corrupted when copied into JavaScript. The string in JavaScript retains the same length as the Python string, but all its characters end up as nulls.

To reproduce this bug outside of this repo, I first created this little test: https://github.com/daniel-chambers/pyodide-string-corruption-repro

The root cause of this appears to be caused by using a signed bitshift when indexing into WebAssembly memory from JavaScript in the `_python2js_ucs2` and `_python2js_ucs4` functions (via the macros in `jsmemops.h`). When a memory address is used that is larger than the max signed 32-bit int value, the signed bitshift mangles the offset into memory view array, causing the string value to come out entirely composed of null values.

The fix is to use unsigned bitshifts to correctly index into the WebAssembly memory array.

I've added a test to the test suite that fails without the fix and succeeds once the fix is in place. I've tested it myself by using the `./run-docker` container, running `make` and then running `pytest -k above_2gb --runtime node` inside the container, with and without the fix. 
The test is basically a translation of the reproduction from the repo above. It's a bit dodgy in that is basically allocates and kicks the memory state of the program around until a failure occurs (it's trying to get a string allocated in the high memory area), but this happens 100% reliably in my experience, so I don't expect it to be flaky. But it _could_ potentially flake if something changes in the way python allocates memory in the future. If you can think of a more deterministic way to reproduce this, or if you want to just ditch the test, I'm happy to do that.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
