### PR TITLE
Add control for JsBind over the js name of an attribute

### DIFF
--- a/src/core/jsbind.c
+++ b/src/core/jsbind.c
@@ -656,7 +656,7 @@ jsbind_init(PyObject* core_mod)
   FAIL_IF_NULL(jsbind);
   no_default = PyObject_GetAttrString(jsbind, "no_default");
   FAIL_IF_NULL(no_default);
-  default_signature = PyObject_GetAttrString(jsbind, "default_signature");
+  default_signature = PyObject_GetAttrString(jsbind, "_default_signature");
   FAIL_IF_NULL(default_signature);
 
   success = true;

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2829,9 +2829,7 @@ JsProxy_Dir(PyObject* self, PyObject* _args)
     _Py_IDENTIFIER(_reverse_dir_names);
     PyObject* translated = _PyObject_CallMethodIdObjArgs(
       jsbind, &PyId__reverse_dir_names, JsProxy_SIG(self), pydir, NULL);
-    if (translated == NULL) {
-      FAIL();
-    }
+    FAIL_IF_NULL(translated);
     Py_SETREF(pydir, translated);
   }
   // Merge and sort

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -343,10 +343,10 @@ JsProxy_bind_class(PyObject* self, PyObject* sig)
 
   // Call `sig = jsbind.bind_class_sig(sig)` and then delegate to
   // JsProxy_bind_sig.
-  // bind_class_sig takes sig and returns type[sig].
-  _Py_IDENTIFIER(bind_class_sig);
+  // _bind_class_sig takes sig and returns type[sig].
+  _Py_IDENTIFIER(_bind_class_sig);
   PyObject* class_sig =
-    _PyObject_CallMethodIdOneArg(jsbind, &PyId_bind_class_sig, sig);
+    _PyObject_CallMethodIdOneArg(jsbind, &PyId__bind_class_sig, sig);
   FAIL_IF_NULL(class_sig);
   result = JsProxy_bind_sig(self, class_sig);
 finally:
@@ -572,9 +572,9 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
   int got_converter = 0;
   PyObject* sig = NULL;
   if (JsProxy_SIG(self) != NULL) {
-    _Py_IDENTIFIER(get_attr_sig);
+    _Py_IDENTIFIER(_get_attr_sig);
     get_attr_sig_res = _PyObject_CallMethodIdObjArgs(
-      jsbind, &PyId_get_attr_sig, JsProxy_SIG(self), attr, NULL);
+      jsbind, &PyId__get_attr_sig, JsProxy_SIG(self), attr, NULL);
     FAIL_IF_NULL(get_attr_sig_res);
 
     // js_name_obj and sig are borrowed references into get_attr_sig_res, and
@@ -689,9 +689,9 @@ JsProxy_SetAttr(PyObject* self, PyObject* attr, PyObject* pyvalue)
   // (e.g. snake_case Python attr -> camelCase JS property).
   const char* js_key = key;
   if (JsProxy_SIG(self) != NULL) {
-    _Py_IDENTIFIER(resolve_js_name);
+    _Py_IDENTIFIER(_resolve_js_name);
     js_name_obj = _PyObject_CallMethodIdObjArgs(
-      jsbind, &PyId_resolve_js_name, JsProxy_SIG(self), attr, NULL);
+      jsbind, &PyId__resolve_js_name, JsProxy_SIG(self), attr, NULL);
     FAIL_IF_NULL(js_name_obj);
     js_key = PyUnicode_AsUTF8(js_name_obj);
     FAIL_IF_NULL(js_key);
@@ -2826,9 +2826,9 @@ JsProxy_Dir(PyObject* self, PyObject* _args)
   // If a signature is attached, run the JS names through any reverse name
   // translation it provides (e.g. camelCase -> snake_case).
   if (JsProxy_SIG(self) != NULL) {
-    _Py_IDENTIFIER(reverse_dir_names);
+    _Py_IDENTIFIER(_reverse_dir_names);
     PyObject* translated = _PyObject_CallMethodIdObjArgs(
-      jsbind, &PyId_reverse_dir_names, JsProxy_SIG(self), pydir, NULL);
+      jsbind, &PyId__reverse_dir_names, JsProxy_SIG(self), pydir, NULL);
     if (translated == NULL) {
       FAIL();
     }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -564,32 +564,45 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
     FAIL();
   }
 
-  jsresult = JsProxy_GetAttr_js(JsProxy_VAL(self), key);
-  if (JsvError_Check(jsresult)) {
-    if (!PyErr_Occurred()) {
-      PyErr_SetString(PyExc_AttributeError, key);
-    }
-    FAIL();
-  }
-
+  // If we have a signature, ask jsbind both for the converter info and for the
+  // JS property name to look up (the sig may translate Python names to JS
+  // names, e.g. snake_case -> camelCase). Otherwise the JS name is just the
+  // Python name.
+  const char* js_key = key;
+  int got_converter = 0;
+  PyObject* sig = NULL;
   if (JsProxy_SIG(self) != NULL) {
     _Py_IDENTIFIER(get_attr_sig);
     get_attr_sig_res = _PyObject_CallMethodIdObjArgs(
       jsbind, &PyId_get_attr_sig, JsProxy_SIG(self), attr, NULL);
     FAIL_IF_NULL(get_attr_sig_res);
 
-    bool got_converter;
-    PyObject* sig;
-    if (!PyArg_ParseTuple(get_attr_sig_res, "pO", &got_converter, &sig)) {
+    // js_name_obj and sig are borrowed references into get_attr_sig_res, and
+    // js_key points into js_name_obj's internal UTF-8 buffer. All three are
+    // kept alive by get_attr_sig_res, which is only Py_CLEARed in the finally
+    // block below.
+    PyObject* js_name_obj;
+    if (!PyArg_ParseTuple(
+          get_attr_sig_res, "OpO", &js_name_obj, &got_converter, &sig)) {
       FAIL();
     }
-    if (got_converter) {
-      pyresult = Js2PyConverter_convert(sig, jsresult, Jsv_null);
-      goto success;
+    js_key = PyUnicode_AsUTF8(js_name_obj);
+    FAIL_IF_NULL(js_key);
+  }
+
+  jsresult = JsProxy_GetAttr_js(JsProxy_VAL(self), js_key);
+  if (JsvError_Check(jsresult)) {
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_AttributeError, key);
     }
-    if (!Py_IsNone(sig)) {
-      attr_sig = Py_XNewRef(sig);
-    }
+    FAIL();
+  }
+  if (got_converter) {
+    pyresult = Js2PyConverter_convert(sig, jsresult, Jsv_null);
+    goto success;
+  }
+  if (sig != NULL && !Py_IsNone(sig)) {
+    attr_sig = Py_XNewRef(sig);
   }
   // attr_sig might contain the result sig or it might be NULL.
   // TODO: maybe allow being strict and requiring that we get a sig?
@@ -657,6 +670,7 @@ static int
 JsProxy_SetAttr(PyObject* self, PyObject* attr, PyObject* pyvalue)
 {
   bool success = false;
+  PyObject* js_name_obj = NULL;
 
   const char* key = PyUnicode_AsUTF8(attr);
   FAIL_IF_NULL(key);
@@ -671,15 +685,28 @@ JsProxy_SetAttr(PyObject* self, PyObject* attr, PyObject* pyvalue)
     }
   }
 
+  // If a signature is attached, ask it to translate the attribute name
+  // (e.g. snake_case Python attr -> camelCase JS property).
+  const char* js_key = key;
+  if (JsProxy_SIG(self) != NULL) {
+    _Py_IDENTIFIER(resolve_js_name);
+    js_name_obj = _PyObject_CallMethodIdObjArgs(
+      jsbind, &PyId_resolve_js_name, JsProxy_SIG(self), attr, NULL);
+    FAIL_IF_NULL(js_name_obj);
+    js_key = PyUnicode_AsUTF8(js_name_obj);
+    FAIL_IF_NULL(js_key);
+  }
+
   if (pyvalue == NULL) {
-    FAIL_IF_MINUS_ONE(JsProxy_DelAttr_js(JsProxy_VAL(self), key));
+    FAIL_IF_MINUS_ONE(JsProxy_DelAttr_js(JsProxy_VAL(self), js_key));
   } else {
     JsVal jsvalue = python2js(pyvalue);
-    FAIL_IF_MINUS_ONE(JsProxy_SetAttr_js(JsProxy_VAL(self), key, jsvalue));
+    FAIL_IF_MINUS_ONE(JsProxy_SetAttr_js(JsProxy_VAL(self), js_key, jsvalue));
   }
 
   success = true;
 finally:
+  Py_CLEAR(js_name_obj);
   return success ? 0 : -1;
 }
 
@@ -2796,6 +2823,17 @@ JsProxy_Dir(PyObject* self, PyObject* _args)
   jsdir = JsProxy_Dir_js(JsProxy_VAL(self));
   pydir = js2python(jsdir);
   FAIL_IF_NULL(pydir);
+  // If a signature is attached, run the JS names through any reverse name
+  // translation it provides (e.g. camelCase -> snake_case).
+  if (JsProxy_SIG(self) != NULL) {
+    _Py_IDENTIFIER(reverse_dir_names);
+    PyObject* translated = _PyObject_CallMethodIdObjArgs(
+      jsbind, &PyId_reverse_dir_names, JsProxy_SIG(self), pydir, NULL);
+    if (translated == NULL) {
+      FAIL();
+    }
+    Py_SETREF(pydir, translated);
+  }
   // Merge and sort
   FAIL_IF_MINUS_ONE(_PySet_Update(result_set, pydir));
   if (JsvArray_Check(JsProxy_VAL(self))) {

--- a/src/core/jsproxy_call.c
+++ b/src/core/jsproxy_call.c
@@ -377,9 +377,9 @@ JsMethod_Vectorcall_impl(JsVal func,
   // Recursion error?
   FAIL_IF_NONZERO(Py_EnterRecursiveCall(" while calling a JavaScript object"));
   if (sig) {
-    _Py_IDENTIFIER(func_to_sig);
+    _Py_IDENTIFIER(_func_to_sig);
     call_sig = (JsFuncSignature*)_PyObject_CallMethodIdOneArg(
-      jsbind, &PyId_func_to_sig, sig);
+      jsbind, &PyId__func_to_sig, sig);
     FAIL_IF_NULL(call_sig);
   }
   if (Py_IsNone((PyObject*)call_sig)) {

--- a/src/py/_pyodide/camel_to_snake.py
+++ b/src/py/_pyodide/camel_to_snake.py
@@ -1,0 +1,92 @@
+import re
+
+_SNAKE_TO_CAMEL_RE = re.compile(r"_([a-z])")
+_CAMEL_TO_SNAKE_RE = re.compile(r"([a-z0-9])([A-Z])")
+
+
+def snake_to_camel(name: str) -> str:
+    """Convert a snake_case Python attribute name to a camelCase JS name.
+
+    Leading underscores are preserved (so dunder names like ``__call__`` are
+    untouched). A single trailing underscore is also preserved so that the
+    reserved-word transform in ``pre.js`` still works (e.g. ``class_`` -> ``class_``).
+    Internal underscores are removed and the following character is upper-cased.
+
+    >>> snake_to_camel("foo_bar")
+    'fooBar'
+    >>> snake_to_camel("foo_bar_baz")
+    'fooBarBaz'
+    >>> snake_to_camel("already_lowerCase")
+    'alreadyLowerCase'
+    >>> snake_to_camel("__call__")
+    '__call__'
+    >>> snake_to_camel("class_")
+    'class_'
+    """
+    if not name:
+        return name
+    # Python TitleCase ==> JavaScript TitleCase
+    # If first alpha character is uppercase, it's in title case ==> leave it alone.
+    first_alpha = next((c for c in name if c.isalnum()), None)
+    if first_alpha is None or first_alpha.isupper():
+        return name
+    # Preserve leading underscores (dunders, sunders, private names).
+    if name[:2] == "__":
+        return name
+    # Preserve all trailing underscores (used to escape reserved words).
+    rstripped = name.rstrip("_")
+    trailing = name[len(rstripped) :]
+    stripped = rstripped.lstrip("_")
+    leading = rstripped[: -len(stripped)]
+    return (
+        leading
+        + _SNAKE_TO_CAMEL_RE.sub(lambda m: m.group(1).upper(), stripped)
+        + trailing
+    )
+
+
+def camel_to_snake(name: str) -> str:
+    """Convert a camelCase JS name to a snake_case Python attribute name.
+
+    Inverse of :func:`snake_to_camel` for typical inputs.
+
+    >>> camel_to_snake("fooBar")
+    'foo_bar'
+    >>> camel_to_snake("XMLHttpRequest")
+    'XMLHttpRequest'
+    >>> camel_to_snake("anXMLHttpRequest")
+    'an_xml_http_request'
+    >>> camel_to_snake("ALL_UPPERCASE")
+    'ALL_UPPERCASE'
+    >>> camel_to_snake("_TitleCasePrivate")
+    '_TitleCasePrivate'
+    >>> camel_to_snake("__call__")
+    '__call__'
+    """
+    if not name:
+        return name
+    # JavaScript TitleCase ==> Python TitleCase
+    # If first alpha character is uppercase, it's in title case ==> leave it alone.
+    first_alpha = next((c for c in name if c.isalnum()), None)
+    if first_alpha is None or first_alpha.isupper():
+        return name
+    # Lowercase everything except uppercase letters that are preceded by an
+    # underscore (so e.g. "a_A" round-trips instead of collapsing to "a_a"/"aA").
+    out = []
+    saw_underscore = False
+    saw_uppercase = False
+    for c in name:
+        # print("c", c, "out", out, "saw_underscore", saw_underscore)
+        if saw_underscore or not c.isupper():
+            out.append(c)
+        elif saw_uppercase:
+            # Two uppercase, send XML ==> xml not x_m_l
+            out.extend(c.lower())
+        else:
+            # last character wasn't an underscore or uppercase and current
+            # character is uppercase
+            out.extend(["_", c.lower()])
+        saw_underscore = c == "_"
+        saw_uppercase = c.isupper()
+    # print(out)
+    return "".join(out)

--- a/src/py/_pyodide/jsbind.py
+++ b/src/py/_pyodide/jsbind.py
@@ -318,7 +318,7 @@ def _build_name_cache(sig):
     return cache
 
 
-def resolve_js_name(sig: type, py_name: str) -> str:
+def _resolve_js_name(sig: type, py_name: str) -> str:
     """Translate a Python attribute name to its JS property name for ``sig``.
 
     Used by the C JsProxy machinery. Resolution order:
@@ -351,7 +351,7 @@ def resolve_js_name(sig: type, py_name: str) -> str:
     return js
 
 
-def reverse_dir_names(sig: type, js_names: list) -> list:
+def _reverse_dir_names(sig: type, js_names: list) -> list:
     """Translate a list of JS property names back to Python attribute names.
 
     Used by ``dir(jsproxy)`` when a signature is attached. If no inverse
@@ -359,10 +359,10 @@ def reverse_dir_names(sig: type, js_names: list) -> list:
     """
     if sig is None:
         return js_names
-    return [reverse_js_name(sig, n) for n in js_names]
+    return [_reverse_js_name(sig, n) for n in js_names]
 
 
-def reverse_js_name(sig: type, jsname: str) -> str:
+def _reverse_js_name(sig: type, jsname: str) -> str:
     """Translate a JS property name back to its Python attribute name for ``sig``.
 
     Used by ``dir()``. The lookup is best-effort: if the inverse cannot be
@@ -386,7 +386,7 @@ def reverse_js_name(sig: type, jsname: str) -> str:
 
 
 
-class TypeConverter:
+class _TypeConverter:
     def unpack_generic_alias(self, x: _GenericAlias) -> Any:
         if isinstance(x, _UnionGenericAlias):
             if len(x.__args__) != 2:
@@ -445,11 +445,11 @@ class TypeConverter:
         return None
 
 
-type_converter = TypeConverter()
+_type_converter = _TypeConverter()
 
 
-def get_attr_sig_prop(attr_sig):
-    """Helper for get_attr_sig in case that the attribute we're looking up is a
+def _get_attr_sig_prop(attr_sig):
+    """Helper for _get_attr_sig in case that the attribute we're looking up is a
     property with annotation.
     """
     # If the attribute is marked with BindClass, then we should attach bind it
@@ -457,20 +457,20 @@ def get_attr_sig_prop(attr_sig):
     if isinstance(attr_sig, BindClass):
         return (False, attr_sig)
     # Otherwise, make it into a converter.
-    if converter := type_converter.js2py_annotation(attr_sig):
+    if converter := _type_converter.js2py_annotation(attr_sig):
         return (True, converter)
     return (False, None)
 
 
-def get_attr_sig_method_helper(sig, attr):
+def _get_attr_sig_method_helper(sig, attr):
     """Check if sig has a method named attr. If so, get the appropriate
     signature.
 
-    Returns: None or a valid get_attr_sig return value.
+    Returns: None or a valid _get_attr_sig return value.
     """
     res_attr = getattr_static(sig, attr, None)
     # If it isn't a static method, it has one too many arguments. Easiest way to
-    # communicate this to func_to_sig is to use __get__ to bind an argument. We
+    # communicate this to _func_to_sig is to use __get__ to bind an argument. We
     # have to do this manually because `sig` is a class not an instance.
     if res_attr and callable(res_attr):
         # The argument to __get__ doesn't matter.
@@ -492,17 +492,17 @@ def get_attr_sig_method_helper(sig, attr):
     return attr_sig
 
 
-def get_attr_sig_method(sig, attr):
+def _get_attr_sig_method(sig, attr):
     if not hasattr(sig, "_method_cache"):
         sig._method_cache = {}
     if res_attr := sig._method_cache.get(attr, None):
         return res_attr
-    res = get_attr_sig_method_helper(sig, attr)
+    res = _get_attr_sig_method_helper(sig, attr)
     sig._method_cache[attr] = res
     return res
 
 
-def get_attr_sig(sig, attr):
+def _get_attr_sig(sig, attr):
     """Called from JsProxy_GetAttr when the proxy has a signature.
 
     Must return a triple:
@@ -513,7 +513,7 @@ def get_attr_sig(sig, attr):
     ``js_name`` is the JS property name to look up (after applying any name
     translation configured on ``sig``).
     """
-    js_name = resolve_js_name(sig, attr)
+    js_name = _resolve_js_name(sig, attr)
     # Look up type hints and cache them if we haven't yet. We could use
     # `functools.cache` for this, but it seems to keep `sig` alive for longer
     # than necessary.
@@ -522,9 +522,9 @@ def get_attr_sig(sig, attr):
         sig._type_hints = get_type_hints(sig, include_extras=True)
     # See if there is an attribute type hint
     if prop_sig := sig._type_hints.get(attr, None):
-        got_converter, value = get_attr_sig_prop(prop_sig)
+        got_converter, value = _get_attr_sig_prop(prop_sig)
         return (js_name, got_converter, value)
-    if res := get_attr_sig_method(sig, attr):
+    if res := _get_attr_sig_method(sig, attr):
         return (js_name, False, res)
     return (js_name, False, None)
 
@@ -532,7 +532,7 @@ def get_attr_sig(sig, attr):
 no_default = Parameter.empty
 
 
-def func_to_sig(f):
+def _func_to_sig(f):
     """Called from jsproxy_call.c when we're about to call a callable.
 
     Has to return an appropriate JsFuncSignature.
@@ -557,12 +557,12 @@ def func_to_sig(f):
     if cls:
         f = cls.__init__.__get__(cls)
 
-    res = func_to_sig_inner(f, cls)
+    res = _func_to_sig_inner(f, cls)
     setattr(cache, cache_name, res)
     return res
 
 
-def func_to_sig_inner(f, cls):
+def _func_to_sig_inner(f, cls):
     sig = signature(f)
     posparams = []
     posparams_defaults = []
@@ -577,7 +577,7 @@ def func_to_sig_inner(f, cls):
 
     for p in sig.parameters.values():
         converter = (
-            type_converter.py2js_annotation(types.get(p.name, None)) or py2js_default
+            _type_converter.py2js_annotation(types.get(p.name, None)) or py2js_default
         )
         match p.kind:
             case Parameter.POSITIONAL_ONLY:
@@ -602,7 +602,7 @@ def func_to_sig_inner(f, cls):
         # We use a bitflag to check which kwparams have been passed to fill in
         # defaults / raise type error.
         raise RuntimeError("Cannot handle function with more than 64 kwonly args")
-    result = type_converter.js2py_annotation(types.get("return", cls))
+    result = _type_converter.js2py_annotation(types.get("return", cls))
     if iscoroutinefunction(f):
         if result is None:
             result = js2py_default
@@ -629,10 +629,10 @@ def _default_sig_stencil(*args, **kwargs):
     pass
 
 
-default_signature = func_to_sig_inner(_default_sig_stencil, None)
+_default_signature = _func_to_sig_inner(_default_sig_stencil, None)
 
 
-def bind_class_sig(sig):
+def _bind_class_sig(sig):
     """Called from JsProxy_bind_class.
 
     Just replace sig with type[sig]. This is consistent with what we'd get from

--- a/src/py/_pyodide/jsbind.py
+++ b/src/py/_pyodide/jsbind.py
@@ -1,3 +1,4 @@
+import re
 from inspect import (
     Parameter,
     getattr_static,
@@ -83,8 +84,306 @@ class Default:
     pass
 
 
+_SNAKE_TO_CAMEL_RE = re.compile(r"_([a-zA-Z0-9])")
+_CAMEL_TO_SNAKE_RE1 = re.compile(r"(.)([A-Z][a-z]+)")
+_CAMEL_TO_SNAKE_RE2 = re.compile(r"([a-z0-9])([A-Z])")
+
+
+def snake_to_camel(name: str) -> str:
+    """Convert a snake_case Python attribute name to a camelCase JS name.
+
+    Leading underscores are preserved (so dunder names like ``__call__`` are
+    untouched). A single trailing underscore is also preserved so that the
+    reserved-word transform in ``pre.js`` still works (e.g. ``class_`` -> ``class_``).
+    Internal underscores are removed and the following character is upper-cased.
+
+    >>> snake_to_camel("foo_bar")
+    'fooBar'
+    >>> snake_to_camel("foo_bar_baz")
+    'fooBarBaz'
+    >>> snake_to_camel("already_lowerCase")
+    'alreadyLowerCase'
+    >>> snake_to_camel("__call__")
+    '__call__'
+    >>> snake_to_camel("class_")
+    'class_'
+    """
+    if not name:
+        return name
+    # Preserve leading underscores (dunders, sunders, private names).
+    if name[:2] == "__":
+        return name
+    # Preserve all trailing underscores (used to escape reserved words).
+    stripped = name.rstrip("_")
+    trailing = name[len(stripped) :]
+    return (
+        _SNAKE_TO_CAMEL_RE.sub(lambda m: m.group(1).upper(), stripped) + trailing
+    )
+
+
+def camel_to_snake(name: str) -> str:
+    """Convert a camelCase JS name to a snake_case Python attribute name.
+
+    Inverse of :func:`snake_to_camel` for typical inputs.
+
+    >>> camel_to_snake("fooBar")
+    'foo_bar'
+    >>> camel_to_snake("XMLHttpRequest")
+    'xml_http_request'
+    >>> camel_to_snake("__call__")
+    '__call__'
+    """
+    if not name:
+        return name
+    if name[:2] == "__":
+        return name
+    stripped = name.rstrip("_")
+    trailing = name[len(stripped) :]
+    s1 = _CAMEL_TO_SNAKE_RE1.sub(r"\1_\2", stripped)
+    s2 = _CAMEL_TO_SNAKE_RE2.sub(r"\1_\2", s1)
+    return s2.lower() + trailing
+
+
 class BindClass:
-    pass
+    """Marker base class for jsbind signature classes.
+
+    Subclasses describe the structure of a JS object so that attribute
+    accesses, method calls, and conversions can be type-checked at the
+    boundary.
+
+    Subclasses may configure how Python attribute names are mapped onto JS
+    property names by overriding the ``_js_name`` static method::
+
+        class Screaming(BindClass):
+            @staticmethod
+            def _js_name(name: str) -> str:
+                return name.upper()
+
+    Per-member overrides are available via :class:`JsName` /
+    :func:`js_name` (pin an exact JS name) and :class:`CamelCase` /
+    :func:`camel_case` (apply ``snake_to_camel`` to a single member).
+
+    See :class:`CamelCase` for a built-in mixin that exposes camelCase JS
+    properties via snake_case Python attribute names.
+    """
+
+    @staticmethod
+    def _js_name(py_name: str) -> str:
+        return py_name
+
+
+class CamelCase(BindClass):
+    """A :class:`BindClass` mixin that translates ``snake_case`` Python
+    attribute names to ``camelCase`` JS property names.
+
+    Use as a base class instead of :class:`BindClass`::
+
+        class Foo(CamelCase):
+            x_y: int
+
+            def do_something(self, /) -> None: ...
+
+    Then ``foo.x_y`` reads JS ``foo.xY`` and ``foo.do_something()`` calls
+    JS ``foo.doSomething()``.
+
+    Individual members may opt out via :class:`JsName` / :func:`js_name`
+    to pin an exact JS name::
+
+        class Foo(CamelCase):
+            my_id: Annotated[int, JsName("id")]
+
+            @js_name("doStuff")
+            def do_stuff(self, /): ...
+    """
+
+    _js_name = staticmethod(snake_to_camel)
+
+
+class JsName:
+    """Annotation marker that pins a specific JS property name.
+
+    Use inside :class:`typing.Annotated` on attribute or return-value
+    annotations of a :class:`BindClass` subclass to override any class-level
+    name translation::
+
+        from typing import Annotated
+        from _pyodide.jsbind import CamelCase, JsName
+
+        class Foo(CamelCase):
+            # Read JS property "id" instead of the default "myId".
+            my_id: Annotated[int, JsName("id")]
+
+    For methods, the :func:`js_name` decorator is more convenient.
+    """
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f"JsName({self.name!r})"
+
+
+# Annotation markers that act as per-attribute name translators. Mapping is
+# ``marker -> translator(py_name) -> js_name``. The marker may either be a
+# class (e.g. :class:`CamelCase`) or any object usable as ``Annotated`` metadata.
+_NAME_TRANSLATORS: "dict[Any, Any]" = {
+    CamelCase: snake_to_camel,
+}
+
+
+def js_name(name: str):
+    """Decorator that pins the JS property name for a method.
+
+    The decorated method's Python name will be translated to ``name`` when
+    looking it up on the underlying JS object, regardless of any class-level
+    name translation::
+
+        class Foo(CamelCase):
+            @js_name("doStuff")
+            def do_stuff(self, /): ...
+    """
+
+    def decorator(f):
+        f.__js_name__ = name
+        return f
+
+    return decorator
+
+
+def camel_case(f):
+    """Decorator that opts a single method into ``snake_case`` ->
+    ``camelCase`` JS-name translation, regardless of the class-level
+    configuration::
+
+        class Foo(BindClass):
+            @camel_case
+            def do_stuff(self, /): ...   # calls jsproxy.doStuff()
+    """
+    f.__js_name__ = snake_to_camel(f.__name__)
+    return f
+
+
+def _extract_js_name_override(annotation, py_name):
+    """If ``annotation`` is ``Annotated[T, ...]`` and one of the metadata
+    items is a :class:`JsName` instance or a registered name-translator
+    marker (such as :class:`CamelCase`), return the resulting JS name.
+    Otherwise return ``None``."""
+    if not isinstance(annotation, _AnnotatedAlias):
+        return None
+    for meta in annotation.__metadata__:
+        if isinstance(meta, JsName):
+            return meta.name
+        translator = _NAME_TRANSLATORS.get(meta)
+        if translator is not None:
+            return translator(py_name)
+    return None
+
+
+def _build_name_cache(sig):
+    """Build (and cache) the ``py_name -> js_name`` mapping for ``sig``.
+
+    The cache is computed once per signature class on first attribute access
+    and stored as ``sig._js_name_cache``. It contains an entry for every
+    Python attribute name with an explicit override (via an
+    ``Annotated[..., JsName(...)]`` / ``Annotated[..., CamelCase]``
+    annotation, or an ``@js_name`` / ``@camel_case`` decorator) plus an
+    entry for any name encountered at runtime that falls through to the
+    class-level ``_js_name`` translator.
+    """
+    cache: dict[str, str] = {}
+    # Annotated[..., JsName(...)] / Annotated[..., CamelCase] markers.
+    if not hasattr(sig, "_type_hints"):
+        try:
+            sig._type_hints = get_type_hints(sig, include_extras=True)
+        except Exception:
+            sig._type_hints = {}
+    for py, ann in sig._type_hints.items():
+        explicit = _extract_js_name_override(ann, py)
+        if explicit is not None:
+            cache[py] = explicit
+    # Method decorators (@js_name / @camel_case).
+    for cls in getattr(sig, "__mro__", (sig,)):
+        for py, member in getattr(cls, "__dict__", {}).items():
+            if py in cache:
+                continue
+            explicit = getattr(member, "__js_name__", None)
+            if isinstance(explicit, str):
+                cache[py] = explicit
+    sig._js_name_cache = cache
+    # Eagerly build the reverse map for dir(). This is O(n) but only done
+    # once per sig class.
+    sig._js_name_reverse_cache = {js: py for py, js in cache.items()}
+    return cache
+
+
+def resolve_js_name(sig: type, py_name: str) -> str:
+    """Translate a Python attribute name to its JS property name for ``sig``.
+
+    Used by the C JsProxy machinery. Resolution order:
+
+    1. Explicit override (``JsName`` / ``CamelCase`` annotation,
+       ``@js_name`` / ``@camel_case`` decorator).
+    2. ``sig._js_name(py_name)`` (the class-level translator).
+    3. ``py_name`` unchanged.
+
+    The result is memoized on ``sig._js_name_cache`` so subsequent lookups
+    of the same name don't re-run any translation.
+    """
+    if sig is None:
+        return py_name
+    cache = getattr(sig, "_js_name_cache", None)
+    if cache is None:
+        cache = _build_name_cache(sig)
+    js = cache.get(py_name)
+    if js is not None:
+        return js
+    translator = getattr(sig, "_js_name", None)
+    if translator is None:
+        js = py_name
+    else:
+        js = translator(py_name)
+    # Memoize the fallback result too so subsequent accesses don't pay the
+    # cost of looking up _js_name and calling it again.
+    cache[py_name] = js
+    sig._js_name_reverse_cache.setdefault(js, py_name)
+    return js
+
+
+def reverse_dir_names(sig: type, js_names: list) -> list:
+    """Translate a list of JS property names back to Python attribute names.
+
+    Used by ``dir(jsproxy)`` when a signature is attached. If no inverse
+    translation is available the names are returned unchanged.
+    """
+    if sig is None:
+        return js_names
+    return [reverse_js_name(sig, n) for n in js_names]
+
+
+def reverse_js_name(sig: type, jsname: str) -> str:
+    """Translate a JS property name back to its Python attribute name for ``sig``.
+
+    Used by ``dir()``. The lookup is best-effort: if the inverse cannot be
+    determined, ``jsname`` is returned unchanged.
+    """
+    if sig is None:
+        return jsname
+    if getattr(sig, "_js_name_cache", None) is None:
+        _build_name_cache(sig)
+    rev = sig._js_name_reverse_cache
+    if jsname in rev:
+        return rev[jsname]
+    # Special-case the snake/camel inverse without forcing every BindClass
+    # to provide an inverse function.
+    translator = getattr(sig, "_js_name", None)
+    if translator is snake_to_camel:
+        return camel_to_snake(jsname)
+    return jsname
+
+
+
 
 
 class TypeConverter:
@@ -106,7 +405,15 @@ class TypeConverter:
             arg = x.__args__[0]
             return create_promise_converter(self.js2py_annotation(arg))
         if isinstance(x, _AnnotatedAlias):
-            return x.__metadata__[0]
+            # Skip over name-translation markers; they only configure the JS
+            # property name, not the value conversion.
+            for meta in x.__metadata__:
+                if isinstance(meta, JsName):
+                    continue
+                if meta in _NAME_TRANSLATORS:
+                    continue
+                return meta
+            return None
         return None
 
     def js2py_annotation(self, annotation: Any) -> "Js2PyConverter":
@@ -198,11 +505,15 @@ def get_attr_sig_method(sig, attr):
 def get_attr_sig(sig, attr):
     """Called from JsProxy_GetAttr when the proxy has a signature.
 
-    Must return a pair:
+    Must return a triple:
 
-        (False, sig) -- if the result is a JsProxy bind sig to it
-        (True, converter) -- apply converter to the result
+        (js_name, False, sig) -- if the result is a JsProxy bind sig to it
+        (js_name, True, converter) -- apply converter to the result
+
+    ``js_name`` is the JS property name to look up (after applying any name
+    translation configured on ``sig``).
     """
+    js_name = resolve_js_name(sig, attr)
     # Look up type hints and cache them if we haven't yet. We could use
     # `functools.cache` for this, but it seems to keep `sig` alive for longer
     # than necessary.
@@ -211,10 +522,11 @@ def get_attr_sig(sig, attr):
         sig._type_hints = get_type_hints(sig, include_extras=True)
     # See if there is an attribute type hint
     if prop_sig := sig._type_hints.get(attr, None):
-        return get_attr_sig_prop(prop_sig)
+        got_converter, value = get_attr_sig_prop(prop_sig)
+        return (js_name, got_converter, value)
     if res := get_attr_sig_method(sig, attr):
-        return (False, res)
-    return (False, None)
+        return (js_name, False, res)
+    return (js_name, False, None)
 
 
 no_default = Parameter.empty

--- a/src/py/_pyodide/jsbind.py
+++ b/src/py/_pyodide/jsbind.py
@@ -138,8 +138,6 @@ class CamelCase(BindClass):
             def do_stuff(self, /): ...
     """
 
-    _js_name = staticmethod(snake_to_camel)  # type: ignore[assignment]
-
 
 class JsName:
     """Annotation marker that pins a specific JS property name.
@@ -280,19 +278,16 @@ def _resolve_js_name(sig: type | None, py_name: str) -> str:
     if sig is None:
         return py_name
     cache, reverse = _get_name_cache(sig)
-    js = cache.get(py_name)
-    if js is not None:
-        return js
-    translator = getattr(sig, "_js_name", None)
-    if translator is None:
-        js = py_name
+    js_name = cache.get(py_name)
+    if js_name is not None:
+        return js_name
+    if issubclass(sig, CamelCase):
+        js_name = snake_to_camel(py_name)
     else:
-        js = translator(py_name)
-    # Memoize the fallback result too so subsequent accesses don't pay the
-    # cost of looking up _js_name and calling it again.
-    cache[py_name] = js
-    reverse.setdefault(js, py_name)
-    return js
+        js_name = py_name
+    cache[py_name] = js_name
+    reverse[js_name] = py_name
+    return js_name
 
 
 def _reverse_dir_names(sig: type | None, js_names: list[str]) -> list[str]:
@@ -306,23 +301,20 @@ def _reverse_dir_names(sig: type | None, js_names: list[str]) -> list[str]:
     return [_reverse_js_name(sig, n) for n in js_names]
 
 
-def _reverse_js_name(sig: type | None, jsname: str) -> str:
+def _reverse_js_name(sig: type, js_name: str) -> str:
     """Translate a JS property name back to its Python attribute name for ``sig``.
 
     The lookup is best-effort: if the inverse cannot be determined,
-    ``jsname`` is returned unchanged.
+    ``js_name`` is returned unchanged.
     """
-    if sig is None:
-        return jsname
     _, reverse = _get_name_cache(sig)
-    if jsname in reverse:
-        return reverse[jsname]
-    # Special-case the snake/camel inverse without forcing every BindClass
-    # to provide an inverse function.
-    translator = getattr(sig, "_js_name", None)
-    if translator is snake_to_camel:
-        return camel_to_snake(jsname)
-    return jsname
+    if js_name in reverse:
+        return reverse[js_name]
+    # If it's a CamelCase class, apply camel_to_snake to try to invert
+    # snake_to_camel.
+    if issubclass(sig, CamelCase):
+        return camel_to_snake(js_name)
+    return js_name
 
 
 class _TypeConverter:

--- a/src/py/_pyodide/jsbind.py
+++ b/src/py/_pyodide/jsbind.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Callable
 from inspect import (
     Parameter,
     getattr_static,
@@ -116,9 +117,7 @@ def snake_to_camel(name: str) -> str:
     # Preserve all trailing underscores (used to escape reserved words).
     stripped = name.rstrip("_")
     trailing = name[len(stripped) :]
-    return (
-        _SNAKE_TO_CAMEL_RE.sub(lambda m: m.group(1).upper(), stripped) + trailing
-    )
+    return _SNAKE_TO_CAMEL_RE.sub(lambda m: m.group(1).upper(), stripped) + trailing
 
 
 def camel_to_snake(name: str) -> str:
@@ -196,7 +195,7 @@ class CamelCase(BindClass):
             def do_stuff(self, /): ...
     """
 
-    _js_name = staticmethod(snake_to_camel)
+    _js_name = staticmethod(snake_to_camel)  # type: ignore[assignment]
 
 
 class JsName:
@@ -233,7 +232,7 @@ _NAME_TRANSLATORS: "dict[Any, Any]" = {
 }
 
 
-def js_name(name: str):
+def js_name[F: Callable[..., Any]](name: str) -> Callable[[F], F]:
     """Decorator that pins the JS property name for a method.
 
     The decorated method's Python name will be translated to ``name`` when
@@ -245,14 +244,14 @@ def js_name(name: str):
             def do_stuff(self, /): ...
     """
 
-    def decorator(f):
-        f.__js_name__ = name
+    def decorator(f: F) -> F:
+        f.__js_name__ = name  # type: ignore[attr-defined]
         return f
 
     return decorator
 
 
-def camel_case(f):
+def camel_case[F: Callable[..., Any]](f: F) -> F:
     """Decorator that opts a single method into ``snake_case`` ->
     ``camelCase`` JS-name translation, regardless of the class-level
     configuration::
@@ -261,7 +260,7 @@ def camel_case(f):
             @camel_case
             def do_stuff(self, /): ...   # calls jsproxy.doStuff()
     """
-    f.__js_name__ = snake_to_camel(f.__name__)
+    f.__js_name__ = snake_to_camel(f.__name__)  # type: ignore[attr-defined]
     return f
 
 
@@ -281,25 +280,27 @@ def _extract_js_name_override(annotation, py_name):
     return None
 
 
-def _build_name_cache(sig):
-    """Build (and cache) the ``py_name -> js_name`` mapping for ``sig``.
+def _get_name_cache(sig: type) -> tuple[dict[str, str], dict[str, str]]:
+    """Return the ``(py_to_js, js_to_py)`` name caches for ``sig``, building
+    them lazily on first access.
 
-    The cache is computed once per signature class on first attribute access
-    and stored as ``sig._js_name_cache``. It contains an entry for every
-    Python attribute name with an explicit override (via an
-    ``Annotated[..., JsName(...)]`` / ``Annotated[..., CamelCase]``
-    annotation, or an ``@js_name`` / ``@camel_case`` decorator) plus an
-    entry for any name encountered at runtime that falls through to the
-    class-level ``_js_name`` translator.
+    The forward cache contains an entry for every Python attribute name with
+    an explicit override (via an ``Annotated[..., JsName(...)]`` /
+    ``Annotated[..., CamelCase]`` annotation, or an ``@js_name`` /
+    ``@camel_case`` decorator). After the first call, ``_resolve_js_name``
+    also memoizes results from the class-level ``_js_name`` translator into
+    the same cache.
     """
+    if res := getattr(sig, "_js_name_cache", None):
+        return res
     cache: dict[str, str] = {}
     # Annotated[..., JsName(...)] / Annotated[..., CamelCase] markers.
     if not hasattr(sig, "_type_hints"):
         try:
-            sig._type_hints = get_type_hints(sig, include_extras=True)
+            sig._type_hints = get_type_hints(sig, include_extras=True)  # type: ignore[attr-defined]
         except Exception:
-            sig._type_hints = {}
-    for py, ann in sig._type_hints.items():
+            sig._type_hints = {}  # type: ignore[attr-defined]
+    for py, ann in sig._type_hints.items():  # type: ignore[attr-defined]
         explicit = _extract_js_name_override(ann, py)
         if explicit is not None:
             cache[py] = explicit
@@ -311,31 +312,31 @@ def _build_name_cache(sig):
             explicit = getattr(member, "__js_name__", None)
             if isinstance(explicit, str):
                 cache[py] = explicit
-    sig._js_name_cache = cache
     # Eagerly build the reverse map for dir(). This is O(n) but only done
     # once per sig class.
-    sig._js_name_reverse_cache = {js: py for py, js in cache.items()}
-    return cache
+    reverse: dict[str, str] = {js: py for py, js in cache.items()}
+    res = (cache, reverse)
+    sig._js_name_cache = res  # type: ignore[attr-defined]
+    return res
 
 
-def _resolve_js_name(sig: type, py_name: str) -> str:
+def _resolve_js_name(sig: type | None, py_name: str) -> str:
     """Translate a Python attribute name to its JS property name for ``sig``.
 
-    Used by the C JsProxy machinery. Resolution order:
+    Called from C in ``JsProxy_GetAttr_helper`` and ``JsProxy_SetAttr``
+    (``src/core/jsproxy.c``). Resolution order:
 
     1. Explicit override (``JsName`` / ``CamelCase`` annotation,
        ``@js_name`` / ``@camel_case`` decorator).
     2. ``sig._js_name(py_name)`` (the class-level translator).
     3. ``py_name`` unchanged.
 
-    The result is memoized on ``sig._js_name_cache`` so subsequent lookups
-    of the same name don't re-run any translation.
+    The result is memoized so subsequent lookups of the same name don't
+    re-run any translation.
     """
     if sig is None:
         return py_name
-    cache = getattr(sig, "_js_name_cache", None)
-    if cache is None:
-        cache = _build_name_cache(sig)
+    cache, reverse = _get_name_cache(sig)
     js = cache.get(py_name)
     if js is not None:
         return js
@@ -347,14 +348,14 @@ def _resolve_js_name(sig: type, py_name: str) -> str:
     # Memoize the fallback result too so subsequent accesses don't pay the
     # cost of looking up _js_name and calling it again.
     cache[py_name] = js
-    sig._js_name_reverse_cache.setdefault(js, py_name)
+    reverse.setdefault(js, py_name)
     return js
 
 
-def _reverse_dir_names(sig: type, js_names: list) -> list:
+def _reverse_dir_names(sig: type | None, js_names: list[str]) -> list[str]:
     """Translate a list of JS property names back to Python attribute names.
 
-    Used by ``dir(jsproxy)`` when a signature is attached. If no inverse
+    Called from C in ``JsProxy_Dir`` (``src/core/jsproxy.c``). If no inverse
     translation is available the names are returned unchanged.
     """
     if sig is None:
@@ -362,28 +363,23 @@ def _reverse_dir_names(sig: type, js_names: list) -> list:
     return [_reverse_js_name(sig, n) for n in js_names]
 
 
-def _reverse_js_name(sig: type, jsname: str) -> str:
+def _reverse_js_name(sig: type | None, jsname: str) -> str:
     """Translate a JS property name back to its Python attribute name for ``sig``.
 
-    Used by ``dir()``. The lookup is best-effort: if the inverse cannot be
-    determined, ``jsname`` is returned unchanged.
+    The lookup is best-effort: if the inverse cannot be determined,
+    ``jsname`` is returned unchanged.
     """
     if sig is None:
         return jsname
-    if getattr(sig, "_js_name_cache", None) is None:
-        _build_name_cache(sig)
-    rev = sig._js_name_reverse_cache
-    if jsname in rev:
-        return rev[jsname]
+    _, reverse = _get_name_cache(sig)
+    if jsname in reverse:
+        return reverse[jsname]
     # Special-case the snake/camel inverse without forcing every BindClass
     # to provide an inverse function.
     translator = getattr(sig, "_js_name", None)
     if translator is snake_to_camel:
         return camel_to_snake(jsname)
     return jsname
-
-
-
 
 
 class _TypeConverter:
@@ -503,7 +499,8 @@ def _get_attr_sig_method(sig, attr):
 
 
 def _get_attr_sig(sig, attr):
-    """Called from JsProxy_GetAttr when the proxy has a signature.
+    """Called from C in ``JsProxy_GetAttr_helper`` (``src/core/jsproxy.c``)
+    when the proxy has a signature.
 
     Must return a triple:
 
@@ -533,7 +530,8 @@ no_default = Parameter.empty
 
 
 def _func_to_sig(f):
-    """Called from jsproxy_call.c when we're about to call a callable.
+    """Called from C in ``jsproxy_call.c`` when we're about to call a
+    callable.
 
     Has to return an appropriate JsFuncSignature.
     """

--- a/src/py/_pyodide/jsbind.py
+++ b/src/py/_pyodide/jsbind.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Callable
 from inspect import (
     Parameter,
@@ -30,6 +29,8 @@ from _pyodide_core import (
     py2js_deep,
     py2js_default,
 )
+
+from .camel_to_snake import camel_to_snake, snake_to_camel
 
 
 class Py2JsConverterMeta(type):
@@ -83,64 +84,6 @@ class Deep:
 
 class Default:
     pass
-
-
-_SNAKE_TO_CAMEL_RE = re.compile(r"_([a-zA-Z0-9])")
-_CAMEL_TO_SNAKE_RE1 = re.compile(r"(.)([A-Z][a-z]+)")
-_CAMEL_TO_SNAKE_RE2 = re.compile(r"([a-z0-9])([A-Z])")
-
-
-def snake_to_camel(name: str) -> str:
-    """Convert a snake_case Python attribute name to a camelCase JS name.
-
-    Leading underscores are preserved (so dunder names like ``__call__`` are
-    untouched). A single trailing underscore is also preserved so that the
-    reserved-word transform in ``pre.js`` still works (e.g. ``class_`` -> ``class_``).
-    Internal underscores are removed and the following character is upper-cased.
-
-    >>> snake_to_camel("foo_bar")
-    'fooBar'
-    >>> snake_to_camel("foo_bar_baz")
-    'fooBarBaz'
-    >>> snake_to_camel("already_lowerCase")
-    'alreadyLowerCase'
-    >>> snake_to_camel("__call__")
-    '__call__'
-    >>> snake_to_camel("class_")
-    'class_'
-    """
-    if not name:
-        return name
-    # Preserve leading underscores (dunders, sunders, private names).
-    if name[:2] == "__":
-        return name
-    # Preserve all trailing underscores (used to escape reserved words).
-    stripped = name.rstrip("_")
-    trailing = name[len(stripped) :]
-    return _SNAKE_TO_CAMEL_RE.sub(lambda m: m.group(1).upper(), stripped) + trailing
-
-
-def camel_to_snake(name: str) -> str:
-    """Convert a camelCase JS name to a snake_case Python attribute name.
-
-    Inverse of :func:`snake_to_camel` for typical inputs.
-
-    >>> camel_to_snake("fooBar")
-    'foo_bar'
-    >>> camel_to_snake("XMLHttpRequest")
-    'xml_http_request'
-    >>> camel_to_snake("__call__")
-    '__call__'
-    """
-    if not name:
-        return name
-    if name[:2] == "__":
-        return name
-    stripped = name.rstrip("_")
-    trailing = name[len(stripped) :]
-    s1 = _CAMEL_TO_SNAKE_RE1.sub(r"\1_\2", stripped)
-    s2 = _CAMEL_TO_SNAKE_RE2.sub(r"\1_\2", s1)
-    return s2.lower() + trailing
 
 
 class BindClass:

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -2789,7 +2789,7 @@ async def test_js_proxy_str(selenium):
 
 @run_in_pyodide
 def test_bind_jsfunc_sig(selenium):
-    from _pyodide.jsbind import func_to_sig_inner
+    from _pyodide.jsbind import _func_to_sig_inner
 
     def f(
         a: dict[str, int],
@@ -2798,7 +2798,7 @@ def test_bind_jsfunc_sig(selenium):
         raise NotImplementedError
 
     assert (
-        repr(func_to_sig_inner(f, None))
+        repr(_func_to_sig_inner(f, None))
         == "<JsSignature (a: dict[str, int], /) -> list[int]>"
     )
 

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -2472,7 +2472,7 @@ def test_bind_js_name_setattr(selenium):
     a_px: JsProxy = run_js("({id: 1})")
     a = a_px.bind_sig(A)
     a.identifier = 99
-    assert a_px.id == 99
+    assert a_px.id == 99  # type: ignore[attr-defined]
 
 
 @run_in_pyodide
@@ -2584,9 +2584,7 @@ def test_bind_camel_case_annotation(selenium):
         # No marker: name is *not* translated (would otherwise be otherThing).
         other_thing: int
 
-    a_px: JsProxy = run_js(
-        "({fullName: 'Ada', itemList: [1,2,3], other_thing: 9})"
-    )
+    a_px: JsProxy = run_js("({fullName: 'Ada', itemList: [1,2,3], other_thing: 9})")
     a = a_px.bind_sig(A)
     assert a.full_name == "Ada"
     assert a.item_list == [1, 2, 3]
@@ -2613,7 +2611,7 @@ def test_bind_camel_case_decorator_overrides_class(selenium):
         # Class-level translator: full_name -> FULL_NAME.
         full_name: str
         # CamelCase marker overrides Screaming on this attribute only.
-        item_list: Annotated[list, CamelCase]
+        item_list: Annotated[list[int], CamelCase]
         # JsName overrides everything.
         identifier: Annotated[int, JsName("id")]
 
@@ -2668,7 +2666,7 @@ def test_bind_dir_all_overrides(selenium):
         # Class-level (CamelCase): plain_attr -> plainAttr.
         plain_attr: int
         # Per-attribute CamelCase marker (no double translation).
-        item_list: Annotated[list, CamelCase]
+        item_list: Annotated[list[int], CamelCase]
         # JsName override.
         identifier: Annotated[int, JsName("id")]
 

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -2272,6 +2272,468 @@ def test_bind_getattr(selenium):
 
 
 @run_in_pyodide
+def test_snake_to_camel_helpers(selenium):
+    from _pyodide.jsbind import camel_to_snake, snake_to_camel
+
+    assert snake_to_camel("foo") == "foo"
+    assert snake_to_camel("foo_bar") == "fooBar"
+    assert snake_to_camel("foo_bar_baz") == "fooBarBaz"
+    assert snake_to_camel("a_b_c_d") == "aBCD"
+    # All trailing underscores preserved (reserved-word escape).
+    assert snake_to_camel("class_") == "class_"
+    assert snake_to_camel("from_") == "from_"
+    assert snake_to_camel("foo_bar__") == "fooBar__"
+    assert snake_to_camel("foo___") == "foo___"
+    # Dunders untouched.
+    assert snake_to_camel("__call__") == "__call__"
+    assert snake_to_camel("__init__") == "__init__"
+    # Empty / single-char.
+    assert snake_to_camel("") == ""
+    assert snake_to_camel("x") == "x"
+
+    assert camel_to_snake("foo") == "foo"
+    assert camel_to_snake("fooBar") == "foo_bar"
+    assert camel_to_snake("fooBarBaz") == "foo_bar_baz"
+    assert camel_to_snake("XMLHttpRequest") == "xml_http_request"
+    assert camel_to_snake("__call__") == "__call__"
+    assert camel_to_snake("class_") == "class_"
+    assert camel_to_snake("fooBar__") == "foo_bar__"
+    assert camel_to_snake("foo___") == "foo___"
+
+
+@run_in_pyodide
+def test_bind_camelcase(selenium):
+    from typing import Annotated
+
+    from _pyodide.jsbind import CamelCase, Deep
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        first_name: str
+        last_name: str
+        item_list: Annotated[list[int], Deep]
+
+        def get_full_name(self, /) -> str:
+            return ""
+
+        def add_item(self, x: int, /) -> None:
+            pass
+
+    a_px: JsProxy = run_js(
+        """
+        ({
+            firstName: "Ada",
+            lastName: "Lovelace",
+            itemList: [1, 2, 3],
+            getFullName() { return this.firstName + " " + this.lastName; },
+            addItem(x) { this.itemList.push(x); },
+        })
+        """
+    )
+    a = a_px.bind_sig(A)
+    # Attribute lookup translates snake_case -> camelCase.
+    assert a.first_name == "Ada"
+    assert a.last_name == "Lovelace"
+    assert a.item_list == [1, 2, 3]
+    # Method calls translate too.
+    assert a.get_full_name() == "Ada Lovelace"
+    a.add_item(4)
+    assert a.item_list == [1, 2, 3, 4]
+    # setattr translates too.
+    a.first_name = "Grace"
+    assert a.get_full_name() == "Grace Lovelace"
+
+
+@run_in_pyodide
+def test_bind_camelcase_class(selenium):
+    from typing import Annotated
+
+    from _pyodide.jsbind import CamelCase, Deep
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        first_name: str
+
+        def __init__(self, name: str, /): ...
+
+        def upper_name(self, /) -> str:
+            return ""
+
+        def get_items(self, /) -> Annotated[list[int], Deep]:
+            return []
+
+    A_px: JsProxy = run_js(
+        """
+        (class {
+            constructor(name) { this.firstName = name; }
+            upperName() { return this.firstName.toUpperCase(); }
+            getItems() { return [1, 2, 3]; }
+        })
+        """
+    )
+    Bound = A_px.bind_class(A)
+    a = Bound("ada")
+    assert a.first_name == "ada"
+    assert a.upper_name() == "ADA"
+    assert a.get_items() == [1, 2, 3]
+
+
+@run_in_pyodide
+def test_bind_custom_name_translation(selenium):
+    """A user-supplied ``_js_name`` function should be honored."""
+    from _pyodide.jsbind import BindClass
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class ScreamingSnake(BindClass):
+        @staticmethod
+        def _js_name(name: str) -> str:
+            return name.upper()
+
+    class A(ScreamingSnake):
+        my_attr: int
+
+        def my_method(self, /) -> int:
+            return 0
+
+    a_px: JsProxy = run_js("({MY_ATTR: 7, MY_METHOD() { return 42; }})")
+    a = a_px.bind_sig(A)
+    assert a.my_attr == 7
+    assert a.my_method() == 42
+
+
+@run_in_pyodide
+def test_bind_js_name_decorator(selenium):
+    """``@js_name`` pins the JS property name for a method."""
+    from _pyodide.jsbind import CamelCase, js_name
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        @js_name("doStuff")
+        def perform(self, /) -> int:
+            return 0
+
+        # No decorator: still uses the camelCase translation.
+        def get_value(self, /) -> int:
+            return 0
+
+    a_px: JsProxy = run_js(
+        """
+        ({
+            doStuff() { return 7; },
+            getValue() { return 42; },
+        })
+        """
+    )
+    a = a_px.bind_sig(A)
+    assert a.perform() == 7
+    assert a.get_value() == 42
+
+
+@run_in_pyodide
+def test_bind_js_name_annotation(selenium):
+    """``Annotated[T, JsName(...)]`` pins the JS property name for an attribute."""
+    from typing import Annotated
+
+    from _pyodide.jsbind import CamelCase, Deep, JsName
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        # JsName overrides the camelCase default.
+        identifier: Annotated[int, JsName("id")]
+        # Combine JsName with another marker.
+        items: Annotated[list[int], Deep, JsName("xs")]
+        # No JsName: still translated to "fullName".
+        full_name: str
+
+    a_px: JsProxy = run_js("({id: 7, xs: [1,2,3], fullName: 'Ada'})")
+    a = a_px.bind_sig(A)
+    assert a.identifier == 7
+    assert a.items == [1, 2, 3]
+    assert a.full_name == "Ada"
+
+
+@run_in_pyodide
+def test_bind_js_name_setattr(selenium):
+    """``@js_name`` and ``JsName`` are also honored by setattr."""
+    from typing import Annotated
+
+    from _pyodide.jsbind import CamelCase, JsName
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        identifier: Annotated[int, JsName("id")]
+
+    a_px: JsProxy = run_js("({id: 1})")
+    a = a_px.bind_sig(A)
+    a.identifier = 99
+    assert a_px.id == 99
+
+
+@run_in_pyodide
+def test_bind_js_name_dir(selenium):
+    """``dir()`` reverse-translates explicit JsName overrides."""
+    from typing import Annotated
+
+    from _pyodide.jsbind import CamelCase, JsName, js_name
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        identifier: Annotated[int, JsName("id")]
+
+        @js_name("doStuff")
+        def perform(self, /) -> int:
+            return 0
+
+    a_px: JsProxy = run_js("({id: 1, doStuff() {}, fullName: 'x'})")
+    a = a_px.bind_sig(A)
+    names = dir(a)
+    # Explicit overrides come back as their Python names.
+    assert "identifier" in names
+    assert "perform" in names
+    # Non-overridden camelCase still gets translated.
+    assert "full_name" in names
+
+
+@run_in_pyodide
+def test_bind_camelcase_reserved_word_escape(selenium):
+    """Trailing-underscore escaping for reserved JS words must compose with
+    snake_to_camel translation. JS properties named ``from``, ``from_`` and
+    ``from__`` should be accessible from Python as ``from_``, ``from__`` and
+    ``from___`` respectively, since one trailing underscore is consumed by
+    the reserved-word transform in pre.js."""
+    from _pyodide.jsbind import CamelCase
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        def from_(self, /) -> int:
+            return 0
+
+        def from__(self, /) -> int:
+            return 0
+
+        def from___(self, /) -> int:
+            return 0
+
+    a_px: JsProxy = run_js(
+        """
+        ({
+            from() { return 1; },
+            from_() { return 2; },
+            from__() { return 3; },
+        })
+        """
+    )
+    a = a_px.bind_sig(A)
+    assert a.from_() == 1
+    assert a.from__() == 2
+    assert a.from___() == 3
+
+
+@run_in_pyodide
+def test_bind_camel_case_decorator(selenium):
+    """``@camel_case`` opts a single method on a non-CamelCase class into
+    snake -> camel translation."""
+    from _pyodide.jsbind import BindClass, camel_case
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(BindClass):
+        @camel_case
+        def do_stuff(self, /) -> int:
+            return 0
+
+        # No decorator: name is *not* translated (would otherwise be otherThing).
+        def other_thing(self, /) -> int:
+            return 0
+
+    a_px: JsProxy = run_js(
+        """
+        ({
+            doStuff() { return 7; },
+            other_thing() { return 42; },
+        })
+        """
+    )
+    a = a_px.bind_sig(A)
+    assert a.do_stuff() == 7
+    assert a.other_thing() == 42
+
+
+@run_in_pyodide
+def test_bind_camel_case_annotation(selenium):
+    """``Annotated[T, CamelCase]`` opts a single attribute into camelCase."""
+    from typing import Annotated
+
+    from _pyodide.jsbind import BindClass, CamelCase, Deep
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(BindClass):
+        # CamelCase as a per-attribute marker.
+        full_name: Annotated[str, CamelCase]
+        # Combined with another marker on the same attribute.
+        item_list: Annotated[list[int], Deep, CamelCase]
+        # No marker: name is *not* translated (would otherwise be otherThing).
+        other_thing: int
+
+    a_px: JsProxy = run_js(
+        "({fullName: 'Ada', itemList: [1,2,3], other_thing: 9})"
+    )
+    a = a_px.bind_sig(A)
+    assert a.full_name == "Ada"
+    assert a.item_list == [1, 2, 3]
+    assert a.other_thing == 9
+
+
+@run_in_pyodide
+def test_bind_camel_case_decorator_overrides_class(selenium):
+    """``@camel_case`` and ``Annotated[..., CamelCase]`` override the
+    class-level translator. The class here uses SCREAMING_CASE so it is
+    obvious which names are produced by which translator."""
+    from typing import Annotated
+
+    from _pyodide.jsbind import BindClass, CamelCase, JsName, camel_case, js_name
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class Screaming(BindClass):
+        @staticmethod
+        def _js_name(name: str) -> str:
+            return name.upper()
+
+    class A(Screaming):
+        # Class-level translator: full_name -> FULL_NAME.
+        full_name: str
+        # CamelCase marker overrides Screaming on this attribute only.
+        item_list: Annotated[list, CamelCase]
+        # JsName overrides everything.
+        identifier: Annotated[int, JsName("id")]
+
+        # Class-level translator: do_thing -> DO_THING.
+        def do_thing(self, /) -> int:
+            return 0
+
+        # @camel_case overrides Screaming for this method only.
+        @camel_case
+        def do_stuff(self, /) -> int:
+            return 0
+
+        # @js_name overrides everything.
+        @js_name("perform")
+        def execute(self, /) -> int:
+            return 0
+
+    a_px: JsProxy = run_js(
+        """
+        ({
+            FULL_NAME: 'Ada',
+            itemList: [1, 2, 3],
+            id: 7,
+            DO_THING() { return 0; },
+            doStuff() { return 1; },
+            perform() { return 2; },
+        })
+        """
+    )
+    a = a_px.bind_sig(A)
+    assert a.full_name == "Ada"
+    assert list(a.item_list) == [1, 2, 3]
+    assert a.identifier == 7
+    assert a.do_thing() == 0
+    assert a.do_stuff() == 1
+    assert a.execute() == 2
+
+
+@run_in_pyodide
+def test_bind_dir_all_overrides(selenium):
+    """``dir()`` reverse-translates names from every per-member override
+    mechanism (``@camel_case``, ``Annotated[..., CamelCase]``,
+    ``Annotated[..., JsName(...)]``, ``@js_name``) plus the class-level
+    snake_case <-> camelCase translation provided by :class:`CamelCase`."""
+    from typing import Annotated
+
+    from _pyodide.jsbind import CamelCase, JsName, camel_case, js_name
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        # Class-level (CamelCase): plain_attr -> plainAttr.
+        plain_attr: int
+        # Per-attribute CamelCase marker (no double translation).
+        item_list: Annotated[list, CamelCase]
+        # JsName override.
+        identifier: Annotated[int, JsName("id")]
+
+        # Class-level (CamelCase): plain_method -> plainMethod.
+        def plain_method(self, /) -> int:
+            return 0
+
+        # @camel_case opts an individual method in (no double translation).
+        @camel_case
+        def do_stuff(self, /) -> int:
+            return 0
+
+        # @js_name override.
+        @js_name("perform")
+        def execute(self, /) -> int:
+            return 0
+
+    a_px: JsProxy = run_js(
+        """
+        ({
+            plainAttr: 1,
+            itemList: [1, 2, 3],
+            id: 7,
+            plainMethod() { return 0; },
+            doStuff() { return 1; },
+            perform() { return 2; },
+        })
+        """
+    )
+    a = a_px.bind_sig(A)
+    names = set(dir(a))
+    # Every Python-side name should appear in dir().
+    assert "plain_attr" in names
+    assert "item_list" in names
+    assert "identifier" in names
+    assert "plain_method" in names
+    assert "do_stuff" in names
+    assert "execute" in names
+    # The raw JS-side names should not (they are reverse-translated).
+    assert "plainAttr" not in names
+    assert "itemList" not in names
+    assert "id" not in names
+    assert "plainMethod" not in names
+    assert "doStuff" not in names
+    assert "perform" not in names
+
+
+@run_in_pyodide
+def test_bind_camelcase_dir(selenium):
+    """``dir(jsproxy)`` should reverse-translate camelCase JS names."""
+    from _pyodide.jsbind import CamelCase
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    class A(CamelCase):
+        first_name: str
+
+    a_px: JsProxy = run_js("({firstName: 'Ada', lastName: 'Lovelace'})")
+    a = a_px.bind_sig(A)
+    names = dir(a)
+    assert "first_name" in names
+    assert "last_name" in names
+
+
+@run_in_pyodide
 def test_to_js_no_leak(selenium):
     from js import Object
     from pyodide.ffi import to_js

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -15,6 +15,8 @@ from pytest_pyodide.hypothesis import (
     std_hypothesis_settings,
 )
 
+from _pyodide.camel_to_snake import camel_to_snake, snake_to_camel
+
 
 class NoHypothesisUnpickler(pickle.Unpickler):
     def find_class(self, module, name):
@@ -2271,10 +2273,7 @@ def test_bind_getattr(selenium):
     assert t.g({"a": 7}, {"b": 9}, {"c": 11}) == [1, 2, 3]
 
 
-@run_in_pyodide
-def test_snake_to_camel_helpers(selenium):
-    from _pyodide.jsbind import camel_to_snake, snake_to_camel
-
+def test_snake_to_camel_helpers():
     assert snake_to_camel("foo") == "foo"
     assert snake_to_camel("foo_bar") == "fooBar"
     assert snake_to_camel("foo_bar_baz") == "fooBarBaz"
@@ -2294,11 +2293,104 @@ def test_snake_to_camel_helpers(selenium):
     assert camel_to_snake("foo") == "foo"
     assert camel_to_snake("fooBar") == "foo_bar"
     assert camel_to_snake("fooBarBaz") == "foo_bar_baz"
-    assert camel_to_snake("XMLHttpRequest") == "xml_http_request"
+    assert camel_to_snake("XMLHttpRequest") == "XMLHttpRequest"
     assert camel_to_snake("__call__") == "__call__"
     assert camel_to_snake("class_") == "class_"
     assert camel_to_snake("fooBar__") == "foo_bar__"
     assert camel_to_snake("foo___") == "foo___"
+
+
+# Conditions:
+# 1. An identifier
+# 2. no two uppercase characters in a row
+# 3. underscore not followed by lower case letter
+#
+# Restriction 3. results from the decision to convert blahXML to blah_xml instead of blah_x_m_l.
+# blah_xml round trips back to blahXml.
+#
+# Restruction 4 results from a_a ==> a_a ==> aA
+@st.composite
+def _okay_identifiers(draw):
+    # First character: letter, or underscore
+    first = draw(
+        st.sampled_from("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_")
+    )
+    chars = [first]
+    n = draw(st.integers(min_value=0, max_value=20))
+    for _ in range(n):
+        prev = chars[-1]
+        # After uppercase letter, the next char cannot be uppercase.
+        if prev.isupper():
+            c = draw(st.sampled_from("abcdefghijklmnopqrstuvwxyz0123456789_"))
+        # After "_", the next char cannot be lowercase.
+        elif prev == "_":
+            c = draw(st.sampled_from("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"))
+        else:
+            c = draw(
+                st.sampled_from(
+                    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+                )
+            )
+        chars.append(c)
+    return "".join(chars)
+
+
+@given(s=_okay_identifiers())
+@example(s="a_A")
+@settings(deadline=10000)
+def test_camel_to_snake_to_camel_roundtrip1(s):
+    print("s", s, "camel_to_snake", camel_to_snake(s))
+    assert snake_to_camel(camel_to_snake(s)) == s
+
+
+def test_camel_to_snake_acronym():
+    sn = camel_to_snake("blahXML")
+    assert sn == "blah_xml"
+    roundtrip = snake_to_camel(sn)
+    assert roundtrip == "blahXml"
+
+
+@given(s=st.from_regex(r"[A-Za-z0-9_]*", fullmatch=True))
+def test_camel_to_snake_idempotent(s):
+    once = camel_to_snake(s)
+    assert camel_to_snake(once) == once
+
+
+# First alpha character is uppercase ==> No change for camel_to_snake ==> roundtrips
+@given(s=st.from_regex(r"_*[A-Z][A-Za-z0-9_]*", fullmatch=True))
+@settings(deadline=10000)
+def test_camel_to_snake_to_camel_roundtrip2(s):
+    assert snake_to_camel(camel_to_snake(s)) == s
+
+
+# Conditions:
+# 1. An identifier
+# 2. All lower case
+# 3. At least two non-underscore characters between any two underscores
+@given(s=st.from_regex(r"_?[a-z0-9]+(?:_[a-z0-9]{2,})*_?", fullmatch=True))
+@example(s="_a")
+@example(s="_A")
+def test_snake_to_camel_to_snake_roundtrip1(s):
+    print("s", s, "snake_to_camel", snake_to_camel(s))
+    assert camel_to_snake(snake_to_camel(s)) == s
+
+
+@given(s=st.from_regex(r"_*[A-Z][A-Za-z0-9_]*", fullmatch=True))
+def test_snake_to_camel_to_snake_roundtrip2(s):
+    print("s", s, "snake_to_camel", snake_to_camel(s))
+    assert camel_to_snake(snake_to_camel(s)) == s
+
+
+def test_snake_to_camel_acronym():
+    s = snake_to_camel("a_b_c_d_e")
+    assert s == "aBCDE"
+    assert camel_to_snake(s) == "a_bcde"
+
+
+@given(s=st.from_regex(r"[A-Za-z0-9_]*", fullmatch=True))
+def test_snake_to_camel_idempotent(s):
+    once = snake_to_camel(s)
+    assert snake_to_camel(once) == once
 
 
 @run_in_pyodide


### PR DESCRIPTION
So that we can access things via a different name in Python from the JS name.