### PR TITLE
Potential fix for code scanning alert no. 139: Use of insecure SSL/TLS version

### DIFF
--- a/src/tests/test_python_socket.py
+++ b/src/tests/test_python_socket.py
@@ -1049,6 +1049,7 @@ def test_tls_starttls_send_recv(selenium_nodesock, self_signed_cert):
         s.connect((host, port))
 
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)  # type: ignore[attr-defined]
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         ctx.check_hostname = False
 
         ss = ctx.wrap_socket(s, server_hostname="localhost")

--- a/src/tests/test_python_socket.py
+++ b/src/tests/test_python_socket.py
@@ -1049,7 +1049,7 @@ def test_tls_starttls_send_recv(selenium_nodesock, self_signed_cert):
         s.connect((host, port))
 
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)  # type: ignore[attr-defined]
-        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2  # type: ignore[attr-defined]
         ctx.check_hostname = False
 
         ss = ctx.wrap_socket(s, server_hostname="localhost")


### PR DESCRIPTION
Potential fix for [https://github.com/pyodide/pyodide/security/code-scanning/139](https://github.com/pyodide/pyodide/security/code-scanning/139)

Use an explicit TLS floor on the client context so only TLS 1.2+ is negotiated. The best fix is to keep `ssl.PROTOCOL_TLS_CLIENT` (preserves client defaults/behavior) and set:

- `ctx.minimum_version = ssl.TLSVersion.TLSv1_2`

This directly addresses both alert variants (TLSv1 and TLSv1_1 allowed).  
Edit only `src/tests/test_python_socket.py` in the `run` function inside `test_tls_starttls_send_recv`, immediately after creating `ctx`.

No new imports or dependencies are required, since `ssl` is already imported in that scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
