### PR TITLE
Compile `compression.zstd` as added in CPython 3.14

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -180,6 +180,7 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-lffi \
 	-llzma \
 	-lsqlite3 \
+	-lzstd \
 	-lstdc++ \
 	-lidbfs.js \
 	-lnodefs.js \
@@ -300,6 +301,7 @@ ifeq ($(DISABLE_DYLINK), 1)
 		-lhiwire \
 		-llzma \
 		-lsqlite3 \
+		-lzstd \
 		-lidbfs.js \
 		-lnodefs.js \
 		-lproxyfs.js

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -186,8 +186,8 @@ $(PYINSTALL)/lib/libzstd.a:
 		&& . $(PYODIDE_ROOT)/pyodide_env.sh \
 		&& emcmake cmake build/cmake \
 			-B build-wasm \
-			-DCMAKE_BUILD_TYPE=Release \
-			-DCMAKE_C_FLAGS="-fPIC -Os" \
+			-DCMAKE_BUILD_TYPE=MinSizeRel \
+			-DCMAKE_C_FLAGS="-fPIC" \
 			-DZSTD_BUILD_SHARED=OFF \
 			-DZSTD_BUILD_STATIC=ON \
 			-DZSTD_BUILD_PROGRAMS=OFF \

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -194,6 +194,7 @@ $(PYINSTALL)/lib/libzstd.a:
 			-DZSTD_BUILD_TESTS=OFF \
 			-DZSTD_BUILD_CONTRIB=OFF \
 			-DZSTD_MULTITHREAD_SUPPORT=OFF \
+			-DZSTD_LEGACY_SUPPORT=OFF \
 			-DCMAKE_INSTALL_PREFIX=$(ZSTDBUILD)/dist \
 		&& emmake make -C build-wasm \
 		&& emmake make -C build-wasm install \

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -193,6 +193,7 @@ $(PYINSTALL)/lib/libzstd.a:
 			-DZSTD_BUILD_PROGRAMS=OFF \
 			-DZSTD_BUILD_TESTS=OFF \
 			-DZSTD_BUILD_CONTRIB=OFF \
+			-DZSTD_MULTITHREAD_SUPPORT=OFF \
 			-DCMAKE_INSTALL_PREFIX=$(ZSTDBUILD)/dist \
 		&& emmake make -C build-wasm \
 		&& emmake make -C build-wasm install \

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -21,6 +21,9 @@ HIWIRE_COMMIT=6a1e67280a15d929ebeceee54a6358c9c8d5f697
 LZMABUILD=$(ROOT)/build/lzma
 LZMATARBALL=https://github.com/xz-mirror/xz/releases/download/v5.2.2/xz-5.2.2.tar.gz
 
+ZSTDBUILD=$(ROOT)/build/zstd
+ZSTDTARBALL=https://github.com/python/cpython-source-deps/archive/refs/tags/zstd-1.5.7.tar.gz
+
 # Not mandatory, but try to match the version of SQLite used in Emscripten
 # https://github.com/emscripten-core/emscripten/blob/4.0.9/tools/ports/sqlite3.py
 SQLITE3BUILD=$(ROOT)/build/sqlite3
@@ -30,13 +33,15 @@ ifdef CPYTHON_DEBUG
 	MAYBE_WITH_PYDEBUG=--with-pydebug
 endif
 
-all: $(PYINSTALL)/lib/$(PYLIB) libffi libhiwire liblzma
+all: $(PYINSTALL)/lib/$(PYLIB) libffi libhiwire liblzma libzstd
 
 libffi: $(PYINSTALL)/lib/libffi.a
 
 libhiwire: $(PYINSTALL)/lib/libhiwire.a
 
 liblzma: $(PYINSTALL)/lib/liblzma.a
+
+libzstd: $(PYINSTALL)/lib/libzstd.a
 
 libsqlite3: $(PYINSTALL)/lib/libsqlite3.a
 
@@ -171,6 +176,33 @@ $(PYINSTALL)/lib/liblzma.a :
 	mkdir -p $(PYINSTALL)/include/lzma
 	cp -r $(LZMABUILD)/dist/include/* $(PYINSTALL)/include/lzma
 
+$(PYINSTALL)/lib/libzstd.a:
+	rm -rf $(ZSTDBUILD)
+	mkdir $(ZSTDBUILD)
+	(\
+		cd $(ZSTDBUILD) \
+		&& wget -q -O - $(ZSTDTARBALL) | tar -xz --strip-components=1 \
+		&& . $(PYODIDE_ROOT)/emsdk/emsdk/emsdk_env.sh \
+		&& . $(PYODIDE_ROOT)/pyodide_env.sh \
+		&& emcmake cmake build/cmake \
+			-B build-wasm \
+			-DCMAKE_BUILD_TYPE=Release \
+			-DCMAKE_C_FLAGS="-fPIC -Os" \
+			-DZSTD_BUILD_SHARED=OFF \
+			-DZSTD_BUILD_STATIC=ON \
+			-DZSTD_BUILD_PROGRAMS=OFF \
+			-DZSTD_BUILD_TESTS=OFF \
+			-DZSTD_BUILD_CONTRIB=OFF \
+			-DCMAKE_INSTALL_PREFIX=$(ZSTDBUILD)/dist \
+		&& emmake make -C build-wasm \
+		&& emmake make -C build-wasm install \
+	)
+	mkdir -p $(PYINSTALL)/lib
+	rm -rf $(PYINSTALL)/include/zstd
+	mkdir -p $(PYINSTALL)/include/zstd
+	cp $(ZSTDBUILD)/dist/lib/libzstd.a $(PYINSTALL)/lib/
+	cp -r $(ZSTDBUILD)/dist/include/* $(PYINSTALL)/include/zstd/
+
 $(PYINSTALL)/lib/libsqlite3.a:
 	rm -rf $(SQLITE3BUILD)
 	mkdir $(SQLITE3BUILD)
@@ -239,7 +271,7 @@ $(PYBUILD)/Makefile: $(PYBUILD)/.patched
 $(PYBUILD)/Modules/Setup.local: Setup.local
 	cp Setup.local $(PYBUILD)/Modules/
 
-$(PYBUILD)/$(PYLIB): $(PYBUILD)/Makefile $(PYBUILD)/pyconfig.h $(PYBUILD)/Modules/Setup.local $(PYINSTALL)/lib/libffi.a $(PYINSTALL)/lib/liblzma.a $(PYINSTALL)/lib/libsqlite3.a
+$(PYBUILD)/$(PYLIB): $(PYBUILD)/Makefile $(PYBUILD)/pyconfig.h $(PYBUILD)/Modules/Setup.local $(PYINSTALL)/lib/libffi.a $(PYINSTALL)/lib/liblzma.a $(PYINSTALL)/lib/libsqlite3.a $(PYINSTALL)/lib/libzstd.a
 	cp Setup.local $(PYBUILD)/Modules/
 	( \
 		cd $(PYBUILD); \

--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -17,6 +17,7 @@ zlib zlibmodule.c
 _hmac hmacmodule.c _hacl/Hacl_Hash_MD5.c _hacl/Hacl_Hash_SHA1.c _hacl/Hacl_Hash_SHA2.c _hacl/Hacl_Hash_SHA3.c _hacl/Hacl_Hash_Blake2b.c _hacl/Hacl_Hash_Blake2s.c _hacl/Hacl_HMAC.c _hacl/Hacl_Streaming_HMAC.c _hacl/Lib_Memzero0.c -I$(srcdir)/Modules/_hacl -I$(srcdir)/Modules/_hacl/include -I$(srcdir)/Modules/_hacl/internal
 _sqlite3 _sqlite/blob.c _sqlite/connection.c _sqlite/cursor.c _sqlite/microprotocols.c _sqlite/module.c _sqlite/prepare_protocol.c _sqlite/row.c _sqlite/statement.c _sqlite/util.c -lsqlite3
 _lzma _lzmamodule.c -I../lzma/dist/include -L../lzma/dist/lib -llzma
+_zstd _zstd/_zstdmodule.c _zstd/compressor.c _zstd/decompressor.c _zstd/zstddict.c -I../zstd/dist/include -L../zstd/dist/lib -lzstd
 
 *disabled*
 pwd

--- a/docs/development/maintainers.md
+++ b/docs/development/maintainers.md
@@ -357,7 +357,12 @@ The desired version of CPython must be available at:
 
    (TODO: make this list shorter.)
 
-5. Rebase the patches:
+5. Check [python/cpython-source-deps](https://github.com/python/cpython-source-deps) for
+   updated versions of bundled C libraries. Pyodide bundles `zstd` from this repository
+   (see `ZSTDTARBALL` in `cpython/Makefile`). Update the tag and URL if a newer version
+   is available, and verify the build still works.
+
+6. Rebase the patches:
 
    - Clone CPython and cd into it. Checkout the Python version you are upgrading
      from. For instance, if the old version is 3.13.2, use `git checkout v3.13.2`
@@ -388,11 +393,11 @@ The desired version of CPython must be available at:
      git format-patch v3.14.1 -o ~/path/to/pyodide/cpython/patches/
      ```
 
-6. Try to build Python with `make -C cpython`. Fix any build errors. If you
+7. Try to build Python with `make -C cpython`. Fix any build errors. If you
    modify the Python source in-tree after a failed build, it may be useful to
    run `make rebuild`.
 
-7. Try to finish the build with a top-level `make`. Fix compile errors in
+8. Try to finish the build with a top-level `make`. Fix compile errors in
    `src/core` and any link errors. It may be useful to apply
    [`upgrade_pythoncapi.py --no-compat`](https://github.com/python/pythoncapi-compat/blob/main/upgrade_pythoncapi.py)
    to the C extension in `src/core`.
@@ -402,7 +407,7 @@ The desired version of CPython must be available at:
    [greenlet TPythonState.cpp](https://github.com/python-greenlet/greenlet/blob/master/src/greenlet/TPythonState.cpp)
    to figure out how to fix it.
 
-8. Run:
+9. Run:
 
    ```sh
    python tools/make_test_list.py
@@ -412,15 +417,15 @@ The desired version of CPython must be available at:
    either fix the failures or update `src/tests/python_tests.yaml` to skip or
    xfail them.
 
-9. Try to build packages with:
+10. Try to build packages with:
 
-   ```sh
-   pyodide build-recipes '*'
-   ```
+    ```sh
+    pyodide build-recipes '*'
+    ```
 
-10. Fix failing package tests.
+11. Fix failing package tests.
 
-11. Update standard library stubs in `src/templates`. We currently have
+12. Update standard library stubs in `src/templates`. We currently have
     `webbrowser.py` and `ssl.py` that we implement ourselves. If you are
     updating the Python version, you may need to update these stubs. Review the
     Python docs for the standard library modules and check if the APIs have

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -46,6 +46,10 @@ myst:
   `loadPackage("pydoc_data")` to use. The `fullstdlib` option in loadPyodide is deprecated and a no-op.
   {pr}`6151`
 
+- {{ Feature }} The `compression.zstd` module (new in CPython 3.14) is now bundled in
+  Pyodide, providing native zstd compression and decompression support via `_zstd`.
+  {pr}`6240`
+
 - {{ Enhancement }} A JavaScript object is now treated as an array-like object
   if it has a `length` property and is iterable. Every JsProxy of an array-like
   object now implements subscripting.

--- a/src/tests/python_tests.yaml
+++ b/src/tests/python_tests.yaml
@@ -988,4 +988,6 @@
 - test_zlib
 - test_zoneinfo.test_zoneinfo
 - test_zoneinfo.test_zoneinfo_property
-- test_zstd
+- test_zstd:
+    skip:
+    - FreeThreadingMethodTests


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

xref #6233, #6033, #5995. This PR adds [the `compression.zstd` module](https://docs.python.org/3/library/compression.zstd.html) which is now available in Python 3.14, but we weren't including it. 

I caught this while working on https://github.com/zarr-developers/numcodecs/pull/529 locally as part of a dependency that used the module, but I couldn't import it.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
