### PR TITLE
Correctly report stdlib module tests as skipped instead of passed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,6 +167,8 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -r requirements.txt
+          # workaround: virtualenv 21.3.3 is breaking the Python activation TODO see what changed
+          pip install "virtualenv<21.3.3"
 
       - name: Build emsdk
         shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,26 +152,19 @@ jobs:
           which go
 
       - name: Install dependencies (ubuntu)
-        shell: bash -l {0}
         if: ${{ contains(runner.os, 'ubuntu') }}
         run: |
           sudo apt install -y build-essential git xxd
 
       - name: Install dependencies (macos)
-        shell: bash -l {0}
         if: ${{ contains(runner.os, 'macos') }}
         run: |
           brew install coreutils
 
       - name: Install dependencies (Python)
-        shell: bash -l {0}
-        run: |
-          pip install -r requirements.txt
-          # workaround: virtualenv 21.3.3 is breaking the Python activation TODO see what changed
-          pip install "virtualenv<21.3.3"
+        run: pip install -r requirements.txt
 
       - name: Build emsdk
-        shell: bash -l {0}
         run: |
           which ccache
 
@@ -180,7 +173,6 @@ jobs:
           ccache -s
 
       - name: Build Cpython
-        shell: bash -l {0}
         run: |
           # This is necessary to use the ccache from emsdk
           source pyodide_env.sh
@@ -192,7 +184,6 @@ jobs:
           ccache -s
 
       - name: build Pyodide with packages ${{ matrix.pyodide_packages }}
-        shell: bash -l {0}
         env:
           PYODIDE_PACKAGES: ${{ matrix.pyodide_packages }}
           PYODIDE_JOBS: ${{ env.PYODIDE_JOBS }}
@@ -204,12 +195,10 @@ jobs:
           ccache -s
 
       - name: Build windows python.exe
-        shell: bash -l {0}
         run: |
           make dist/python.exe
 
       - name: check-size
-        shell: bash -l {0}
         run: |
           ls -lh dist/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.21'
+          go-version: "1.21"
 
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
@@ -152,19 +152,26 @@ jobs:
           which go
 
       - name: Install dependencies (ubuntu)
+        shell: bash -l {0}
         if: ${{ contains(runner.os, 'ubuntu') }}
         run: |
           sudo apt install -y build-essential git xxd
 
       - name: Install dependencies (macos)
+        shell: bash -l {0}
         if: ${{ contains(runner.os, 'macos') }}
         run: |
           brew install coreutils
 
       - name: Install dependencies (Python)
-        run: pip install -r requirements.txt
+        shell: bash -l {0}
+        run: |
+          echo "virtualenv<21.3.3" > /tmp/pyodide-pip-constraints.txt
+          echo "PIP_CONSTRAINT=/tmp/pyodide-pip-constraints.txt" >> "$GITHUB_ENV"
+          pip install -r requirements.txt
 
       - name: Build emsdk
+        shell: bash -l {0}
         run: |
           which ccache
 
@@ -173,6 +180,7 @@ jobs:
           ccache -s
 
       - name: Build Cpython
+        shell: bash -l {0}
         run: |
           # This is necessary to use the ccache from emsdk
           source pyodide_env.sh
@@ -184,6 +192,7 @@ jobs:
           ccache -s
 
       - name: build Pyodide with packages ${{ matrix.pyodide_packages }}
+        shell: bash -l {0}
         env:
           PYODIDE_PACKAGES: ${{ matrix.pyodide_packages }}
           PYODIDE_JOBS: ${{ env.PYODIDE_JOBS }}
@@ -195,10 +204,12 @@ jobs:
           ccache -s
 
       - name: Build windows python.exe
+        shell: bash -l {0}
         run: |
           make dist/python.exe
 
       - name: check-size
+        shell: bash -l {0}
         run: |
           ls -lh dist/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,9 +166,7 @@ jobs:
       - name: Install dependencies (Python)
         shell: bash -l {0}
         run: |
-          echo "virtualenv<21.3.3" > /tmp/pyodide-pip-constraints.txt
-          echo "PIP_CONSTRAINT=/tmp/pyodide-pip-constraints.txt" >> "$GITHUB_ENV"
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
 
       - name: Build emsdk
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.14
+  - pip
   - nodejs>=18,<22.5 # Node.js 22.5 has some issues with installing packages https://github.com/nodejs/node/issues/53902
   - ccache
   - f2c

--- a/src/tests/test_core_python.py
+++ b/src/tests/test_core_python.py
@@ -110,7 +110,7 @@ def test_cpython_core(main_test, selenium, request):
         if res == 4:
             pytest.skip("No tests ran")
         elif isinstance(res, str) and res.startswith("skip:"):
-            pytest.skip(res[len("skip:"):] or f"{name} skipped")
+            pytest.skip(res[len("skip:") :] or f"{name} skipped")
     except selenium.JavascriptException:
         print(selenium.logs)
         raise

--- a/src/tests/test_core_python.py
+++ b/src/tests/test_core_python.py
@@ -69,9 +69,11 @@ def test_cpython_core(main_test, selenium, request):
             dedent(
                 f"""
                 res = None
+                import importlib
                 import platform
-                from test.libregrtest.main import main
                 import sys
+                import unittest
+                from test.libregrtest.main import main
                 sys.excepthook = sys.__excepthook__
 
                 platform.platform(aliased=True)
@@ -80,20 +82,35 @@ def test_cpython_core(main_test, selenium, request):
                     # This uses raise() which doesn't work.
                     del _testcapi.raise_SIGINT_then_send_None
 
-                match_tests = [[pat, False] for pat in {ignore_tests}]
+                # Detect module-level skips (e.g. optional C extension not
+                # compiled in) before running libregrtest. libregrtest exits
+                # with code 0 for both "all passed" and "module skipped", so
+                # without this check pytest would report a vacuous PASSED
+                # instead of SKIPPED.
                 try:
-                    main(["{name}"], match_tests=match_tests, verbose=True, verbose3=True)
-                except SystemExit as e:
-                    if e.code == 4:
-                        res = e.code
-                    elif e.code != 0:
-                        raise RuntimeError(f"Failed with code: {{e.code}}")
+                    importlib.import_module("test.{name}")
+                except unittest.SkipTest as e:
+                    res = f"skip:{{e}}"
+                finally:
+                    sys.modules.pop("test.{name}", None)
+
+                if res is None:
+                    match_tests = [[pat, False] for pat in {ignore_tests}]
+                    try:
+                        main(["{name}"], match_tests=match_tests, verbose=True, verbose3=True)
+                    except SystemExit as e:
+                        if e.code == 4:
+                            res = e.code
+                        elif e.code != 0:
+                            raise RuntimeError(f"Failed with code: {{e.code}}")
                 res
                 """
             )
         )
         if res == 4:
             pytest.skip("No tests ran")
+        elif isinstance(res, str) and res.startswith("skip:"):
+            pytest.skip(res[len("skip:"):] or f"{name} skipped")
     except selenium.JavascriptException:
         print(selenium.logs)
         raise


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Our CI reports `PASSED` for the `zstd` module, even when we don't have it compiled (I'm trying to compile it in #6240), which is incorrect. It should be `SKIPPED` instead. See https://app.circleci.com/pipelines/github/pyodide/pyodide/10086/workflows/2849923e-a4d7-4601-8221-b19fe81877b1/jobs/161453?invite=true#step-102-92420_79.

This PR changes our test harness to more accurately note this behaviour, and we now correctly report that it's `SKIPPED`: https://app.circleci.com/pipelines/github/pyodide/pyodide/10090/workflows/dd24f595-2187-4e90-9282-0093fa95c21a/jobs/161566?invite=true#step-102-92562_79.

Before:
`= 1407 passed, 105 skipped, 8 deselected, 67 xfailed, 11 warnings in 1270.43s (0:21:10) =`

After:
`= 1180 passed, 332 skipped, 8 deselected, 67 xfailed, 11 warnings in 1184.55s (0:19:44) =`
