### PR TITLE
Fix incorrect heldValue passed to the finalization registry

### DIFF
--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1471,7 +1471,7 @@ EM_JS_VAL(JsVal, create_once_callable, (PyObject * obj, bool may_syncify), {
     Module.finalizationRegistry.unregister(wrapper);
     _Py_DecRef(obj);
   };
-  Module.finalizationRegistry.register(wrapper, [ obj, undefined ], wrapper);
+  Module.finalizationRegistry.register(wrapper, { ptr: obj }, wrapper);
   return wrapper;
 });
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1471,7 +1471,7 @@ EM_JS_VAL(JsVal, create_once_callable, (PyObject * obj, bool may_syncify), {
     Module.finalizationRegistry.unregister(wrapper);
     _Py_DecRef(obj);
   };
-  Module.finalizationRegistry.register(wrapper, { ptr: obj }, wrapper);
+  Module.finalizationRegistry.register(wrapper, { ptr : obj }, wrapper);
   return wrapper;
 });
 

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -81,6 +81,9 @@ if (globalThis.FinalizationRegistry) {
       }
       try {
         Py_ENTER();
+        if (ptr === undefined) {
+          console.log("ptr is undefined");
+        }
         _Py_DecRef(ptr);
         Py_EXIT();
       } catch (e) {

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -81,9 +81,6 @@ if (globalThis.FinalizationRegistry) {
       }
       try {
         Py_ENTER();
-        if (ptr === undefined) {
-          console.log("ptr is undefined");
-        }
         _Py_DecRef(ptr);
         Py_EXIT();
       } catch (e) {
@@ -1187,7 +1184,7 @@ export class PyIterableMethods {
       shared.cache.json_adaptor_map,
       isJsonAdaptor(this),
     );
-    Module.finalizationRegistry.register(result, [iterptr, undefined], token);
+    Module.finalizationRegistry.register(result, { ptr: iterptr }, token);
     return result;
   }
 }
@@ -1284,7 +1281,7 @@ export class PyAsyncIterableMethods {
     }
 
     let result = aiter_helper(iterptr, token);
-    Module.finalizationRegistry.register(result, [iterptr, undefined], token);
+    Module.finalizationRegistry.register(result, { ptr: iterptr }, token);
     return result;
   }
 }


### PR DESCRIPTION
I don't think this was causing any real prod issues, but while investigating the memory corruption bug in CF workers, I found this was incorrect.

Our finalization registry takes a value in `{ ptr, cache}` format, but in some places we were passing arrays

https://github.com/pyodide/pyodide/blob/b495c51893b238c5fb8f77a6f1a18bbda8913f25/src/core/pyproxy.ts#L74-L90

The format was changed in https://github.com/pyodide/pyodide/pull/4025/changes , but we forgot to update the callers for a few years.

I think we were either 1) silently calling `Py_DecRef(undefined)` which is no-op (hopefully) or 2) the finalizationregistry was never used becuase of the explicit memory management in proxy destroy