### PR TITLE
Add docstring examples for register_js_module and unregister_js_module

### DIFF
--- a/src/py/_pyodide/_importhook.py
+++ b/src/py/_pyodide/_importhook.py
@@ -67,6 +67,16 @@ class JsFinder(MetaPathFinder):
 
         jsproxy :
             JavaScript object backing the module
+
+        Examples
+        --------
+        >>> from pyodide.code import run_js # doctest: +RUN_IN_PYODIDE
+        >>> from pyodide.ffi import register_js_module
+        >>> my_js_module = run_js("({greet: (name) => 'hello, ' + name})")
+        >>> register_js_module("my_js_module", my_js_module)
+        >>> import my_js_module
+        >>> my_js_module.greet("world")
+        'hello, world'
         """
         assert JsProxy is not None
         if not isinstance(name, str):
@@ -93,6 +103,13 @@ class JsFinder(MetaPathFinder):
         ----------
         name :
             Name of the module to unregister
+
+        Examples
+        --------
+        >>> from pyodide.code import run_js # doctest: +RUN_IN_PYODIDE
+        >>> from pyodide.ffi import register_js_module, unregister_js_module
+        >>> register_js_module("tmp_js_module", run_js("({value: 42})"))
+        >>> unregister_js_module("tmp_js_module")
         """
         try:
             del self.jsproxies[name]


### PR DESCRIPTION
### Description

Adds `Examples` sections (RUN_IN_PYODIDE doctests) to `register_js_module` and `unregister_js_module` in `_importhook.py`, ticking two items off the checklist in #1955 where @rth said "Feel to take one of the methods indicated above and make a PR."

### Issue related
Towards #1955

### Checklist

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [ ] Add / update tests
- [x] Add new / update outdated documentation