### PR TITLE
Fix stack leak when starting a new stack switching task

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -89,6 +89,12 @@ myst:
   0x00FF would be corrupted when read from JavaScript when they were located at
   a WebAssembly memory address above 2GB. {pr}`6217`
 
+- {{ Fix }} Stack switching used to sometimes leak stack memory, this is now
+  fixed. As a side effect, `callPromising()` and `runPythonAsync()` now always
+  yields to the event loop once before Python begins executing, so the ordering
+  of such calls may change.
+  {pr}`6260`
+
 ## Version 0.29.3
 
 _January 28, 2026_

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -57,6 +57,7 @@ declare function DEREF_U32(ptr: number, offset: number): number;
 declare function Py_ENTER(): void;
 declare function Py_EXIT(): void;
 // end-pyodide-skip
+declare function enterTask(): void;
 
 function isPyProxy(jsobj: any): jsobj is PyProxy {
   try {
@@ -582,11 +583,20 @@ async function callPyObjectKwargsPromising(
   const kwargs_values = Object.values(kwargs);
   const num_kwargs = kwargs_names.length;
   jsargs.push(...kwargs_values);
-
-  const stackTop = stackSave();
-  const exc = stackAlloc(4);
+  // We have to take ownership of the pointer before we sleep or else it could
+  // get freed out from under us. This also fixes a bug that was around before
+  // we added the sleep.
+  _Py_IncRef(ptrobj);
+  // Sleep so we release any stack frames above this point. Otherwise, we would
+  // have a hard time reclaiming them later. Also, enterTask() may wish to move
+  // the stack pointer up and we can't reasonably evict our caller from the
+  // stack.
+  await new Promise<void>((res) => API.scheduleCallback(res, 0));
   let result;
+  const exc = _malloc(4);
   try {
+    // enterTask() decides where the stackStop of the new task should be.
+    enterTask();
     Py_ENTER();
     // promisingApply clears the error flag and saves any error into excStatus.
     // This ensures that tasks that are run between when promisingApply resolves
@@ -609,26 +619,27 @@ async function callPyObjectKwargsPromising(
   } catch (e) {
     API.fatal_error(e);
   }
-  // Unwrap result
-  result = result[0];
-  if (result === Module.error) {
-    _PyErr_SetRaisedException(HEAPU32[exc / 4]);
-    try {
+  try {
+    // Unwrap result
+    result = result[0];
+    if (result === Module.error) {
+      _PyErr_SetRaisedException(HEAPU32[exc / 4]);
       _pythonexc2js();
-    } finally {
-      stackRestore(stackTop);
     }
-  }
-  // Automatically schedule coroutines
-  if (result && result.type === "coroutine" && result._ensure_future) {
-    Py_ENTER();
-    const is_coroutine = __iscoroutinefunction(ptrobj);
-    Py_EXIT();
-    if (is_coroutine) {
-      result._ensure_future();
+    // Automatically schedule coroutines
+    if (result && result.type === "coroutine" && result._ensure_future) {
+      Py_ENTER();
+      const is_coroutine = __iscoroutinefunction(ptrobj);
+      Py_EXIT();
+      if (is_coroutine) {
+        result._ensure_future();
+      }
     }
+    return result;
+  } finally {
+    _free(exc);
+    _Py_DecRef(ptrobj);
   }
-  return result;
 }
 
 Module.callPyObjectMaybePromising = async function (

--- a/src/core/pyproxy.ts
+++ b/src/core/pyproxy.ts
@@ -587,10 +587,11 @@ async function callPyObjectKwargsPromising(
   // get freed out from under us. This also fixes a bug that was around before
   // we added the sleep.
   _Py_IncRef(ptrobj);
-  // Sleep so we release any stack frames above this point. Otherwise, we would
-  // have a hard time reclaiming them later. Also, enterTask() may wish to move
-  // the stack pointer up and we can't reasonably evict our caller from the
-  // stack.
+  // Yield to the event loop before starting the task. We may have been called by
+  // WebAssembly stack frames which own data on the stack. We can't overwrite that
+  // data until those stack frames are finished with it. Returning to the event
+  // loop first unwinds all the caller frames. That way enterTask() is free to
+  // place the task wherever it likes.
   await new Promise<void>((res) => API.scheduleCallback(res, 0));
   let result;
   const exc = _malloc(4);

--- a/src/core/stack_switching/stack_state.mjs
+++ b/src/core/stack_switching/stack_state.mjs
@@ -39,14 +39,18 @@
  */
 const stackStates = [];
 
+// Keep track of the running average task size. We could have a special case for
+// taskSizeCount = 0 to prevent dividing by zero, but it's simpler just to start
+// wtih some single value in the running average.
 let taskSizeTotal = 500;
 let taskSizeCount = 1;
-let stackTop;
 
 function setStackPosition(stackPosition) {
   evictStackUpTo(stackPosition);
   stackRestore(stackPosition);
 }
+
+let stackTop;
 
 /**
  * Decide where the stack stop for a new task should be and evict any tasks that
@@ -81,7 +85,9 @@ export function enterTask() {
     lastStop = state.stop;
   }
   // No large enough gaps found. Last, check if the current stack position is
-  // below the bottom used stack position and if so move the stack up.
+  // below the bottom used stack position and if so move the stack up. This can
+  // happen if a task higher on the stack exited first followed by a task lower
+  // on the stack.
   const bottomUsed = stackStates.at(-1)?.start ?? stackTop;
   if (bottomUsed > stackSave()) {
     setStackPosition(bottomUsed);

--- a/src/core/stack_switching/stack_state.mjs
+++ b/src/core/stack_switching/stack_state.mjs
@@ -39,11 +39,9 @@
  */
 const stackStates = [];
 
-let taskSizeTotal = 0n;
-let taskSizeCount = 0n;
+let taskSizeTotal = 500;
+let taskSizeCount = 1;
 let stackTop;
-
-let maxStackStop = Infinity;
 
 function setStackPosition(stackPosition) {
   evictStackUpTo(stackPosition);
@@ -58,15 +56,8 @@ function setStackPosition(stackPosition) {
 export function enterTask() {
   // If this is the first task we enter, record the current stack position as
   // the top of the entire stack and leave it alone.
-  if (!stackTop) {
+  if (stackTop === undefined) {
     stackTop = stackSave();
-    return;
-  }
-  if (stackStates.length === 0) {
-    // If there are no active tasks we should always use the top of the stack.
-    if (stackTop > stackSave()) {
-      setStackPosition(stackTop);
-    }
     return;
   }
   // Search for a gap in the stack large enough that we feel like sticking a
@@ -78,23 +69,19 @@ export function enterTask() {
   // If we make threshold bigger, we will use up more stack space but also copy
   // less stack around. If we make it smaller, we use less stack space but copy
   // more stack.
-  const threshold = Number(taskSizeTotal / taskSizeCount) * 0.8;
-  let lastStop = stackStates.at(-1).stop;
-  for (let idx = stackStates.length - 2; idx >= 0; idx--) {
-    const state = stackStates[idx];
+  const threshold = (taskSizeTotal / taskSizeCount) * 0.8;
+  let lastStop = stackStates.at(-1)?.stop;
+  for (let idx = stackStates.length - 2; idx >= -1; idx--) {
+    const state = idx >= 0 ? stackStates[idx] : {start: stackTop, stop: stackTop};
     if (state.start - lastStop > threshold) {
-      setStackPosition(lastStart);
+      setStackPosition(state.start);
       return;
     }
     lastStop = state.stop;
   }
-  if (stackTop - lastStop > threshold) {
-    setStackPosition(stackTop);
-    return;
-  }
   // No large enough gaps found. Last, check if the current stack position is
   // below the bottom used stack position and if so move the stack up.
-  const bottomUsed = stackStates.at(-1).start;
+  const bottomUsed = stackStates.at(-1)?.start ?? stackTop;
   if (bottomUsed > stackSave()) {
     setStackPosition(bottomUsed);
     return;
@@ -107,13 +94,13 @@ function evictStackUpTo(stop) {
   // and save them
   while (
     stackStates.length > 0 &&
-    stackStates[stackStates.length - 1].stop < stop
+    stackStates.at(-1).stop < stop
   ) {
     total += stackStates.pop()._save();
   }
   // Part of one more object may need to be ejected.
-  const last = stackStates[stackStates.length - 1];
-  if (last && last !== stop) {
+  const last = stackStates.at(-1);
+  if (last && last.stop !== stop) {
     total += last._save_up_to(stop);
   }
   // If we just saved all of the last stackState it needs to be removed.
@@ -154,7 +141,7 @@ export class StackState {
      * stack.
      */
     this._copy = new Uint8Array(0);
-    taskSizeTotal += BigInt(this.stop - this.start);
+    taskSizeTotal += this.stop - this.start;
     taskSizeCount++;
     if (this.start !== this.stop) {
       // Edge case that probably never happens: If start and stop are equal, the

--- a/src/core/stack_switching/stack_state.mjs
+++ b/src/core/stack_switching/stack_state.mjs
@@ -39,6 +39,59 @@
  */
 const stackStates = [];
 
+const stackStarts = new Map();
+const stackStopFreeList = [];
+let maxStackStop = Infinity;
+
+/**
+ * Decide where the stack stop for a new task should be and evict any tasks that
+ * are in the way.
+ * @private
+ */
+export function enterTask() {
+  let stackPosition = stackSave();
+  let found;
+  for (let i = stackStopFreeList.length - 1; i >= 0; i--) {
+    if (stackStopFreeList[i] > stackPosition) {
+      found = i;
+      break;
+    }
+  }
+  if (found === undefined) {
+    return;
+  }
+  stackPosition = stackStopFreeList[found];
+  stackStopFreeList.splice(found, 1);
+  evictStackUpTo(stackPosition);
+  stackRestore(stackPosition);
+}
+
+function evictStackUpTo(stop) {
+  let total = 0;
+  // Search up the stack for things that need to be ejected in their entirety
+  // and save them
+  while (
+    stackStates.length > 0 &&
+    stackStates[stackStates.length - 1].stop < stop
+  ) {
+    total += stackStates.pop()._save();
+  }
+  // Part of one more object may need to be ejected.
+  const last = stackStates[stackStates.length - 1];
+  if (last && last !== this) {
+    total += last._save_up_to(stop);
+  }
+  // If we just saved all of the last stackState it needs to be removed.
+  // Alternatively, the current StackState may be on the stackStates list.
+  // Technically it would make sense to leave it there, but we will add it
+  // back if we suspend again and if we exit normally it gets removed from the
+  // stack.
+  if (last && last.stop === stop) {
+    stackStates.pop();
+  }
+  return total;
+}
+
 /**
  * A class to help us keep track of the argument stack data for our individual
  * continuations. The suspender automatically and opaquely handles the call
@@ -55,6 +108,7 @@ export class StackState {
   constructor() {
     /** current stack pointer */
     this.start = stackSave();
+    stackStarts.set(this.start, (stackStarts.get(this.start) ?? 0) + 1);
     /**
      * The value the stack pointer had when we entered Python. This is how far
      * up the stack the current continuation cares about. This was recorded just
@@ -78,34 +132,27 @@ export class StackState {
    * @returns How much data we copied. (Only for debugging purposes.)
    */
   restore() {
-    let total = 0;
-    // Search up the stack for things that need to be ejected in their entirety
-    // and save them
-    while (
-      stackStates.length > 0 &&
-      stackStates[stackStates.length - 1].stop < this.stop
-    ) {
-      total += stackStates.pop()._save();
+    const val = stackStarts.get(this.start);
+    if (val === undefined) {
+      throw new Error("Should not happen");
     }
-    // Part of one more object may need to be ejected.
-    const last = stackStates[stackStates.length - 1];
-    if (last && last !== this) {
-      total += last._save_up_to(this.stop);
+    if (val - 1 === 0) {
+      stackStarts.delete(this.start);
+    } else {
+      stackStarts.set(this.start, val - 1);
     }
-    // If we just saved all of the last stackState it needs to be removed.
-    // Alternatively, the current StackState may be on the stackStates list.
-    // Technically it would make sense to leave it there, but we will add it
-    // back if we suspend again and if we exit normally it gets removed from the
-    // stack.
-    if (last && last.stop === this.stop) {
-      stackStates.pop();
-    }
+
+    let total = evictStackUpTo(this.stop);
     if (this._copy.length !== 0) {
       // Now that we've saved everything that might be in our way we can restore
       // the current stack data if need be.
       Module.HEAP8.set(this._copy, this.start);
       total += this._copy.length;
       this._copy = new Uint8Array(0);
+    }
+    const curStack = stackSave();
+    if (curStack > this.start && !stackStarts.has(curStack)) {
+      stackStopFreeList.push(curStack);
     }
     // Restore stack pointers
     Module.stackStop = this.stop;

--- a/src/core/stack_switching/stack_state.mjs
+++ b/src/core/stack_switching/stack_state.mjs
@@ -72,7 +72,8 @@ export function enterTask() {
   const threshold = (taskSizeTotal / taskSizeCount) * 0.8;
   let lastStop = stackStates.at(-1)?.stop;
   for (let idx = stackStates.length - 2; idx >= -1; idx--) {
-    const state = idx >= 0 ? stackStates[idx] : {start: stackTop, stop: stackTop};
+    const state =
+      idx >= 0 ? stackStates[idx] : { start: stackTop, stop: stackTop };
     if (state.start - lastStop > threshold) {
       setStackPosition(state.start);
       return;
@@ -92,10 +93,7 @@ function evictStackUpTo(stop) {
   let total = 0;
   // Search up the stack for things that need to be ejected in their entirety
   // and save them
-  while (
-    stackStates.length > 0 &&
-    stackStates.at(-1).stop < stop
-  ) {
+  while (stackStates.length > 0 && stackStates.at(-1).stop < stop) {
     total += stackStates.pop()._save();
   }
   // Part of one more object may need to be ejected.

--- a/src/core/stack_switching/stack_state.mjs
+++ b/src/core/stack_switching/stack_state.mjs
@@ -39,9 +39,16 @@
  */
 const stackStates = [];
 
-const stackStarts = new Map();
-const stackStopFreeList = [];
+let taskSizeTotal = 0n;
+let taskSizeCount = 0n;
+let stackTop;
+
 let maxStackStop = Infinity;
+
+function setStackPosition(stackPosition) {
+  evictStackUpTo(stackPosition);
+  stackRestore(stackPosition);
+}
 
 /**
  * Decide where the stack stop for a new task should be and evict any tasks that
@@ -49,21 +56,49 @@ let maxStackStop = Infinity;
  * @private
  */
 export function enterTask() {
-  let stackPosition = stackSave();
-  let found;
-  for (let i = stackStopFreeList.length - 1; i >= 0; i--) {
-    if (stackStopFreeList[i] > stackPosition) {
-      found = i;
-      break;
-    }
-  }
-  if (found === undefined) {
+  // If this is the first task we enter, record the current stack position as
+  // the top of the entire stack and leave it alone.
+  if (!stackTop) {
+    stackTop = stackSave();
     return;
   }
-  stackPosition = stackStopFreeList[found];
-  stackStopFreeList.splice(found, 1);
-  evictStackUpTo(stackPosition);
-  stackRestore(stackPosition);
+  if (stackStates.length === 0) {
+    // If there are no active tasks we should always use the top of the stack.
+    if (stackTop > stackSave()) {
+      setStackPosition(stackTop);
+    }
+    return;
+  }
+  // Search for a gap in the stack large enough that we feel like sticking a
+  // task in it. We search from bottom to top because insertion is cheaper
+  // closer to the bottom. (More specifically, if the tasks run a long time then
+  // it costs the same no matter where we insert but if they are short lived
+  // inserting lower is better).
+
+  // If we make threshold bigger, we will use up more stack space but also copy
+  // less stack around. If we make it smaller, we use less stack space but copy
+  // more stack.
+  const threshold = Number(taskSizeTotal / taskSizeCount) * 0.8;
+  let lastStop = stackStates.at(-1).stop;
+  for (let idx = stackStates.length - 2; idx >= 0; idx--) {
+    const state = stackStates[idx];
+    if (state.start - lastStop > threshold) {
+      setStackPosition(lastStart);
+      return;
+    }
+    lastStop = state.stop;
+  }
+  if (stackTop - lastStop > threshold) {
+    setStackPosition(stackTop);
+    return;
+  }
+  // No large enough gaps found. Last, check if the current stack position is
+  // below the bottom used stack position and if so move the stack up.
+  const bottomUsed = stackStates.at(-1).start;
+  if (bottomUsed > stackSave()) {
+    setStackPosition(bottomUsed);
+    return;
+  }
 }
 
 function evictStackUpTo(stop) {
@@ -78,7 +113,7 @@ function evictStackUpTo(stop) {
   }
   // Part of one more object may need to be ejected.
   const last = stackStates[stackStates.length - 1];
-  if (last && last !== this) {
+  if (last && last !== stop) {
     total += last._save_up_to(stop);
   }
   // If we just saved all of the last stackState it needs to be removed.
@@ -108,7 +143,6 @@ export class StackState {
   constructor() {
     /** current stack pointer */
     this.start = stackSave();
-    stackStarts.set(this.start, (stackStarts.get(this.start) ?? 0) + 1);
     /**
      * The value the stack pointer had when we entered Python. This is how far
      * up the stack the current continuation cares about. This was recorded just
@@ -120,6 +154,8 @@ export class StackState {
      * stack.
      */
     this._copy = new Uint8Array(0);
+    taskSizeTotal += BigInt(this.stop - this.start);
+    taskSizeCount++;
     if (this.start !== this.stop) {
       // Edge case that probably never happens: If start and stop are equal, the
       // current continuation occupies no arg stack space.
@@ -132,16 +168,6 @@ export class StackState {
    * @returns How much data we copied. (Only for debugging purposes.)
    */
   restore() {
-    const val = stackStarts.get(this.start);
-    if (val === undefined) {
-      throw new Error("Should not happen");
-    }
-    if (val - 1 === 0) {
-      stackStarts.delete(this.start);
-    } else {
-      stackStarts.set(this.start, val - 1);
-    }
-
     let total = evictStackUpTo(this.stop);
     if (this._copy.length !== 0) {
       // Now that we've saved everything that might be in our way we can restore
@@ -149,10 +175,6 @@ export class StackState {
       Module.HEAP8.set(this._copy, this.start);
       total += this._copy.length;
       this._copy = new Uint8Array(0);
-    }
-    const curStack = stackSave();
-    if (curStack > this.start && !stackStarts.has(curStack)) {
-      stackStopFreeList.push(curStack);
     }
     // Restore stack pointers
     Module.stackStop = this.stop;

--- a/src/core/stack_switching/stack_switching.mjs
+++ b/src/core/stack_switching/stack_switching.mjs
@@ -12,7 +12,7 @@ export {
   validSuspender,
   suspenderGlobal,
 } from "./suspenders.mjs";
-export { StackState } from "./stack_state.mjs";
+export { StackState, enterTask } from "./stack_state.mjs";
 
 let canConstructWasm = true;
 try {

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -54,6 +54,7 @@ declare global {
   // _PyList_New, _PyDict_New, _PyDict_SetItem, _PySet_New, _PySet_Add
   // _PyEval_SaveThread, _PyEval_RestoreThread,
   //   _PyErr_CheckSignals, _PyErr_SetString
+  export const _malloc: (sz: number) => number;
   export const _free: (a: number) => void;
   export const __PyTraceback_Add: (a: number, b: number, c: number) => void;
   export const _PyRun_SimpleString: (ptr: number) => number;
@@ -69,6 +70,7 @@ declare global {
   export const _PyGILState_Check: () => number;
   export const __PyErr_CheckSignals: () => number;
   export const _PyErr_SetRaisedException: (ptr: number) => void;
+  export function restoreStack(a: number): void;
 }
 
 // Our own functions we use from JavaScript. These all need to be labeled with

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -70,7 +70,6 @@ declare global {
   export const _PyGILState_Check: () => number;
   export const __PyErr_CheckSignals: () => number;
   export const _PyErr_SetRaisedException: (ptr: number) => void;
-  export function restoreStack(a: number): void;
 }
 
 // Our own functions we use from JavaScript. These all need to be labeled with

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -11,15 +11,8 @@ STACK_CHECK_AFTER_JS = """
 let lastStack = Infinity;
 let curStack = pyodide._module.stackSave();
 pyodide.runPython("def nothing(): pass");
-
-// flush free list
-while (curStack != lastStack) {
-    lastStack = curStack;
-    await pyodide.globals.nothing.callPromising();
-    curStack = pyodide._module.stackSave();
-    console.log(`flush free list! ${lastStack}, ${curStack}`);
-}
-
+// Reset stack address
+await pyodide.globals.nothing.callPromising();
 return pyodide._module.stackSave();
 """
 

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -3,6 +3,44 @@ from pytest_pyodide import run_in_pyodide
 
 from conftest import requires_jspi
 
+STACK_CHECK_JS = """
+return pyodide._module.stackSave();
+"""
+
+STACK_CHECK_AFTER_JS = """
+let lastStack = Infinity;
+let curStack = pyodide._module.stackSave();
+pyodide.runPython("def nothing(): pass");
+
+// flush free list
+while (curStack != lastStack) {
+    lastStack = curStack;
+    await pyodide.globals.nothing.callPromising();
+    curStack = pyodide._module.stackSave();
+    console.log(`flush free list! ${lastStack}, ${curStack}`);
+}
+
+return pyodide._module.stackSave();
+"""
+
+
+@pytest.fixture(autouse=True)
+def assert_no_stack_leak(request):
+    selenium = (
+        request.getfixturevalue("selenium")
+        if "selenium" in request.fixturenames
+        else None
+    )
+    if selenium is None:
+        yield
+        return
+    before = selenium.run_js(STACK_CHECK_JS)
+    yield
+    after = selenium.run_js(STACK_CHECK_AFTER_JS)
+    assert before == after, (
+        f"stack pointer leak: before={before} after={after} diff={before - after} bytes"
+    )
+
 
 @requires_jspi
 @pytest.mark.requires_dynamic_linking
@@ -543,7 +581,7 @@ def test_switch_from_except_block(selenium):
         const g = pyodide.globals.get("g");
         const g1 = g.callPromising("a");
         const g2 = g.callPromising("b");
-        pe('tt')
+        await pe.callPromising('tt');
         await g1;
         await g2;
         pyodide.globals.delete("result");
@@ -787,3 +825,38 @@ def test_async_promising_async_error(selenium):
     # In bad cases, the previous exception was a fatal error but we didn't
     # notice. Check that no fatal error occurred by running Python.
     selenium.run("")
+
+
+@pytest.mark.skip_refcount_check
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_return_promising_no_crash(selenium):
+    """This used to fatally fail.
+
+    The fix was to incref ptrobj before await Module.promisingApply(...), so
+    presumably the crash involved the pointer to g getting freed out from
+    underneath? I'm honestly not sure how it worked.
+    """
+    selenium.run_js(
+        """
+        globalThis.f = function f() {
+            return task.callPromising();
+        };
+        pyodide.runPython(`
+            from asyncio import sleep
+            from pyodide.ffi import run_sync
+
+            def task():
+                run_sync(sleep(1))
+
+            def g():
+                from js import f
+                return f()
+        `);
+        const task = pyodide.globals.get("task");
+        const g = pyodide.globals.get("g");
+        await Promise.all([g(), g()]);
+        g.destroy();
+        task.destroy();
+        """
+    )

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -27,6 +27,9 @@ def assert_no_stack_leak(request):
     if selenium is None:
         yield
         return
+    if selenium.browser in ("firefox", "safari"):
+        yield
+        return
     before = selenium.run_js(STACK_CHECK_JS)
     yield
     after = selenium.run_js(STACK_CHECK_AFTER_JS)


### PR DESCRIPTION
This is a second attempt to fix #6249. The idea is that before we start a task, we call a function that decides where it should be allocated and potentially moves the stack pointer and ejects appropriate tasks from the stack.
The logic works as follows: We look up the stack for gaps between tasks. If the gap between a pair of tasks (or the topmost task and the stack top) is less than 80% of the average task size, we insert below the higher task. If there is no large enough gap, then we just check whether there is a gap between the stack pointer and the lowest location used by any existing task, if there is such a gap we move the stack pointer up before starting our new task.
