### PR TITLE
fix: convert JsException message to string in AbortError to prevent fatal errors (closes #4249)

### DIFF
--- a/src/py/pyodide/http/_exceptions.py
+++ b/src/py/pyodide/http/_exceptions.py
@@ -51,7 +51,7 @@ class BodyUsedError(OSError):
 
 class AbortError(OSError):
     def __init__(self, reason: JsException) -> None:
-        super().__init__(reason.message)
+        super().__init__(str(reason.message))
 
 
 # pyxhr exceptions


### PR DESCRIPTION
## What
Fixes fatal errors in scipy tests caused by passing a non-string `reason.message` (a JavaScript error object) to `OSError.__init__` in `AbortError`.

## Fix
Wrap `reason.message` with `str()` to ensure it is converted to a string before being passed to the superclass constructor.

Closes #4249