### PR TITLE
Add type conversion logic for datetime <==> Date

### DIFF
--- a/docs/usage/type-conversions.md
+++ b/docs/usage/type-conversions.md
@@ -80,6 +80,7 @@ JavaScript:
 | {py:data}`None`                 | {js:data}`undefined`                     |
 | {py:data}`pyodide.ffi.jsnull`   | {js:data}`null`                          |
 | {py:data}`pyodide.ffi.JsBigInt` | {js:data}`BigInt`                        |
+| {py:data}`datetime.datetime`    | {js.data}`Date`                          |
 
 \* An {py:class}`int` is converted to a {js:data}`Number` if the absolute value
 is less than or equal to {js:data}`Number.MAX_SAFE_INTEGER` otherwise it is
@@ -105,6 +106,7 @@ Python:
 | {js:data}`Boolean`   | {py:class}`bool`                                      |
 | {js:data}`undefined` | {py:data}`None`                                       |
 | {js:data}`null`      | {py:data}`pyodide.ffi.jsnull`                         |
+| {js:data}`Date`      | {py:data}`datetime.datetime`                          |
 
 \* A {js:data}`Number` is converted to an {py:class}`int` if the absolute value
 is less than or equal to {js:data}`Number.MAX_SAFE_INTEGER` and its fractional

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -1,11 +1,13 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "datetime.h"
 
 #include "error_handling.h"
 #include "js2python.h"
 #include "python2js.h"
 
 #include <emscripten.h>
+#include <math.h>
 
 #include "jsmemops.h"
 #include "jsproxy.h"
@@ -25,6 +27,7 @@ _js2python_none(void)
 }
 
 EMSCRIPTEN_KEEPALIVE int compat_null_to_none = 0;
+EMSCRIPTEN_KEEPALIVE int auto_convert_date = 1;
 
 EMSCRIPTEN_KEEPALIVE PyObject*
 _js2python_null(void)
@@ -59,6 +62,45 @@ EMSCRIPTEN_KEEPALIVE PyObject*
 _js2python_bigint(PyObject* val)
 {
   return PyObject_CallOneArg(py_JsBigInt, val);
+}
+
+EMSCRIPTEN_KEEPALIVE int
+_js2python_should_convert_date(void)
+{
+  return auto_convert_date;
+}
+
+// Convert a JS Date timestamp (UTC milliseconds since epoch) to a
+// timezone-aware Python datetime. Microsecond precision comes from
+// the fractional part of timestamp_ms / 1000, handled internally by
+// datetime.fromtimestamp().
+EMSCRIPTEN_KEEPALIVE PyObject*
+_js2python_datetime(double timestamp_ms)
+{
+  double timestamp_s = timestamp_ms / 1000.0;
+
+  PyObject* ts_obj = PyFloat_FromDouble(timestamp_s);
+  if (ts_obj == NULL) {
+    return NULL;
+  }
+
+  PyObject* result = PyObject_CallMethod(
+    py_datetime_class, "fromtimestamp", "OO", ts_obj, py_timezone_utc);
+  Py_DECREF(ts_obj);
+  if (result == NULL) {
+    // fromtimestamp raises OverflowError if the timestamp is out of range,
+    // or OSError on localtime() failure.
+    // https://docs.python.org/3/library/datetime.html#datetime.date.fromtimestamp
+    if (PyErr_ExceptionMatches(PyExc_OverflowError) ||
+        PyErr_ExceptionMatches(PyExc_OSError)) {
+      PyErr_Clear();
+      PyErr_SetString(conversion_error,
+                      "Cannot convert JavaScript Date to Python datetime: "
+                      "timestamp out of range for datetime");
+    }
+    return NULL;
+  }
+  return result;
 }
 
 EM_JS_REF(PyObject*, js2python_immutable_js, (JsVal value), {

--- a/src/core/js2python.h
+++ b/src/core/js2python.h
@@ -28,5 +28,6 @@ int
 js2python_init();
 
 extern int compat_null_to_none;
+extern int auto_convert_date;
 
 #endif /* JS2PYTHON_H */

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -121,6 +121,12 @@ function js2python_convertImmutableInner(value) {
     } else {
       return __js2python_pyproxy(shared.ptr);
     }
+  } else if (__js2python_should_convert_date() && value instanceof Date) {
+    let ts = value.getTime();
+    if (!Number.isNaN(ts)) {
+      return __js2python_datetime(ts);
+    }
+    // If the timestamp is invalid, fall through to create a JsProxy
   }
   return undefined;
 }

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -1,6 +1,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "python2js.h"
 #include "Python.h"
+#include "datetime.h"
 #include "docstring.h"
 #include "error_handling.h"
 #include "js2python.h"
@@ -188,6 +189,53 @@ _python2js_unicode(PyObject* x)
     default:
       assert(false /* invalid Unicode kind */);
   }
+}
+
+// clang-format off
+EM_JS_VAL(JsVal, _python2js_date_from_ms, (double timestamp_ms), {
+  return new Date(timestamp_ms);
+});
+// clang-format on
+
+// clang-format off
+EM_JS_VAL(JsVal, _python2js_date_from_utc_components,
+(int year, int month, int day, int hour, int minute, int second, int ms), {
+  return new Date(Date.UTC(year, month - 1, day, hour, minute, second, ms));
+});
+// clang-format on
+
+static JsVal
+_python2js_datetime(PyObject* x)
+{
+  PyObject* ts_obj = NULL;
+  JsVal result = JS_ERROR;
+
+  int has_tz = PyDateTime_DATE_GET_TZINFO(x) != Py_None;
+
+  if (has_tz) {
+    ts_obj = PyObject_CallMethod(x, "timestamp", NULL);
+    if (ts_obj == NULL) {
+      goto finally;
+    }
+    double ts = PyFloat_AsDouble(ts_obj);
+    if (ts == -1.0 && PyErr_Occurred()) {
+      goto finally;
+    }
+    result = _python2js_date_from_ms(ts * 1000.0);
+  } else {
+    result = _python2js_date_from_utc_components(
+      PyDateTime_GET_YEAR(x),
+      PyDateTime_GET_MONTH(x),
+      PyDateTime_GET_DAY(x),
+      PyDateTime_DATE_GET_HOUR(x),
+      PyDateTime_DATE_GET_MINUTE(x),
+      PyDateTime_DATE_GET_SECOND(x),
+      PyDateTime_DATE_GET_MICROSECOND(x) / 1000);
+  }
+
+finally:
+  Py_CLEAR(ts_obj);
+  return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -386,6 +434,9 @@ _python2js_immutable(PyObject* x)
     return _python2js_float(x);
   } else if (PyUnicode_Check(x)) {
     return _python2js_unicode(x);
+  } else if (auto_convert_date && py_datetime_class != NULL &&
+             Py_TYPE(x) == (PyTypeObject*)py_datetime_class) {
+    return _python2js_datetime(x);
   }
   return Jsv_novalue;
 }
@@ -1020,6 +1071,8 @@ static PyMethodDef methods[] = {
 
 PyObject* py_jsnull = NULL;
 PyObject* py_JsBigInt = NULL;
+PyObject* py_datetime_class = NULL;
+PyObject* py_timezone_utc = NULL;
 
 int
 python2js_init(PyObject* core)
@@ -1033,6 +1086,21 @@ python2js_init(PyObject* core)
   FAIL_IF_NULL(py_jsnull);
   py_JsBigInt = PyObject_GetAttrString(docstring_source, "JsBigInt");
   FAIL_IF_NULL(py_JsBigInt);
+
+  PyDateTime_IMPORT;
+  if (PyDateTimeAPI == NULL) {
+    FAIL();
+  }
+  PyObject* datetime_mod = PyImport_ImportModule("datetime");
+  FAIL_IF_NULL(datetime_mod);
+  py_datetime_class = PyObject_GetAttrString(datetime_mod, "datetime");
+  FAIL_IF_NULL(py_datetime_class);
+  PyObject* tz = PyObject_GetAttrString(datetime_mod, "timezone");
+  FAIL_IF_NULL(tz);
+  py_timezone_utc = PyObject_GetAttrString(tz, "utc");
+  FAIL_IF_NULL(py_timezone_utc);
+  Py_CLEAR(tz);
+  Py_CLEAR(datetime_mod);
 
   success = true;
 finally:

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -65,5 +65,7 @@ python2js_init(PyObject* core);
 
 extern PyObject* py_jsnull;
 extern PyObject* py_JsBigInt;
+extern PyObject* py_datetime_class;
+extern PyObject* py_timezone_utc;
 
 #endif /* PYTHON2JS_H */

--- a/src/js/api.ts
+++ b/src/js/api.ts
@@ -60,6 +60,10 @@ API.setCompatNullToNone = function (compat: boolean): void {
   Module.HEAP8[Module._compat_null_to_none] = +compat;
 };
 
+API.setAutoConvertDate = function (enable: boolean): void {
+  Module.HEAP8[Module._auto_convert_date] = +enable;
+};
+
 /** @hidden */
 export type NativeFS = {
   syncfs: () => Promise<void>;

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -205,6 +205,13 @@ export interface PyodideConfig {
   toJsLiteralMap?: boolean;
 
   /**
+   * Set to ``false`` to disable automatic conversion between JavaScript
+   * ``Date`` objects and Python ``datetime.datetime`` objects.
+   * Default: ``true``.
+   */
+  autoConvertDate?: boolean;
+
+  /**
    * Determine the value of ``sys.executable``.
    * @ignore
    */
@@ -398,6 +405,9 @@ function configureAPI(
   }
   if (config.toJsLiteralMap) {
     API.setCompatToJsLiteralMap(true);
+  }
+  if (config.autoConvertDate === false) {
+    API.setAutoConvertDate(false);
   }
 
   if (API.version !== version && config.checkAPIVersion) {

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -330,6 +330,7 @@ export interface PyodideModule extends PythonModule {
   _compat_to_string_repr: number;
   _compat_null_to_none: number;
   _compat_dict_to_literalmap: number;
+  _auto_convert_date: number;
   js2python_convert: (
     obj: any,
     options: {
@@ -503,6 +504,7 @@ export interface API {
   setPyProxyToStringMethod: (useRepr: boolean) => void;
   setCompatNullToNone: (compat: boolean) => void;
   setCompatToJsLiteralMap: (compat: boolean) => void;
+  setAutoConvertDate: (enable: boolean) => void;
 
   _pyodide: any;
   pyodide_py: any;

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -1,6 +1,7 @@
 # See also test_pyproxy, test_jsproxy, and test_python.
 import io
 import pickle
+from datetime import UTC
 from typing import Any
 
 import pytest
@@ -2539,3 +2540,157 @@ def test_js_bigint_construct_typed_array(selenium):
     # Without JsBigInt we can't construct a BigInt64Array
     a = BigInt64Array.new([JsBigInt(x) for x in range(1, 10, 2)])
     assert list(a) == list(range(1, 10, 2))
+
+
+@run_in_pyodide
+def test_js_date_to_python_datetime(selenium):
+    from datetime import datetime
+
+    from pyodide.code import run_js
+
+    d = run_js("new Date('2024-06-15T12:30:45.123Z')")
+    assert isinstance(d, datetime)
+    assert d.tzinfo == UTC
+    assert d.year == 2024
+    assert d.month == 6
+    assert d.day == 15
+    assert d.hour == 12
+    assert d.minute == 30
+    assert d.second == 45
+    assert d.microsecond == 123000
+
+
+@run_in_pyodide
+def test_python_datetime_to_js_date(selenium):
+    from datetime import datetime
+
+    from pyodide.code import run_js
+
+    dt = datetime(2024, 6, 15, 12, 30, 45, 123000, tzinfo=UTC)
+    check_fn = run_js(
+        """
+        (d) => {
+            return [
+                d instanceof Date,
+                d.getUTCFullYear(),
+                d.getUTCMonth(),
+                d.getUTCDate(),
+                d.getUTCHours(),
+                d.getUTCMinutes(),
+                d.getUTCSeconds(),
+                d.getUTCMilliseconds(),
+            ];
+        }
+        """
+    )
+    result_list = check_fn(dt).to_py()
+    assert result_list[0] is True
+    assert result_list[1] == 2024
+    assert result_list[2] == 5  # JS months are 0-indexed
+    assert result_list[3] == 15
+    assert result_list[4] == 12
+    assert result_list[5] == 30
+    assert result_list[6] == 45
+    assert result_list[7] == 123
+
+
+@run_in_pyodide
+def test_date_roundtrip_js_to_python_to_js(selenium):
+    from pyodide.code import run_js
+
+    original_ts = run_js("new Date('2024-06-15T12:30:45.123Z').getTime()")
+    dt = run_js("new Date('2024-06-15T12:30:45.123Z')")
+    roundtrip_ts = run_js("(d) => d.getTime()")(dt)
+    assert roundtrip_ts == original_ts
+
+
+@run_in_pyodide
+def test_date_pre_epoch(selenium):
+    from datetime import datetime
+
+    from pyodide.code import run_js
+
+    d = run_js("new Date('1960-01-15T08:30:00.000Z')")
+    assert isinstance(d, datetime)
+    assert d.year == 1960
+    assert d.month == 1
+    assert d.day == 15
+    assert d.hour == 8
+    assert d.minute == 30
+
+
+@run_in_pyodide
+def test_date_epoch(selenium):
+    from datetime import datetime
+
+    from pyodide.code import run_js
+
+    d = run_js("new Date(0)")
+    assert isinstance(d, datetime)
+    assert d == datetime(1970, 1, 1, tzinfo=UTC)
+
+
+@run_in_pyodide
+def test_date_invalid_date_fallback_to_jsproxy(selenium):
+    from pyodide.code import run_js
+    from pyodide.ffi import JsProxy
+
+    d = run_js("new Date('not-a-date')")
+    assert isinstance(d, JsProxy)
+
+
+@run_in_pyodide
+def test_naive_datetime_to_js_treated_as_utc(selenium):
+    from datetime import datetime
+
+    from pyodide.code import run_js
+
+    dt_naive = datetime(2024, 6, 15, 12, 30, 45)
+    dt_aware = datetime(2024, 6, 15, 12, 30, 45, tzinfo=UTC)
+    get_time = run_js("(d) => d.getTime()")
+    ts_naive = get_time(dt_naive)
+    ts_aware = get_time(dt_aware)
+    assert ts_naive == ts_aware
+
+
+def test_date_disabled_with_opt_out(selenium_standalone_noload):
+    selenium = selenium_standalone_noload
+    selenium.run_js(
+        """
+        let pyodide = await loadPyodide({
+            autoConvertDate: false
+        });
+        pyodide.runPython(`
+            from pyodide.code import run_js
+            from pyodide.ffi import JsProxy
+
+            d = run_js("new Date('2024-06-15T12:30:45.123Z')")
+            assert isinstance(d, JsProxy), f"Expected JsProxy, got {type(d)}"
+        `);
+        """
+    )
+
+
+@run_in_pyodide
+def test_date_microsecond_truncation(selenium):
+    from datetime import datetime
+
+    from pyodide.code import run_js
+
+    dt = datetime(2024, 6, 15, 12, 30, 45, 123456, tzinfo=UTC)
+    ms = run_js("(d) => d.getUTCMilliseconds()")(dt)
+    assert ms == 123  # sub-ms truncated
+
+
+@run_in_pyodide
+def test_date_negative_timestamp_microseconds(selenium):
+    from datetime import datetime
+
+    from pyodide.code import run_js
+
+    d = run_js("new Date('1969-07-20T20:17:40.123Z')")
+    assert isinstance(d, datetime)
+    assert d.year == 1969
+    assert d.month == 7
+    assert d.day == 20
+    assert d.microsecond == 123000


### PR DESCRIPTION
### Description

Convert js.Date to Python datetime.datetime and vice versa.

This is something that we want to use in Cloudflare Workers, but probably need some discussion whether we want to make it as a default or not. I added a flag in `loadPyodide` so that we can opt-in/opt-out.

### Checklist

- [ ] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [x] Add new / update outdated documentation
