### PR TITLE
emsdk/patches: remove trailing whitespace

### DIFF
--- a/emsdk/patches/0002-Fix-promise-order.patch
+++ b/emsdk/patches/0002-Fix-promise-order.patch
@@ -22,7 +22,7 @@ index 786c8ba70..1f14884da 100644
    // Create a second promise bound the first one to return the caller.  It's
    // then up to the caller to destroy this promise.
    em_promise_t ret = emscripten_promise_create();
-+  
++
 +  // The order matters here. Calling emscripten_dlopen before resolving the second promise
 +  // may destroy the first promise before resolving the value.
    emscripten_promise_resolve(ret, EM_PROMISE_MATCH, p);


### PR DESCRIPTION
Hi! A small thing I've noticed when adding cross-platform way to apply patches in https://github.com/pyodide/pyodide-build that's using `git apply` instead if `patch`.

An example see `Run the recipe integration tests (test-recipe)` step in the run https://github.com/pyodide/pyodide-build/actions/runs/26489237384/job/78003296000 as an example.

When applying patches it warns about some redundant whitespaces:
```
Checking patch src/lib/libdylink.js...
Applied patch src/lib/libdylink.js cleanly.
Checking patch tools/emscripten.py...
Applied patch tools/emscripten.py cleanly.
/home/runner/.cache/.pyodide-xbuildenv-0.34.5.dev6+gc2dab7386/0.29.4/xbuildenv/pyodide-root/emsdk/patches/0003-dylink-Fix-rpath-calculation-in-nested-dependencies.patch:38: trailing whitespace.
#endif      
Checking patch src/lib/libdylink.js...
Hunk #1 succeeded at 911 (offset 3 lines).
Hunk #2 succeeded at 1051 (offset 3 lines).
Applied patch src/lib/libdylink.js cleanly.
warning: 1 line adds whitespace errors.
/home/runner/.cache/.pyodide-xbuildenv-0.34.5.dev6+gc2dab7386/0.29.4/xbuildenv/pyodide-root/emsdk/patches/0004-Fix-promise-order.patch:26: trailing whitespace.
  
Checking patch system/lib/libc/dynlink.c...
Applied patch system/lib/libc/dynlink.c cleanly.
warning: 1 line adds whitespace errors.
```

To fix those warnings, I've changed `0004-Fix-promise-order.patch` in this PR, `0003-dylink-Fix-rpath-calculation-in-nested-dependencies.patch` doesn't need a fix, since it was removed in https://github.com/pyodide/pyodide/commit/75e53251.
