### PR TITLE
Add 314.0.0 release xbuildenv metadata to v1 JSON endpoint

### DIFF
--- a/metadata/pyodide-cross-build-environments-v1.json
+++ b/metadata/pyodide-cross-build-environments-v1.json
@@ -1,5 +1,13 @@
 {
   "releases": {
+    "314.0.0": {
+      "version": "314.0.0",
+      "url": "https://github.com/pyodide/pyodide/releases/download/314.0.0/xbuildenv-314.0.0.tar.bz2",
+      "sha256": "6e76cf18251bd7d046bdb7ef35c9f938c8e995f10d88397497ca4b7020f27ba6",
+      "python_version": "3.14.2",
+      "emscripten_version": "5.0.3",
+      "min_pyodide_build_version": "0.26.0"
+    },
     "314.0.0a2": {
       "version": "314.0.0a2",
       "url": "https://github.com/pyodide/pyodide/releases/download/314.0.0a2/xbuildenv-314.0.0a2.tar.bz2",


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Add 314.0.0 release xbuildenv metadata to v1 JSON endpoint metadata despite it being frozen, because we haven't released pyodide-build with 0.35.0 yet (I am doing that as we speak after merging https://github.com/pyodide/pyodide-build/pull/371) so that we can ease the transition for downstream users, such as cibuildwheel, and those who use use pyodide-build manually and would like to build for 3.14 but cannot update its version immediately.

xref #6257, https://github.com/pypa/cibuildwheel/pull/2906