### PR TITLE
perf(ffi): speed up JS-to-Python string conversion

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -17,6 +17,8 @@ myst:
 
 ## Unreleased
 
+- {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`
+
 ## Version 314.0.0
 
 _June 09, 2026_

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -16,11 +16,13 @@ function js2python_string(value) {
     const unit = value.charCodeAt(i);
     let code_point;
     // A high surrogate (0xD800-0xDBFF) followed by a low surrogate
-    // (0xDC00-0xDFFF) is a surrogate pair encoding a single code point.
-    // `codePointAt` combines them; we then skip the trailing low surrogate.
-    // Lone surrogates (high without a following low, or a low surrogate) are
-    // left as-is: `codePointAt` returns the bare code unit, matching the
-    // behavior of the previous string-iterator implementation.
+    // (0xDC00-0xDFFF) is a surrogate pair encoding a single code point. We
+    // combine them with the standard UTF-16 decoding formula and then skip
+    // the trailing low surrogate. Lone surrogates (high without a following
+    // low, or a low surrogate) are left as-is as their bare code-unit value,
+    // matching the behavior of the previous string-iterator implementation.
+    // See:
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt
     if (unit >= 0xd800 && unit <= 0xdbff) {
       const next = value.charCodeAt(i + 1);
       if (next >= 0xdc00 && next <= 0xdfff) {

--- a/src/core/js2python.js
+++ b/src/core/js2python.js
@@ -6,14 +6,36 @@ function js2python_string(value) {
   // to determine if is needs to be a 1-, 2- or 4-byte string, since
   // Python handles all 3.
   let max_code_point = 0;
-  const code_points = [];
-  for (let c of value) {
-    let code_point = c.codePointAt(0);
-    code_points.push(code_point);
+  // `value.length` counts UTF-16 code units, which is an upper bound on the
+  // number of code points (a surrogate pair is two units but one code point),
+  // so a typed array of that length is large enough to hold every code point.
+  const length = value.length;
+  const code_points = new Uint32Array(length);
+  let num_code_points = 0;
+  for (let i = 0; i < length; i++) {
+    const unit = value.charCodeAt(i);
+    let code_point;
+    // A high surrogate (0xD800-0xDBFF) followed by a low surrogate
+    // (0xDC00-0xDFFF) is a surrogate pair encoding a single code point.
+    // `codePointAt` combines them; we then skip the trailing low surrogate.
+    // Lone surrogates (high without a following low, or a low surrogate) are
+    // left as-is: `codePointAt` returns the bare code unit, matching the
+    // behavior of the previous string-iterator implementation.
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        code_point = (unit - 0xd800) * 0x400 + (next - 0xdc00) + 0x10000;
+        i++;
+      } else {
+        code_point = unit;
+      }
+    } else {
+      code_point = unit;
+    }
+    code_points[num_code_points++] = code_point;
     max_code_point = code_point > max_code_point ? code_point : max_code_point;
   }
 
-  let num_code_points = code_points.length;
   let result = _PyUnicode_New(num_code_points, max_code_point);
   if (result === 0) {
     throw new PropagateError();

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -143,6 +143,47 @@ def test_large_string_conversion(selenium):
 
 
 @run_in_pyodide
+def test_js2python_string_codepoints(selenium):
+    """JS string -> Python str conversion (js2python_string) must handle all
+    three Python internal representations (UCS1/UCS2/UCS4) and decode UTF-16
+    surrogate pairs into a single astral code point, while passing lone
+    surrogates through as their bare code-unit value.
+    """
+    from pyodide.code import run_js
+
+    # A JS string returned to Python is converted by js2python_string.
+    js_string = run_js("(s) => s")
+
+    # UCS1 (<= U+00FF), UCS2 (<= U+FFFF), UCS4 (astral / emoji).
+    assert js_string("pyodidé") == "pyodidé"
+    assert js_string("碘化物") == "碘化物"
+    assert js_string("🐍") == "🐍"
+    assert js_string("a😀b漢c") == "a😀b漢c"
+
+    # A surrogate pair built from its two UTF-16 code units must decode to the
+    # single astral code point, not two separate characters.
+    pair = run_js("() => String.fromCharCode(0xD83D, 0xDE00)")()
+    assert pair == "😀"
+    assert len(pair) == 1
+    assert ord(pair) == 0x1F600
+
+    # Lone surrogates pass through as their bare code-unit value.
+    lone_high = run_js("() => String.fromCharCode(0xD83D)")()
+    assert len(lone_high) == 1
+    assert ord(lone_high) == 0xD83D
+    lone_low = run_js("() => String.fromCharCode(0xDE00)")()
+    assert len(lone_low) == 1
+    assert ord(lone_low) == 0xDE00
+
+    # A high surrogate not followed by a low surrogate stays lone, and the
+    # following character is preserved.
+    mixed = run_js("() => String.fromCharCode(0xD83D, 0x0041)")()
+    assert len(mixed) == 2
+    assert ord(mixed[0]) == 0xD83D
+    assert mixed[1] == "A"
+
+
+@run_in_pyodide
 def test_string_conversion_above_2gb(selenium):
     """Regression test for a Python str -> JS string conversion bug that
     fired only when the str's data buffer was allocated above the 2 GB WASM


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #6278.

## What

`js2python_string` in `src/core/js2python.js` converts a JS string to a Python string by iterating with `for (let c of value)` + `c.codePointAt(0)`, pushing each code point into a plain JS array while tracking the max code point, then writing into the Python string buffer with `ASSIGN_U8/U16/U32`.

Two sources of overhead:
- the `for..of` string iterator allocates a one-character string per code point;
- a plain JS array of numbers is slower than a typed array.

This PR replaces the collection pass with an indexed `charCodeAt` loop that:
- handles surrogate pairs manually (a high surrogate `0xD800-0xDBFF` followed by a low surrogate `0xDC00-0xDFFF` is combined into one code point and the trailing unit is skipped);
- leaves lone surrogates as their bare code-unit value, exactly matching the previous string-iterator behavior;
- stores code points into a preallocated `Uint32Array(value.length)` (`value.length` UTF-16 units is an upper bound on the code-point count), tracking the real code-point count;
- passes the real code-point count (not `value.length`) to `_PyUnicode_New`.

The existing kind-dispatched write loops are unchanged apart from using the typed array and real count.

## Benchmark

Standalone Node 26 / V8 microbenchmark of the collection loop (old `for..of` vs. new indexed loop), ns per call:

| input | old | new | speedup |
|------|-----|-----|---------|
| 64 chars | ~218 ns | ~166 ns | ~1.3x |
| 4096 chars | ~13900 ns | ~5300 ns | ~2.6x |

## Correctness

A standalone Node script compared old vs. new code-point output (code points + max code point) on: empty string, ASCII, latin-1, BMP, emoji, mixed astral, valid surrogate pairs, `U+10FFFF`, lone high surrogate, lone low surrogate, high surrogate at end of string, two high surrogates in a row, and a reversed low+high pair. All matched. A fuzzer over 200,000 random strings (mixing ASCII, BMP, and raw surrogate code units, including lone surrogates) also produced identical output for both implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)