### PR TITLE
perf(ffi): cache _js_type_flags lookup in JsProxy instances

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -23,6 +23,8 @@ myst:
 
 - {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`
 
+- {{ Performance }} Sped up JsProxy operations by caching type flags. {pr}`6282`
+
 ## Version 314.0.0
 
 _June 09, 2026_

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -170,8 +170,16 @@ typedef struct
   } tf;
   JsRef js;
   PyObject* signature;
+  // Cache for the type's _js_type_flags, computed lazily by JsProxy_getflags.
+  // JS_TYPE_FLAGS_UNCACHED (-2) means "not yet computed"; it cannot collide
+  // with a valid flags value (>= 0) nor with the -1 error return. The flags
+  // are immutable per type (set once in JsProxy_create_subtype and never
+  // mutated), so caching them per instance is safe.
+  int js_type_flags_cache;
 } JsProxy;
 // clang-format on
+
+#define JS_TYPE_FLAGS_UNCACHED (-2)
 
 // Layout of dict and ExceptionFields needs to exactly match the layout of the
 // same-name fields of BaseException. Otherwise bad things will happen. Check it
@@ -223,12 +231,22 @@ _Static_assert(sizeof(PyBaseExceptionObject) ==
 int
 JsProxy_getflags(PyObject* self)
 {
+  int cached = ((JsProxy*)self)->js_type_flags_cache;
+  if (cached != JS_TYPE_FLAGS_UNCACHED) {
+    return cached;
+  }
   DECLARE_PY_OBJECT(pyflags);
   pyflags = _PyObject_GetAttrId((PyObject*)Py_TYPE(self), &PyId__js_type_flags);
   if (pyflags == NULL) {
     return -1;
   }
-  return PyLong_AsLong(pyflags);
+  int result = PyLong_AsLong(pyflags);
+  // PyLong_AsLong returns -1 on error; don't cache an error result.
+  if (result == -1 && PyErr_Occurred()) {
+    return -1;
+  }
+  ((JsProxy*)self)->js_type_flags_cache = result;
+  return result;
 }
 
 #define OBJMAP_HEREDITARY 1
@@ -3301,6 +3319,7 @@ JsProxy_cinit(PyObject* obj, JsVal val, PyObject* sig)
   JsProxy* self = (JsProxy*)obj;
   self->js = hiwire_new_deduplicate(val);
   self->signature = Py_XNewRef(sig);
+  self->js_type_flags_cache = JS_TYPE_FLAGS_UNCACHED;
 #ifdef DEBUG_F
   extern bool tracerefs;
   if (tracerefs) {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #6278.

## What

`JsProxy_getflags` (in `src/core/jsproxy.c`) previously did a full Python attribute lookup of `_js_type_flags` on the instance type plus a `PyLong_AsLong` unboxing **on every call**. It is invoked from hot container paths:

- `JsProxy_get_objmap_flags` — used in `JsArray_subscript` element access and iteration-result handling
- `JsProxy_is_py_json`
- `JsProxy_clear`

So the same dict lookup + unboxing repeated identical work on every container access.

## Change

Cache the flags per instance in the `JsProxy` struct. A new `int js_type_flags_cache` field is initialized to the sentinel `JS_TYPE_FLAGS_UNCACHED` (`-2`) in `JsProxy_cinit`. `JsProxy_getflags` now computes the flags once on first call, stores them, and returns the cached `int` on every subsequent call.

Before: one Python attribute lookup + unboxing per container operation.
After: one struct-field read after the first call.

The sentinel `-2` cannot collide with any valid flags value (always `>= 0`) nor with the `-1` error return. Error propagation is preserved: if the attribute lookup or `PyLong_AsLong` fails, the function returns `-1` and does **not** cache.

Lazy caching (rather than eager init) was chosen because it covers every instance-creation path uniformly, including any Python-level subclassing of `JsProxy`.

## Safety analysis

- **Flags are immutable per type.** `_js_type_flags` is set exactly once, in `JsProxy_create_subtype` (`PyObject_SetAttr` on the freshly created heap type), and is never mutated afterward. Grepping the whole repo for `_js_type_flags` confirms the only write is that one site; all other references are reads (the C getflags, the `__subclasscheck__` logic in `_pyodide/_core_docs.py`, and tests). An instance never changes its type, so a per-instance cache is correct.
- **All instances pass through `JsProxy_cinit`.** Every `JsProxy` struct is allocated in `JsProxy_create_with_type` (the only `tp_alloc` for the `JsProxy` layout), which always calls `JsProxy_cinit`, so the sentinel is always initialized. The `JsException` path (`JsException_new`) routes back through `js2python` → `JsProxy_create_with_type` → `JsProxy_cinit`. The separate `JsMethodCallSingleton` and `Buffer` structs are distinct types and are never passed to `JsProxy_getflags`.
- **GC / struct layout.** The new field is a plain `int` appended at the end of the struct (after `signature`), so it does not disturb the BaseException layout `_Static_assert`s (which only cover `dict`, the `ExceptionFields` union, and the leading portion of the struct). `tp_basicsize` is computed via `sizeof(JsProxy)`, so the allocation grows automatically. The field needs no `tp_traverse` visiting (not a `PyObject*`) and survives `tp_clear` (used in `JsProxy_clear`, which reads the flags) since it is not cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)