### PR TITLE
Experimental opt-in pthreads build (PYODIDE_PTHREADS=1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,15 +59,31 @@ src/core/pyodide_pre.gen.dat: src/js/generated/_pyodide.out.js src/core/pre.js s
 	echo '()<::>{' >> $@                       # zero argument argspec and start body
 	cat src/js/generated/_pyodide.out.js >> $@ # All of _pyodide.out.js is body
 	echo '}' >> $@                             # Close function body
+# This tail executes at module-evaluation time, including inside pthread
+# workers, where Pyodide's JS state does not exist. Skip init on workers.
+	echo 'var IS_PYODIDE_PTHREAD = typeof ENVIRONMENT_IS_PTHREAD !== "undefined" && ENVIRONMENT_IS_PTHREAD;' >> $@
 	cat src/core/stack_switching/stack_switching.out.js >> $@
 	cat src/core/pre.js >> $@                  # Execute pre.js too
-	echo "pyodide_js_init();" >> $@            # Then execute the function.
+	echo "if (!IS_PYODIDE_PTHREAD) pyodide_js_init();" >> $@ # Then execute the function.
 
 
 # Don't use ccache here because it does not support #embed properly.
 # https://github.com/ccache/ccache/discussions/1366
 src/core/pyodide_pre.o: src/core/pyodide_pre.c src/core/pyodide_pre.gen.dat emsdk/emsdk/.complete
-	unset _EMCC_CCACHE && emcc --std=c23 -c $< -o $@
+	unset _EMCC_CCACHE && emcc --std=c23 $(PTHREAD_FLAG) -c $< -o $@
+
+# JSEvents needs _emscripten_run_callback_on_thread (native code in libhtml5)
+# under pthreads, but AUTO_NATIVE_LIBRARIES=0 keeps libhtml5 out of the link
+# and linking all of it (MAIN_MODULE links whole archives) drags in unwanted
+# JS library deps, so compile just the one file that defines it.
+ifdef PYODIDE_PTHREADS
+MAIN_MODULE_PTHREAD_OBJS=src/core/emscripten_html5_callback.o
+endif
+
+src/core/emscripten_html5_callback.o: emsdk/emsdk/.complete
+	emcc -pthread $(OPTFLAGS) \
+		-I emsdk/emsdk/upstream/emscripten/system/lib/libc \
+		-c emsdk/emsdk/upstream/emscripten/system/lib/html5/callback.c -o $@
 
 src/core/jsverror.wasm: src/core/jsverror.wat emsdk/emsdk/.complete
 	./emsdk/emsdk/upstream/bin/wasm-as $< -o $@ -all
@@ -109,6 +125,7 @@ $(CPYTHONINSTALL)/.installed-pyodide: $(CPYTHONINSTALL)/include/pyodide/.install
 dist/pyodide.asm.mjs: \
 	dist \
 	src/core/main.o  \
+	$(MAIN_MODULE_PTHREAD_OBJS) \
 	$(wildcard src/py/lib/*.py) \
 	$(CPYTHONLIB) \
 	$(CPYTHONINSTALL)/.installed-pyodide
@@ -116,8 +133,8 @@ dist/pyodide.asm.mjs: \
 	@date +"[%F %T] Building pyodide.asm.mjs..."
    # TODO(ryanking13): Link libgl to a side module not to the main module.
    # For unknown reason, a side module cannot see symbols when libGL is linked to it.
-	embuilder build libgl
-	$(CXX) -o dist/pyodide.asm.mjs -lpyodide src/core/main.o $(MAIN_MODULE_LDFLAGS)
+	embuilder build $(if $(PYODIDE_PTHREADS),libGL-mt-getprocaddr,libgl)
+	$(CXX) -o dist/pyodide.asm.mjs -lpyodide src/core/main.o $(MAIN_MODULE_PTHREAD_OBJS) $(MAIN_MODULE_LDFLAGS)
 
 	if [[ -n $${PYODIDE_SOURCEMAP+x} ]] || [[ -n $${PYODIDE_SYMBOLS+x} ]] || [[ -n $${PYODIDE_DEBUG_JS+x} ]]; then \
 		cd dist && npx prettier -w pyodide.asm.mjs ; \

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -130,6 +130,17 @@ ifdef PYODIDE_ASSERTIONS
 	EXTRA_CFLAGS+= -DDEBUG_F
 endif
 
+# Experimental pthreads support (see docs/development/pthreads-prototype.md).
+# Opt in with PYODIDE_PTHREADS=1. Every object linked into the main module and
+# every side module must be compiled with -pthread, so it goes into the base
+# flags, which pyodide-build also picks up for package builds.
+ifdef PYODIDE_PTHREADS
+	export PTHREAD_FLAG=-pthread
+	EXTRA_CFLAGS+= -pthread
+	EXTRA_LDFLAGS+= -pthread -Wno-pthreads-mem-growth
+	MAIN_MODULE_PTHREAD_LDFLAGS=-sPTHREAD_POOL_SIZE=8 -sPTHREAD_POOL_SIZE_STRICT=0
+endif
+
 
 export OPTFLAGS=-O2
 export CFLAGS_BASE=\
@@ -198,7 +209,8 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) \
 	-lsdl.js \
 	--js-library=src/core/libjsverror.js \
 	-sMAX_WEBGL_VERSION=2  \
-	-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0
+	-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0 \
+	$(MAIN_MODULE_PTHREAD_LDFLAGS)
 
 EXPORTS=_main \
    ,_free \

--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,8 @@ import contextlib
 import os
 import pathlib
 import re
+import shutil
+import subprocess
 import sys
 from collections.abc import Sequence
 
@@ -20,6 +22,9 @@ from pytest_pyodide import get_global_config
 from pytest_pyodide.utils import package_is_built as _package_is_built
 
 os.environ["IN_PYTEST"] = "1"
+
+# Set when testing an experimental pthreads build (PYODIDE_PTHREADS=1 make).
+PYODIDE_PTHREADS = os.environ.get("PYODIDE_PTHREADS", "") not in ("", "0")
 
 
 def set_configs():
@@ -39,11 +44,19 @@ def set_configs():
         ],
     )
 
-    pytest_pyodide_config.set_flags(
-        "node",
-        pytest_pyodide_config.get_flags("node")
-        + ["--experimental-wasm-stack-switching"],
+    # Node >= 24 enables JSPI by default and rejects the old flag.
+    node_major = 0
+    node_version = shutil.which("node") and subprocess.run(
+        ["node", "--version"], capture_output=True, text=True, check=False
     )
+    if node_version and node_version.stdout.startswith("v"):
+        node_major = int(node_version.stdout[1:].split(".")[0])
+    if node_major < 24:
+        pytest_pyodide_config.set_flags(
+            "node",
+            pytest_pyodide_config.get_flags("node")
+            + ["--experimental-wasm-stack-switching"],
+        )
 
     # There are a bunch of global objects that occasionally enter the hiwire cache
     # but never leave. The refcount checks get angry about them if they aren't preloaded.
@@ -75,22 +88,61 @@ def set_configs():
         """,
     )
 
-    pytest_pyodide_config.set_load_pyodide_script(
-        "node",
-        """
-        const {readFileSync} = require("fs");
-        let snap = readFileSync("snapshot.bin");
-        snap = new Uint8Array(snap.buffer);
-        let pyodide = await loadPyodide({
-            jsglobals: self,
-            _loadSnapshot: snap,
-        });
-        """,
-    )
+    if PYODIDE_PTHREADS:
+        # Snapshots don't work with shared memory (the snapshot code copies
+        # Module.HEAP8, which is a SharedArrayBuffer view in pthread builds).
+        pytest_pyodide_config.set_load_pyodide_script(
+            "node",
+            """
+            let pyodide = await loadPyodide({
+                jsglobals: self,
+            });
+            """,
+        )
+    else:
+        pytest_pyodide_config.set_load_pyodide_script(
+            "node",
+            """
+            const {readFileSync} = require("fs");
+            let snap = readFileSync("snapshot.bin");
+            snap = new Uint8Array(snap.buffer);
+            let pyodide = await loadPyodide({
+                jsglobals: self,
+                _loadSnapshot: snap,
+            });
+            """,
+        )
     pytest_pyodide_config.add_node_extra_globals(["URL", "Headers", "Response"])
 
 
 set_configs()
+
+if PYODIDE_PTHREADS:
+    # Browsers only expose SharedArrayBuffer (required by pthreads) on
+    # cross-origin isolated pages, so the test servers must send COOP/COEP.
+    from pytest_pyodide.server import spawn_web_server
+
+    COI_HEADERS = {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp",
+    }
+
+    @pytest.fixture(scope="session")
+    def web_server_main(request):
+        with spawn_web_server(
+            request.config.option.dist_dir, extra_headers=COI_HEADERS
+        ) as output:
+            yield output
+
+    @pytest.fixture(scope="session")
+    def web_server_secondary(request):
+        # CORP lets the COEP-isolated main page load this server's resources.
+        headers = COI_HEADERS | {"Cross-Origin-Resource-Policy": "cross-origin"}
+        with spawn_web_server(
+            request.config.option.dist_dir, extra_headers=headers
+        ) as output:
+            yield output
+
 
 only_node = pytest.mark.xfail_browsers(
     chrome="node only", firefox="node only", safari="node only"

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -33,6 +33,16 @@ ifdef CPYTHON_DEBUG
 	MAYBE_WITH_PYDEBUG=--with-pydebug
 endif
 
+# Experimental pthreads support, opt in with PYODIDE_PTHREADS=1.
+# wasm-ld refuses to link shared memory if any object lacks the atomics and
+# bulk-memory features, so every vendored static library needs -pthread too.
+ifdef PYODIDE_PTHREADS
+	MAYBE_ENABLE_WASM_PTHREADS=--enable-wasm-pthreads
+	SQLITE_THREADSAFE_FLAG=--enable-threadsafe
+else
+	SQLITE_THREADSAFE_FLAG=--disable-threadsafe
+endif
+
 all: $(PYINSTALL)/lib/$(PYLIB) libffi libhiwire liblzma libzstd
 
 libffi: $(PYINSTALL)/lib/libffi.a
@@ -125,7 +135,7 @@ $(PYINSTALL)/lib/libffi.a :
 		&& git fetch --depth 1 $(LIBFFIREPO) $(LIBFFI_COMMIT) \
 		&& git checkout FETCH_HEAD \
 		&& . $(PYODIDE_ROOT)/emsdk/emsdk/emsdk_env.sh \
-		&& ./testsuite/emscripten/build.sh --wasm-bigint \
+		&& EMCC_CFLAGS="$(PTHREAD_FLAG)" ./testsuite/emscripten/build.sh --wasm-bigint \
 		&& make install \
 	)
 	cp $(FFIBUILD)/target/include/*.h $(PYBUILD)/Include/
@@ -141,7 +151,8 @@ $(PYINSTALL)/lib/libhiwire.a :
 		&& git fetch --depth 1 $(HIWIREREPO) $(HIWIRE_COMMIT) \
 		&& git checkout FETCH_HEAD \
 		&& . $(PYODIDE_ROOT)/emsdk/emsdk/emsdk_env.sh \
-		&& CC=emcc EMSCRIPTEN_DEDUPLICATE=1 EXTERN_FAIL=1 make \
+		&& . $(PYODIDE_ROOT)/pyodide_env.sh \
+		&& CC=emcc EMSCRIPTEN_DEDUPLICATE=1 EXTERN_FAIL=1 EMCC_CFLAGS="$(PTHREAD_FLAG)" make \
 	)
 	cp -r $(HIWIREBUILD)/dist/lib $(PYINSTALL)/
 	rm -rf $(PYINSTALL)/include/hiwire
@@ -156,7 +167,7 @@ $(PYINSTALL)/lib/liblzma.a :
 		&& . $(PYODIDE_ROOT)/emsdk/emsdk/emsdk_env.sh \
 		&& . $(PYODIDE_ROOT)/pyodide_env.sh \
 		&& emconfigure ./configure \
-			CFLAGS="-fPIC -Os" \
+			CFLAGS="-fPIC -Os $(PTHREAD_FLAG)" \
 			--disable-xz \
 			--disable-xzdec \
 			--disable-lzmadec \
@@ -187,7 +198,7 @@ $(PYINSTALL)/lib/libzstd.a:
 		&& emcmake cmake build/cmake \
 			-B build-wasm \
 			-DCMAKE_BUILD_TYPE=MinSizeRel \
-			-DCMAKE_C_FLAGS="-fPIC" \
+			-DCMAKE_C_FLAGS="-fPIC $(PTHREAD_FLAG)" \
 			-DZSTD_BUILD_SHARED=OFF \
 			-DZSTD_BUILD_STATIC=ON \
 			-DZSTD_BUILD_PROGRAMS=OFF \
@@ -214,9 +225,9 @@ $(PYINSTALL)/lib/libsqlite3.a:
 		&& . $(PYODIDE_ROOT)/emsdk/emsdk/emsdk_env.sh \
 		&& . $(PYODIDE_ROOT)/pyodide_env.sh \
 		&& emconfigure ./configure \
-			CFLAGS="-fPIC -Os" \
+			CFLAGS="-fPIC -Os $(PTHREAD_FLAG)" \
 			--disable-readline \
-			--disable-threadsafe \
+			$(SQLITE_THREADSAFE_FLAG) \
 			--disable-shared \
 			--enable-static \
 			--disable-static-shell \
@@ -267,6 +278,7 @@ $(PYBUILD)/Makefile: $(PYBUILD)/.patched
 			  --prefix=$(PYINSTALL)  \
 			  --with-build-python=$$(which python$(PYMAJOR).$(PYMINOR)) \
 			  $(MAYBE_WITH_PYDEBUG) \
+			  $(MAYBE_ENABLE_WASM_PTHREADS) \
 	)
 
 

--- a/cpython/adjust_sysconfig.py
+++ b/cpython/adjust_sysconfig.py
@@ -48,6 +48,11 @@ def adjust_sysconfig(config_vars: dict[str, str]):
         CXX="c++",
         LDCXXSHARED="c++",
     )
+    # Pyodide links the main module itself and never uses LINKFORSHARED, but
+    # configure --enable-wasm-pthreads puts -sPROXY_TO_PTHREAD in it, which
+    # must not leak into package builds via sysconfigdata.
+    if "LINKFORSHARED" in config_vars:
+        config_vars["LINKFORSHARED"] = ""
     config_vars["PYODIDE_ABI_VERSION"] = os.environ["PYODIDE_ABI_VERSION"]
     config_vars["PYEMSCRIPTEN_PLATFORM_VERSION"] = os.environ["PYODIDE_ABI_VERSION"]
     config_vars["PYEMSCRIPTEN_ABI_VERSION"] = os.environ["PYODIDE_ABI_VERSION"]

--- a/cpython/patches/0010-Disable-wasm-gc-trampoline-in-pthreads-builds.patch
+++ b/cpython/patches/0010-Disable-wasm-gc-trampoline-in-pthreads-builds.patch
@@ -1,0 +1,39 @@
+From: Pyodide pthreads prototype <pyodide@pyodide.org>
+Date: Thu, 11 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Disable the wasm-gc call trampoline in pthreads builds
+
+The wasm-gc trampoline function pointer is created with addFunction on
+the main thread. Every pthread has its own WebAssembly.Table and
+Emscripten only mirrors dlopen'd libraries between thread tables, not
+addFunction entries, so the table index stored in (shared)
+_PyRuntimeState is out of bounds on worker threads: the first Python
+call on a spawned thread crashes with "RuntimeError: table index is out
+of bounds" in _PyEM_TrampolineCall. Instantiating the trampoline module
+would also fail on the main thread because its hardcoded memory import
+is not declared shared ("mismatch in shared state of memory").
+
+Fall back to the JS trampoline when wasmMemory is a SharedArrayBuffer;
+it resolves the function pointer through the calling thread's own table.
+
+---
+--- a/Python/emscripten_trampoline.c	2026-06-11 01:07:43
++++ b/Python/emscripten_trampoline.c	2026-06-11 01:07:43
+@@ -55,6 +55,18 @@
+ }
+ // Try to compile wasm-gc trampoline if possible.
+ function getPyEMTrampolinePtr() {
++    // In pthreads builds the trampoline must not be used: the function
++    // pointer is created with addFunction on the main thread, but every
++    // pthread has its own WebAssembly.Table, and addFunction entries are not
++    // mirrored to other threads (only dlopen'd libraries are synced). The
++    // table index stored in _PyRuntimeState would be out of bounds on worker
++    // threads. Also, instantiating the trampoline module would fail anyway
++    // because its memory import is not declared shared. Fall back to the JS
++    // trampoline, which resolves func through the calling thread's own table.
++    if (typeof SharedArrayBuffer !== "undefined" && wasmMemory
++        && wasmMemory.buffer instanceof SharedArrayBuffer) {
++        return 0;
++    }
+     // Starting with iOS 18.3.1, WebKit on iOS has an issue with the garbage
+     // collector that breaks the call trampoline. See #130418 and
+     // https://bugs.webkit.org/show_bug.cgi?id=293113 for details.

--- a/docs/development/pthreads-prototype.md
+++ b/docs/development/pthreads-prototype.md
@@ -1,0 +1,139 @@
+# Experimental pthreads build (prototype)
+
+This branch carries an opt-in, experimental build of Pyodide with CPython
+threading (pthreads) enabled, investigating the state of Emscripten's
+pthreads + dynamic-linking support (see issue
+[#237](https://github.com/pyodide/pyodide/issues/237)). It is a prototype:
+not ABI-stable, not CI-tested, and not intended to ship as-is.
+
+## Building
+
+```sh
+PYODIDE_PTHREADS=1 make all-but-packages
+PYODIDE_PTHREADS=1 PYODIDE_PACKAGES="tag:pytest,tag:pyodide.test,numpy,!test-rust-abi,!test-rust-panic" make -C packages
+```
+
+Everything is guarded by `ifdef PYODIDE_PTHREADS`, so the default build is
+unchanged. The flag adds `-pthread` to `CFLAGS_BASE`/`LDFLAGS_BASE` (which
+pyodide-build also picks up, so package side modules need no extra
+configuration), passes `--enable-wasm-pthreads` to CPython's configure,
+builds sqlite threadsafe, adds `-pthread` to every vendored static library
+(wasm-ld refuses `--shared-memory` if any object lacks the atomics and
+bulk-memory features), and links the main module with
+`-sPTHREAD_POOL_SIZE=8 -sPTHREAD_POOL_SIZE_STRICT=0`.
+
+Testing:
+
+```sh
+# Node (no special setup needed)
+PYODIDE_PTHREADS=1 pytest src/tests/test_core_python.py --runtime node -m long_running -k thread
+
+# Browser: SharedArrayBuffer requires cross-origin isolation, so the regular
+# `python -m http.server` is not enough:
+python tools/serve_coi.py 8000 --directory dist
+# then check `crossOriginIsolated === true` in devtools.
+```
+
+The pytest fixtures in `conftest.py` automatically serve COOP/COEP headers
+and skip memory snapshots when `PYODIDE_PTHREADS=1` is set.
+
+## Results (Emscripten 5.0.3, Pyodide 314.1.0.dev0, June 2026)
+
+| Rung | Node 26 | Chrome (headless, COI) |
+| --- | --- | --- |
+| Boot, `sys._emscripten_info.pthreads == True` | pass | pass |
+| `threading.Thread` start/run/join | pass | pass |
+| Locks, `queue`, `ThreadPoolExecutor` | pass | pass |
+| CPython stdlib: `test_thread`, `test_threading`, `test_threading_local`, `test_threadedtempfile`, `test_thread_local_bytecode`, `test_importlib.test_threaded_import` | pass | not run |
+| dlopen numpy before threads (baseline) | pass | pass |
+| dlopen numpy **while a Python thread runs** | pass | not run |
+| import numpy **inside a spawned thread** (per-thread dylib table sync) | pass | not run |
+| re-dlopen of an already-loaded library (ctypes) | pass | not run |
+| 48 numpy matmuls on 12 threads (pool size 8, deferred spawn) | pass (0.6 s) | pass (4 threads) |
+
+Stdlib failures, both platform gaps rather than threading bugs (annotated in
+`src/tests/python_tests.yaml`): `test_concurrent_futures.test_thread_pool`
+(imports `InterpreterPoolExecutor`, needs the `_interpreters` module) and
+`test_threadsignals` (`signal.alarm` does not exist on Emscripten).
+
+## Bugs found and fixed along the way
+
+1. **CPython's wasm-gc call trampoline is incompatible with pthreads**
+   (`cpython/patches/0010-Disable-wasm-gc-trampoline-in-pthreads-builds.patch`).
+   Two independent problems, both worth reporting upstream to CPython:
+   - The hardcoded trampoline wasm binary imports `env.memory` without the
+     shared flag, so instantiation fails at boot in a shared-memory build
+     ("LinkError: mismatch in shared state of memory, declared = 0,
+     imported = 1").
+   - Worse: the trampoline function pointer is created with `addFunction` on
+     the main thread and stored in (shared) `_PyRuntimeState`. Every pthread
+     has its **own** `WebAssembly.Table`, and Emscripten only mirrors
+     dlopen'd libraries between thread tables, not `addFunction` entries.
+     The first Python call on a spawned thread crashes with
+     "RuntimeError: table index is out of bounds" in `_PyEM_TrampolineCall`.
+     The crash is nearly invisible: the worker dies, sets
+     `crashed_thread_id`, and the main thread later throws the cryptic
+     `Error: unwind` from `_emscripten_yield` the next time it enters wasm.
+   The patch falls back to the JS trampoline (which resolves the function
+   pointer through the calling thread's own table) whenever `wasmMemory` is
+   a `SharedArrayBuffer`. A proper fix could instantiate the trampoline once
+   per thread instead.
+
+2. **Pyodide's injected JS runs in every pthread worker.** The
+   `pyodide_pre.gen.dat` tail (`pre.js`, `stack_switching.out.js`,
+   `pyodide_js_init()`) executes at module-evaluation time, which includes
+   pthread workers, where `Module.API` and `Module.preRun` do not exist. The
+   recipe now defines `IS_PYODIDE_PTHREAD` (via `ENVIRONMENT_IS_PTHREAD`)
+   and skips `pyodide_js_init()` on workers; `pre.js` and
+   `stack_switching.mjs` got matching guards.
+
+3. **`JSEvents` needs native code from `libhtml5` under pthreads**
+   (`_emscripten_run_callback_on_thread`), but `AUTO_NATIVE_LIBRARIES=0`
+   keeps it out of the link and `MAIN_MODULE=1` whole-archive linking of
+   `-lhtml5` drags in `emscripten_wget.c` and unwanted JS library deps. The
+   Makefile compiles just `system/lib/html5/callback.c` into the link.
+
+4. **`embuilder build libgl --pthreads` no longer exists** in Emscripten
+   5.x; the multithreaded port variant is the named target
+   `libGL-mt-getprocaddr`.
+
+5. **Memory snapshots are incompatible with shared memory** (the snapshot
+   code copies `Module.HEAP8`, which views a `SharedArrayBuffer`). The
+   conftest skips snapshots under `PYODIDE_PTHREADS=1`; `make all` (which
+   builds `dist/snapshot.bin`) has not been adapted — use
+   `make all-but-packages` + `make -C packages`.
+
+## Upstream issues we expected to hit but did not (on 5.0.3)
+
+- [emscripten#26913](https://github.com/emscripten-core/emscripten/issues/26913)
+  (`_emscripten_dlsync_threads` deadlock): a regression introduced by the
+  futex rework in 5.0.7 and fixed post-5.0.7 — 5.0.3 predates it, which is
+  presumably why dlopen-with-live-threads worked here. An Emscripten upgrade
+  should re-run probe 2 (`/tmp` probes are reproduced in the issue-comment
+  draft below).
+- [emscripten#26227](https://github.com/emscripten-core/emscripten/issues/26227)
+  (re-dlopen deadlock): not reproduced via the ctypes re-dlopen path.
+
+## Known gaps / follow-up work
+
+- **FFI is not thread-safe.** Hiwire/JsProxy state and the `js` module exist
+  per JS realm; touching them from a spawned thread is undefined behavior.
+  Threads must stick to pure-Python/native compute. A real design (proxying
+  to the main thread, or per-thread hiwire state) is the largest open item.
+- **jsverror wiring is main-thread-only**: workers get no-op stubs from
+  `src/core/libjsverror.js`, so JS-error funneling into wasm is degraded off
+  the main thread.
+- **ABI**: `-pthread` changes the ABI; every package wheel must be rebuilt.
+  A shipped threaded Pyodide means a second ABI tag / build matrix.
+- **Deployment**: COOP/COEP cross-origin isolation breaks header-less hosts
+  and CDN loading without CORP/CORS — a threaded build can only be opt-in.
+- **PYODIDE_SYMBOLS=1 + pthreads breaks boot** (`API._pyodide` undefined in
+  `finalizeBootstrap`) — the RUNTIME_DEBUG instrumentation appears to
+  interact with the EM_JS injection; debug with `EXTRA_LDFLAGS=-g2` instead.
+- **Snapshots** (above), `test_snapshots.py` should be skipped.
+- The default (non-pthread) build is expected to be unchanged but was not
+  re-verified after the Makefile edits; run normal CI before merging
+  anything from this branch.
+- Stress areas not yet probed: JSPI/stack-switching × threads
+  (`test_stack_switching.py`), `ALLOW_MEMORY_GROWTH` view-staleness under
+  growth on a worker, Firefox/Safari, fs access from threads.

--- a/src/core/pre.js
+++ b/src/core/pre.js
@@ -1,4 +1,6 @@
-const API = Module.API;
+// In pthread workers Module.API does not exist; the assignments below then
+// write into a throwaway object. EM_JS bodies still need the API global.
+const API = Module.API ?? {};
 const Hiwire = {};
 const Tests = {};
 API.tests = Tests;

--- a/src/core/stack_switching/stack_switching.mjs
+++ b/src/core/stack_switching/stack_switching.mjs
@@ -36,6 +36,8 @@ Module.newJspiSupported = newJspiSupported;
 Module.oldJspiSupported = oldJspiSupported;
 Module.jspiSupported = jspiSupported;
 
-if (jspiSupported) {
+// Module.preRun is undefined in pthread workers; suspenders are
+// main-thread-only anyways.
+if (jspiSupported && Module.preRun) {
   Module.preRun.push(initSuspenders);
 }

--- a/src/tests/python_tests.yaml
+++ b/src/tests/python_tests.yaml
@@ -199,7 +199,10 @@
 - test_concurrent_futures.test_interpreter_pool
 - test_concurrent_futures.test_process_pool
 - test_concurrent_futures.test_shutdown
-- test_concurrent_futures.test_thread_pool
+- test_concurrent_futures.test_thread_pool:
+    # In pthreads builds the tests run but fail at import:
+    # InterpreterPoolExecutor needs the _interpreters module (not built).
+    xfail: needs _interpreters module
 - test_concurrent_futures.test_wait
 - test_configparser
 - test_contains
@@ -847,7 +850,10 @@
 - test_threadedtempfile
 - test_threading
 - test_threading_local
-- test_threadsignals
+- test_threadsignals:
+    # In pthreads builds the tests run but use signal.alarm, which does not
+    # exist on Emscripten.
+    xfail: needs signal.alarm
 - test_time:
     skip:
     - test_pthread_getcpuclockid   #  time.pthread_getcpuclockid(threading.get_ident()) fails

--- a/tools/serve_coi.py
+++ b/tools/serve_coi.py
@@ -1,0 +1,42 @@
+"""Serve a directory with the cross-origin isolation headers.
+
+SharedArrayBuffer (required by pthread builds) is only available on
+cross-origin isolated pages, so plain ``python -m http.server`` is not enough
+to test a PYODIDE_PTHREADS build in a browser. Usage:
+
+    python tools/serve_coi.py [port] [--directory dist]
+
+Then open http://localhost:8000/console.html and check that
+``crossOriginIsolated`` is true in the devtools console.
+"""
+
+import sys
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+
+class COIRequestHandler(SimpleHTTPRequestHandler):
+    def end_headers(self) -> None:
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        super().end_headers()
+
+
+def main() -> None:
+    port = 8000
+    directory = "dist"
+    args = sys.argv[1:]
+    if "--directory" in args:
+        i = args.index("--directory")
+        directory = args[i + 1]
+        del args[i : i + 2]
+    if args:
+        port = int(args[0])
+    handler = partial(COIRequestHandler, directory=directory)
+    with ThreadingHTTPServer(("", port), handler) as httpd:
+        print(f"Serving {directory} at http://localhost:{port} with COOP/COEP")
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Prototype implementation of the plan in #6284, investigating Emscripten pthreads + dynamic linking for CPython threading (#237). Everything is behind `ifdef PYODIDE_PTHREADS`; the default build is unchanged.

## What works (Emscripten 5.0.3, Node 26 + headless Chrome with COOP/COEP)

- `threading.Thread` start/run/join, locks, `queue`, `concurrent.futures.ThreadPoolExecutor`
- CPython stdlib `test_thread`, `test_threading`, `test_threading_local`, `test_threadedtempfile`, `test_thread_local_bytecode`, `test_importlib.test_threaded_import` pass under `--runtime node`
- dlopen under threads: loading a `-pthread` numpy wheel while a Python thread runs, importing numpy *inside* a spawned thread (per-thread dylib table sync), and re-dlopen all work — emscripten#26913 is a 5.0.7 regression that 5.0.3 predates, so an Emscripten upgrade must re-run these probes
- 48 numpy matmuls across 12 threads (pool of 8 + deferred spawn) in ~0.6 s in Node

Full results matrix and follow-up list: `docs/development/pthreads-prototype.md`.

## Changes

- **Build**: `-pthread` in `CFLAGS_BASE`/`LDFLAGS_BASE` (propagates to package side modules through pyodide-build with no pyodide-build changes), `--enable-wasm-pthreads` for CPython, threadsafe sqlite, `-pthread` for all vendored static libs, `-sPTHREAD_POOL_SIZE=8` on the main module link.
- **CPython patch** (`cpython/patches/0010`): fall back to the JS call trampoline on shared memory. The wasm-gc trampoline funcptr is created with `addFunction` on the main thread, but every pthread has its own `WebAssembly.Table` and Emscripten only mirrors dlopen'd libraries between thread tables — the first Python call on a spawned thread crashes with `table index is out of bounds`, surfacing only as a cryptic `Error: unwind` on the main thread. (Affects any CPython Emscripten pthreads build; should be reported upstream.)
- **Runtime**: guard Pyodide's injected JS (`pre.js`, `pyodide_js_init()`) against executing in pthread workers; compile `system/lib/html5/callback.c` into the link (JSEvents needs `_emscripten_run_callback_on_thread`, excluded by `AUTO_NATIVE_LIBRARIES=0`); `libGL-mt-getprocaddr` embuilder target.
- **Test infra**: COOP/COEP headers on the pytest web servers and snapshots disabled when `PYODIDE_PTHREADS=1`; `tools/serve_coi.py` for manual browser testing; Node ≥ 24 flag fix.

## Known gaps (documented, not addressed here)

FFI is not thread-safe (spawned threads must not touch `js`/`pyodide.ffi`); jsverror wiring is main-thread-only; `-pthread` is an ABI break requiring a full package rebuild matrix; COOP/COEP makes deployment opt-in-only; JSPI × threads untested; the default build needs a normal CI run to confirm it is untouched.

Closes #6284. Refs #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)