### PR TITLE
Use defer to clean up PyObject references

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -137,6 +137,7 @@ export CFLAGS_BASE=\
 	$(DBGFLAGS) \
 	-fPIC \
 	-fwasm-exceptions \
+	-fdefer-ts \
 	-sSUPPORT_LONGJMP=wasm \
 	$(EXTRA_CFLAGS)
 

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -137,7 +137,6 @@ export CFLAGS_BASE=\
 	$(DBGFLAGS) \
 	-fPIC \
 	-fwasm-exceptions \
-	-fdefer-ts \
 	-sSUPPORT_LONGJMP=wasm \
 	$(EXTRA_CFLAGS)
 
@@ -318,6 +317,7 @@ export MAIN_MODULE_CFLAGS= $(CFLAGS_BASE) \
 	-Werror=incompatible-pointer-types \
 	-Werror=unused-result \
 	-mreference-types \
+	-fdefer-ts \
 	-I$(PYTHONINCLUDE) \
 	-I$(PYTHONINCLUDE)/..
 

--- a/src/core/_pyodide_core.c
+++ b/src/core/_pyodide_core.c
@@ -69,7 +69,8 @@ init_pyodide_proxy()
   });
   bool success = false;
   // Enable JavaScript access to the _pyodide module.
-  PyObject* _pyodide = PyImport_ImportModule("_pyodide");
+  DECLARE_PY_OBJECT(_pyodide);
+  _pyodide = PyImport_ImportModule("_pyodide");
   FAIL_IF_NULL(_pyodide);
   JsVal _pyodide_proxy = python2js(_pyodide);
   FAIL_IF_JS_ERROR(_pyodide_proxy);
@@ -77,7 +78,6 @@ init_pyodide_proxy()
 
   success = true;
 finally:
-  Py_CLEAR(_pyodide);
   return success ? 0 : -1;
 }
 
@@ -86,7 +86,7 @@ PyObject*
 PyInit__pyodide_core(void)
 {
   bool success = false;
-  PyObject* _pyodide = NULL;
+  DECLARE_PY_OBJECT(_pyodide);
   PyObject* core_module = NULL;
 
   _pyodide = PyImport_ImportModule("_pyodide");
@@ -119,7 +119,6 @@ PyInit__pyodide_core(void)
 
   success = true;
 finally:
-  Py_CLEAR(_pyodide);
   if (!success) {
     Py_CLEAR(core_module);
   }

--- a/src/core/docstring.c
+++ b/src/core/docstring.c
@@ -10,8 +10,8 @@ int
 set_method_docstring(PyMethodDef* method, PyObject* parent)
 {
   bool success = false;
-  PyObject* py_method = NULL;
-  PyObject* py_result = NULL;
+  DECLARE_PY_OBJECT(py_method);
+  DECLARE_PY_OBJECT(py_result);
 
   py_method = PyObject_GetAttrString(parent, method->ml_name);
   if (py_method == NULL) {
@@ -40,8 +40,6 @@ set_method_docstring(PyMethodDef* method, PyObject* parent)
 
   success = true;
 finally:
-  Py_CLEAR(py_method);
-  Py_CLEAR(py_result);
   return success ? 0 : -1;
 }
 

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -148,16 +148,16 @@ EMSCRIPTEN_KEEPALIVE JsVal
 wrap_exception()
 {
   bool success = false;
-  PyObject* exc = NULL;
-  PyObject* typestr = NULL;
+  DECLARE_PY_OBJECT(exc);
+  DECLARE_PY_OBJECT(typestr);
 
   exc = PyErr_GetRaisedException();
 
   if (PyErr_GivenExceptionMatches(exc, PyExc_ModuleNotFoundError)) {
-    PyObject* res = _PyObject_CallMethodIdOneArg(
+    DECLARE_PY_OBJECT(res);
+    res = _PyObject_CallMethodIdOneArg(
       _pyodide_importhook, &PyId_add_note_to_module_not_found_error, exc);
     FAIL_IF_NULL(res);
-    Py_CLEAR(res);
   }
 
   capture_stderr();
@@ -206,8 +206,6 @@ finally:
     Js_static_string(msg, "Error occurred while formatting traceback");
     jserror = new_error("PyodideInternalError", JsvString_FromId(&msg), 0);
   }
-  Py_CLEAR(exc);
-  Py_CLEAR(typestr);
   return jserror;
 }
 
@@ -261,7 +259,7 @@ int
 error_handling_init(PyObject* core_module)
 {
   bool success = false;
-  PyObject* _pyodide_core_docs = NULL;
+  DECLARE_PY_OBJECT(_pyodide_core_docs);
 
   _pyodide_core_docs = PyImport_ImportModule("_pyodide._core_docs");
   FAIL_IF_NULL(_pyodide_core_docs);
@@ -281,6 +279,5 @@ error_handling_init(PyObject* core_module)
 
   success = true;
 finally:
-  Py_CLEAR(_pyodide_core_docs);
   return success ? 0 : -1;
 }

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -188,6 +188,13 @@ console_error_obj(JsVal obj);
 #define FAIL() goto finally
 #endif
 
+#define DECLARE_PY_OBJECT(x)                                                   \
+  PyObject* x = NULL;                                                          \
+  _Defer                                                                       \
+  {                                                                            \
+    Py_CLEAR(x);                                                               \
+  }
+
 #define FAIL_IF_NULL(ref)                                                      \
   do {                                                                         \
     if (unlikely((ref) == NULL)) {                                             \

--- a/src/core/jsbind.c
+++ b/src/core/jsbind.c
@@ -116,7 +116,7 @@ static PyTypeObject Py2JsConverterType = {
 JsVal
 Py2JsConverter_convert(PyObject* converter, PyObject* pyval, JsVal proxies)
 {
-  PyObject* pre_converted = NULL;
+  DECLARE_PY_OBJECT(pre_converted);
   JsVal result = JS_ERROR;
 
   int status = PyObject_IsInstance(converter, (PyObject*)&Py2JsConverterType);
@@ -137,7 +137,6 @@ Py2JsConverter_convert(PyObject* converter, PyObject* pyval, JsVal proxies)
   result =
     Py2JsConverter_converter(converter)(converter, pre_converted, proxies);
 finally:
-  Py_CLEAR(pre_converted);
   return result;
 }
 
@@ -580,13 +579,13 @@ add_py2js_converter(PyObject* core_mod,
 {
   bool success = false;
 
-  PyObject* converter = Py2JsConverter_cnew(func);
+  DECLARE_PY_OBJECT(converter);
+  converter = Py2JsConverter_cnew(func);
   FAIL_IF_NULL(converter);
   FAIL_IF_MINUS_ONE(PyObject_SetAttrString(core_mod, name, converter));
 
   success = true;
 finally:
-  Py_CLEAR(converter);
   return success ? 0 : -1;
 }
 
@@ -597,13 +596,13 @@ add_js2py_converter(PyObject* core_mod,
 {
   bool success = false;
 
-  PyObject* converter = Js2PyConverter_cnew(func);
+  DECLARE_PY_OBJECT(converter);
+  converter = Js2PyConverter_cnew(func);
   FAIL_IF_NULL(converter);
   FAIL_IF_MINUS_ONE(PyObject_SetAttrString(core_mod, name, converter));
 
   success = true;
 finally:
-  Py_CLEAR(converter);
   return success ? 0 : -1;
 }
 

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -544,8 +544,8 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
 
   bool success = false;
   JsVal jsresult = JS_ERROR;
-  DECLARE_PY_OBJECT(get_attr_sig_res);
-  DECLARE_PY_OBJECT(attr_sig);
+  PyObject* get_attr_sig_res = NULL;
+  PyObject* attr_sig = NULL;
   // result:
   PyObject* pyresult = NULL;
 
@@ -623,6 +623,8 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
 success:
   success = true;
 finally:
+  Py_CLEAR(attr_sig);
+  Py_CLEAR(get_attr_sig_res);
   if (!success) {
     Py_CLEAR(pyresult);
   }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1171,7 +1171,7 @@ _agen_handle_result_js_c(PyObject* set_result,
   if (status == 0) {
     PyObject_CallOneArg(set_result, pyvalue);
     // Not sure what to do if there is an error here...
-    goto finally;
+    return;
   }
 
   if (status == 1) {
@@ -1198,15 +1198,12 @@ return_error:
   if (closing && (PyErr_GivenExceptionMatches(e, PyExc_StopAsyncIteration) ||
                   PyErr_GivenExceptionMatches(e, PyExc_GeneratorExit))) {
     PyObject_CallOneArg(set_result, Py_None);
-    goto finally;
+    return;
   }
 
   PyObject_CallOneArg(set_exception, e);
   // Don't know what to do if there was an error...
   PyErr_Clear();
-  goto finally;
-
-finally:;
 }
 
 // clang-format off

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -223,14 +223,12 @@ _Static_assert(sizeof(PyBaseExceptionObject) ==
 int
 JsProxy_getflags(PyObject* self)
 {
-  PyObject* pyflags =
-    _PyObject_GetAttrId((PyObject*)Py_TYPE(self), &PyId__js_type_flags);
+  DECLARE_PY_OBJECT(pyflags);
+  pyflags = _PyObject_GetAttrId((PyObject*)Py_TYPE(self), &PyId__js_type_flags);
   if (pyflags == NULL) {
     return -1;
   }
-  int result = PyLong_AsLong(pyflags);
-  Py_CLEAR(pyflags);
-  return result;
+  return PyLong_AsLong(pyflags);
 }
 
 #define OBJMAP_HEREDITARY 1
@@ -345,12 +343,11 @@ JsProxy_bind_class(PyObject* self, PyObject* sig)
   // JsProxy_bind_sig.
   // bind_class_sig takes sig and returns type[sig].
   _Py_IDENTIFIER(bind_class_sig);
-  PyObject* class_sig =
-    _PyObject_CallMethodIdOneArg(jsbind, &PyId_bind_class_sig, sig);
+  DECLARE_PY_OBJECT(class_sig);
+  class_sig = _PyObject_CallMethodIdOneArg(jsbind, &PyId_bind_class_sig, sig);
   FAIL_IF_NULL(class_sig);
   result = JsProxy_bind_sig(self, class_sig);
 finally:
-  Py_CLEAR(class_sig);
   return result;
 }
 
@@ -547,8 +544,8 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
 
   bool success = false;
   JsVal jsresult = JS_ERROR;
-  PyObject* get_attr_sig_res = NULL;
-  PyObject* attr_sig = NULL;
+  DECLARE_PY_OBJECT(get_attr_sig_res);
+  DECLARE_PY_OBJECT(attr_sig);
   // result:
   PyObject* pyresult = NULL;
 
@@ -626,8 +623,6 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
 success:
   success = true;
 finally:
-  Py_CLEAR(attr_sig);
-  Py_CLEAR(get_attr_sig_res);
   if (!success) {
     Py_CLEAR(pyresult);
   }
@@ -877,10 +872,10 @@ JsException_reduce(PyObject* self, PyObject* Py_UNUSED(ignored))
   // Record name, message, and stack.
   // See _core_docs.JsException._new_exc where the unpickling will happen.
   PyObject* res = NULL;
-  PyObject* args = NULL;
-  PyObject* name = NULL;
-  PyObject* message = NULL;
-  PyObject* stack = NULL;
+  DECLARE_PY_OBJECT(args);
+  DECLARE_PY_OBJECT(name);
+  DECLARE_PY_OBJECT(message);
+  DECLARE_PY_OBJECT(stack);
 
   name = PyObject_GetAttrString(self, "name");
   FAIL_IF_NULL(name);
@@ -900,10 +895,6 @@ JsException_reduce(PyObject* self, PyObject* Py_UNUSED(ignored))
   }
 
 finally:
-  Py_CLEAR(args);
-  Py_CLEAR(name);
-  Py_CLEAR(message);
-  Py_CLEAR(stack);
   return res;
 }
 
@@ -1151,8 +1142,8 @@ _agen_handle_result_js_c(PyObject* set_result,
                          JsVal jsvalue,
                          bool closing)
 {
-  PyObject* pyvalue = NULL;
-  PyObject* e = NULL;
+  DECLARE_PY_OBJECT(pyvalue);
+  DECLARE_PY_OBJECT(e);
 
   if (closing && status == 0) {
     // If closing, status should not be yielding.
@@ -1213,9 +1204,7 @@ return_error:
   PyErr_Clear();
   goto finally;
 
-finally:
-  Py_CLEAR(pyvalue);
-  Py_CLEAR(e);
+finally:;
 }
 
 // clang-format off
@@ -1267,9 +1256,9 @@ PyObject*
 _agen_handle_result(JsVal promise, bool closing)
 {
   bool success = false;
-  PyObject* loop = NULL;
-  PyObject* set_result = NULL;
-  PyObject* set_exception = NULL;
+  DECLARE_PY_OBJECT(loop);
+  DECLARE_PY_OBJECT(set_result);
+  DECLARE_PY_OBJECT(set_exception);
   PyObject* result = NULL;
 
   loop = _PyObject_CallMethodIdNoArgs(asyncio_mod, &PyId_get_event_loop);
@@ -1299,9 +1288,6 @@ finally:
   if (!success) {
     Py_CLEAR(result);
   }
-  Py_CLEAR(loop);
-  Py_CLEAR(set_result);
-  Py_CLEAR(set_exception);
   return result;
 }
 
@@ -1672,7 +1658,7 @@ static int
 JsArray_ass_subscript(PyObject* self, PyObject* item, PyObject* pyvalue)
 {
   bool success = false;
-  PyObject* seq = NULL;
+  DECLARE_PY_OBJECT(seq);
   Py_ssize_t i;
   if (PySlice_Check(item)) {
     Py_ssize_t start, stop, step, slicelength;
@@ -1756,7 +1742,6 @@ JsArray_ass_subscript(PyObject* self, PyObject* item, PyObject* pyvalue)
   }
   success = true;
 finally:
-  Py_CLEAR(seq);
   return success ? 0 : -1;
 }
 
@@ -1782,7 +1767,7 @@ JsTypedArray_ass_subscript(PyObject* o, PyObject* item, PyObject* pyvalue)
 static int
 JsArray_extend_by_python_iterable(JsVal jsarray, PyObject* iterable)
 {
-  PyObject* it = NULL;
+  DECLARE_PY_OBJECT(it);
   bool success = false;
 
   if (PyList_CheckExact(iterable) || PyTuple_CheckExact(iterable)) {
@@ -1833,7 +1818,6 @@ JsArray_extend_by_python_iterable(JsVal jsarray, PyObject* iterable)
   }
   success = true;
 finally:
-  Py_CLEAR(it);
   return success ? 0 : -1;
 }
 
@@ -1987,7 +1971,7 @@ static PyObject*
 JsArray_pop(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
   PyObject* pyresult = NULL;
-  PyObject* iobj = NULL;
+  DECLARE_PY_OBJECT(iobj);
   Py_ssize_t index = -1;
 
   if (!_PyArg_CheckPositional("pop", nargs, 0, 1)) {
@@ -2022,7 +2006,6 @@ JsArray_pop(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   pyresult = js2python(jsresult);
 
 finally:
-  Py_CLEAR(iobj);
   return pyresult;
 }
 
@@ -2444,9 +2427,9 @@ static PyObject*
 JsProxy_aenter(JsProxy* self, PyObject* Py_UNUSED(ignored))
 {
   bool success = false;
-  PyObject* loop = NULL;
+  DECLARE_PY_OBJECT(loop);
   PyObject* result = NULL;
-  PyObject* status = NULL;
+  DECLARE_PY_OBJECT(status);
 
   loop = _PyObject_CallMethodIdNoArgs(asyncio_mod, &PyId_get_event_loop);
   FAIL_IF_NULL(loop);
@@ -2460,8 +2443,6 @@ JsProxy_aenter(JsProxy* self, PyObject* Py_UNUSED(ignored))
 
   success = true;
 finally:
-  Py_CLEAR(loop);
-  Py_CLEAR(status);
   if (!success) {
     Py_CLEAR(result);
   }
@@ -2686,20 +2667,20 @@ JsMap_update(JsProxy* self, PyObject* args, PyObject* kwds)
     return NULL;
   }
   if (arg != NULL) {
-    PyObject* status = _PyObject_CallMethodIdObjArgs(
+    DECLARE_PY_OBJECT(status);
+    status = _PyObject_CallMethodIdObjArgs(
       MutableMapping, &PyId_update, self, arg, NULL);
     if (status == NULL) {
       return NULL;
     }
-    Py_CLEAR(status);
   }
   if (kwds != NULL) {
-    PyObject* status = _PyObject_CallMethodIdObjArgs(
+    DECLARE_PY_OBJECT(status);
+    status = _PyObject_CallMethodIdObjArgs(
       MutableMapping, &PyId_update, self, arg, NULL);
     if (status == NULL) {
       return NULL;
     }
-    Py_CLEAR(status);
   }
   Py_RETURN_NONE;
 }
@@ -2773,12 +2754,12 @@ static PyObject*
 JsProxy_Dir(PyObject* self, PyObject* _args)
 {
   bool success = false;
-  PyObject* object__dir__ = NULL;
-  PyObject* keys = NULL;
-  PyObject* result_set = NULL;
+  DECLARE_PY_OBJECT(object__dir__);
+  DECLARE_PY_OBJECT(keys);
+  DECLARE_PY_OBJECT(result_set);
   JsVal jsdir = JS_ERROR;
-  PyObject* pydir = NULL;
-  PyObject* keys_str = NULL;
+  DECLARE_PY_OBJECT(pydir);
+  DECLARE_PY_OBJECT(keys_str);
 
   PyObject* result = NULL;
 
@@ -2811,11 +2792,6 @@ JsProxy_Dir(PyObject* self, PyObject* _args)
 
   success = true;
 finally:
-  Py_CLEAR(object__dir__);
-  Py_CLEAR(keys);
-  Py_CLEAR(result_set);
-  Py_CLEAR(pydir);
-  Py_CLEAR(keys_str);
   if (!success) {
     Py_CLEAR(result);
   }
@@ -2913,10 +2889,10 @@ PyObject*
 wrap_promise(JsVal promise, JsVal done_callback, PyObject* js2py_converter)
 {
   bool success = false;
-  PyObject* loop = NULL;
-  PyObject* helpers = NULL;
-  PyObject* set_result = NULL;
-  PyObject* set_exception = NULL;
+  DECLARE_PY_OBJECT(loop);
+  DECLARE_PY_OBJECT(helpers);
+  DECLARE_PY_OBJECT(set_result);
+  DECLARE_PY_OBJECT(set_exception);
 
   PyObject* result = NULL;
 
@@ -2945,10 +2921,6 @@ wrap_promise(JsVal promise, JsVal done_callback, PyObject* js2py_converter)
 
   success = true;
 finally:
-  Py_CLEAR(loop);
-  Py_CLEAR(helpers);
-  Py_CLEAR(set_result);
-  Py_CLEAR(set_exception);
   if (!success) {
     Py_CLEAR(result);
   }
@@ -2972,7 +2944,7 @@ JsProxy_Await(PyObject* self)
                  str_utf8);
     return NULL;
   }
-  PyObject* fut = NULL;
+  DECLARE_PY_OBJECT(fut);
   PyObject* result = NULL;
 
   fut = wrap_promise(JsProxy_VAL(self), Jsv_null, NULL);
@@ -2980,7 +2952,6 @@ JsProxy_Await(PyObject* self)
   result = _PyObject_CallMethodIdNoArgs(fut, &PyId___await__);
 
 finally:
-  Py_CLEAR(fut);
   return result;
 }
 
@@ -4276,8 +4247,8 @@ skip_container_slots:
 
   bool success = false;
   void* mem = NULL;
-  PyObject* bases = NULL;
-  PyObject* flags_obj = NULL;
+  DECLARE_PY_OBJECT(bases);
+  DECLARE_PY_OBJECT(flags_obj);
   PyObject* result = NULL;
 
   // PyType_FromSpecWithBases copies "members" automatically into the end of the
@@ -4364,11 +4335,10 @@ skip_container_slots:
     abc = MutableMapping;
   }
   if (abc) {
-    PyObject* register_result =
-      _PyObject_CallMethodIdOneArg(abc, &PyId_register, result);
+    DECLARE_PY_OBJECT(register_result);
+    register_result = _PyObject_CallMethodIdOneArg(abc, &PyId_register, result);
     abc = NULL; // abc is borrowed, don't decref
     FAIL_IF_NULL(register_result);
-    Py_CLEAR(register_result);
   }
 
   Py_SET_TYPE(result, (PyTypeObject*)JsProxy_metaclass);
@@ -4379,8 +4349,6 @@ skip_container_slots:
 
   success = true;
 finally:
-  Py_CLEAR(bases);
-  Py_CLEAR(flags_obj);
   if (!success && mem != NULL) {
     PyMem_Free(mem);
   }
@@ -4397,7 +4365,8 @@ static PyObject* JsProxy_TypeDict;
 static PyTypeObject*
 JsProxy_get_subtype(int flags)
 {
-  PyObject* flags_key = PyLong_FromLong(flags);
+  DECLARE_PY_OBJECT(flags_key);
+  flags_key = PyLong_FromLong(flags);
   PyObject* type = PyDict_GetItemWithError(JsProxy_TypeDict, flags_key);
   Py_XINCREF(type);
   if (type != NULL || PyErr_Occurred()) {
@@ -4407,7 +4376,6 @@ JsProxy_get_subtype(int flags)
   FAIL_IF_NULL(type);
   FAIL_IF_MINUS_ONE(PyDict_SetItem(JsProxy_TypeDict, flags_key, type));
 finally:
-  Py_CLEAR(flags_key);
   return (PyTypeObject*)type;
 }
 
@@ -4546,11 +4514,11 @@ JsProxy_create_with_type(int type_flags,
     FAIL_IF_NONZERO(JsBuffer_cinit(result));
   }
   if (type_flags & IS_ERROR) {
-    PyObject* arg =
+    DECLARE_PY_OBJECT(arg);
+    arg =
       JsProxy_create_with_type(type_flags & (~IS_ERROR), object, this, NULL);
     FAIL_IF_NULL(arg);
     PyObject* args = PyTuple_Pack(1, arg);
-    Py_CLEAR(arg);
     FAIL_IF_NULL(args);
     JsException_ARGS(result) = args;
   }
@@ -4630,14 +4598,14 @@ JsProxy_init_docstrings(PyObject* _pyodide_core_docs)
 {
   bool success = false;
 
-  PyObject* _it = NULL;
-  PyObject* JsProxy = NULL;
-  PyObject* JsPromise = NULL;
-  PyObject* JsBuffer = NULL;
-  PyObject* JsArray = NULL;
-  PyObject* JsMutableMap = NULL;
-  PyObject* JsDoubleProxy = NULL;
-  PyObject* JsGenerator = NULL;
+  DECLARE_PY_OBJECT(_it);
+  DECLARE_PY_OBJECT(JsProxy);
+  DECLARE_PY_OBJECT(JsPromise);
+  DECLARE_PY_OBJECT(JsBuffer);
+  DECLARE_PY_OBJECT(JsArray);
+  DECLARE_PY_OBJECT(JsMutableMap);
+  DECLARE_PY_OBJECT(JsDoubleProxy);
+  DECLARE_PY_OBJECT(JsGenerator);
 
   _it = PyObject_GetAttrString(_pyodide_core_docs, "_instantiate_token");
   FAIL_IF_NULL(_it);
@@ -4708,21 +4676,13 @@ JsProxy_init_docstrings(PyObject* _pyodide_core_docs)
 
   success = true;
 finally:
-  Py_CLEAR(_it);
-  Py_CLEAR(JsProxy);
-  Py_CLEAR(JsPromise);
-  Py_CLEAR(JsBuffer);
-  Py_CLEAR(JsArray);
-  Py_CLEAR(JsMutableMap);
-  Py_CLEAR(JsDoubleProxy);
-  Py_CLEAR(JsGenerator);
   return success ? 0 : -1;
 }
 
 static int
 add_flag(PyObject* dict, char* name, int value)
 {
-  PyObject* value_py = NULL;
+  DECLARE_PY_OBJECT(value_py);
   bool success = false;
 
   value_py = PyLong_FromLong(value);
@@ -4731,7 +4691,6 @@ add_flag(PyObject* dict, char* name, int value)
 
   success = true;
 finally:
-  Py_CLEAR(value_py);
   return success ? 0 : -1;
 }
 
@@ -4753,7 +4712,7 @@ run_sync(PyObject* self, PyObject* pyarg)
                  Py_TYPE(pyarg)->tp_name);
     return NULL;
   }
-  PyObject* ensured_future = NULL;
+  DECLARE_PY_OBJECT(ensured_future);
   PyObject* pyresult = NULL;
 
   // For reasons that I absolutely do not comprehend, we leak memory if use a
@@ -4781,7 +4740,6 @@ finally:
   if (pyproxy_Check(jsresult)) {
     destroy_proxy(jsresult, NULL);
   }
-  Py_CLEAR(ensured_future);
   return pyresult;
 }
 
@@ -4818,8 +4776,8 @@ int
 jsproxy_init(PyObject* core_module)
 {
   bool success = false;
-  PyObject* _pyodide_core_docs = NULL;
-  PyObject* flag_dict = NULL;
+  DECLARE_PY_OBJECT(_pyodide_core_docs);
+  DECLARE_PY_OBJECT(flag_dict);
 
   _pyodide_core_docs = PyImport_ImportModule("_pyodide._core_docs");
   FAIL_IF_NULL(_pyodide_core_docs);
@@ -4906,7 +4864,5 @@ jsproxy_init(PyObject* core_module)
 
   success = true;
 finally:
-  Py_CLEAR(_pyodide_core_docs);
-  Py_CLEAR(flag_dict);
   return success ? 0 : -1;
 }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -544,8 +544,8 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
 
   bool success = false;
   JsVal jsresult = JS_ERROR;
-  PyObject* get_attr_sig_res = NULL;
-  PyObject* attr_sig = NULL;
+  DECLARE_PY_OBJECT(get_attr_sig_res);
+  DECLARE_PY_OBJECT(attr_sig);
   // result:
   PyObject* pyresult = NULL;
 
@@ -606,7 +606,7 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
     method_call_singleton->func = hiwire_new(jsresult);
     method_call_singleton->this_ = JsProxy_REF(self);
     hiwire_incref(method_call_singleton->this_);
-    method_call_singleton->signature = Py_NewRef(attr_sig);
+    method_call_singleton->signature = Py_XNewRef(attr_sig);
     goto success;
   }
   if (JsvFunction_Check(jsresult)) {
@@ -623,8 +623,6 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
 success:
   success = true;
 finally:
-  Py_CLEAR(attr_sig);
-  Py_CLEAR(get_attr_sig_res);
   if (!success) {
     Py_CLEAR(pyresult);
   }

--- a/src/core/jsproxy_call.c
+++ b/src/core/jsproxy_call.c
@@ -155,8 +155,8 @@ JsFuncSignature_repr(PyObject* o)
 {
   JsFuncSignature* self = (JsFuncSignature*)o;
   PyObject* result = NULL;
-  PyObject* inspect = NULL;
-  PyObject* sig = NULL;
+  DECLARE_PY_OBJECT(inspect);
+  DECLARE_PY_OBJECT(sig);
 
   inspect = PyImport_ImportModule("inspect");
   FAIL_IF_NULL(inspect);
@@ -167,8 +167,6 @@ JsFuncSignature_repr(PyObject* o)
   FAIL_IF_NULL(result);
 
 finally:
-  Py_CLEAR(inspect);
-  Py_CLEAR(sig);
   return result;
 }
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -354,7 +354,7 @@ bool compat_to_string_repr = false;
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_repr(PyObject* pyobj)
 {
-  PyObject* pyrepr = NULL;
+  DECLARE_PY_OBJECT(pyrepr);
   JsVal jsrepr = JS_ERROR;
 
   if (compat_to_string_repr) {
@@ -366,7 +366,6 @@ _pyproxy_repr(PyObject* pyobj)
   jsrepr = python2js(pyrepr);
 
 finally:
-  Py_CLEAR(pyrepr);
   return jsrepr;
 }
 
@@ -392,7 +391,7 @@ _pyproxy_type(PyObject* ptrobj)
 EMSCRIPTEN_KEEPALIVE int
 _pyproxy_hasattr(PyObject* pyobj, JsVal jskey)
 {
-  PyObject* pykey = NULL;
+  DECLARE_PY_OBJECT(pykey);
   int result = -1;
 
   pykey = js2python(jskey);
@@ -400,7 +399,6 @@ _pyproxy_hasattr(PyObject* pyobj, JsVal jskey)
   result = PyObject_HasAttr(pyobj, pykey);
 
 finally:
-  Py_CLEAR(pykey);
   return result;
 }
 
@@ -470,9 +468,9 @@ EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_getattr(PyObject* pyobj, JsVal key, JsVal proxyCache)
 {
   bool success = false;
-  PyObject* pykey = NULL;
-  PyObject* pydescr = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(pykey);
+  DECLARE_PY_OBJECT(pydescr);
+  DECLARE_PY_OBJECT(pyresult);
   JsVal result = JS_ERROR;
 
   pykey = js2python(key);
@@ -513,9 +511,6 @@ _pyproxy_getattr(PyObject* pyobj, JsVal key, JsVal proxyCache)
 success:
   success = true;
 finally:
-  Py_CLEAR(pykey);
-  Py_CLEAR(pydescr);
-  Py_CLEAR(pyresult);
   if (!success) {
     if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
       PyErr_Clear();
@@ -528,8 +523,8 @@ EMSCRIPTEN_KEEPALIVE int
 _pyproxy_setattr(PyObject* pyobj, JsVal key, JsVal value)
 {
   bool success = false;
-  PyObject* pykey = NULL;
-  PyObject* pyval = NULL;
+  DECLARE_PY_OBJECT(pykey);
+  DECLARE_PY_OBJECT(pyval);
 
   pykey = js2python(key);
   FAIL_IF_NULL(pykey);
@@ -539,8 +534,6 @@ _pyproxy_setattr(PyObject* pyobj, JsVal key, JsVal value)
 
   success = true;
 finally:
-  Py_CLEAR(pykey);
-  Py_CLEAR(pyval);
   return success ? 0 : -1;
 }
 
@@ -548,7 +541,7 @@ EMSCRIPTEN_KEEPALIVE int
 _pyproxy_delattr(PyObject* pyobj, JsVal idkey)
 {
   bool success = false;
-  PyObject* pykey = NULL;
+  DECLARE_PY_OBJECT(pykey);
 
   pykey = js2python(idkey);
   FAIL_IF_NULL(pykey);
@@ -556,7 +549,6 @@ _pyproxy_delattr(PyObject* pyobj, JsVal idkey)
 
   success = true;
 finally:
-  Py_CLEAR(pykey);
   return success ? 0 : -1;
 }
 
@@ -567,8 +559,8 @@ _pyproxy_getitem(PyObject* pyobj,
                  bool is_json_adaptor)
 {
   bool success = false;
-  PyObject* pykey = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(pykey);
+  DECLARE_PY_OBJECT(pyresult);
   JsVal result;
 
   pykey = js2python(jskey);
@@ -584,8 +576,6 @@ finally:
                    PyErr_ExceptionMatches(PyExc_IndexError))) {
     PyErr_Clear();
   }
-  Py_CLEAR(pykey);
-  Py_CLEAR(pyresult);
   if (!success) {
     return JS_ERROR;
   }
@@ -596,8 +586,8 @@ EMSCRIPTEN_KEEPALIVE int
 _pyproxy_setitem(PyObject* pyobj, JsVal jskey, JsVal jsval)
 {
   bool success = false;
-  PyObject* pykey = NULL;
-  PyObject* pyval = NULL;
+  DECLARE_PY_OBJECT(pykey);
+  DECLARE_PY_OBJECT(pyval);
 
   pykey = js2python(jskey);
   FAIL_IF_NULL(pykey);
@@ -607,8 +597,6 @@ _pyproxy_setitem(PyObject* pyobj, JsVal jskey, JsVal jsval)
 
   success = true;
 finally:
-  Py_CLEAR(pykey);
-  Py_CLEAR(pyval);
   return success ? 0 : -1;
 }
 
@@ -616,7 +604,7 @@ EMSCRIPTEN_KEEPALIVE int
 _pyproxy_delitem(PyObject* pyobj, JsVal idkey)
 {
   bool success = false;
-  PyObject* pykey = NULL;
+  DECLARE_PY_OBJECT(pykey);
 
   pykey = js2python(idkey);
   FAIL_IF_NULL(pykey);
@@ -624,7 +612,6 @@ _pyproxy_delitem(PyObject* pyobj, JsVal idkey)
 
   success = true;
 finally:
-  Py_CLEAR(pykey);
   return success ? 0 : -1;
 }
 
@@ -634,8 +621,8 @@ _pyproxy_slice_assign(PyObject* pyobj,
                       Py_ssize_t stop,
                       JsVal val)
 {
-  PyObject* pyval = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(pyval);
+  DECLARE_PY_OBJECT(pyresult);
   JsVal jsresult = JS_ERROR;
 
   pyval = js2python(val);
@@ -651,16 +638,14 @@ _pyproxy_slice_assign(PyObject* pyobj,
   jsresult = python2js_with_depth(pyresult, 1, proxies);
 
 finally:
-  Py_CLEAR(pyresult);
-  Py_CLEAR(pyval);
   return jsresult;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_pop(PyObject* pyobj, bool pop_start)
 {
-  PyObject* idx = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(idx);
+  DECLARE_PY_OBJECT(pyresult);
   JsVal jsresult = JS_ERROR;
   if (pop_start) {
     idx = PyLong_FromLong(0);
@@ -681,15 +666,13 @@ _pyproxy_pop(PyObject* pyobj, bool pop_start)
     }
   }
 finally:
-  Py_CLEAR(idx);
-  Py_CLEAR(pyresult);
   return jsresult;
 }
 
 EMSCRIPTEN_KEEPALIVE int
 _pyproxy_contains(PyObject* pyobj, JsVal idkey)
 {
-  PyObject* pykey = NULL;
+  DECLARE_PY_OBJECT(pykey);
   int result = -1;
 
   pykey = js2python(idkey);
@@ -697,7 +680,6 @@ _pyproxy_contains(PyObject* pyobj, JsVal idkey)
   result = PySequence_Contains(pyobj, pykey);
 
 finally:
-  Py_CLEAR(pykey);
   return result;
 }
 
@@ -705,7 +687,7 @@ EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_ownKeys(PyObject* pyobj)
 {
   bool success = false;
-  PyObject* pydir = NULL;
+  DECLARE_PY_OBJECT(pydir);
 
   pydir = PyObject_Dir(pyobj);
   FAIL_IF_NULL(pydir);
@@ -722,7 +704,6 @@ _pyproxy_ownKeys(PyObject* pyobj)
 
   success = true;
 finally:
-  Py_CLEAR(pydir);
   if (!success) {
     return JS_ERROR;
   }
@@ -770,8 +751,8 @@ _pyproxy_apply(PyObject* callable,
   PyObject** pyargs = pyargs_array;
   pyargs++; // leave a space for self argument in case callable is a bound
             // method
-  PyObject* pykwnames = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(pykwnames);
+  DECLARE_PY_OBJECT(pyresult);
   JsVal result = JS_ERROR;
 
   // Put both arguments and keyword arguments into pyargs
@@ -807,8 +788,6 @@ finally:
   for (Py_ssize_t i = 0; i < last_converted_arg; i++) {
     Py_CLEAR(pyargs[i]);
   }
-  Py_CLEAR(pyresult);
-  Py_CLEAR(pykwnames);
   return result;
 }
 
@@ -865,25 +844,23 @@ _iscoroutinefunction(PyObject* f)
   }
 
   // Wasn't a basic callable, call into inspect.iscoroutinefunction
-  PyObject* result = PyObject_CallOneArg(iscoroutinefunction, f);
+  DECLARE_PY_OBJECT(result);
+  result = PyObject_CallOneArg(iscoroutinefunction, f);
   if (!result) {
     PyErr_Clear();
   }
-  bool ret = Py_IsTrue(result);
-  Py_CLEAR(result);
-  return ret;
+  return Py_IsTrue(result);
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_iter_next(PyObject* iterator, JsVal proxyCache, bool is_json_adaptor)
 {
-  PyObject* item = PyIter_Next(iterator);
+  DECLARE_PY_OBJECT(item);
+  item = PyIter_Next(iterator);
   if (item == NULL) {
     return JS_ERROR;
   }
-  JsVal result = python2js_json_adaptor(item, proxyCache, is_json_adaptor);
-  Py_CLEAR(item);
-  return result;
+  return python2js_json_adaptor(item, proxyCache, is_json_adaptor);
 }
 
 EM_JS(JsVal, _pyproxyGen_make_result, (bool done, JsVal value), {
@@ -894,8 +871,8 @@ EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_Send(PyObject* receiver, JsVal jsval)
 {
   bool success = false;
-  PyObject* v = NULL;
-  PyObject* retval = NULL;
+  DECLARE_PY_OBJECT(v);
+  DECLARE_PY_OBJECT(retval);
 
   v = js2python(jsval);
   FAIL_IF_NULL(v);
@@ -908,8 +885,6 @@ _pyproxyGen_Send(PyObject* receiver, JsVal jsval)
 
   success = true;
 finally:
-  Py_CLEAR(v);
-  Py_CLEAR(retval);
   if (!success) {
     return JS_ERROR;
   }
@@ -922,7 +897,7 @@ _pyproxyGen_return(PyObject* receiver, JsVal jsval)
 {
   bool success = false;
   PySendResult status = PYGEN_ERROR;
-  PyObject* pyresult;
+  DECLARE_PY_OBJECT(pyresult);
 
   JsVal result;
 
@@ -951,7 +926,6 @@ finally:
   if (!success) {
     return JS_ERROR;
   }
-  Py_CLEAR(pyresult);
   return _pyproxyGen_make_result(status == PYGEN_RETURN, result);
 }
 
@@ -959,8 +933,8 @@ EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_throw(PyObject* receiver, JsVal jsval)
 {
   bool success = false;
-  PyObject* pyvalue = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(pyvalue);
+  DECLARE_PY_OBJECT(pyresult);
   PySendResult status = PYGEN_ERROR;
 
   JsVal result;
@@ -986,8 +960,6 @@ _pyproxyGen_throw(PyObject* receiver, JsVal jsval)
   FAIL_IF_JS_ERROR(result);
   success = true;
 finally:
-  Py_CLEAR(pyresult);
-  Py_CLEAR(pyvalue);
   if (!success) {
     return JS_ERROR;
   }
@@ -997,9 +969,9 @@ finally:
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_asend(PyObject* receiver, JsVal jsval)
 {
-  PyObject* v = NULL;
-  PyObject* asend = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(v);
+  DECLARE_PY_OBJECT(asend);
+  DECLARE_PY_OBJECT(pyresult);
   JsVal jsresult = JS_ERROR;
 
   v = js2python(jsval);
@@ -1024,18 +996,15 @@ _pyproxyGen_asend(PyObject* receiver, JsVal jsval)
   FAIL_IF_JS_ERROR(jsresult);
 
 finally:
-  Py_CLEAR(v);
-  Py_CLEAR(asend);
-  Py_CLEAR(pyresult);
   return jsresult;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_areturn(PyObject* receiver)
 {
-  PyObject* v = NULL;
-  PyObject* asend = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(v);
+  DECLARE_PY_OBJECT(asend);
+  DECLARE_PY_OBJECT(pyresult);
   JsVal jsresult = JS_ERROR;
 
   pyresult =
@@ -1046,18 +1015,15 @@ _pyproxyGen_areturn(PyObject* receiver)
   FAIL_IF_JS_ERROR(jsresult);
 
 finally:
-  Py_CLEAR(v);
-  Py_CLEAR(asend);
-  Py_CLEAR(pyresult);
   return jsresult;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_athrow(PyObject* receiver, JsVal jsval)
 {
-  PyObject* v = NULL;
-  PyObject* asend = NULL;
-  PyObject* pyresult = NULL;
+  DECLARE_PY_OBJECT(v);
+  DECLARE_PY_OBJECT(asend);
+  DECLARE_PY_OBJECT(pyresult);
   JsVal jsresult = JS_ERROR;
 
   v = js2python(jsval);
@@ -1077,9 +1043,6 @@ _pyproxyGen_athrow(PyObject* receiver, JsVal jsval)
   FAIL_IF_JS_ERROR(jsresult);
 
 finally:
-  Py_CLEAR(v);
-  Py_CLEAR(asend);
-  Py_CLEAR(pyresult);
   return jsresult;
 }
 
@@ -1087,7 +1050,7 @@ EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_aiter_next(PyObject* aiterator)
 {
   PyTypeObject* t;
-  PyObject* awaitable;
+  DECLARE_PY_OBJECT(awaitable);
 
   t = Py_TYPE(aiterator);
   if (t->tp_as_async == NULL || t->tp_as_async->am_anext == NULL) {
@@ -1100,9 +1063,7 @@ _pyproxy_aiter_next(PyObject* aiterator)
   if (awaitable == NULL) {
     return JS_ERROR;
   }
-  JsVal result = python2js(awaitable);
-  Py_CLEAR(awaitable);
-  return result;
+  return python2js(awaitable);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1240,9 +1201,9 @@ _pyproxy_ensure_future(PyObject* pyobject,
                        JsVal reject_handle)
 {
   bool success = false;
-  PyObject* future = NULL;
-  PyObject* callback = NULL;
-  PyObject* retval = NULL;
+  DECLARE_PY_OBJECT(future);
+  DECLARE_PY_OBJECT(callback);
+  DECLARE_PY_OBJECT(retval);
   future = _PyObject_CallMethodIdOneArg(asyncio, &PyId_ensure_future, pyobject);
   FAIL_IF_NULL(future);
   callback = FutureDoneCallback_cnew(resolve_handle, reject_handle);
@@ -1252,9 +1213,6 @@ _pyproxy_ensure_future(PyObject* pyobject,
 
   success = true;
 finally:
-  Py_CLEAR(future);
-  Py_CLEAR(callback);
-  Py_CLEAR(retval);
   return success ? 0 : -1;
 }
 
@@ -1501,8 +1459,8 @@ create_once_callable_py(PyObject* _mod,
 EMSCRIPTEN_KEEPALIVE int
 create_promise_handles_result_helper(PyObject* handle_result, PyObject* converter, JsVal jsval) {
   bool success = false;
-  PyObject* pyval = NULL;
-  PyObject* result = NULL;
+  DECLARE_PY_OBJECT(pyval);
+  DECLARE_PY_OBJECT(result);
 
   if (converter == NULL || Py_IsNone(converter)) {
     pyval = js2python(jsval);
@@ -1515,8 +1473,6 @@ create_promise_handles_result_helper(PyObject* handle_result, PyObject* converte
 
   success = true;
 finally:
-  Py_CLEAR(pyval);
-  Py_CLEAR(result);
   if (!success) {
     // Not sure what we'll do if this function fails tbh...
     printf("Unexpected error:\n");
@@ -1658,9 +1614,9 @@ pyproxy_init(PyObject* core)
 {
   bool success = false;
 
-  PyObject* collections_abc = NULL;
-  PyObject* docstring_source = NULL;
-  PyObject* inspect = NULL;
+  DECLARE_PY_OBJECT(collections_abc);
+  DECLARE_PY_OBJECT(docstring_source);
+  DECLARE_PY_OBJECT(inspect);
 
   collections_abc = PyImport_ImportModule("collections.abc");
   FAIL_IF_NULL(collections_abc);
@@ -1692,8 +1648,5 @@ pyproxy_init(PyObject* core)
 
   success = true;
 finally:
-  Py_CLEAR(docstring_source);
-  Py_CLEAR(collections_abc);
-  Py_CLEAR(inspect);
   return success ? 0 : -1;
 }

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -211,7 +211,6 @@ static JsVal
 _python2js_sequence(ConversionContext* context, PyObject* x)
 {
   bool success = false;
-  PyObject* pyitem = NULL;
 
   JsVal jsarray = JsvArray_New();
   FAIL_IF_MINUS_ONE(
@@ -219,7 +218,8 @@ _python2js_sequence(ConversionContext* context, PyObject* x)
   Py_ssize_t length = PySequence_Size(x);
   FAIL_IF_MINUS_ONE(length);
   for (Py_ssize_t i = 0; i < length; ++i) {
-    PyObject* pyitem = PySequence_GetItem(x, i);
+    DECLARE_PY_OBJECT(pyitem);
+    pyitem = PySequence_GetItem(x, i);
     FAIL_IF_NULL(pyitem);
     JsVal jsitem = _python2js(context, pyitem);
     FAIL_IF_JS_ERROR(jsitem);
@@ -230,11 +230,9 @@ _python2js_sequence(ConversionContext* context, PyObject* x)
     } else {
       JsvArray_Push(jsarray, jsitem);
     }
-    Py_CLEAR(pyitem);
   }
   success = true;
 finally:
-  Py_CLEAR(pyitem);
   return success ? jsarray : JS_ERROR;
 }
 
@@ -246,9 +244,9 @@ static JsVal
 _python2js_dict(ConversionContext* context, PyObject* x)
 {
   bool success = false;
-  PyObject* items = NULL;
-  PyObject* iter = NULL;
-  PyObject* item = NULL;
+  DECLARE_PY_OBJECT(items);
+  DECLARE_PY_OBJECT(iter);
+  DECLARE_PY_OBJECT(item);
 
   _Py_IDENTIFIER(items);
   JsVal jsdict = context->dict_new(context);
@@ -298,9 +296,6 @@ _python2js_dict(ConversionContext* context, PyObject* x)
     _python2js_add_to_cache(hiwire_get(context->cache), x, jsdict));
   success = true;
 finally:
-  Py_CLEAR(items);
-  Py_CLEAR(iter);
-  Py_CLEAR(item);
   return success ? jsdict : JS_ERROR;
 }
 
@@ -318,8 +313,8 @@ static JsVal
 _python2js_set(ConversionContext* context, PyObject* x)
 {
   bool success = false;
-  PyObject* iter = NULL;
-  PyObject* pykey = NULL;
+  DECLARE_PY_OBJECT(iter);
+  DECLARE_PY_OBJECT(pykey);
   // result:
 
   JsVal jsset = JsvSet_New();
@@ -343,7 +338,6 @@ _python2js_set(ConversionContext* context, PyObject* x)
     _python2js_add_to_cache(hiwire_get(context->cache), x, jsset));
   success = true;
 finally:
-  Py_CLEAR(pykey);
   return success ? jsset : JS_ERROR;
 }
 
@@ -602,7 +596,8 @@ static int
 _JsObject_Set(ConversionContext *context, JsVal obj, JsVal key, JsVal value) {
   int result = _JsObject_Set_js(obj, key, value);
   if (result == -2) {
-    PyObject* pykey = js2python(key);
+    DECLARE_PY_OBJECT(pykey);
+    pykey = js2python(key);
     if (pykey == NULL) {
       PyErr_SetString(
         conversion_error, "Key collision when converting Python dictionary to JavaScript.");
@@ -610,7 +605,6 @@ _JsObject_Set(ConversionContext *context, JsVal obj, JsVal key, JsVal value) {
     }
     PyErr_Format(
       conversion_error, "Key collision when converting Python dictionary to JavaScript. Key: %R", pykey);
-    Py_CLEAR(pykey);
     return -1;
   }
   return result;
@@ -1025,7 +1019,8 @@ int
 python2js_init(PyObject* core)
 {
   bool success = false;
-  PyObject* docstring_source = PyImport_ImportModule("_pyodide._core_docs");
+  DECLARE_PY_OBJECT(docstring_source);
+  docstring_source = PyImport_ImportModule("_pyodide._core_docs");
   FAIL_IF_NULL(docstring_source);
   FAIL_IF_MINUS_ONE(
     add_methods_and_set_docstrings(core, methods, docstring_source));
@@ -1036,6 +1031,5 @@ python2js_init(PyObject* core)
 
   success = true;
 finally:
-  Py_CLEAR(docstring_source);
   return success ? 0 : -1;
 }

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -58,9 +58,9 @@ restoreThreadState(PyThreadState* state)
 EMSCRIPTEN_KEEPALIVE PyThreadState*
 captureThreadState()
 {
-  PyObject* asyncio_module = NULL;
-  PyObject* loop = NULL;
-  PyObject* tmp = NULL;
+  DECLARE_PY_OBJECT(asyncio_module);
+  DECLARE_PY_OBJECT(loop);
+  DECLARE_PY_OBJECT(tmp);
   PyThreadState* result = NULL;
 
   // We need to set the event loop in the new thread state to be the same as the
@@ -87,9 +87,6 @@ captureThreadState()
   }
 
 finally:
-  Py_CLEAR(asyncio_module);
-  Py_CLEAR(loop);
-  Py_CLEAR(tmp);
 
   return result;
 }


### PR DESCRIPTION
This also lead to a crash because of latent undefined behavior -- I had `Py_NewRef(attr_sig);` but `attr_sig` could be null. Reordering the `Py_CLEARS()` made this crash instead of silently doing the right thing.