### PR TITLE
DOC Remove under development statement from 2026 platform

### DIFF
--- a/docs/development/abi.md
+++ b/docs/development/abi.md
@@ -45,7 +45,7 @@ platform instead of the PyEmscripten platform (and used the form
 
 ### Platform Versions
 
-- [pyemscripten_2026_0](abi/314.md) (Python 3.14, under development)
+- [pyemscripten_2026_0](abi/314.md) (Python 3.14)
 - [pyemscripten_2025_0](abi/313.md) (Python 3.13)
 - [pyemscripten_2024_0](abi/312.md) (Python 3.12)
 

--- a/docs/development/abi/314.md
+++ b/docs/development/abi/314.md
@@ -1,10 +1,10 @@
-# pyemscripten_2026_0 (under development)
+# pyemscripten_2026_0
 
-By default, all builds of the Pyodide runtime with Python 3.14 will use the
+By default, all builds of the Pyodide runtime with Python 3.14 use the
 `pyemscripten_2026_0` platform.
 
 This section reflects the planned definition for the `pyemscripten_2026_0`
-platform. This is subject to change without notice.
+platform.
 
 ## Platform Specification
 


### PR DESCRIPTION
Forgot to do this.

- [ ] backport to stable