### PR TITLE
fix(webloop): propagate cancellation in PyodideFuture.then/finally_

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,10 @@ myst:
 ## Unreleased
 
 
+- {{ Fix }} `PyodideFuture.then()` and `finally_()` no longer hang when the
+  source future is cancelled; the cancellation now propagates to the chained
+  future. {pr}`6290`
+
 - {{ Performance }} Sped up conversion of small integers from Python to JavaScript. {pr}`6279`
 
 - {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -106,6 +106,11 @@ class PyodideFuture(Future[T]):
                 raise x
 
         async def callback(fut: Future[T]) -> None:
+            if fut.cancelled():
+                # Propagate cancellation rather than calling fut.exception(),
+                # which would raise CancelledError and leave result pending.
+                result.cancel()
+                return
             e = fut.exception()
             try:
                 if e:
@@ -146,7 +151,6 @@ class PyodideFuture(Future[T]):
         result: PyodideFuture[T] = PyodideFuture()
 
         async def callback(fut: Future[T]) -> None:
-            exc = fut.exception()
             try:
                 r = onfinally()
                 while inspect.isawaitable(r):
@@ -154,7 +158,11 @@ class PyodideFuture(Future[T]):
             except Exception as e:
                 result.set_exception(e)
                 return
-            if exc:
+            # Read the outcome only after onfinally ran: fut.exception() raises
+            # if fut was cancelled, so check cancellation explicitly first.
+            if fut.cancelled():
+                result.cancel()
+            elif (exc := fut.exception()) is not None:
                 result.set_exception(exc)
             else:
                 result.set_result(fut.result())

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -356,6 +356,28 @@ async def test_pyodide_future():
         pass
     assert rf.exception() == e
 
+    # Cancelling the source future must propagate to chained futures rather
+    # than leaving them pending forever (gh-XXXX).
+    fut = PyodideFuture()
+    rf = fut.then(increment)
+    fut.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await rf
+
+    ran = 0
+
+    def incran():
+        nonlocal ran
+        ran += 1
+
+    fut = PyodideFuture()
+    rf = fut.finally_(incran)
+    fut.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await rf
+    # finally_ still runs on cancellation, then propagates the cancellation.
+    assert ran == 1
+
 
 @run_in_pyodide
 async def test_pyodide_future2(selenium):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`PyodideFuture.then()` and `finally_()` call `fut.exception()` **outside** the `try` block in their done-callback. If the source future is cancelled, `Future.exception()` raises `CancelledError`, which kills the chaining task — so the chained future is never resolved and anything awaiting it (`await fut.then(...)`) deadlocks silently.

```python
fut = PyodideFuture()
rf = fut.then(lambda x: x + 1)
fut.cancel()
await rf   # hangs forever
```

## Fix

Check `fut.cancelled()` explicitly and propagate the cancellation to the chained future instead of calling `exception()` on a cancelled future. `finally_` now reads the outcome only after `onfinally` has run (so `finally_` still runs on cancellation, as in JS), then propagates cancel/exception/result.

## Test

Added cancellation cases to the host-runnable `test_pyodide_future`. Verified the new cases hang on `main` (deadlock reproduced) and pass with this fix.