### PR TITLE
fix(ffi): key errorConstructors map by constructor name

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,10 @@ myst:
 ## Unreleased
 
 
+- {{ Fix }} Deserialized JavaScript errors now keep their original type
+  (`TypeError`, `RangeError`, etc.) instead of always becoming a plain `Error`.
+  {pr}`6291`
+
 - {{ Performance }} Sped up conversion of small integers from Python to JavaScript. {pr}`6279`
 
 - {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`

--- a/src/core/error_handling.ts
+++ b/src/core/error_handling.ts
@@ -393,7 +393,7 @@ API.errorConstructors = new Map(
     globalThis.SystemError,
   ]
     .filter((x) => x)
-    .map((x) => [x.constructor.name, x]),
+    .map((x) => [x.name, x]),
 );
 
 API.deserializeError = function (name: string, message: string, stack: string) {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`API.errorConstructors` is built with:

```js
[EvalError, RangeError, ...].filter((x) => x).map((x) => [x.constructor.name, x])
```

`x.constructor` is `Function` for every error constructor, so `x.constructor.name === "Function"` for all of them. The `Map` therefore collapses to a single entry `{"Function" => SystemError}` (last wins).

As a result `API.deserializeError(name, …)` never finds `TypeError`, `RangeError`, etc., always falls back to a plain `Error` with a patched `.name`, and deserialized errors fail `instanceof TypeError`-style checks.

## Fix

Key the map by `x.name` (the error type name, e.g. `"TypeError"`), which is what `deserializeError` looks up.

## Note

`error_handling.ts` references Emscripten runtime globals at module load, so it has no standalone unit-test path; this is covered by the existing error round-trip integration tests in CI.