### PR TITLE
fix(ffi): apply keyword arguments in JsMap.update

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,9 @@ myst:
 ## Unreleased
 
 
+- {{ Fix }} `update()` on a JavaScript `Map` proxy now applies keyword
+  arguments instead of silently dropping them. {pr}`6292`
+
 - {{ Performance }} Sped up conversion of small integers from Python to JavaScript. {pr}`6279`
 
 - {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -2673,8 +2673,10 @@ JsMap_update(JsProxy* self, PyObject* args, PyObject* kwds)
   }
   if (kwds != NULL) {
     DECLARE_PY_OBJECT(status);
+    // kwds is a dict; passing it positionally applies its entries the same way
+    // dict.update(**kwds) would.
     status = _PyObject_CallMethodIdObjArgs(
-      MutableMapping, &PyId_update, self, arg, NULL);
+      MutableMapping, &PyId_update, self, kwds, NULL);
     if (status == NULL) {
       return NULL;
     }

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -1914,6 +1914,15 @@ def test_mappings(selenium):
     m.update({6: 7, 8: 9})
     assert dict(m) == {1: 8, 3: 4, 4: None, 6: 7, 8: 9}
 
+    # update() must also apply keyword arguments, including alongside a
+    # positional argument.
+    m.update(a=10)
+    assert m["a"] == 10
+    m.update({"b": 11}, c=12)
+    assert m["b"] == 11
+    assert m["c"] == 12
+    del m["a"], m["b"], m["c"]
+
     assert m.popitem() in set({1: 8, 3: 4, 4: None, 6: 7, 8: 9}.items())
     assert len(m) == 4
     m.clear()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`JsMap_update` is a `METH_VARARGS | METH_KEYWORDS` method, but its `kwds` branch was a copy-paste of the positional branch and passed `arg` instead of `kwds`:

```c
if (kwds != NULL) {
  status = _PyObject_CallMethodIdObjArgs(MutableMapping, &PyId_update, self, arg, NULL);
  ...
}
```

So `jsmap.update(a=1)` (no positional arg) called `MutableMapping.update(self)` — a no-op — and silently dropped the keyword entries. With both a positional arg and kwargs, the positional update ran twice and the kwargs were still dropped.

## Fix

Pass `kwds` in the keyword branch. `kwds` is a dict, and `MutableMapping.update(self, kwds)` applies a positional mapping the same way `update(**kwds)` applies keywords, so this is the minimal correct change.

## Test

Extended `test_mappings` to cover `update(a=10)` and `update({...}, c=12)`.