### PR TITLE
fix(core): free JsFuncSignature and Buffer objects in dealloc

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,9 @@ myst:
 ## Unreleased
 
 
+- {{ Fix }} Fixed memory leaks of internal `JsFuncSignature` and `Buffer`
+  objects, whose deallocators never freed the object itself. {pr}`6293`
+
 - {{ Performance }} Sped up conversion of small integers from Python to JavaScript. {pr}`6279`
 
 - {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -3455,6 +3455,7 @@ Buffer_dealloc(PyObject* self)
 {
   PyMem_Free(((Buffer*)self)->data);
   ((Buffer*)self)->data = NULL;
+  Py_TYPE(self)->tp_free(self);
 }
 
 static int
@@ -3638,7 +3639,7 @@ JsBuffer_CopyIntoMemoryView(JsVal jsbuffer,
   Buffer* buffer = NULL;
   PyObject* result = NULL;
 
-  buffer = (Buffer*)BufferType.tp_alloc(&BufferType, byteLength);
+  buffer = (Buffer*)BufferType.tp_alloc(&BufferType, 0);
   FAIL_IF_NULL(buffer);
   FAIL_IF_MINUS_ONE(Buffer_cinit(buffer, byteLength, format, itemsize));
   FAIL_IF_MINUS_ONE(JsvBuffer_assignToPtr(jsbuffer, buffer->data));

--- a/src/core/jsproxy_call.c
+++ b/src/core/jsproxy_call.c
@@ -129,7 +129,9 @@ JsFuncSignature_clear(PyObject* o)
 static void
 JsFuncSignature_dealloc(PyObject* self)
 {
+  PyObject_GC_UnTrack(self);
   JsFuncSignature_clear(self);
+  Py_TYPE(self)->tp_free(self);
 }
 
 static int


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

Two `tp_dealloc` handlers freed their contents but never freed the object itself:

- **`JsFuncSignature_dealloc`** (`jsproxy_call.c`): the type has `Py_TPFLAGS_HAVE_GC`, but dealloc only called `JsFuncSignature_clear` — no `PyObject_GC_UnTrack` and no `tp_free`. Every deallocated signature leaks its object memory and remains in the GC generation list with refcount 0, which trips `_PyObject_ASSERT(op, Py_REFCNT(op) > 0)` in debug builds and corrupts GC bookkeeping in release builds.
- **`Buffer_dealloc`** (`jsproxy.c`): freed `self->data` but never called `tp_free`, leaking the `Buffer` object on every `JsBuffer.to_py()` / `to_memoryview()`.

## Fix

Both handlers now follow the existing pattern used by e.g. `Py2JsConverter_dealloc`: untrack (for the GC type), clear, then `Py_TYPE(self)->tp_free(self)`. `BufferType` is not GC-tracked, so it only needs the free.

Also passes `nitems=0` to `BufferType.tp_alloc` — `Buffer` has `tp_itemsize == 0`, so the byte length passed as the item count was ignored but misleading.

## Note

These are memory-lifecycle fixes with no convenient unit test; they are exercised by the existing FFI tests and validated by the debug/refcount-checked builds in CI.