### PR TITLE
fix(ffi): incref shared fields in converter copy()

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,10 @@ myst:
 ## Unreleased
 
 
+- {{ Fix }} Fixed a reference-counting bug when copying FFI converters that
+  could free a converter's pre/post-convert callback while still in use.
+  {pr}`6294`
+
 - {{ Performance }} Sped up conversion of small integers from Python to JavaScript. {pr}`6279`
 
 - {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`

--- a/src/core/jsbind.c
+++ b/src/core/jsbind.c
@@ -42,7 +42,8 @@ Py2JsConverter_copy(PyObject* self, PyObject* _unused)
   if (result == NULL) {
     return NULL;
   }
-  Py2JsConverter_pre_convert(result) = Py2JsConverter_pre_convert(self);
+  Py2JsConverter_pre_convert(result) =
+    Py_XNewRef(Py2JsConverter_pre_convert(self));
   return result;
 }
 
@@ -172,7 +173,12 @@ static PyObject*
 Js2PyConverter_copy(PyObject* self, PyObject* _unused)
 {
   PyObject* result = Js2PyConverter_cnew(Js2PyConverter_converter(self));
-  Js2PyConverter_post_convert(result) = Js2PyConverter_post_convert(self);
+  if (result == NULL) {
+    return NULL;
+  }
+  Js2PyConverter_post_convert(result) =
+    Py_XNewRef(Js2PyConverter_post_convert(self));
+  Js2PyConverter_extra(result) = Py_XNewRef(Js2PyConverter_extra(self));
   return result;
 }
 

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -2160,6 +2160,45 @@ def test_bind_pre_convert(selenium):
 
 
 @run_in_pyodide
+def test_converter_copy_refcount(selenium):
+    # Regression test: Converter.copy() used to share pre_convert/post_convert/extra
+    # without incrementing their refcounts, so deallocating a copy released a
+    # reference still owned by the original (double free / use-after-free).
+    import sys
+
+    from _pyodide_core import (
+        create_promise_converter,
+        js2py_deep,
+        py2js_deep,
+    )
+
+    # pre_convert (Py2JsConverter) and post_convert (Js2PyConverter) are settable
+    # members. Work on copies of the shared singletons so we never mutate them.
+    for base, attr in [(py2js_deep, "pre_convert"), (js2py_deep, "post_convert")]:
+        conv = base.copy()
+        sentinel = ["sentinel"]
+        setattr(conv, attr, sentinel)
+        rc = sys.getrefcount(sentinel)
+        copy = conv.copy()
+        assert sys.getrefcount(sentinel) == rc + 1  # copy() took its own reference
+        assert getattr(copy, attr) is sentinel
+        del copy
+        # Deallocating the copy must release only its own reference.
+        assert sys.getrefcount(sentinel) == rc
+        assert getattr(conv, attr) is sentinel
+
+    # `extra` has no public member; create_promise_converter stores the result
+    # converter there, and copy() must propagate and incref it.
+    result_conv = js2py_deep.copy()
+    promise_conv = create_promise_converter(result_conv)
+    rc = sys.getrefcount(result_conv)
+    copy = promise_conv.copy()
+    assert sys.getrefcount(result_conv) == rc + 1
+    del copy
+    assert sys.getrefcount(result_conv) == rc
+
+
+@run_in_pyodide
 def test_bind_construct(selenium):
     from typing import Annotated, Any, NotRequired, TypedDict
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`Py2JsConverter_copy` / `Js2PyConverter_copy` shared the `pre_convert` / `post_convert` `PyObject*` with the copy without taking a reference:

```c
Py2JsConverter_pre_convert(result) = Py2JsConverter_pre_convert(self);  // no incref
```

But both objects own that field: each ones `tp_clear` does `Py_CLEAR(self->pre_convert)`, and the `Py_T_OBJECT_EX` member setter decrefs the old value when the field is reassigned. `_pyodide/jsbind.py` does exactly that — `converter.copy()` followed by `result.pre_convert = ...` — so the source converter’s `pre_convert` can be freed while the source still references it: a double decref / use-after-free.

## Fix

- `Py_XNewRef` the shared `pre_convert` / `post_convert` in both `copy()` methods.
- Add the missing `NULL` check on the `cnew()` result in `Js2PyConverter_copy`.
- Copy the `extra` field too (used by promise converters to store the result converter); it was previously dropped, so a copied promise converter lost its result converter.

## Note

This is a refcount-lifecycle fix; it has no deterministic unit test and is exercised by the FFI signature-binding tests and the refcount-checked builds in CI.