### PR TITLE
fix(ssl): read into buffer in SSLSocket.read

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,9 @@ myst:
 ## Unreleased
 
 
+- {{ Fix }} `SSLSocket.read()` no longer raises `TypeError` when called with a
+  buffer argument. {pr}`6295`
+
 - {{ Performance }} Sped up conversion of small integers from Python to JavaScript. {pr}`6279`
 
 - {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`

--- a/src/py/ssl.py
+++ b/src/py/ssl.py
@@ -749,10 +749,9 @@ class SSLSocket(socket):
 
     def read(self, len=1024, buffer=None):
         if buffer is not None:
-            data = socket.recv(self, len)
-            n = len(data)
-            buffer[:n] = data
-            return n
+            # `len` shadows the builtin here, so read straight into the buffer
+            # instead of recv()-ing and measuring the result.
+            return socket.recv_into(self, buffer, len)
 
         return socket.recv(self, len)
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`SSLSocket.read(len=1024, buffer=None)` named its first parameter `len` (matching the stdlib signature) and then called `len(data)` in the buffer branch:

```python
def read(self, len=1024, buffer=None):
    if buffer is not None:
        data = socket.recv(self, len)
        n = len(data)        # len is the int parameter -> TypeError
        buffer[:n] = data
        return n
    return socket.recv(self, len)
```

So every buffered read raised `TypeError: int object is not callable`.

## Fix

Read straight into the callers buffer with `socket.recv_into(self, buffer, len)`, which returns the number of bytes read. This avoids the shadowed builtin entirely, drops an intermediate copy, and matches the sibling `recv_into` method in the same file. The public signature is unchanged.

## Note

`src/py/ssl.py` runs only under the Pyodide socket runtime (and is excluded from the lint hooks), so there is no host-side unit test; this path is covered by the CPython `test_ssl` suite in CI.