### PR TITLE
fix(js): reject loadPyodide when wasm instantiation fails

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -18,6 +18,9 @@ myst:
 ## Unreleased
 
 
+- {{ Fix }} `loadPyodide()` now rejects with the underlying error if WebAssembly
+  instantiation fails, instead of hanging forever. {pr}`6296`
+
 - {{ Performance }} Sped up conversion of small integers from Python to JavaScript. {pr}`6279`
 
 - {{ Performance }} Sped up conversion of strings from JavaScript to Python. {pr}`6281`

--- a/src/js/emscripten-settings.ts
+++ b/src/js/emscripten-settings.ts
@@ -70,7 +70,7 @@ export function createSettings(
     // means dependency resolution has already failed and we want to throw an
     // error anyways.
     locateFile: (path: string) => config.indexURL + path,
-    instantiateWasm: getInstantiateWasmFunc(config.indexURL),
+    instantiateWasm: getInstantiateWasmFunc(config.indexURL, API),
   };
   return settings;
 }
@@ -193,6 +193,7 @@ function getFileSystemInitializationFuncs(
 
 function getInstantiateWasmFunc(
   indexURL: string,
+  API: API,
 ): EmscriptenSettings["instantiateWasm"] {
   // @ts-ignore
   if (SOURCEMAP || typeof WasmOffsetConverter !== "undefined") {
@@ -207,6 +208,14 @@ function getInstantiateWasmFunc(
   }
   const { binary, response } = getBinaryResponse(indexURL + "pyodide.asm.wasm");
   const jsvErrorImportPromise = getJsvErrorImport();
+  // Emscripten wraps instantiateWasm in a Promise but only exposes its resolve
+  // (as successCallback) — there is no failure callback. If we just swallow an
+  // instantiation error, that Promise never settles and loadPyodide hangs
+  // forever. Expose a promise that rejects on failure so loadPyodide can reject.
+  let rejectFailure: (e: any) => void;
+  API._instantiateWasmFailed = new Promise<never>((_resolve, reject) => {
+    rejectFailure = reject;
+  });
   return function (
     imports: { [key: string]: { [key: string]: any } },
     successCallback: (
@@ -231,6 +240,7 @@ function getInstantiateWasmFunc(
       } catch (e) {
         console.warn("wasm instantiation failed!");
         console.warn(e);
+        rejectFailure(e);
       }
     })();
 

--- a/src/js/pyodide.ts
+++ b/src/js/pyodide.ts
@@ -372,7 +372,13 @@ async function instantiatePyodideModule(
   createPyodideModule: CreatePyodideModuleFn,
   emscriptenSettings: EmscriptenSettings,
 ): Promise<PyodideModule> {
-  const module = await createPyodideModule(emscriptenSettings);
+  const modulePromise = createPyodideModule(emscriptenSettings);
+  // If wasm instantiation fails asynchronously, modulePromise never settles, so
+  // race it against the failure promise to surface the error instead of hanging.
+  const instantiateWasmFailed = emscriptenSettings.API._instantiateWasmFailed;
+  const module = await (instantiateWasmFailed
+    ? Promise.race([modulePromise, instantiateWasmFailed])
+    : modulePromise);
 
   // Handle early exit
   if (emscriptenSettings.exitCode !== undefined) {

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -498,6 +498,10 @@ export interface API {
   capture_stderr: () => void;
   restore_stderr: () => string;
   fatal_loading_error: (...args: string[]) => never;
+  // Rejects if the asynchronous Module.instantiateWasm callback fails. Emscripten
+  // gives the callback no way to report failure, so we surface it here instead of
+  // letting loadPyodide hang forever. @private
+  _instantiateWasmFailed?: Promise<never>;
   PythonError: any;
   NoGilError: any;
   errorConstructors: Map<string, ErrorConstructor>;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

Emscripten invokes `Module.instantiateWasm` like this (from the generated `pyodide.asm.mjs`):

```js
return new Promise((resolve, reject) => {
  Module["instantiateWasm"](info, (inst, mod) => { resolve(receiveInstance(inst, mod)); });
});
```

The `reject` is never handed to the callback — the only signal we get is `successCallback` (the `resolve`). Pyodides async instantiation path caught any failure (failed `pyodide.asm.wasm` fetch, integrity error, OOM during instantiation) and only did `console.warn`. Since `successCallback` was never called and there is no failure callback, that Promise — and therefore `loadPyodide()` — never settled. The user got an unresolved promise plus a console warning instead of a rejection.

## Fix

`getInstantiateWasmFunc` now creates a `Promise<never>` exposed as `API._instantiateWasmFailed` and rejects it from the `catch`. `instantiatePyodideModule` races the module promise against it, so an instantiation failure rejects `loadPyodide` instead of hanging.

The source-map/asan path (which returns no `instantiateWasm`) leaves `_instantiateWasmFailed` undefined, and that case falls back to awaiting the module promise directly.

## Testing

Type-checked with `tsc --noEmit`. There is no isolated unit-test seam for this path (it requires a valid `pyodide.asm.mjs` paired with an unloadable `.wasm`), so it relies on review and the load-path coverage in CI.