### PR TITLE
Remove finally blocks and make FAIL use a direct return

### DIFF
--- a/docs/development/core.md
+++ b/docs/development/core.md
@@ -62,14 +62,15 @@ The file `error_handling.h` defines several macros to help make error handling a
 In a language with exception handling as a feature, error propagation requires no explicit code, it is only if you want to prevent an error from propagating that you use a `try`/`catch` block. On the other hand, in C all error propagation must be done explicitly.
 
 We define macros to help make error propagation look as simple and uniform as possible.
-They can only be used in a function with a `finally:` label which should handle resource cleanup for both the success branch and all the failing branches (see structure of functions section below). When compiled with `DEBUG_F`, these commands will write a message to `console.error` reporting the line, function, and file where the error occurred.
+They can only be used in a function that begins with a `FAIL_RETURN_VALUE(sentinel)` statement, which declares the error sentinel `fail_return` and a `success` flag. On failure the macros return `fail_return` directly; resource cleanup is handled by `_Defer` blocks that run on every return (see structure of functions section below). When compiled with `DEBUG_F`, these commands will write a message to `console.error` reporting the line, function, and file where the error occurred.
 
-- `FAIL()` -- unconditionally `goto finally;`.
-- `FAIL_IF_NULL(ptr)` -- `goto finally;` if `ptr == NULL`. This should be used with any function that returns a pointer and follows the standard Python calling convention.
-- `FAIL_IF_MINUS_ONE(num)` -- `goto finally;` if `num == -1`. This should be used with any function that returns a number and follows the standard Python calling convention.
-- `FAIL_IF_NONZERO(num)` -- `goto finally;` if `num != 0`. Can be used with functions that return any nonzero error code on failure.
-- `FAIL_IF_ERR_OCCURRED()` -- `goto finally;` if the Python error indicator is set (in other words if `PyErr_Occurred()`).
-- `FAIL_IF_ERR_MATCHES(python_err_type)` -- `goto finally;` if `PyErr_ExceptionMatches(python_err_type)`, for example `FAIL_IF_ERR_MATCHES(PyExc_AttributeError);`
+- `FAIL_RETURN_VALUE(sentinel)` -- declare `fail_return = sentinel` (e.g. `NULL`, `-1`, or `JS_ERROR`) and `bool success = true`. Must be the first statement of the function body, before any `DECLARE_PY_OBJECT` / `_Defer`.
+- `FAIL()` -- unconditionally set `success = false` and `return fail_return;`.
+- `FAIL_IF_NULL(ptr)` -- `FAIL()` if `ptr == NULL`. This should be used with any function that returns a pointer and follows the standard Python calling convention.
+- `FAIL_IF_MINUS_ONE(num)` -- `FAIL()` if `num == -1`. This should be used with any function that returns a number and follows the standard Python calling convention.
+- `FAIL_IF_NONZERO(num)` -- `FAIL()` if `num != 0`. Can be used with functions that return any nonzero error code on failure.
+- `FAIL_IF_ERR_OCCURRED()` -- `FAIL()` if the Python error indicator is set (in other words if `PyErr_Occurred()`).
+- `FAIL_IF_JS_ERROR(val)` -- `FAIL()` if the `JsVal` is a JavaScript error sentinel.
 
 ### JavaScript to CPython calling convention adaptors
 
@@ -174,23 +175,24 @@ JsImport_CreateModule(PyObject* self, PyObject* args)
   }
 ```
 
-2. Forward declaration of owned references. This starts by declaring a success flag `bool success = false`. This will be used in the finally block to decide whether the finally block was entered after a successful execution or after an error. Then declare every reference counted variable that we will create during execution of the function. Finally, declare the variable that we are planning to return.
+2. Forward declaration of owned references. This starts by declaring the error sentinel and `success` flag with `FAIL_RETURN_VALUE(NULL)` (use `-1` for functions returning an `int` error code). `FAIL()` returns this sentinel and sets `success = false`, which `ON_FAIL` cleanup blocks use to decide whether to clear the result. Then declare every reference counted variable that we will create during execution of the function, attaching a `_Defer` block to release it (`DECLARE_PY_OBJECT(x)` does this in one step). Finally, declare the variable that we are planning to return.
    Typically, this will be called `result`, but in this case the function is named `CreateModule` so we name the return variable `module`.
 
 ```C
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   // Note: these are all the objects that we will own. If a function returns
-  // a borrow, we XINCREF the result so that we can CLEAR it in the finally block.
+  // a borrow, we XINCREF the result so that the _Defer block can CLEAR it.
   // Reference counting is hard, so it's good to be as explicit and consistent
   // as possible!
-  PyObject* sys_modules = NULL;
-  PyObject* importlib_machinery = NULL;
-  PyObject* ModuleSpec = NULL;
-  PyObject* spec = NULL;
-  PyObject* __dir__ = NULL;
-  PyObject* module_dict = NULL;
+  DECLARE_PY_OBJECT(sys_modules);
+  DECLARE_PY_OBJECT(importlib_machinery);
+  DECLARE_PY_OBJECT(ModuleSpec);
+  DECLARE_PY_OBJECT(spec);
+  DECLARE_PY_OBJECT(__dir__);
+  DECLARE_PY_OBJECT(module_dict);
   // result
   PyObject* module = NULL;
+  ON_FAIL({ Py_CLEAR(module); });
 ```
 
 3. The body of the function. The vast majority of API calls can return error codes. You MUST check every fallible API for an error. Also, as you are writing the code, you should look up every Python API you use that returns a reference to determine whether it returns a borrowed reference or a new one. If it returns a borrowed reference, immediately `Py_XINCREF()` the result to convert it into an owned reference (before `FAIL_IF_NULL`, to be consistent with the case where you use custom error handling).

--- a/src/core/_pyodide_core.c
+++ b/src/core/_pyodide_core.c
@@ -14,7 +14,7 @@
     } else {                                                                   \
       PyErr_Format(PyExc_ImportError, args);                                   \
     }                                                                          \
-    FAIL();                                                                   \
+    FAIL();                                                                    \
   } while (0)
 
 #define TRY_INIT(mod)                                                          \

--- a/src/core/_pyodide_core.c
+++ b/src/core/_pyodide_core.c
@@ -14,13 +14,8 @@
     } else {                                                                   \
       PyErr_Format(PyExc_ImportError, args);                                   \
     }                                                                          \
-    FAIL();                                                                    \
+    FAIL();                                                                   \
   } while (0)
-
-#define FAIL_IF_STATUS_EXCEPTION(status)                                       \
-  if (PyStatus_Exception(status)) {                                            \
-    goto finally;                                                              \
-  }
 
 #define TRY_INIT(mod)                                                          \
   do {                                                                         \
@@ -67,7 +62,7 @@ init_pyodide_proxy()
     // Emscripten 3.1.44 seems to have removed it??
     wasmImports["open64"] = wasmImports["open"];
   });
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   // Enable JavaScript access to the _pyodide module.
   DECLARE_PY_OBJECT(_pyodide);
   _pyodide = PyImport_ImportModule("_pyodide");
@@ -76,18 +71,17 @@ init_pyodide_proxy()
   FAIL_IF_JS_ERROR(_pyodide_proxy);
   set_pyodide_module(_pyodide_proxy);
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 EM_JS_DEPS(pyodide_core_deps, "stackAlloc,stackRestore,stackSave");
 PyObject*
 PyInit__pyodide_core(void)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(_pyodide);
   PyObject* core_module = NULL;
+  ON_FAIL({ Py_CLEAR(core_module); });
 
   _pyodide = PyImport_ImportModule("_pyodide");
   if (_pyodide == NULL) {
@@ -117,10 +111,5 @@ PyInit__pyodide_core(void)
     FATAL_ERROR("Failed to create _pyodide proxy.");
   }
 
-  success = true;
-finally:
-  if (!success) {
-    Py_CLEAR(core_module);
-  }
   return core_module;
 }

--- a/src/core/docstring.c
+++ b/src/core/docstring.c
@@ -9,7 +9,7 @@ PyObject* py_docstring_mod;
 int
 set_method_docstring(PyMethodDef* method, PyObject* parent)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(py_method);
   DECLARE_PY_OBJECT(py_result);
 
@@ -38,9 +38,7 @@ set_method_docstring(PyMethodDef* method, PyObject* parent)
   memcpy(result, py_result_utf8, size + 1);
   method->ml_doc = result;
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 int
@@ -48,7 +46,7 @@ add_methods_and_set_docstrings(PyObject* module,
                                PyMethodDef* methods,
                                PyObject* docstring_source)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   int i = 0;
   while (methods[i].ml_name != NULL) {
@@ -57,20 +55,16 @@ add_methods_and_set_docstrings(PyObject* module,
   }
   FAIL_IF_MINUS_ONE(PyModule_AddFunctions(module, methods));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 int
 docstring_init()
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   py_docstring_mod = PyImport_ImportModule("_pyodide.docstring");
   FAIL_IF_NULL(py_docstring_mod);
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -144,14 +144,14 @@ EM_JS(void, log_python_error, (JsVal jserror), {
  * WARNING: dereferencing the error pointer stored on the PythonError is a
  * use-after-free bug.
  */
-EMSCRIPTEN_KEEPALIVE JsVal
-wrap_exception()
+// Does the fallible work of wrap_exception. `exc` is borrowed. Returns a JS
+// error on success or JS_ERROR if something went wrong while formatting (in
+// which case wrap_exception builds a fallback error).
+static JsVal
+wrap_exception_inner(PyObject* exc)
 {
-  bool success = false;
-  DECLARE_PY_OBJECT(exc);
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(typestr);
-
-  exc = PyErr_GetRaisedException();
 
   if (PyErr_GivenExceptionMatches(exc, PyExc_ModuleNotFoundError)) {
     DECLARE_PY_OBJECT(res);
@@ -192,9 +192,17 @@ wrap_exception()
   log_python_error(jserror);
 #endif
 
-  success = true;
-finally:
-  if (!success) {
+  return jserror;
+}
+
+EMSCRIPTEN_KEEPALIVE JsVal
+wrap_exception()
+{
+  DECLARE_PY_OBJECT(exc);
+  exc = PyErr_GetRaisedException();
+
+  JsVal jserror = wrap_exception_inner(exc);
+  if (JsvError_Check(jserror)) {
     fail_test();
     PySys_WriteStderr(
       "Pyodide: Internal error occurred while formatting traceback:\n");
@@ -258,7 +266,7 @@ PyObject* conversion_error;
 int
 error_handling_init(PyObject* core_module)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(_pyodide_core_docs);
 
   _pyodide_core_docs = PyImport_ImportModule("_pyodide._core_docs");
@@ -277,7 +285,5 @@ error_handling_init(PyObject* core_module)
   tbmod = PyImport_ImportModule("traceback");
   FAIL_IF_NULL(tbmod);
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -175,12 +175,12 @@ console_error_obj(JsVal obj);
  * Failure apparatus.
  *
  * Error handling returns directly rather than jumping to a cleanup label. Use
- * `FAIL_RETURN_VALUE(val)` as the first statement of the function body (before any
- * DECLARE_PY_OBJECT / _Defer): it declares `fail_return` (the error sentinel
- * returned by FAIL) and a `success` flag (starts true, set false by FAIL) that
- * deferred cleanup blocks can branch on. Resource cleanup must be handled by
- * _Defer blocks, which run on every return (including the early returns
- * performed by FAIL).
+ * `FAIL_RETURN_VALUE(val)` as the first statement of the function body (before
+ * any DECLARE_PY_OBJECT / _Defer): it declares `fail_return` (the error
+ * sentinel returned by FAIL) and a `success` flag (starts true, set false by
+ * FAIL) that deferred cleanup blocks can branch on. Resource cleanup must be
+ * handled by _Defer blocks, which run on every return (including the early
+ * returns performed by FAIL).
  *
  * FAIL() -- set success = false and return the error sentinel `fail_return`.
  * FAIL_IF_NULL(ref) -- FAIL() if ref == NULL

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -154,21 +154,46 @@ console_error_obj(JsVal obj);
  * EM_JS calls behave just like Python API calls when it comes to errors
  * So these can be used equally well for both cases.
  *
- * These all use "goto finally;" so any function that uses them must have
- * a finally label. Luckily, the compiler errors triggered byforgetting
- * this are usually quite clear.
+ * These all return the error sentinel directly, so any function that uses them
+ * must begin with a FAIL_RETURN_VALUE(sentinel) statement (which declares
+ * `fail_return` and the `success` flag). Resource cleanup is handled by _Defer
+ * blocks, which run on every return.
  *
  * We define a feature flag "DEBUG_F" that will use "console.error" to
  * report a message whenever these functions exit with error. This should
  * particularly help to track down problems when C code fails to handle
  * the error generated.
  *
- * FAIL() -- unconditionally goto finally; (but also log it with
+ * FAIL() -- set success = false and return fail_return (also logs with
  *           console.error if DEBUG_F is enabled)
  * FAIL_IF_NULL(ref) -- FAIL() if ref == NULL
  * FAIL_IF_MINUS_ONE(num) -- FAIL() if num == -1
- * FAIL_IF_ERR_OCCURRED(num) -- FAIL() if PyErr_Occurred()
+ * FAIL_IF_ERR_OCCURRED() -- FAIL() if PyErr_Occurred()
  */
+
+/**
+ * Failure apparatus.
+ *
+ * Error handling returns directly rather than jumping to a cleanup label. Use
+ * `FAIL_RETURN_VALUE(val)` as the first statement of the function body (before any
+ * DECLARE_PY_OBJECT / _Defer): it declares `fail_return` (the error sentinel
+ * returned by FAIL) and a `success` flag (starts true, set false by FAIL) that
+ * deferred cleanup blocks can branch on. Resource cleanup must be handled by
+ * _Defer blocks, which run on every return (including the early returns
+ * performed by FAIL).
+ *
+ * FAIL() -- set success = false and return the error sentinel `fail_return`.
+ * FAIL_IF_NULL(ref) -- FAIL() if ref == NULL
+ * FAIL_IF_MINUS_ONE(num) -- FAIL() if num == -1
+ * FAIL_IF_NONZERO(num) -- FAIL() if num != 0
+ * FAIL_IF_ERR_OCCURRED() -- FAIL() if PyErr_Occurred()
+ * FAIL_IF_JS_ERROR(ref) -- FAIL() if the value is a JS error sentinel
+ */
+// Note: uses (!!1)/(!!0) rather than true/false because some files (e.g.
+// jslib.c) intentionally #undef true/false to use them as JS identifiers.
+#define FAIL_RETURN_VALUE(val)                                                 \
+  __auto_type fail_return = (val);                                             \
+  bool __attribute__((unused)) success = (!!1)
 
 #ifdef DEBUG_F
 #define FAIL()                                                                 \
@@ -181,19 +206,16 @@ console_error_obj(JsVal obj);
              __FILE__);                                                        \
     console_error(msg);                                                        \
     free(msg);                                                                 \
-    goto finally;                                                              \
+    success = (!!0);                                                           \
+    return fail_return;                                                        \
   } while (0)
-
 #else
-#define FAIL() goto finally
+#define FAIL()                                                                 \
+  do {                                                                         \
+    success = (!!0);                                                           \
+    return fail_return;                                                        \
+  } while (0)
 #endif
-
-#define DECLARE_PY_OBJECT(x)                                                   \
-  PyObject* x = NULL;                                                          \
-  _Defer                                                                       \
-  {                                                                            \
-    Py_CLEAR(x);                                                               \
-  }
 
 #define FAIL_IF_NULL(ref)                                                      \
   do {                                                                         \
@@ -229,5 +251,23 @@ console_error_obj(JsVal obj);
       FAIL();                                                                  \
     }                                                                          \
   } while (0)
+
+#define DECLARE_PY_OBJECT(x)                                                   \
+  PyObject* x = NULL;                                                          \
+  _Defer                                                                       \
+  {                                                                            \
+    Py_CLEAR(x);                                                               \
+  }
+
+// Register cleanup that only runs on the failure path (i.e. when FAIL() was
+// hit and `success` is false). Place it after declaring the variables it
+// references. Usage: ON_FAIL({ Py_CLEAR(result); });
+#define ON_FAIL(...)                                                           \
+  _Defer                                                                       \
+  {                                                                            \
+    if (!success) {                                                            \
+      __VA_ARGS__                                                              \
+    }                                                                          \
+  }
 
 #endif // ERROR_HANDLING_H

--- a/src/core/jsbind.c
+++ b/src/core/jsbind.c
@@ -602,16 +602,16 @@ add_js2py_converter(PyObject* core_mod,
 }
 
 #define ADD_TYPE(type)                                                         \
-  FAIL_IF_MINUS_ONE(PyType_Ready(&type##Type));                               \
-  FAIL_IF_MINUS_ONE(                                                          \
+  FAIL_IF_MINUS_ONE(PyType_Ready(&type##Type));                                \
+  FAIL_IF_MINUS_ONE(                                                           \
     PyObject_SetAttrString(core_mod, #type, (PyObject*)&type##Type));
 
 #define ADD_PY2JS(name)                                                        \
-  FAIL_IF_MINUS_ONE(                                                          \
+  FAIL_IF_MINUS_ONE(                                                           \
     add_py2js_converter(core_mod, "py2js_" #name, Py2Js_func_##name))
 
 #define ADD_JS2PY(name)                                                        \
-  FAIL_IF_MINUS_ONE(                                                          \
+  FAIL_IF_MINUS_ONE(                                                           \
     add_js2py_converter(core_mod, "js2py_" #name, Js2Py_func_##name))
 
 PyObject* jsbind = NULL;

--- a/src/core/jsbind.c
+++ b/src/core/jsbind.c
@@ -116,6 +116,7 @@ static PyTypeObject Py2JsConverterType = {
 JsVal
 Py2JsConverter_convert(PyObject* converter, PyObject* pyval, JsVal proxies)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(pre_converted);
   JsVal result = JS_ERROR;
 
@@ -136,7 +137,6 @@ Py2JsConverter_convert(PyObject* converter, PyObject* pyval, JsVal proxies)
 
   result =
     Py2JsConverter_converter(converter)(converter, pre_converted, proxies);
-finally:
   return result;
 }
 
@@ -248,6 +248,7 @@ static PyTypeObject Js2PyConverterType = {
 PyObject*
 Js2PyConverter_convert(PyObject* converter, JsVal jsval, JsVal proxies)
 {
+  FAIL_RETURN_VALUE(NULL);
   int status = PyObject_IsInstance(converter, (PyObject*)&Js2PyConverterType);
   if (status == 0) {
     PyErr_Format(
@@ -268,8 +269,6 @@ Js2PyConverter_convert(PyObject* converter, JsVal jsval, JsVal proxies)
   PyObject* post_converted = PyObject_CallOneArg(post_convert, result);
   Py_CLEAR(result);
   return post_converted;
-finally:
-  return NULL;
 }
 
 // Py2Js conversion functions get as arguments:
@@ -525,6 +524,7 @@ EM_JS_VAL(JsVal, wrap_async_generator, (JsVal gen, JsVal proxies), {
 static PyObject*
 Js2Py_func_default_call_result(PyObject* self, JsVal jsresult, JsVal proxies)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* pyresult = NULL;
   // various cases where we want to extend the lifetime of the arguments:
   // 1. if the return value is a promise we extend arguments lifetime until the
@@ -568,7 +568,6 @@ Js2Py_func_default_call_result(PyObject* self, JsVal jsresult, JsVal proxies)
   } else {
     gc_register_proxies(proxies);
   }
-finally:
   return pyresult;
 }
 
@@ -577,16 +576,14 @@ add_py2js_converter(PyObject* core_mod,
                     const char* name,
                     Py2JsConvertFunc* func)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   DECLARE_PY_OBJECT(converter);
   converter = Py2JsConverter_cnew(func);
   FAIL_IF_NULL(converter);
   FAIL_IF_MINUS_ONE(PyObject_SetAttrString(core_mod, name, converter));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 static int
@@ -594,29 +591,27 @@ add_js2py_converter(PyObject* core_mod,
                     const char* name,
                     Js2PyConvertFunc* func)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   DECLARE_PY_OBJECT(converter);
   converter = Js2PyConverter_cnew(func);
   FAIL_IF_NULL(converter);
   FAIL_IF_MINUS_ONE(PyObject_SetAttrString(core_mod, name, converter));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 #define ADD_TYPE(type)                                                         \
-  FAIL_IF_MINUS_ONE(PyType_Ready(&type##Type));                                \
-  FAIL_IF_MINUS_ONE(                                                           \
+  FAIL_IF_MINUS_ONE(PyType_Ready(&type##Type));                               \
+  FAIL_IF_MINUS_ONE(                                                          \
     PyObject_SetAttrString(core_mod, #type, (PyObject*)&type##Type));
 
 #define ADD_PY2JS(name)                                                        \
-  FAIL_IF_MINUS_ONE(                                                           \
+  FAIL_IF_MINUS_ONE(                                                          \
     add_py2js_converter(core_mod, "py2js_" #name, Py2Js_func_##name))
 
 #define ADD_JS2PY(name)                                                        \
-  FAIL_IF_MINUS_ONE(                                                           \
+  FAIL_IF_MINUS_ONE(                                                          \
     add_js2py_converter(core_mod, "js2py_" #name, Js2Py_func_##name))
 
 PyObject* jsbind = NULL;
@@ -635,7 +630,7 @@ static PyMethodDef methods[] = {
 int
 jsbind_init(PyObject* core_mod)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   ADD_TYPE(Py2JsConverter);
   ADD_TYPE(Js2PyConverter);
 
@@ -658,7 +653,5 @@ jsbind_init(PyObject* core_mod)
   default_signature = PyObject_GetAttrString(jsbind, "default_signature");
   FAIL_IF_NULL(default_signature);
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }

--- a/src/core/jslib.c
+++ b/src/core/jslib.c
@@ -52,11 +52,10 @@ jslib_init_buffers(void);
 errcode
 jslib_init(void)
 {
+  FAIL_RETURN_VALUE(-1);
   FAIL_IF_MINUS_ONE(jslib_init_buffers());
   FAIL_IF_MINUS_ONE(jslib_init_js());
   return 0;
-finally:
-  return -1;
 }
 
 // clang-format off

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -311,12 +311,12 @@ JsProxy_clear(PyObject* self)
 static void
 JsProxy_dealloc(PyObject* self)
 {
-  FAIL_IF_MINUS_ONE(JsProxy_clear(self));
+  if (JsProxy_clear(self) == -1) {
+    printf("Internal Pyodide error Unraiseable error in JsProxy_dealloc:\n");
+    PyErr_Print();
+    return;
+  }
   Py_TYPE(self)->tp_free(self);
-  return;
-finally:
-  printf("Internal Pyodide error Unraiseable error in JsProxy_dealloc:\n");
-  PyErr_Print();
 }
 
 // attach a signature to a copy of the JsProxy.
@@ -337,6 +337,7 @@ static PyMethodDef JsProxy_bind_sig_MethodDef = {
 PyObject*
 JsProxy_bind_class(PyObject* self, PyObject* sig)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   // Call `sig = jsbind.bind_class_sig(sig)` and then delegate to
@@ -347,7 +348,6 @@ JsProxy_bind_class(PyObject* self, PyObject* sig)
   class_sig = _PyObject_CallMethodIdOneArg(jsbind, &PyId_bind_class_sig, sig);
   FAIL_IF_NULL(class_sig);
   result = JsProxy_bind_sig(self, class_sig);
-finally:
   return result;
 }
 
@@ -382,6 +382,7 @@ JsProxy_typeof(PyObject* self, void* _unused)
 static PyObject*
 JsProxy_js_id(PyObject* self, void* _unused)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   JsRef idval = JsProxy_REF(self);
@@ -389,7 +390,6 @@ JsProxy_js_id(PyObject* self, void* _unused)
   Py_hash_t result_c = Py_HashBuffer(x, 8);
   FAIL_IF_MINUS_ONE(result_c);
   result = PyLong_FromLong(result_c);
-finally:
   return result;
 }
 
@@ -537,17 +537,18 @@ JsProxy_GetAttr(PyObject* self, PyObject* attr)
 static PyObject*
 JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = _PyObject_GenericGetAttrWithDict(self, attr, NULL, 1);
   if (result != NULL || PyErr_Occurred()) {
     return result;
   }
 
-  bool success = false;
   JsVal jsresult = JS_ERROR;
   DECLARE_PY_OBJECT(get_attr_sig_res);
   DECLARE_PY_OBJECT(attr_sig);
   // result:
   PyObject* pyresult = NULL;
+  ON_FAIL({ Py_CLEAR(pyresult); });
 
   const char* key = PyUnicode_AsUTF8(attr);
   FAIL_IF_NULL(key);
@@ -582,7 +583,7 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
     }
     if (got_converter) {
       pyresult = Js2PyConverter_convert(sig, jsresult, Jsv_null);
-      goto success;
+      return pyresult;
     }
     if (!Py_IsNone(sig)) {
       attr_sig = Py_XNewRef(sig);
@@ -593,7 +594,7 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
   if (pyproxy_Check(jsresult)) {
     pyresult = js2python(jsresult);
     FAIL_IF_NULL(pyresult);
-    goto success;
+    return pyresult;
   }
   if (is_method) {
     if (!JsvFunction_Check(jsresult)) {
@@ -607,7 +608,7 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
     method_call_singleton->this_ = JsProxy_REF(self);
     hiwire_incref(method_call_singleton->this_);
     method_call_singleton->signature = Py_XNewRef(attr_sig);
-    goto success;
+    return pyresult;
   }
   if (JsvFunction_Check(jsresult)) {
     pyresult =
@@ -620,12 +621,6 @@ JsProxy_GetAttr_helper(PyObject* self, PyObject* attr, bool is_method)
   }
   FAIL_IF_NULL(pyresult);
 
-success:
-  success = true;
-finally:
-  if (!success) {
-    Py_CLEAR(pyresult);
-  }
   return pyresult;
 }
 
@@ -651,7 +646,7 @@ EM_JS_NUM(errcode, JsProxy_DelAttr_js, (JsVal jsobj, const char* ptrkey), {
 static int
 JsProxy_SetAttr(PyObject* self, PyObject* attr, PyObject* pyvalue)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   const char* key = PyUnicode_AsUTF8(attr);
   FAIL_IF_NULL(key);
@@ -673,9 +668,7 @@ JsProxy_SetAttr(PyObject* self, PyObject* attr, PyObject* pyvalue)
     FAIL_IF_MINUS_ONE(JsProxy_SetAttr_js(JsProxy_VAL(self), key, jsvalue));
   }
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 static PyObject*
@@ -734,11 +727,10 @@ EM_JS_VAL(JsVal, JsProxy_GetIter_js, (JsVal obj), {
 static PyObject*
 JsProxy_GetIter(PyObject* self)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal iter = JsProxy_GetIter_js(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(iter);
   return js2python_objmap(iter, JsProxy_get_objmap_flags(self));
-finally:
-  return NULL;
 }
 
 // clang-format off
@@ -767,6 +759,7 @@ handle_next_result_js,
 
 PySendResult
 handle_next_result(JsVal next_res, PyObject** result, int objmap_flags){
+  FAIL_RETURN_VALUE(PYGEN_ERROR);
   PySendResult res = PYGEN_ERROR;
   char* msg = NULL;
   *result = NULL;
@@ -798,7 +791,6 @@ handle_next_result(JsVal next_res, PyObject** result, int objmap_flags){
   }
 
   res = done ? PYGEN_RETURN : PYGEN_NEXT;
-finally:
   return res;
 }
 
@@ -807,11 +799,18 @@ finally:
 PySendResult
 JsProxy_am_send(PyObject* self, PyObject* arg, PyObject** result)
 {
+  FAIL_RETURN_VALUE(PYGEN_ERROR);
   *result = NULL;
   PySendResult ret = PYGEN_ERROR;
 
   JsVal proxies = JsvArray_New();
   JsVal jsarg = Jsv_undefined;
+  _Defer
+  {
+    if (arg) {
+      destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
+    }
+  };
   if (arg) {
     jsarg = python2js_track_proxies(arg, proxies, true);
     FAIL_IF_JS_ERROR(jsarg);
@@ -820,10 +819,6 @@ JsProxy_am_send(PyObject* self, PyObject* arg, PyObject** result)
     JsvObject_CallMethodId_OneArg(JsProxy_VAL(self), &JsId_next, jsarg);
   FAIL_IF_JS_ERROR(next_res);
   ret = handle_next_result(next_res, result, JsProxy_get_objmap_flags(self));
-finally:
-  if (arg) {
-    destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
-  }
   return ret;
 }
 
@@ -871,6 +866,7 @@ JsException_reduce(PyObject* self, PyObject* Py_UNUSED(ignored))
 {
   // Record name, message, and stack.
   // See _core_docs.JsException._new_exc where the unpickling will happen.
+  FAIL_RETURN_VALUE(NULL);
   PyObject* res = NULL;
   DECLARE_PY_OBJECT(args);
   DECLARE_PY_OBJECT(name);
@@ -894,7 +890,6 @@ JsException_reduce(PyObject* self, PyObject* Py_UNUSED(ignored))
     res = PyTuple_Pack(2, Py_TYPE(self), args);
   }
 
-finally:
   return res;
 }
 
@@ -935,11 +930,10 @@ JsException_new(PyTypeObject* subtype, PyObject* args, PyObject* kwds)
         args, kwds, "s|ss:__new__", kwlist, &name, &message, &stack)) {
     return NULL;
   }
+  FAIL_RETURN_VALUE(NULL);
   JsVal result = JsException_new_helper(name, message, stack);
   FAIL_IF_JS_ERROR(result);
   return js2python(result);
-finally:
-  return NULL;
 }
 
 static int
@@ -1041,6 +1035,7 @@ JsGenerator_throw_inner(PyObject* self,
                         PyObject* val,
                         PyObject* tb)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
   JsVal throw_res = process_throw_args(self, typ, val, tb);
   FAIL_IF_JS_ERROR(throw_res);
@@ -1053,7 +1048,6 @@ JsGenerator_throw_inner(PyObject* self,
     }
     Py_CLEAR(result);
   }
-finally:
   return result;
 }
 
@@ -1116,11 +1110,10 @@ EM_JS_VAL(JsVal, JsProxy_GetAsyncIter_js, (JsVal obj), {
 static PyObject*
 JsProxy_GetAsyncIter(PyObject* self)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal iter = JsProxy_GetAsyncIter_js(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(iter);
   return js2python(iter);
-finally:
-  return NULL;
 }
 
 /**
@@ -1252,11 +1245,12 @@ _agen_handle_result_js,
 PyObject*
 _agen_handle_result(JsVal promise, bool closing)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(loop);
   DECLARE_PY_OBJECT(set_result);
   DECLARE_PY_OBJECT(set_exception);
   PyObject* result = NULL;
+  ON_FAIL({ Py_CLEAR(result); });
 
   loop = _PyObject_CallMethodIdNoArgs(asyncio_mod, &PyId_get_event_loop);
   FAIL_IF_NULL(loop);
@@ -1280,21 +1274,23 @@ _agen_handle_result(JsVal promise, bool closing)
     FAIL();
   }
 
-  success = true;
-finally:
-  if (!success) {
-    Py_CLEAR(result);
-  }
   return result;
 }
 
 static PyObject*
 JsGenerator_asend(PyObject* self, PyObject* arg)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   JsVal proxies = JsvArray_New();
   JsVal jsarg = Jsv_undefined;
+  _Defer
+  {
+    if (arg) {
+      destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
+    }
+  };
   if (arg != NULL) {
     jsarg = python2js_track_proxies(arg, proxies, true);
     FAIL_IF_JS_ERROR(jsarg);
@@ -1304,10 +1300,6 @@ JsGenerator_asend(PyObject* self, PyObject* arg)
   FAIL_IF_JS_ERROR(next_res);
   result = _agen_handle_result(next_res, false);
 
-finally:
-  if (arg) {
-    destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
-  }
   return result;
 }
 
@@ -1334,13 +1326,13 @@ JsGenerator_athrow(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
     return NULL;
   }
 
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   JsVal throw_res = process_throw_args(self, typ, val, tb);
   FAIL_IF_JS_ERROR(throw_res);
   result = _agen_handle_result(throw_res, false);
 
-finally:
   return result;
 }
 
@@ -1353,13 +1345,13 @@ static PyMethodDef JsGenerator_athrow_MethodDef = {
 static PyObject*
 JsGenerator_aclose(PyObject* self, PyObject* ignored)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   JsVal throw_res = process_throw_args(self, PyExc_GeneratorExit, NULL, NULL);
   FAIL_IF_JS_ERROR(throw_res);
   result = _agen_handle_result(throw_res, true);
 
-finally:
   return result;
 }
 
@@ -1376,11 +1368,10 @@ static PyMethodDef JsGenerator_aclose_MethodDef = {
 static PyObject*
 JsProxy_object_entries(PyObject* self, PyObject* _args)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal jsresult = JsvObject_Entries(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(jsresult);
   return JsProxy_create(jsresult);
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsProxy_object_entries_MethodDef = {
@@ -1396,11 +1387,10 @@ static PyMethodDef JsProxy_object_entries_MethodDef = {
 static PyObject*
 JsProxy_object_keys(PyObject* self, PyObject* _args)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal jsresult = JsvObject_Keys(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(jsresult);
   return JsProxy_create(jsresult);
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsProxy_object_keys_MethodDef = {
@@ -1416,11 +1406,10 @@ static PyMethodDef JsProxy_object_keys_MethodDef = {
 static PyObject*
 JsProxy_object_values(PyObject* self, PyObject* _args)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal jsresult = JsvObject_Values(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(jsresult);
   return JsProxy_create(jsresult);
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsProxy_object_values_MethodDef = {
@@ -1523,11 +1512,11 @@ JsProxy_length(PyObject* self)
 static PyObject*
 JsProxy_item_array(PyObject* self, Py_ssize_t i)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* pyresult = NULL;
   JsVal jsresult = JsvArray_Get(JsProxy_VAL(self), i);
   FAIL_IF_JS_ERROR(jsresult);
   pyresult = js2python(jsresult);
-finally:
   return pyresult;
 }
 
@@ -1537,6 +1526,7 @@ finally:
 static PyObject*
 JsArray_subscript(PyObject* self, PyObject* item)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* pyresult = NULL;
 
   if (PyIndex_Check(item)) {
@@ -1556,7 +1546,7 @@ JsArray_subscript(PyObject* self, PyObject* item)
       FAIL();
     }
     pyresult = js2python_objmap(jsresult, JsProxy_get_objmap_flags(self));
-    goto success;
+    return pyresult;
   }
   if (PySlice_Check(item)) {
     Py_ssize_t start, stop, step;
@@ -1574,19 +1564,18 @@ JsArray_subscript(PyObject* self, PyObject* item)
     }
     FAIL_IF_JS_ERROR(jsresult);
     pyresult = js2python_objmap(jsresult, JsProxy_get_objmap_flags(self));
-    goto success;
+    return pyresult;
   }
   PyErr_Format(PyExc_TypeError,
                "list indices must be integers or slices, not %.200s",
                Py_TYPE(item)->tp_name);
-success:
-finally:
   return pyresult;
 }
 
 PyObject*
 JsArray_sq_item(PyObject* o, Py_ssize_t i)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* pyresult = NULL;
 
   JsVal jsresult = JsvArray_Get(JsProxy_VAL(o), i);
@@ -1598,30 +1587,26 @@ JsArray_sq_item(PyObject* o, Py_ssize_t i)
   }
   pyresult = js2python(jsresult);
   FAIL_IF_NULL(pyresult);
-finally:
   return pyresult;
 }
 
 Py_ssize_t
 JsArray_sq_ass_item(PyObject* o, Py_ssize_t i, PyObject* pyval)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   if (pyval == NULL) {
     // Delete
     JsVal jsval = JsvArray_Delete(JsProxy_VAL(o), i);
     FAIL_IF_JS_ERROR(jsval);
-    success = true;
-    goto finally;
+    return 0;
   }
 
   JsVal jsval = python2js(pyval);
   FAIL_IF_JS_ERROR(jsval);
   FAIL_IF_MINUS_ONE(JsvArray_Set(JsProxy_VAL(o), i, jsval));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 Py_ssize_t
@@ -1654,7 +1639,7 @@ JsTypedArray_subscript(PyObject* o, PyObject* item)
 static int
 JsArray_ass_subscript(PyObject* self, PyObject* item, PyObject* pyvalue)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(seq);
   Py_ssize_t i;
   if (PySlice_Check(item)) {
@@ -1681,8 +1666,7 @@ JsArray_ass_subscript(PyObject* self, PyObject* item, PyObject* pyvalue)
     }
     if (pyvalue == NULL) {
       if (slicelength <= 0) {
-        success = true;
-        goto finally;
+        return 0;
       }
       if (step < 0) {
         // We have to delete in backwards order so make sure step > 0.
@@ -1696,8 +1680,7 @@ JsArray_ass_subscript(PyObject* self, PyObject* item, PyObject* pyvalue)
       if (step != 1 && !slicelength) {
         // At this point, assigning to an extended slice of length 0 must be a
         // no-op
-        success = true;
-        goto finally;
+        return 0;
       }
       FAIL_IF_MINUS_ONE(JsvArray_slice_assign(JsProxy_VAL(self),
                                               slicelength,
@@ -1707,8 +1690,7 @@ JsArray_ass_subscript(PyObject* self, PyObject* item, PyObject* pyvalue)
                                               PySequence_Fast_GET_SIZE(seq),
                                               PySequence_Fast_ITEMS(seq)));
     }
-    success = true;
-    goto finally;
+    return 0;
   } else if (PyIndex_Check(item)) {
     i = PyNumber_AsSsize_t(item, PyExc_IndexError);
     if (i == -1)
@@ -1737,9 +1719,7 @@ JsArray_ass_subscript(PyObject* self, PyObject* item, PyObject* pyvalue)
     FAIL_IF_JS_ERROR(jsvalue);
     FAIL_IF_MINUS_ONE(JsvArray_Set(JsProxy_VAL(self), i, jsvalue));
   }
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 /**
@@ -1764,8 +1744,8 @@ JsTypedArray_ass_subscript(PyObject* o, PyObject* item, PyObject* pyvalue)
 static int
 JsArray_extend_by_python_iterable(JsVal jsarray, PyObject* iterable)
 {
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(it);
-  bool success = false;
 
   if (PyList_CheckExact(iterable) || PyTuple_CheckExact(iterable)) {
     iterable = PySequence_Fast(iterable, "argument must be iterable");
@@ -1774,8 +1754,7 @@ JsArray_extend_by_python_iterable(JsVal jsarray, PyObject* iterable)
     Py_ssize_t n = PySequence_Fast_GET_SIZE(iterable);
     if (n == 0) {
       /* short circuit when iterable is empty */
-      success = true;
-      goto finally;
+      return 0;
     }
     /* note that we may still have self == iterable here for the
      * situation a.extend(a), but the following code works
@@ -1813,9 +1792,7 @@ JsArray_extend_by_python_iterable(JsVal jsarray, PyObject* iterable)
       JsvArray_Push(jsarray, jsval);
     }
   }
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 EM_JS(void, destroy_jsarray_entries, (JsVal array), {
@@ -1835,22 +1812,14 @@ EM_JS(void, destroy_jsarray_entries, (JsVal array), {
 static PyObject*
 JsArray_extend_meth(PyObject* o, PyObject* iterable)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
 
   JsVal temp = JsvArray_New();
+  ON_FAIL({ destroy_jsarray_entries(temp); });
   // Make sure that if anything goes wrong the original array stays unmodified
   FAIL_IF_MINUS_ONE(JsArray_extend_by_python_iterable(temp, iterable));
   JsvArray_Extend(JsProxy_VAL(o), temp);
-  success = true;
-finally:
-  if (!success) {
-    destroy_jsarray_entries(temp);
-  }
-  if (success) {
-    Py_RETURN_NONE;
-  } else {
-    return NULL;
-  }
+  Py_RETURN_NONE;
 }
 
 static PyMethodDef JsArray_extend_MethodDef = {
@@ -1862,8 +1831,9 @@ static PyMethodDef JsArray_extend_MethodDef = {
 static PyObject*
 JsArray_sq_concat(PyObject* self, PyObject* other)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* pyresult = NULL;
-  bool success = true;
+  ON_FAIL({ Py_CLEAR(pyresult); });
 
   JsVal jsresult = JsvArray_ShallowCopy(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(jsresult);
@@ -1871,23 +1841,18 @@ JsArray_sq_concat(PyObject* self, PyObject* other)
   FAIL_IF_NULL(pyresult);
   FAIL_IF_MINUS_ONE(
     JsArray_extend_by_python_iterable(JsProxy_VAL(pyresult), other));
-finally:
-  if (!success) {
-    Py_CLEAR(pyresult);
-  }
   return pyresult;
 }
 
 static PyObject*
 JsArray_sq_inplace_concat(PyObject* self, PyObject* other)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = JsArray_extend_meth(self, other);
   FAIL_IF_NULL(result);
   Py_DECREF(result);
   Py_INCREF(self);
   return self;
-finally:
-  return NULL;
 }
 
 EM_JS_VAL(JsVal, JsArray_repeat_js, (JsVal o, Py_ssize_t count), {
@@ -1902,12 +1867,10 @@ EM_JS_VAL(JsVal, JsArray_repeat_js, (JsVal o, Py_ssize_t count), {
 static PyObject*
 JsArray_sq_repeat(PyObject* o, Py_ssize_t count)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal jsresult = JsArray_repeat_js(JsProxy_Val(o), count);
   FAIL_IF_JS_ERROR(jsresult);
   return js2python(jsresult);
-
-finally:
-  return NULL;
 }
 
 EM_JS_NUM(errcode, JsArray_inplace_repeat_js, (JsVal o, Py_ssize_t count), {
@@ -1919,29 +1882,22 @@ EM_JS_NUM(errcode, JsArray_inplace_repeat_js, (JsVal o, Py_ssize_t count), {
 static PyObject*
 JsArray_sq_inplace_repeat(PyObject* o, Py_ssize_t count)
 {
+  FAIL_RETURN_VALUE(NULL);
   FAIL_IF_MINUS_ONE(JsArray_inplace_repeat_js(JsProxy_VAL(o), count));
   Py_INCREF(o);
   return o;
-finally:
-  return NULL;
 }
 
 static PyObject*
 JsArray_append(PyObject* self, PyObject* arg)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
 
   JsVal jsarg = python2js(arg);
   FAIL_IF_JS_ERROR(jsarg);
   JsvArray_Push(JsProxy_VAL(self), jsarg);
 
-  success = true;
-finally:
-  if (success) {
-    Py_RETURN_NONE;
-  } else {
-    return NULL;
-  }
+  Py_RETURN_NONE;
 }
 
 static PyMethodDef JsArray_append_MethodDef = {
@@ -1967,6 +1923,7 @@ valid_index(Py_ssize_t i, Py_ssize_t limit)
 static PyObject*
 JsArray_pop(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* pyresult = NULL;
   DECLARE_PY_OBJECT(iobj);
   Py_ssize_t index = -1;
@@ -2002,7 +1959,6 @@ JsArray_pop(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   FAIL_IF_JS_ERROR(jsresult);
   pyresult = js2python(jsresult);
 
-finally:
   return pyresult;
 }
 
@@ -2045,11 +2001,10 @@ class ReversedIterator {
 static PyObject*
 JsArray_reversed(PyObject* self, PyObject* ignored)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal iter = JsArray_reversed_iterator(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(iter);
   return js2python(iter);
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsArray_reversed_MethodDef = {
@@ -2235,12 +2190,11 @@ JsArray_insert(PyObject* self, PyObject* args)
   if (!PyArg_ParseTuple(args, "nO:insert", &index, &pyvalue)) {
     return NULL;
   }
+  FAIL_RETURN_VALUE(NULL);
   JsVal jsvalue = python2js(pyvalue);
   FAIL_IF_JS_ERROR(jsvalue);
   FAIL_IF_MINUS_ONE(JsvArray_Insert(JsProxy_VAL(self), index, jsvalue));
   Py_RETURN_NONE;
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsArray_insert_MethodDef = {
@@ -2252,12 +2206,11 @@ static PyMethodDef JsArray_insert_MethodDef = {
 static PyObject*
 JsArray_remove(PyObject* self, PyObject* arg)
 {
+  FAIL_RETURN_VALUE(NULL);
   int index = JsArray_index_helper(self, arg, 0, PY_SSIZE_T_MAX);
   FAIL_IF_MINUS_ONE(index);
   JsvArray_Delete(JsProxy_VAL(self), index);
   Py_RETURN_NONE;
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsArray_remove_MethodDef = {
@@ -2290,6 +2243,7 @@ EM_JS_VAL(JsVal, JsProxy_subscript_js, (JsVal obj, JsVal key), {
 static PyObject*
 JsProxy_subscript(PyObject* self, PyObject* pyidx)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal idx = python2js(pyidx);
   FAIL_IF_JS_ERROR(idx);
   JsVal result = JsProxy_subscript_js(JsProxy_VAL(self), idx);
@@ -2300,8 +2254,6 @@ JsProxy_subscript(PyObject* self, PyObject* pyidx)
     FAIL();
   }
   return js2python(result);
-finally:
-  return NULL;
 }
 
 /**
@@ -2314,7 +2266,7 @@ finally:
 static int
 JsProxy_ass_subscript(PyObject* self, PyObject* pyidx, PyObject* pyvalue)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   JsVal idx = python2js(pyidx);
   FAIL_IF_JS_ERROR(idx);
@@ -2334,9 +2286,7 @@ JsProxy_ass_subscript(PyObject* self, PyObject* pyidx, PyObject* pyvalue)
     FAIL_IF_JS_ERROR(
       JsvObject_CallMethodId_TwoArgs(JsProxy_VAL(self), &JsId_set, idx, value));
   }
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 /**
@@ -2348,6 +2298,7 @@ finally:
 static int
 JsProxy_includes(JsProxy* self, PyObject* obj)
 {
+  FAIL_RETURN_VALUE(-1);
   int result = -1;
   JsVal jsobj = python2js(obj);
   FAIL_IF_JS_ERROR(jsobj);
@@ -2356,7 +2307,6 @@ JsProxy_includes(JsProxy* self, PyObject* obj)
   FAIL_IF_JS_ERROR(jsresult);
   result = Jsv_to_bool(jsresult);
 
-finally:
   return result;
 }
 
@@ -2368,6 +2318,7 @@ finally:
 static int
 JsProxy_has(JsProxy* self, PyObject* obj)
 {
+  FAIL_RETURN_VALUE(-1);
   int result = -1;
   JsVal jsobj = python2js(obj);
   FAIL_IF_JS_ERROR(jsobj);
@@ -2376,7 +2327,6 @@ JsProxy_has(JsProxy* self, PyObject* obj)
   FAIL_IF_JS_ERROR(jsresult);
   result = Jsv_to_bool(jsresult);
 
-finally:
   return result;
 }
 
@@ -2423,10 +2373,11 @@ EM_JS_VAL(JsVal, JsProxy_aexit_js, (JsVal obj), {
 static PyObject*
 JsProxy_aenter(JsProxy* self, PyObject* Py_UNUSED(ignored))
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(loop);
   PyObject* result = NULL;
   DECLARE_PY_OBJECT(status);
+  ON_FAIL({ Py_CLEAR(result); });
 
   loop = _PyObject_CallMethodIdNoArgs(asyncio_mod, &PyId_get_event_loop);
   FAIL_IF_NULL(loop);
@@ -2437,12 +2388,6 @@ JsProxy_aenter(JsProxy* self, PyObject* Py_UNUSED(ignored))
   status =
     _PyObject_CallMethodIdOneArg(result, &PyId_set_result, (PyObject*)self);
   FAIL_IF_NULL(status);
-
-  success = true;
-finally:
-  if (!success) {
-    Py_CLEAR(result);
-  }
 
   return result;
 }
@@ -2457,6 +2402,7 @@ JsProxy_aexit(JsProxy* self, PyObject* const* args, Py_ssize_t nargs)
   if (!_PyArg_CheckPositional("__aexit__", nargs, 0, 3)) {
     return NULL;
   }
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   // We have to return an awaitable here but [Symbol.asyncDispose]() does not.
@@ -2468,7 +2414,6 @@ JsProxy_aexit(JsProxy* self, PyObject* const* args, Py_ssize_t nargs)
   result = wrap_promise(jsresult, Jsv_null, NULL);
   FAIL_IF_NULL(result);
 
-finally:
   return result;
 }
 
@@ -2496,11 +2441,10 @@ EM_JS_VAL(JsVal, JsMap_GetIter_js, (JsVal obj), {
 static PyObject*
 JsMap_GetIter(PyObject* self)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal iter = JsMap_GetIter_js(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(iter);
   return js2python(iter);
-finally:
-  return NULL;
 }
 
 static PyObject*
@@ -2750,7 +2694,7 @@ EM_JS_VAL(JsVal, JsProxy_Dir_js, (JsVal jsobj), {
 static PyObject*
 JsProxy_Dir(PyObject* self, PyObject* _args)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(object__dir__);
   DECLARE_PY_OBJECT(keys);
   DECLARE_PY_OBJECT(result_set);
@@ -2759,6 +2703,7 @@ JsProxy_Dir(PyObject* self, PyObject* _args)
   DECLARE_PY_OBJECT(keys_str);
 
   PyObject* result = NULL;
+  ON_FAIL({ Py_CLEAR(result); });
 
   // First get base __dir__ via object.__dir__(self)
   // Would have been nice if they'd supplied PyObject_GenericDir...
@@ -2787,11 +2732,6 @@ JsProxy_Dir(PyObject* self, PyObject* _args)
   FAIL_IF_MINUS_ONE(PyList_Extend(result, result_set));
   FAIL_IF_MINUS_ONE(PyList_Sort(result));
 
-  success = true;
-finally:
-  if (!success) {
-    Py_CLEAR(result);
-  }
   return result;
 }
 
@@ -2885,13 +2825,14 @@ JsProxy_Bool(PyObject* self)
 PyObject*
 wrap_promise(JsVal promise, JsVal done_callback, PyObject* js2py_converter)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(loop);
   DECLARE_PY_OBJECT(helpers);
   DECLARE_PY_OBJECT(set_result);
   DECLARE_PY_OBJECT(set_exception);
 
   PyObject* result = NULL;
+  ON_FAIL({ Py_CLEAR(result); });
 
   loop = _PyObject_CallMethodIdNoArgs(asyncio_mod, &PyId_get_event_loop);
   FAIL_IF_NULL(loop);
@@ -2916,11 +2857,6 @@ wrap_promise(JsVal promise, JsVal done_callback, PyObject* js2py_converter)
   FAIL_IF_JS_ERROR(
     JsvObject_CallMethodId(promise, &JsId_then, promise_handles));
 
-  success = true;
-finally:
-  if (!success) {
-    Py_CLEAR(result);
-  }
   return result;
 }
 
@@ -2941,6 +2877,7 @@ JsProxy_Await(PyObject* self)
                  str_utf8);
     return NULL;
   }
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(fut);
   PyObject* result = NULL;
 
@@ -2948,7 +2885,6 @@ JsProxy_Await(PyObject* self)
   FAIL_IF_NULL(fut);
   result = _PyObject_CallMethodIdNoArgs(fut, &PyId___await__);
 
-finally:
   return result;
 }
 
@@ -2971,6 +2907,7 @@ JsProxy_then(JsProxy* self, PyObject* args, PyObject* kwds)
     return NULL;
   }
 
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   if (Py_IsNone(onfulfilled)) {
@@ -2993,7 +2930,6 @@ JsProxy_then(JsProxy* self, PyObject* args, PyObject* kwds)
   }
   result = JsProxy_create(result_promise);
 
-finally:
   // don't clear onfulfilled, onrejected, they are borrowed from arguments.
   return result;
 }
@@ -3010,6 +2946,7 @@ static PyMethodDef JsProxy_then_MethodDef = {
 static PyObject*
 JsProxy_catch(JsProxy* self, PyObject* onrejected)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   JsVal promise = JsvPromise_Resolve(JsProxy_VAL(self));
@@ -3027,7 +2964,6 @@ JsProxy_catch(JsProxy* self, PyObject* onrejected)
   }
   result = JsProxy_create(result_promise);
 
-finally:
   return result;
 }
 
@@ -3047,6 +2983,7 @@ static PyMethodDef JsProxy_catch_MethodDef = {
 static PyObject*
 JsProxy_finally(JsProxy* self, PyObject* onfinally)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal promise = JsvPromise_Resolve(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(promise);
   // Finally method is called no matter what so we can use
@@ -3061,8 +2998,6 @@ JsProxy_finally(JsProxy* self, PyObject* onfinally)
   }
 
   return JsProxy_create(result_promise);
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsProxy_finally_MethodDef = {
@@ -3100,13 +3035,13 @@ JsProxy_as_object_map(PyObject* self,
     return NULL;
   }
 
+  FAIL_RETURN_VALUE(NULL);
   int type_flags = IS_OBJECT_MAP;
   PyObject* proxy = JsProxy_create_with_type(
     type_flags, JsProxy_VAL(self), JsMethod_THIS(self), NULL);
   FAIL_IF_NULL(proxy);
   JsObjMap_HEREDITARY(proxy) = hereditary;
 
-finally:
   return proxy;
 }
 
@@ -3142,11 +3077,10 @@ EM_JS_VAL(JsVal, JsObjMap_GetIter_js, (JsVal obj), {
 static PyObject*
 JsObjMap_GetIter(PyObject* self)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal iter = JsObjMap_GetIter_js(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(iter);
   return js2python(iter);
-finally:
-  return NULL;
 }
 
 EM_JS_NUM(int, JsObjMap_length_js, (JsVal obj), {
@@ -3179,6 +3113,7 @@ JsObjMap_subscript(PyObject* self, PyObject* pyidx)
     return NULL;
   }
 
+  FAIL_RETURN_VALUE(NULL);
   PyObject* pyresult = NULL;
 
   JsVal key = python2js(pyidx);
@@ -3195,7 +3130,6 @@ JsObjMap_subscript(PyObject* self, PyObject* pyidx)
     pyresult = JsProxy_create_objmap(result, JsProxy_get_objmap_flags(self));
   }
 
-finally:
   return pyresult;
 }
 
@@ -3231,7 +3165,7 @@ JsObjMap_ass_subscript(PyObject* self, PyObject* pykey, PyObject* pyvalue)
     return -1;
   }
 
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   JsVal value = JS_ERROR;
   JsVal key = python2js(pykey);
   if (pyvalue != NULL) {
@@ -3245,9 +3179,7 @@ JsObjMap_ass_subscript(PyObject* self, PyObject* pykey, PyObject* pyvalue)
     }
     FAIL();
   }
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 EM_JS_NUM(int, JsObjMap_contains_js, (JsVal obj, JsVal key), {
@@ -3262,12 +3194,10 @@ JsObjMap_contains(PyObject* self, PyObject* obj)
     // TODO: maybe support symbols??
     return 0;
   }
+  FAIL_RETURN_VALUE(-1);
   JsVal jsobj = python2js(obj);
   FAIL_IF_JS_ERROR(jsobj);
   return JsObjMap_contains_js(JsProxy_VAL(self), jsobj);
-
-finally:
-  return -1;
 }
 
 // clang-format off
@@ -3329,8 +3259,8 @@ JsModule_GetAll(PyObject* self, PyObject** all)
   if (!JsProxy_Check(self)) {
     return 0;
   }
+  FAIL_RETURN_VALUE(-1);
   PyObject* pyresult;
-  int success = -1;
 
   JsVal jsresult = JsModule_GetAll_js(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(jsresult);
@@ -3338,9 +3268,7 @@ JsModule_GetAll(PyObject* self, PyObject** all)
   FAIL_IF_NULL(pyresult);
   *all = pyresult;
 
-  success = 0;
-finally:
-  return success;
+  return 0;
 }
 
 ////////////////////////////////////////////////////////////
@@ -3393,6 +3321,7 @@ static PyMethodDef JsMethod_Construct_MethodDef = {
 static PyObject*
 JsMethod_descr_get(PyObject* self, PyObject* obj, PyObject* type)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   if (Py_IsNone(obj) || obj == NULL) {
@@ -3404,7 +3333,6 @@ JsMethod_descr_get(PyObject* self, PyObject* obj, PyObject* type)
   FAIL_IF_JS_ERROR(jsobj);
   result = JsProxy_create_with_this(JsProxy_VAL(self), jsobj, NULL, false);
 
-finally:
   return result;
 }
 
@@ -3556,8 +3484,12 @@ static PyObject*
 JsBuffer_assign_to(PyObject* obj, PyObject* target)
 {
   JsProxy* self = (JsProxy*)obj;
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   Py_buffer view = { 0 };
+  _Defer
+  {
+    PyBuffer_Release(&view);
+  };
 
   FAIL_IF_MINUS_ONE(
     PyObject_GetBuffer(target, &view, PyBUF_ANY_CONTIGUOUS | PyBUF_WRITABLE));
@@ -3566,13 +3498,7 @@ JsBuffer_assign_to(PyObject* obj, PyObject* target)
   FAIL_IF_MINUS_ONE(check_buffer_compatibility(self, view, safe, dir));
   FAIL_IF_MINUS_ONE(JsvBuffer_assignToPtr(JsProxy_VAL(self), view.buf));
 
-  success = true;
-finally:
-  PyBuffer_Release(&view);
-  if (success) {
-    Py_RETURN_NONE;
-  }
-  return NULL;
+  Py_RETURN_NONE;
 }
 
 static PyMethodDef JsBuffer_assign_to_MethodDef = {
@@ -3590,8 +3516,12 @@ static PyObject*
 JsBuffer_assign(PyObject* obj, PyObject* source)
 {
   JsProxy* self = (JsProxy*)obj;
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   Py_buffer view = { 0 };
+  _Defer
+  {
+    PyBuffer_Release(&view);
+  };
 
   FAIL_IF_MINUS_ONE(PyObject_GetBuffer(source, &view, PyBUF_ANY_CONTIGUOUS));
   bool safe = JsBuffer_CHECK_ASSIGNMENTS(self);
@@ -3599,13 +3529,7 @@ JsBuffer_assign(PyObject* obj, PyObject* source)
   FAIL_IF_MINUS_ONE(check_buffer_compatibility(self, view, safe, dir));
   FAIL_IF_MINUS_ONE(JsvBuffer_assignFromPtr(JsProxy_VAL(self), view.buf));
 
-  success = true;
-finally:
-  PyBuffer_Release(&view);
-  if (success) {
-    Py_RETURN_NONE;
-  }
-  return NULL;
+  Py_RETURN_NONE;
 }
 
 static PyMethodDef JsBuffer_assign_MethodDef = {
@@ -3634,9 +3558,14 @@ JsBuffer_CopyIntoMemoryView(JsVal jsbuffer,
                             char* format,
                             Py_ssize_t itemsize)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   Buffer* buffer = NULL;
   PyObject* result = NULL;
+  ON_FAIL({ Py_CLEAR(result); });
+  _Defer
+  {
+    Py_CLEAR(buffer);
+  };
 
   buffer = (Buffer*)BufferType.tp_alloc(&BufferType, byteLength);
   FAIL_IF_NULL(buffer);
@@ -3645,12 +3574,6 @@ JsBuffer_CopyIntoMemoryView(JsVal jsbuffer,
   result = PyMemoryView_FromObject((PyObject*)buffer);
   FAIL_IF_NULL(result);
 
-  success = true;
-finally:
-  Py_CLEAR(buffer);
-  if (!success) {
-    Py_CLEAR(result);
-  }
   return result;
 }
 
@@ -3661,17 +3584,13 @@ finally:
 static PyObject*
 JsBuffer_CopyIntoBytes(JsVal jsbuffer, Py_ssize_t byteLength)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
 
   PyObject* result = PyBytes_FromStringAndSize(NULL, byteLength);
+  ON_FAIL({ Py_CLEAR(result); });
   FAIL_IF_NULL(result);
   char* data = PyBytes_AS_STRING(result);
   FAIL_IF_MINUS_ONE(JsvBuffer_assignToPtr(jsbuffer, data));
-  success = true;
-finally:
-  if (!success) {
-    Py_CLEAR(result);
-  }
   return result;
 }
 
@@ -3713,6 +3632,7 @@ JsBuffer_DecodeString_js,
 static PyObject*
 JsBuffer_ToString(JsVal jsbuffer, char* encoding)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
 
   JsVal jsresult = JsBuffer_DecodeString_js(jsbuffer, encoding);
@@ -3725,7 +3645,6 @@ JsBuffer_ToString(JsVal jsbuffer, char* encoding)
   result = js2python(jsresult);
   FAIL_IF_NULL(result);
 
-finally:
   return result;
 }
 
@@ -3769,12 +3688,11 @@ get_fileno(PyObject* file)
 static PyObject*
 JsBuffer_write_to_file(PyObject* self, PyObject* file)
 {
+  FAIL_RETURN_VALUE(NULL);
   int fd = get_fileno(file);
   FAIL_IF_MINUS_ONE(fd);
   FAIL_IF_MINUS_ONE(JsvBuffer_writeToFile(JsProxy_VAL(self), fd));
   Py_RETURN_NONE;
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsBuffer_write_to_file_MethodDef = {
@@ -3786,12 +3704,11 @@ static PyMethodDef JsBuffer_write_to_file_MethodDef = {
 static PyObject*
 JsBuffer_read_from_file(PyObject* jsbuffer, PyObject* file)
 {
+  FAIL_RETURN_VALUE(NULL);
   int fd = get_fileno(file);
   FAIL_IF_MINUS_ONE(fd);
   FAIL_IF_MINUS_ONE(JsvBuffer_readFromFile(JsProxy_VAL(jsbuffer), fd));
   Py_RETURN_NONE;
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsBuffer_read_from_file_MethodDef = {
@@ -3803,12 +3720,11 @@ static PyMethodDef JsBuffer_read_from_file_MethodDef = {
 static PyObject*
 JsBuffer_into_file(PyObject* jsbuffer, PyObject* file)
 {
+  FAIL_RETURN_VALUE(NULL);
   int fd = get_fileno(file);
   FAIL_IF_MINUS_ONE(fd);
   FAIL_IF_MINUS_ONE(JsvBuffer_intoFile(JsProxy_VAL(jsbuffer), fd));
   Py_RETURN_NONE;
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsBuffer_into_file_MethodDef = {
@@ -3861,7 +3777,7 @@ JsBuffer_get_info, (JsVal jsobj,
 int
 JsBuffer_cinit(PyObject* self)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   // TODO: should logic here be any different if we're on wasm heap?
   // format string is borrowed from get_buffer_datatype, DO NOT DEALLOCATE!
   JsBuffer_get_info(JsProxy_VAL(self),
@@ -3881,9 +3797,7 @@ JsBuffer_cinit(PyObject* self)
     FAIL();
   }
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 EM_JS_REF(PyObject*, JsDoubleProxy_unwrap_js, (JsVal id), {
@@ -3911,11 +3825,10 @@ EM_JS_VAL(JsVal, JsProxy_to_weakref_js, (JsVal pyproxy), {
 static PyObject*
 JsProxy_to_weakref(PyObject* self, PyObject* _ignored)
 {
+  FAIL_RETURN_VALUE(NULL);
   JsVal jsresult = JsProxy_to_weakref_js(JsProxy_VAL(self));
   FAIL_IF_JS_ERROR(jsresult);
   return js2python(jsresult);
-finally:
-  return NULL;
 }
 
 static PyMethodDef JsProxy_to_weakref_MethodDef = {
@@ -4242,11 +4155,16 @@ skip_container_slots:
   members[cur_member++] = (PyMemberDef){ 0 };
   getsets[cur_getset++] = (PyGetSetDef){ 0 };
 
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   void* mem = NULL;
   DECLARE_PY_OBJECT(bases);
   DECLARE_PY_OBJECT(flags_obj);
   PyObject* result = NULL;
+  ON_FAIL({
+    if (mem != NULL) {
+      PyMem_Free(mem);
+    }
+  });
 
   // PyType_FromSpecWithBases copies "members" automatically into the end of the
   // type. It doesn't store the slots. But it just copies the pointer to
@@ -4344,11 +4262,6 @@ skip_container_slots:
   FAIL_IF_MINUS_ONE(PyObject_SetAttr(
     result, _PyUnicode_FromId(&PyId__js_type_flags), flags_obj));
 
-  success = true;
-finally:
-  if (!success && mem != NULL) {
-    PyMem_Free(mem);
-  }
   return result;
 }
 
@@ -4362,17 +4275,17 @@ static PyObject* JsProxy_TypeDict;
 static PyTypeObject*
 JsProxy_get_subtype(int flags)
 {
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(flags_key);
   flags_key = PyLong_FromLong(flags);
   PyObject* type = PyDict_GetItemWithError(JsProxy_TypeDict, flags_key);
   Py_XINCREF(type);
   if (type != NULL || PyErr_Occurred()) {
-    goto finally;
+    return (PyTypeObject*)type;
   }
   type = JsProxy_create_subtype(flags);
   FAIL_IF_NULL(type);
   FAIL_IF_MINUS_ONE(PyDict_SetItem(JsProxy_TypeDict, flags_key, type));
-finally:
   return (PyTypeObject*)type;
 }
 
@@ -4495,9 +4408,14 @@ JsProxy_create_with_type(int type_flags,
                          JsVal this,
                          PyObject* sig)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   PyTypeObject* type = NULL;
   PyObject* result = NULL;
+  ON_FAIL({ Py_CLEAR(result); });
+  _Defer
+  {
+    Py_CLEAR(type);
+  };
 
   type = JsProxy_get_subtype(type_flags);
   FAIL_IF_NULL(type);
@@ -4520,12 +4438,6 @@ JsProxy_create_with_type(int type_flags,
     JsException_ARGS(result) = args;
   }
 
-  success = true;
-finally:
-  Py_CLEAR(type);
-  if (!success) {
-    Py_CLEAR(result);
-  }
   return result;
 }
 
@@ -4593,7 +4505,7 @@ JsProxy_Val(PyObject* x)
 int
 JsProxy_init_docstrings(PyObject* _pyodide_core_docs)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   DECLARE_PY_OBJECT(_it);
   DECLARE_PY_OBJECT(JsProxy);
@@ -4671,24 +4583,20 @@ JsProxy_init_docstrings(PyObject* _pyodide_core_docs)
   SET_DOCSTRING(JsGenerator, JsGenerator_close_MethodDef);
 #undef SET_DOCSTRING
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 static int
 add_flag(PyObject* dict, char* name, int value)
 {
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(value_py);
-  bool success = false;
 
   value_py = PyLong_FromLong(value);
   FAIL_IF_NULL(value_py);
   FAIL_IF_MINUS_ONE(PyDict_SetItemString(dict, name, value_py));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 PyObject*
@@ -4709,16 +4617,28 @@ run_sync(PyObject* self, PyObject* pyarg)
                  Py_TYPE(pyarg)->tp_name);
     return NULL;
   }
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(ensured_future);
   PyObject* pyresult = NULL;
+  JsVal jsarg = JS_ERROR;
+  JsVal jsresult = JS_ERROR;
+  _Defer
+  {
+    if (pyproxy_Check(jsarg)) {
+      destroy_proxy(jsarg, NULL);
+    }
+    if (pyproxy_Check(jsresult)) {
+      destroy_proxy(jsresult, NULL);
+    }
+  };
 
   // For reasons that I absolutely do not comprehend, we leak memory if use a
   // coroutine directly, but if we ensure_future it first we don't.
   ensured_future =
     _PyObject_CallMethodIdOneArg(asyncio_mod, &PyId_ensure_future, pyarg);
-  JsVal jsarg = python2js(ensured_future);
+  jsarg = python2js(ensured_future);
   FAIL_IF_JS_ERROR(jsarg);
-  JsVal jsresult = JsvPromise_Syncify(jsarg);
+  jsresult = JsvPromise_Syncify(jsarg);
   if (JsvError_Check(jsresult)) {
     if (!PyErr_Occurred()) {
       PyErr_SetString(
@@ -4730,13 +4650,6 @@ run_sync(PyObject* self, PyObject* pyarg)
   }
   pyresult = js2python(jsresult);
 
-finally:
-  if (pyproxy_Check(jsarg)) {
-    destroy_proxy(jsarg, NULL);
-  }
-  if (pyproxy_Check(jsresult)) {
-    destroy_proxy(jsresult, NULL);
-  }
   return pyresult;
 }
 
@@ -4772,7 +4685,7 @@ static PyMethodDef* run_sync_MethodDef = &methods[0];
 int
 jsproxy_init(PyObject* core_module)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(_pyodide_core_docs);
   DECLARE_PY_OBJECT(flag_dict);
 
@@ -4859,7 +4772,5 @@ jsproxy_init(PyObject* core_module)
   FAIL_IF_MINUS_ONE(PyType_Ready(&JsMethodCallSingletonType));
   method_call_singleton = make_method_call_singleton();
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }

--- a/src/core/jsproxy_call.c
+++ b/src/core/jsproxy_call.c
@@ -423,9 +423,10 @@ JsMethod_Construct_impl(JsVal func,
   _Defer
   {
     Py_LeaveRecursiveCall(/* " in JsMethod_Construct" */);
-    Js_static_string(msg,
-                     "This borrowed proxy was automatically destroyed. Try using "
-                     "create_proxy or create_once_callable.");
+    Js_static_string(
+      msg,
+      "This borrowed proxy was automatically destroyed. Try using "
+      "create_proxy or create_once_callable.");
     destroy_proxies(proxies, &msg);
   };
 

--- a/src/core/jsproxy_call.c
+++ b/src/core/jsproxy_call.c
@@ -154,6 +154,7 @@ static PyObject*
 JsFuncSignature_repr(PyObject* o)
 {
   JsFuncSignature* self = (JsFuncSignature*)o;
+  FAIL_RETURN_VALUE(NULL);
   PyObject* result = NULL;
   DECLARE_PY_OBJECT(inspect);
   DECLARE_PY_OBJECT(sig);
@@ -166,7 +167,6 @@ JsFuncSignature_repr(PyObject* o)
   result = PyUnicode_FromFormat("<JsSignature %S>", sig);
   FAIL_IF_NULL(result);
 
-finally:
   return result;
 }
 
@@ -222,9 +222,14 @@ JsMethod_ConvertArgs(JsFuncSignature* sig,
                      PyObject* kwnames,
                      JsVal proxies)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   JsVal kwargs;
   JsVal jsargs = JsvArray_New();
-  bool success = false;
+  ON_FAIL({
+    if (!PyErr_Occurred()) {
+      PyErr_SetString(PyExc_SystemError, "Oops");
+    }
+  });
 
   int nargs = PyVectorcall_NARGS(nargsf);
   int pos_params_size = PyTuple_GET_SIZE(sig->posparams);
@@ -267,7 +272,7 @@ JsMethod_ConvertArgs(JsFuncSignature* sig,
   Py_ssize_t nkwargs = kwnames == NULL ? 0 : PyTuple_GET_SIZE(kwnames);
   bool has_kwargs = (nkwargs > 0) || (PyTuple_GET_SIZE(sig->kwparam_names) > 0);
   if (!has_kwargs) {
-    goto success;
+    return jsargs;
   }
   // store kwargs into an object which we'll use as the last argument.
   kwargs = JsvObject_New();
@@ -325,7 +330,7 @@ JsMethod_ConvertArgs(JsFuncSignature* sig,
   JsvArray_Push(jsargs, kwargs);
 
   FAIL_IF_ERR_OCCURRED();
-  goto success;
+  return jsargs;
 set_args_error: {
   // Calling the template function with the same args should raise an
   // appropriate error
@@ -333,26 +338,15 @@ set_args_error: {
   if (res) {
     Py_CLEAR(res);
     PyErr_SetString(PyExc_SystemError, "Expected an error but none was raised");
-    goto finally;
+    FAIL();
   }
   if (PyErr_ExceptionMatches(PyExc_TypeError)) {
-    goto finally;
+    FAIL();
   }
   PyErr_SetString(PyExc_SystemError,
                   "Expected a TypeError but other type of error was raised");
-  goto finally;
+  FAIL();
 }
-
-success:
-  success = true;
-finally:
-  if (!success) {
-    jsargs = JS_ERROR;
-    if (!PyErr_Occurred()) {
-      PyErr_SetString(PyExc_SystemError, "Oops");
-    }
-  }
-  return jsargs;
 }
 
 /**
@@ -366,11 +360,24 @@ JsMethod_Vectorcall_impl(JsVal func,
                          size_t nargsf,
                          PyObject* kwnames)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   JsVal jsresult = JS_ERROR;
   JsFuncSignature* call_sig = NULL;
   PyObject* pyresult = NULL;
   JsVal proxies = JsvArray_New();
+  ON_FAIL({
+    if (!JsvError_Check(jsresult) && pyproxy_Check(jsresult)) {
+      // TODO: don't destroy proxies with roundtrip = true?
+      JsvArray_Push(proxies, jsresult);
+    }
+    destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
+    Py_CLEAR(pyresult);
+  });
+  _Defer
+  {
+    Py_LeaveRecursiveCall(/* " in JsMethod_Vectorcall" */);
+    Py_CLEAR(call_sig);
+  };
 
   // Recursion error?
   FAIL_IF_NONZERO(Py_EnterRecursiveCall(" while calling a JavaScript object"));
@@ -399,19 +406,6 @@ JsMethod_Vectorcall_impl(JsVal func,
   pyresult = Js2PyConverter_convert(result_converter, jsresult, proxies);
   FAIL_IF_NULL(pyresult);
 
-  success = true;
-finally:
-  Py_LeaveRecursiveCall(/* " in JsMethod_Vectorcall" */);
-  if (!success) {
-
-    if (!JsvError_Check(jsresult) && pyproxy_Check(jsresult)) {
-      // TODO: don't destroy proxies with roundtrip = true?
-      JsvArray_Push(proxies, jsresult);
-    }
-    destroy_proxies(proxies, &PYPROXY_DESTROYED_AT_END_OF_FUNCTION_CALL);
-    Py_CLEAR(pyresult);
-  }
-  Py_CLEAR(call_sig);
   return pyresult;
 }
 
@@ -422,9 +416,18 @@ JsMethod_Construct_impl(JsVal func,
                         size_t nargs,
                         PyObject* kwnames)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(NULL);
   PyObject* pyresult = NULL;
   JsVal proxies = JsvArray_New();
+  ON_FAIL({ Py_CLEAR(pyresult); });
+  _Defer
+  {
+    Py_LeaveRecursiveCall(/* " in JsMethod_Construct" */);
+    Js_static_string(msg,
+                     "This borrowed proxy was automatically destroyed. Try using "
+                     "create_proxy or create_once_callable.");
+    destroy_proxies(proxies, &msg);
+  };
 
   // Recursion error?
   FAIL_IF_NONZERO(Py_EnterRecursiveCall(" in JsMethod_Construct"));
@@ -437,27 +440,16 @@ JsMethod_Construct_impl(JsVal func,
   pyresult = js2python(jsresult);
   FAIL_IF_NULL(pyresult);
 
-  success = true;
-finally:
-  Py_LeaveRecursiveCall(/* " in JsMethod_Construct" */);
-  Js_static_string(msg,
-                   "This borrowed proxy was automatically destroyed. Try using "
-                   "create_proxy or create_once_callable.");
-  destroy_proxies(proxies, &msg);
-  if (!success) {
-    Py_CLEAR(pyresult);
-  }
   return pyresult;
 }
 
 int
 jsproxy_call_init(PyObject* core_mod)
 {
+  FAIL_RETURN_VALUE(-1);
   FAIL_IF_MINUS_ONE(PyType_Ready(&JsFuncSignatureType));
   FAIL_IF_MINUS_ONE(PyObject_SetAttrString(
     core_mod, "JsFuncSignature", (PyObject*)&JsFuncSignatureType));
 
   return 0;
-finally:
-  return -1;
 }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -5,42 +5,41 @@
 #include <jslib.h>
 #include <stdbool.h>
 
-#define FAIL_IF_STATUS_EXCEPTION(status)                                       \
-  if (PyStatus_Exception(status)) {                                            \
-    goto finally;                                                              \
-  }
-
 // Initialize python. exit() and print message to stderr on failure.
 static void
 initialize_python(int argc, char** argv)
 {
-  bool success = false;
   PyStatus status;
 
   PyPreConfig preconfig;
   PyPreConfig_InitPythonConfig(&preconfig);
 
   status = Py_PreInitializeFromBytesArgs(&preconfig, argc, argv);
-  FAIL_IF_STATUS_EXCEPTION(status);
+  if (PyStatus_Exception(status)) {
+    // This will exit().
+    Py_ExitStatusException(status);
+  }
 
   PyConfig config;
   PyConfig_InitPythonConfig(&config);
+  _Defer
+  {
+    PyConfig_Clear(&config);
+  };
 
   status = PyConfig_SetBytesArgv(&config, argc, argv);
-  FAIL_IF_STATUS_EXCEPTION(status);
+  if (PyStatus_Exception(status)) {
+    Py_ExitStatusException(status);
+  }
 
   status = PyConfig_SetBytesString(&config, &config.home, "/");
-  FAIL_IF_STATUS_EXCEPTION(status);
+  if (PyStatus_Exception(status)) {
+    Py_ExitStatusException(status);
+  }
 
   config.write_bytecode = false;
   status = Py_InitializeFromConfig(&config);
-  FAIL_IF_STATUS_EXCEPTION(status);
-
-  success = true;
-finally:
-  PyConfig_Clear(&config);
-  if (!success) {
-    // This will exit().
+  if (PyStatus_Exception(status)) {
     Py_ExitStatusException(status);
   }
 }

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -183,7 +183,7 @@ type_getflags(PyTypeObject* obj_type)
   PyBufferProcs* buffer_proto =
     obj_type->tp_as_buffer ? obj_type->tp_as_buffer : &null_buffer_proto;
 
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   int result = 0;
 #define SET_FLAG_IF(flag, cond)                                                \
   if (cond) {                                                                  \
@@ -258,9 +258,7 @@ type_getflags(PyTypeObject* obj_type)
   SET_FLAG_IF(IS_DICT, Py_Is(obj_type, &PyDict_Type));
 #undef SET_FLAG_IF
 
-  success = true;
-finally:
-  return success ? result : -1;
+  return result;
 }
 
 static int dict_flags;
@@ -270,6 +268,7 @@ static int list_flags;
 EMSCRIPTEN_KEEPALIVE int
 pyproxy_getflags(PyObject* pyobj, bool is_json_adaptor)
 {
+  FAIL_RETURN_VALUE(-1);
   // Fast paths for some common cases
   if (PyDict_CheckExact(pyobj)) {
     int result = dict_flags;
@@ -320,7 +319,6 @@ pyproxy_getflags(PyObject* pyobj, bool is_json_adaptor)
       result |= IS_JSON_ADAPTOR_DICT;
     }
   }
-finally:
   return result;
 }
 
@@ -354,6 +352,7 @@ bool compat_to_string_repr = false;
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_repr(PyObject* pyobj)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(pyrepr);
   JsVal jsrepr = JS_ERROR;
 
@@ -365,7 +364,6 @@ _pyproxy_repr(PyObject* pyobj)
   FAIL_IF_NULL(pyrepr);
   jsrepr = python2js(pyrepr);
 
-finally:
   return jsrepr;
 }
 
@@ -391,6 +389,7 @@ _pyproxy_type(PyObject* ptrobj)
 EMSCRIPTEN_KEEPALIVE int
 _pyproxy_hasattr(PyObject* pyobj, JsVal jskey)
 {
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(pykey);
   int result = -1;
 
@@ -398,7 +397,6 @@ _pyproxy_hasattr(PyObject* pyobj, JsVal jskey)
   FAIL_IF_NULL(pykey);
   result = PyObject_HasAttr(pyobj, pykey);
 
-finally:
   return result;
 }
 
@@ -467,11 +465,16 @@ python2js_json_adaptor(PyObject* x, JsVal proxyCache, bool is_json_adaptor)
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_getattr(PyObject* pyobj, JsVal key, JsVal proxyCache)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(pykey);
   DECLARE_PY_OBJECT(pydescr);
   DECLARE_PY_OBJECT(pyresult);
   JsVal result = JS_ERROR;
+  ON_FAIL({
+    if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+      PyErr_Clear();
+    }
+  });
 
   pykey = js2python(key);
   FAIL_IF_NULL(pykey);
@@ -487,7 +490,7 @@ _pyproxy_getattr(PyObject* pyobj, JsVal key, JsVal proxyCache)
   JsVal cached_proxy = proxy_cache_get(proxyCache, pydescr); /* borrowed */
   if (!JsvError_Check(cached_proxy)) {
     result = cached_proxy;
-    goto success;
+    return result;
   }
   if (PyErr_Occurred()) {
     FAIL();
@@ -508,21 +511,13 @@ _pyproxy_getattr(PyObject* pyobj, JsVal key, JsVal proxyCache)
     proxy_cache_set(proxyCache, pydescr, result);
   }
 
-success:
-  success = true;
-finally:
-  if (!success) {
-    if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-      PyErr_Clear();
-    }
-  }
   return result;
 };
 
 EMSCRIPTEN_KEEPALIVE int
 _pyproxy_setattr(PyObject* pyobj, JsVal key, JsVal value)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(pykey);
   DECLARE_PY_OBJECT(pyval);
 
@@ -532,24 +527,20 @@ _pyproxy_setattr(PyObject* pyobj, JsVal key, JsVal value)
   FAIL_IF_NULL(pyval);
   FAIL_IF_MINUS_ONE(PyObject_SetAttr(pyobj, pykey, pyval));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE int
 _pyproxy_delattr(PyObject* pyobj, JsVal idkey)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(pykey);
 
   pykey = js2python(idkey);
   FAIL_IF_NULL(pykey);
   FAIL_IF_MINUS_ONE(PyObject_DelAttr(pyobj, pykey));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
@@ -558,10 +549,16 @@ _pyproxy_getitem(PyObject* pyobj,
                  JsVal proxyCache,
                  bool is_json_adaptor)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(pykey);
   DECLARE_PY_OBJECT(pyresult);
   JsVal result;
+  ON_FAIL({
+    if (PyErr_ExceptionMatches(PyExc_KeyError) ||
+        PyErr_ExceptionMatches(PyExc_IndexError)) {
+      PyErr_Clear();
+    }
+  });
 
   pykey = js2python(jskey);
   FAIL_IF_NULL(pykey);
@@ -570,22 +567,13 @@ _pyproxy_getitem(PyObject* pyobj,
   result = python2js_json_adaptor(pyresult, proxyCache, is_json_adaptor);
   FAIL_IF_JS_ERROR(result);
 
-  success = true;
-finally:
-  if (!success && (PyErr_ExceptionMatches(PyExc_KeyError) ||
-                   PyErr_ExceptionMatches(PyExc_IndexError))) {
-    PyErr_Clear();
-  }
-  if (!success) {
-    return JS_ERROR;
-  }
   return result;
 };
 
 EMSCRIPTEN_KEEPALIVE int
 _pyproxy_setitem(PyObject* pyobj, JsVal jskey, JsVal jsval)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(pykey);
   DECLARE_PY_OBJECT(pyval);
 
@@ -595,24 +583,20 @@ _pyproxy_setitem(PyObject* pyobj, JsVal jskey, JsVal jsval)
   FAIL_IF_NULL(pyval);
   FAIL_IF_MINUS_ONE(PyObject_SetItem(pyobj, pykey, pyval));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE int
 _pyproxy_delitem(PyObject* pyobj, JsVal idkey)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(pykey);
 
   pykey = js2python(idkey);
   FAIL_IF_NULL(pykey);
   FAIL_IF_MINUS_ONE(PyObject_DelItem(pyobj, pykey));
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
@@ -621,6 +605,7 @@ _pyproxy_slice_assign(PyObject* pyobj,
                       Py_ssize_t stop,
                       JsVal val)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(pyval);
   DECLARE_PY_OBJECT(pyresult);
   JsVal jsresult = JS_ERROR;
@@ -637,13 +622,13 @@ _pyproxy_slice_assign(PyObject* pyobj,
   JsVal proxies = JsvArray_New();
   jsresult = python2js_with_depth(pyresult, 1, proxies);
 
-finally:
   return jsresult;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_pop(PyObject* pyobj, bool pop_start)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(idx);
   DECLARE_PY_OBJECT(pyresult);
   JsVal jsresult = JS_ERROR;
@@ -665,13 +650,13 @@ _pyproxy_pop(PyObject* pyobj, bool pop_start)
       FAIL();
     }
   }
-finally:
   return jsresult;
 }
 
 EMSCRIPTEN_KEEPALIVE int
 _pyproxy_contains(PyObject* pyobj, JsVal idkey)
 {
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(pykey);
   int result = -1;
 
@@ -679,14 +664,13 @@ _pyproxy_contains(PyObject* pyobj, JsVal idkey)
   FAIL_IF_NULL(pykey);
   result = PySequence_Contains(pyobj, pykey);
 
-finally:
   return result;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_ownKeys(PyObject* pyobj)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(pydir);
 
   pydir = PyObject_Dir(pyobj);
@@ -702,11 +686,6 @@ _pyproxy_ownKeys(PyObject* pyobj)
     JsvArray_Push(dir, entry);
   }
 
-  success = true;
-finally:
-  if (!success) {
-    return JS_ERROR;
-  }
   return dir;
 }
 
@@ -745,6 +724,7 @@ _pyproxy_apply(PyObject* callable,
                JsVal jskwnames,
                size_t numkwargs)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   size_t total_args = numposargs + numkwargs;
   size_t last_converted_arg = total_args;
   PyObject* pyargs_array[total_args + 1];
@@ -754,6 +734,14 @@ _pyproxy_apply(PyObject* callable,
   DECLARE_PY_OBJECT(pykwnames);
   DECLARE_PY_OBJECT(pyresult);
   JsVal result = JS_ERROR;
+  _Defer
+  {
+    // If we failed to convert one of the arguments, then pyargs is partially
+    // uninitialized. Only clear the part that actually has stuff in it.
+    for (Py_ssize_t i = 0; i < last_converted_arg; i++) {
+      Py_CLEAR(pyargs[i]);
+    }
+  };
 
   // Put both arguments and keyword arguments into pyargs
   for (Py_ssize_t i = 0; i < total_args; ++i) {
@@ -782,12 +770,6 @@ _pyproxy_apply(PyObject* callable,
   FAIL_IF_NULL(pyresult);
   result = python2js(pyresult);
 
-finally:
-  // If we failed to convert one of the arguments, then pyargs is partially
-  // uninitialized. Only clear the part that actually has stuff in it.
-  for (Py_ssize_t i = 0; i < last_converted_arg; i++) {
-    Py_CLEAR(pyargs[i]);
-  }
   return result;
 }
 
@@ -870,7 +852,7 @@ EM_JS(JsVal, _pyproxyGen_make_result, (bool done, JsVal value), {
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_Send(PyObject* receiver, JsVal jsval)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(v);
   DECLARE_PY_OBJECT(retval);
 
@@ -883,11 +865,6 @@ _pyproxyGen_Send(PyObject* receiver, JsVal jsval)
   JsVal result = python2js(retval);
   FAIL_IF_JS_ERROR(result);
 
-  success = true;
-finally:
-  if (!success) {
-    return JS_ERROR;
-  }
   return _pyproxyGen_make_result(status == PYGEN_RETURN, result);
 }
 
@@ -895,7 +872,7 @@ EMSCRIPTEN_KEEPALIVE
 JsVal
 _pyproxyGen_return(PyObject* receiver, JsVal jsval)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
   PySendResult status = PYGEN_ERROR;
   DECLARE_PY_OBJECT(pyresult);
 
@@ -910,8 +887,7 @@ _pyproxyGen_return(PyObject* receiver, JsVal jsval)
       PyErr_Clear();
       status = PYGEN_RETURN;
       result = jsval;
-      success = true;
-      goto finally;
+      return _pyproxyGen_make_result(status == PYGEN_RETURN, result);
     }
     //
     FAIL_IF_MINUS_ONE(_PyGen_FetchStopIterationValue(&pyresult));
@@ -921,18 +897,13 @@ _pyproxyGen_return(PyObject* receiver, JsVal jsval)
   }
   result = python2js(pyresult);
   FAIL_IF_JS_ERROR(result);
-  success = true;
-finally:
-  if (!success) {
-    return JS_ERROR;
-  }
   return _pyproxyGen_make_result(status == PYGEN_RETURN, result);
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_throw(PyObject* receiver, JsVal jsval)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(pyvalue);
   DECLARE_PY_OBJECT(pyresult);
   PySendResult status = PYGEN_ERROR;
@@ -958,17 +929,13 @@ _pyproxyGen_throw(PyObject* receiver, JsVal jsval)
   }
   result = python2js(pyresult);
   FAIL_IF_JS_ERROR(result);
-  success = true;
-finally:
-  if (!success) {
-    return JS_ERROR;
-  }
   return _pyproxyGen_make_result(status == PYGEN_RETURN, result);
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_asend(PyObject* receiver, JsVal jsval)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(v);
   DECLARE_PY_OBJECT(asend);
   DECLARE_PY_OBJECT(pyresult);
@@ -995,13 +962,13 @@ _pyproxyGen_asend(PyObject* receiver, JsVal jsval)
   jsresult = python2js(pyresult);
   FAIL_IF_JS_ERROR(jsresult);
 
-finally:
   return jsresult;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_areturn(PyObject* receiver)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(v);
   DECLARE_PY_OBJECT(asend);
   DECLARE_PY_OBJECT(pyresult);
@@ -1014,13 +981,13 @@ _pyproxyGen_areturn(PyObject* receiver)
   jsresult = python2js(pyresult);
   FAIL_IF_JS_ERROR(jsresult);
 
-finally:
   return jsresult;
 }
 
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxyGen_athrow(PyObject* receiver, JsVal jsval)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(v);
   DECLARE_PY_OBJECT(asend);
   DECLARE_PY_OBJECT(pyresult);
@@ -1042,7 +1009,6 @@ _pyproxyGen_athrow(PyObject* receiver, JsVal jsval)
   jsresult = python2js(pyresult);
   FAIL_IF_JS_ERROR(jsresult);
 
-finally:
   return jsresult;
 }
 
@@ -1121,16 +1087,14 @@ FutureDoneCallback_call_resolve(FutureDoneCallback* self, PyObject* result)
 int
 FutureDoneCallback_call_reject(FutureDoneCallback* self)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   // wrap_exception looks up the current exception and wraps it in a Js error.
   JsVal excval = wrap_exception();
   FAIL_IF_JS_ERROR(excval);
   JsvFunction_Call_OneArg(hiwire_get(self->reject_handle), excval);
   // TODO: Should we really be just ignoring errors here??
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 /**
@@ -1200,7 +1164,7 @@ _pyproxy_ensure_future(PyObject* pyobject,
                        JsVal resolve_handle,
                        JsVal reject_handle)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(future);
   DECLARE_PY_OBJECT(callback);
   DECLARE_PY_OBJECT(retval);
@@ -1211,9 +1175,7 @@ _pyproxy_ensure_future(PyObject* pyobject,
     _PyObject_CallMethodIdOneArg(future, &PyId_add_done_callback, callback);
   FAIL_IF_NULL(retval);
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1458,9 +1420,14 @@ create_once_callable_py(PyObject* _mod,
 
 EMSCRIPTEN_KEEPALIVE int
 create_promise_handles_result_helper(PyObject* handle_result, PyObject* converter, JsVal jsval) {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(pyval);
   DECLARE_PY_OBJECT(result);
+  ON_FAIL({
+    // Not sure what we'll do if this function fails tbh...
+    printf("Unexpected error:\n");
+    PyErr_Print();
+  });
 
   if (converter == NULL || Py_IsNone(converter)) {
     pyval = js2python(jsval);
@@ -1471,14 +1438,7 @@ create_promise_handles_result_helper(PyObject* handle_result, PyObject* converte
   result = PyObject_CallOneArg(handle_result, pyval);
   FAIL_IF_NULL(result);
 
-  success = true;
-finally:
-  if (!success) {
-    // Not sure what we'll do if this function fails tbh...
-    printf("Unexpected error:\n");
-    PyErr_Print();
-  }
-  return success ? 0 : -1;
+  return 0;
 }
 
 /**
@@ -1612,7 +1572,7 @@ static PyMethodDef methods[] = {
 int
 pyproxy_init(PyObject* core)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
 
   DECLARE_PY_OBJECT(collections_abc);
   DECLARE_PY_OBJECT(docstring_source);
@@ -1646,7 +1606,5 @@ pyproxy_init(PyObject* core)
   tuple_flags = type_getflags(&PyTuple_Type);
   list_flags = type_getflags(&PyList_Type);
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -90,6 +90,7 @@ _python2js_float(PyObject* x)
 static JsVal
 _python2js_bigint(PyObject* x)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   int overflow;
   long x_long = PyLong_AsLongAndOverflow(x, &overflow);
   if (x_long == -1) {
@@ -103,22 +104,21 @@ _python2js_bigint(PyObject* x)
       size_t ndigits = (nbits >> 5) + 1;
       unsigned int digits[ndigits];
       FAIL_IF_MINUS_ONE(_PyLong_AsByteArray((PyLongObject*)x,
-                                            (unsigned char*)digits,
-                                            4 * ndigits,
-                                            true /* little endian */,
-                                            true /* signed */,
-                                            true /* with_exceptions */));
+                                             (unsigned char*)digits,
+                                             4 * ndigits,
+                                             true /* little endian */,
+                                             true /* signed */,
+                                             true /* with_exceptions */));
       return JsvBigInt_fromDigits(digits, ndigits);
     }
   }
   return JsvBigInt_fromInt(x_long);
-finally:
-  return JS_ERROR;
 }
 
 static JsVal
 _python2js_long(PyObject* x)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   int overflow;
   long x_long = PyLong_AsLongAndOverflow(x, &overflow);
   if (x_long == -1 && !overflow) {
@@ -135,8 +135,6 @@ _python2js_long(PyObject* x)
   JsVal res = _python2js_bigint(x);
   FAIL_IF_JS_ERROR(res);
   return Jsv_BigIntToNum(res);
-finally:
-  return JS_ERROR;
 }
 
 // python2js string conversion
@@ -223,7 +221,7 @@ _python2js_unicode(PyObject* x)
 static JsVal
 _python2js_sequence(ConversionContext* context, PyObject* x)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
 
   JsVal jsarray = JsvArray_New();
   FAIL_IF_MINUS_ONE(
@@ -244,9 +242,7 @@ _python2js_sequence(ConversionContext* context, PyObject* x)
       JsvArray_Push(jsarray, jsitem);
     }
   }
-  success = true;
-finally:
-  return success ? jsarray : JS_ERROR;
+  return jsarray;
 }
 
 /**
@@ -256,7 +252,7 @@ finally:
 static JsVal
 _python2js_dict(ConversionContext* context, PyObject* x)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(items);
   DECLARE_PY_OBJECT(iter);
   DECLARE_PY_OBJECT(item);
@@ -307,9 +303,7 @@ _python2js_dict(ConversionContext* context, PyObject* x)
   }
   FAIL_IF_MINUS_ONE(
     _python2js_add_to_cache(hiwire_get(context->cache), x, jsdict));
-  success = true;
-finally:
-  return success ? jsdict : JS_ERROR;
+  return jsdict;
 }
 
 /**
@@ -325,7 +319,7 @@ finally:
 static JsVal
 _python2js_set(ConversionContext* context, PyObject* x)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(JS_ERROR);
   DECLARE_PY_OBJECT(iter);
   DECLARE_PY_OBJECT(pykey);
   // result:
@@ -349,9 +343,7 @@ _python2js_set(ConversionContext* context, PyObject* x)
   // Otherwise, we'd fail on the set that contains itself.
   FAIL_IF_MINUS_ONE(
     _python2js_add_to_cache(hiwire_get(context->cache), x, jsset));
-  success = true;
-finally:
-  return success ? jsset : JS_ERROR;
+  return jsset;
 }
 
 /**
@@ -362,7 +354,7 @@ finally:
 #define RETURN_IF_HAS_VALUE(x)                                                 \
   do {                                                                         \
     JsVal _fresh_result = x;                                                   \
-    FAIL_IF_JS_ERROR(_fresh_result);                                           \
+    FAIL_IF_JS_ERROR(_fresh_result);                                          \
     if (!JsvNoValue_Check(_fresh_result)) {                                    \
       return _fresh_result;                                                    \
     }                                                                          \
@@ -425,6 +417,7 @@ python2js__default_converter(JsVal jscontext, PyObject* object);
 static JsVal
 _python2js_deep(ConversionContext* context, PyObject* x)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   RETURN_IF_HAS_VALUE(_python2js_immutable(x));
   RETURN_IF_HAS_VALUE(_python2js_proxy(x));
   if (context->eager_converter) {
@@ -450,7 +443,6 @@ _python2js_deep(ConversionContext* context, PyObject* x)
     return pyproxy_new(x);
   }
   PyErr_SetString(conversion_error, "No conversion known for x.");
-finally:
   return JS_ERROR;
 }
 
@@ -498,6 +490,7 @@ EM_JS(JsVal, _python2js_cache_lookup, (JsVal cache, PyObject* pyparent), {
 EMSCRIPTEN_KEEPALIVE JsVal
 _python2js(ConversionContext *context, PyObject* x)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
   JsVal val = _python2js_cache_lookup(hiwire_get(context->cache), x);
   if (!JsvError_Check(val)) {
     return val;
@@ -519,8 +512,6 @@ _python2js(ConversionContext *context, PyObject* x)
     context->depth++;
     return result;
   }
-finally:
-  return JS_ERROR;
 }
 
 /**
@@ -531,6 +522,18 @@ finally:
 JsVal
 python2js_inner(PyObject* x, JsVal proxies, bool track_proxies, bool gc_register, bool is_json_adaptor)
 {
+  FAIL_RETURN_VALUE(JS_ERROR);
+  ON_FAIL({
+    if (PyErr_Occurred()) {
+      if (!PyErr_ExceptionMatches(conversion_error)) {
+        _PyErr_FormatFromCause(conversion_error,
+                               "Conversion from python to javascript failed");
+      }
+    } else {
+      fail_test();
+      PyErr_SetString(internal_error, "Internal error occurred in python2js");
+    }
+  });
   RETURN_IF_HAS_VALUE(_python2js_immutable(x));
   RETURN_IF_HAS_VALUE(_python2js_proxy(x));
   if (track_proxies && JsvError_Check(proxies)) {
@@ -543,17 +546,6 @@ python2js_inner(PyObject* x, JsVal proxies, bool track_proxies, bool gc_register
     JsvArray_Push(proxies, proxy);
   }
   return proxy;
-finally:
-  if (PyErr_Occurred()) {
-    if (!PyErr_ExceptionMatches(conversion_error)) {
-      _PyErr_FormatFromCause(conversion_error,
-                             "Conversion from python to javascript failed");
-    }
-  } else {
-    fail_test();
-    PyErr_SetString(internal_error, "Internal error occurred in python2js");
-  }
-  return JS_ERROR;
 }
 
 /**
@@ -864,6 +856,7 @@ to_js(PyObject* self,
       Py_ssize_t nargs,
       PyObject* kwnames)
 {
+  FAIL_RETURN_VALUE(NULL);
   PyObject* obj = NULL;
   int depth = -1;
   PyObject* pyproxies = NULL;
@@ -945,6 +938,18 @@ to_js(PyObject* self,
   if (py_eager_converter) {
     js_eager_converter = python2js(py_eager_converter);
   }
+  _Defer
+  {
+    if (pyproxy_Check(js_dict_converter)) {
+      destroy_proxy(js_dict_converter, NULL);
+    }
+    if (pyproxy_Check(js_default_converter)) {
+      destroy_proxy(js_default_converter, NULL);
+    }
+    if (pyproxy_Check(js_eager_converter)) {
+      destroy_proxy(js_eager_converter, NULL);
+    }
+  };
   JsVal js_result = python2js_custom(obj,
                                      depth,
                                      proxies,
@@ -957,16 +962,6 @@ to_js(PyObject* self,
     py_result = JsProxy_create(js_result);
   } else {
     py_result = js2python(js_result);
-  }
-finally:
-  if (pyproxy_Check(js_dict_converter)) {
-    destroy_proxy(js_dict_converter, NULL);
-  }
-  if (pyproxy_Check(js_default_converter)) {
-    destroy_proxy(js_default_converter, NULL);
-  }
-  if (pyproxy_Check(js_eager_converter)) {
-    destroy_proxy(js_eager_converter, NULL);
   }
   return py_result;
 }
@@ -988,11 +983,11 @@ EM_JS_NUM(errcode, destroy_proxies_js, (JsVal proxies_id), {
 static PyObject*
 destroy_proxies_(PyObject* self, PyObject* arg)
 {
+  FAIL_RETURN_VALUE(NULL);
   if (!JsProxy_Check(arg)) {
     PyErr_SetString(PyExc_TypeError, "Expected a JsProxy for the argument");
     return NULL;
   }
-  bool success = false;
 
   JsVal proxies = JsProxy_Val(arg);
   if (!JsvArray_Check(proxies)) {
@@ -1002,13 +997,7 @@ destroy_proxies_(PyObject* self, PyObject* arg)
   }
   FAIL_IF_MINUS_ONE(destroy_proxies_js(proxies));
 
-  success = true;
-finally:
-  if (success) {
-    Py_RETURN_NONE;
-  } else {
-    return NULL;
-  }
+  Py_RETURN_NONE;
 }
 
 static PyMethodDef methods[] = {
@@ -1031,7 +1020,7 @@ PyObject* py_JsBigInt = NULL;
 int
 python2js_init(PyObject* core)
 {
-  bool success = false;
+  FAIL_RETURN_VALUE(-1);
   DECLARE_PY_OBJECT(docstring_source);
   docstring_source = PyImport_ImportModule("_pyodide._core_docs");
   FAIL_IF_NULL(docstring_source);
@@ -1042,7 +1031,5 @@ python2js_init(PyObject* core)
   py_JsBigInt = PyObject_GetAttrString(docstring_source, "JsBigInt");
   FAIL_IF_NULL(py_JsBigInt);
 
-  success = true;
-finally:
-  return success ? 0 : -1;
+  return 0;
 }

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -104,11 +104,11 @@ _python2js_bigint(PyObject* x)
       size_t ndigits = (nbits >> 5) + 1;
       unsigned int digits[ndigits];
       FAIL_IF_MINUS_ONE(_PyLong_AsByteArray((PyLongObject*)x,
-                                             (unsigned char*)digits,
-                                             4 * ndigits,
-                                             true /* little endian */,
-                                             true /* signed */,
-                                             true /* with_exceptions */));
+                                            (unsigned char*)digits,
+                                            4 * ndigits,
+                                            true /* little endian */,
+                                            true /* signed */,
+                                            true /* with_exceptions */));
       return JsvBigInt_fromDigits(digits, ndigits);
     }
   }
@@ -354,7 +354,7 @@ _python2js_set(ConversionContext* context, PyObject* x)
 #define RETURN_IF_HAS_VALUE(x)                                                 \
   do {                                                                         \
     JsVal _fresh_result = x;                                                   \
-    FAIL_IF_JS_ERROR(_fresh_result);                                          \
+    FAIL_IF_JS_ERROR(_fresh_result);                                           \
     if (!JsvNoValue_Check(_fresh_result)) {                                    \
       return _fresh_result;                                                    \
     }                                                                          \

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -58,6 +58,7 @@ restoreThreadState(PyThreadState* state)
 EMSCRIPTEN_KEEPALIVE PyThreadState*
 captureThreadState()
 {
+  FAIL_RETURN_VALUE(NULL);
   DECLARE_PY_OBJECT(asyncio_module);
   DECLARE_PY_OBJECT(loop);
   DECLARE_PY_OBJECT(tmp);
@@ -85,8 +86,6 @@ captureThreadState()
     PyErr_SetString(PyExc_SystemError, "Unexpected error when stack switching");
     FAIL();
   }
-
-finally:
 
   return result;
 }


### PR DESCRIPTION
Added a macro `FAIL_RETURN_VALUE()` which we can pass `NULL`, `-1`, or `JS_ERROR` as appropriate to indicate what value the function returns for failure. It also declares success and sets it to true. Make `FAIL()` set sucess to false and return the `FAIL_RETURN_VALUE()`. I also added `ON_FAIL()` which is `_Defer { if (!success) { ... } }`.

I used these things to get rid of finally blocks.
