### PR TITLE
Clamp call_later() delay to setTimeout()'s 32-bit limit

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -17,6 +17,11 @@ myst:
 
 ## Unreleased
 
+- {{ Fix }} `WebLoop.call_later()` now clamps delays past `setTimeout()`'s
+  32-bit signed integer limit instead of passing them through, fixing a
+  `TimeoutOverflowWarning` for very long delays and for
+  `asyncio.sleep(math.inf)`. {pr}`6306`
+
 - {{ Performance }} Sped up PyProxy creation. {pr}`6280`
 
 - {{ Fix }} `PyodideFuture.then()` and `finally_()` no longer hang when the

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -20,6 +20,9 @@ if IN_PYODIDE:
 T = TypeVar("T")
 S = TypeVar("S")
 
+# setTimeout()'s max delay: a 32-bit signed int, in ms.
+_MAX_TIMEOUT_MS = 2**31 - 1
+
 
 class PyodideFuture(Future[T]):
     """A :py:class:`~asyncio.Future` with extra :js:meth:`~Promise.then`,
@@ -471,7 +474,8 @@ class WebLoop(asyncio.AbstractEventLoop):
                     raise
 
         scheduleCallback(
-            create_once_callable(run_handle, _may_syncify=True), delay * 1000
+            create_once_callable(run_handle, _may_syncify=True),
+            min(delay * 1000, _MAX_TIMEOUT_MS),
         )
 
         return h

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -43,7 +43,10 @@ def test_asyncio_sleep_infinite_delay(selenium):
         import pytest
 
         task = asyncio.ensure_future(asyncio.sleep(math.inf))
-        await asyncio.sleep(0)
+        # Without the clamp in WebLoop.call_later(), browsers convert the
+        # Infinity delay to 0 and fire (almost) immediately, so check after
+        # a real wait rather than just yielding once.
+        await asyncio.sleep(0.1)
         assert not task.done()
         task.cancel()
         with pytest.raises(asyncio.CancelledError):

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -34,6 +34,25 @@ def test_asyncio_sleep(selenium):
     )
 
 
+def test_asyncio_sleep_infinite_delay(selenium):
+    @run_in_pyodide
+    async def test(selenium):
+        import asyncio
+        import math
+
+        import pytest
+
+        task = asyncio.ensure_future(asyncio.sleep(math.inf))
+        await asyncio.sleep(0)
+        assert not task.done()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    test(selenium)
+    assert "TimeoutOverflowWarning" not in selenium.logs
+
+
 def test_cancel_handle(selenium_standalone_refresh):
     selenium_standalone_refresh.run_js(
         """


### PR DESCRIPTION

<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

Fixes #6304

`WebLoop.call_later()` passes `delay * 1000` straight to `scheduleCallback()`, which calls `setTimeout(callback, timeout)` for anything over 2ms (`src/js/scheduler.ts`). `setTimeout`'s delay is a 32-bit signed int, max `2147483647` ms (~24.8 days), so `math.inf` or any longer delay triggers a `TimeoutOverflowWarning` and gets silently clamped by the JS engine instead of by us.

Clamped the delay to that same 32-bit limit ourselves before handing it to `scheduleCallback`, so `math.inf` is covered by the same `min()` call without needing a special case.

### Before / after
Ran `asyncio.sleep()` with a normal delay, a delay over the 32-bit limit, and `math.inf`, logging the actual `ms` value `call_later` hands to `setTimeout`:

before:
```
sleep(1.5):
  -> scheduled for 1500.0 ms
sleep(1000000000.0):
  -> scheduled for 1000000000000.0 ms
(node:228631) TimeoutOverflowWarning: 1000000000000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
sleep(inf):
  -> scheduled for inf ms
(node:228631) TimeoutOverflowWarning: Infinity does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

after:
```
sleep(1.5):
  -> scheduled for 1500.0 ms
sleep(1000000000.0):
  -> scheduled for 2147483647 ms
sleep(inf):
  -> scheduled for 2147483647 ms
```


### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests

