### PR TITLE
`WebLoop.call_later()`: skip scheduling for `math.inf` delays

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -22,6 +22,10 @@ myst:
   `TimeoutOverflowWarning` for very long delays and for
   `asyncio.sleep(math.inf)`. {pr}`6306`
 
+- {{ Fix }} `asyncio.sleep(math.inf)` no longer resolves on its own after
+  ~24.8 days; it now stays pending until cancelled, matching
+  `asyncio.BaseEventLoop`. {pr}`6310`
+
 - {{ Performance }} Sped up PyProxy creation. {pr}`6280`
 
 - {{ Fix }} `PyodideFuture.then()` and `finally_()` no longer hang when the

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -17,14 +17,11 @@ myst:
 
 ## Unreleased
 
-- {{ Fix }} `WebLoop.call_later()` now clamps delays past `setTimeout()`'s
-  32-bit signed integer limit instead of passing them through, fixing a
-  `TimeoutOverflowWarning` for very long delays and for
-  `asyncio.sleep(math.inf)`. {pr}`6306`
-
-- {{ Fix }} `asyncio.sleep(math.inf)` no longer resolves on its own after
-  ~24.8 days; it now stays pending until cancelled, matching
-  `asyncio.BaseEventLoop`. {pr}`6310`
+- {{ Fix }} `setTimeout()`'s 32-bit signed integer limit was causing a
+  `TimeoutOverflowWarning` for delays past ~24.8 days in
+  `WebLoop.call_later()`. Finite delays past that limit are now clamped to
+  it, and an infinite delay (`asyncio.sleep(math.inf)`) now stays pending
+  until cancelled. {pr}`6306`, {pr}`6310`
 
 - {{ Performance }} Sped up PyProxy creation. {pr}`6280`
 

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
 import inspect
+import math
 import os
 import sys
 import time
@@ -454,6 +455,8 @@ class WebLoop(asyncio.AbstractEventLoop):
         if delay < 0:
             raise ValueError("Can't schedule in the past")
         h = asyncio.Handle(callback, args, self, context=context)
+        if delay == math.inf:
+            return h
 
         def run_handle():
             self._install_asyncgen_hooks()

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -34,15 +34,14 @@ def test_asyncio_sleep(selenium):
     )
 
 
-def test_asyncio_sleep_infinite_delay(selenium):
+def test_asyncio_sleep_overflowing_delay(selenium):
     @run_in_pyodide
     async def test(selenium):
         import asyncio
-        import math
 
         import pytest
 
-        task = asyncio.ensure_future(asyncio.sleep(math.inf))
+        task = asyncio.ensure_future(asyncio.sleep(1e9))
         await asyncio.sleep(0.1)
         assert not task.done()
         task.cancel()
@@ -53,30 +52,27 @@ def test_asyncio_sleep_infinite_delay(selenium):
     assert "TimeoutOverflowWarning" not in selenium.logs
 
 
-def test_call_later_skips_scheduling_for_infinite_delay(selenium):
-    @run_in_pyodide
-    async def test(selenium):
-        import asyncio
-        import math
+@run_in_pyodide
+async def test_call_later_skips_scheduling_for_infinite_delay(selenium):
+    import asyncio
+    import math
 
-        from pyodide import webloop
+    from pyodide import webloop
 
-        scheduled = []
-        orig_scheduleCallback = webloop.scheduleCallback  # type: ignore[attr-defined]
-        webloop.scheduleCallback = lambda cb, ms: scheduled.append(ms)  # type: ignore[attr-defined]
-        try:
-            loop = asyncio.get_event_loop()
-            # math.inf must never be scheduled; a finite overflow still clamps.
-            h = loop.call_later(math.inf, lambda: None)
-            assert scheduled == []
-            assert not h.cancelled()
+    scheduled = []
+    orig_scheduleCallback = webloop.scheduleCallback  # type: ignore[attr-defined]
+    webloop.scheduleCallback = lambda cb, ms: scheduled.append(ms)  # type: ignore[attr-defined]
+    try:
+        loop = asyncio.get_event_loop()
+        # math.inf must never be scheduled; a finite overflow still clamps.
+        h = loop.call_later(math.inf, lambda: None)
+        assert scheduled == []
+        assert not h.cancelled()
 
-            loop.call_later(1e9, lambda: None)
-            assert scheduled == [webloop._MAX_TIMEOUT_MS]
-        finally:
-            webloop.scheduleCallback = orig_scheduleCallback  # type: ignore[attr-defined]
-
-    test(selenium)
+        loop.call_later(1e9, lambda: None)
+        assert scheduled == [webloop._MAX_TIMEOUT_MS]
+    finally:
+        webloop.scheduleCallback = orig_scheduleCallback  # type: ignore[attr-defined]
 
 
 def test_cancel_handle(selenium_standalone_refresh):

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -43,9 +43,6 @@ def test_asyncio_sleep_infinite_delay(selenium):
         import pytest
 
         task = asyncio.ensure_future(asyncio.sleep(math.inf))
-        # Without the clamp in WebLoop.call_later(), browsers convert the
-        # Infinity delay to 0 and fire (almost) immediately, so check after
-        # a real wait rather than just yielding once.
         await asyncio.sleep(0.1)
         assert not task.done()
         task.cancel()
@@ -54,6 +51,32 @@ def test_asyncio_sleep_infinite_delay(selenium):
 
     test(selenium)
     assert "TimeoutOverflowWarning" not in selenium.logs
+
+
+def test_call_later_skips_scheduling_for_infinite_delay(selenium):
+    @run_in_pyodide
+    async def test(selenium):
+        import asyncio
+        import math
+
+        from pyodide import webloop
+
+        scheduled = []
+        orig_scheduleCallback = webloop.scheduleCallback  # type: ignore[attr-defined]
+        webloop.scheduleCallback = lambda cb, ms: scheduled.append(ms)  # type: ignore[attr-defined]
+        try:
+            loop = asyncio.get_event_loop()
+            # math.inf must never be scheduled; a finite overflow still clamps.
+            h = loop.call_later(math.inf, lambda: None)
+            assert scheduled == []
+            assert not h.cancelled()
+
+            loop.call_later(1e9, lambda: None)
+            assert scheduled == [webloop._MAX_TIMEOUT_MS]
+        finally:
+            webloop.scheduleCallback = orig_scheduleCallback  # type: ignore[attr-defined]
+
+    test(selenium)
 
 
 def test_cancel_handle(selenium_standalone_refresh):


### PR DESCRIPTION
### Description

As discussed in the comments on #6306, clamping `math.inf` to ~24.8 days breaks use cases like `anyio.sleep_forever()`, which rely on the delay never resolving on its own (e.g. holding a `CancelScope` open until cancelled).

This PR makes `call_later()` skip scheduling entirely when `delay == math.inf`, so it never fires unless cancelled, matching `asyncio.BaseEventLoop`. Finite delays past the 32-bit limit are still clamped as before.

### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests