### PR TITLE
[NodeSockFS] Fix releasing stream lock when there is a pending reader

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -49,6 +49,8 @@ myst:
 
 - {{ Performance }} Sped up JsProxy operations by caching type flags. {pr}`6282`
 
+- {{ Fix }} Fixed Node.js socket stream lock release order. {pr}`6312`
+
 ## Version 314.0.0
 
 _June 09, 2026_

--- a/src/js/fs/nodesockfs.ts
+++ b/src/js/fs/nodesockfs.ts
@@ -319,9 +319,17 @@ export async function initializeNodeSockFS(
     },
 
     close(sock: NodeSock): number {
+      // Signal the pump to stop before touching the reader.
+      sock.closed = true;
+      notifyDataAvailable(sock);
+      maybeResumePump(sock);
+
       if (sock.wcgSocket) {
         if (sock.reader) {
-          sock.reader.releaseLock();
+          // cancel() settles any pending read(), then releaseLock() frees
+          // the stream lock. Direct releaseLock() throws when a read is outstanding.
+          const reader = sock.reader;
+          reader.cancel().then(() => reader.releaseLock(), () => {});
           sock.reader = null;
         }
         if (sock.writer) {
@@ -335,10 +343,6 @@ export async function initializeNodeSockFS(
       sock.recvBufferBytes = 0;
       sock.connected = false;
       sock.connecting = false;
-      sock.closed = true;
-
-      notifyDataAvailable(sock);
-      maybeResumePump(sock);
       return 0;
     },
 
@@ -445,7 +449,8 @@ export async function initializeNodeSockFS(
 
       if (how === SHUT_RD || how === SHUT_RDWR) {
         if (sock.reader) {
-          sock.reader.releaseLock();
+          const reader = sock.reader;
+          reader.cancel().then(() => reader.releaseLock(), () => {});
           sock.reader = null;
           sock.recvBuffer = [];
           sock.recvBufferBytes = 0;

--- a/src/js/fs/nodesockfs.ts
+++ b/src/js/fs/nodesockfs.ts
@@ -325,20 +325,8 @@ export async function initializeNodeSockFS(
       maybeResumePump(sock);
 
       if (sock.wcgSocket) {
-        if (sock.reader) {
-          // cancel() settles any pending read(), then releaseLock() frees
-          // the stream lock. Direct releaseLock() throws when a read is outstanding.
-          const reader = sock.reader;
-          reader.cancel().then(
-            () => reader.releaseLock(),
-            () => {},
-          );
-          sock.reader = null;
-        }
-        if (sock.writer) {
-          sock.writer.releaseLock();
-          sock.writer = null;
-        }
+        sock.reader = null;
+        sock.writer = null;
         sock.wcgSocket.close().catch(() => {});
         sock.wcgSocket = null;
       }
@@ -452,11 +440,7 @@ export async function initializeNodeSockFS(
 
       if (how === SHUT_RD || how === SHUT_RDWR) {
         if (sock.reader) {
-          const reader = sock.reader;
-          reader.cancel().then(
-            () => reader.releaseLock(),
-            () => {},
-          );
+          sock.reader.releaseLock();
           sock.reader = null;
           sock.recvBuffer = [];
           sock.recvBufferBytes = 0;

--- a/src/js/fs/nodesockfs.ts
+++ b/src/js/fs/nodesockfs.ts
@@ -329,7 +329,10 @@ export async function initializeNodeSockFS(
           // cancel() settles any pending read(), then releaseLock() frees
           // the stream lock. Direct releaseLock() throws when a read is outstanding.
           const reader = sock.reader;
-          reader.cancel().then(() => reader.releaseLock(), () => {});
+          reader.cancel().then(
+            () => reader.releaseLock(),
+            () => {},
+          );
           sock.reader = null;
         }
         if (sock.writer) {
@@ -450,7 +453,10 @@ export async function initializeNodeSockFS(
       if (how === SHUT_RD || how === SHUT_RDWR) {
         if (sock.reader) {
           const reader = sock.reader;
-          reader.cancel().then(() => reader.releaseLock(), () => {});
+          reader.cancel().then(
+            () => reader.releaseLock(),
+            () => {},
+          );
           sock.reader = null;
           sock.recvBuffer = [];
           sock.recvBufferBytes = 0;


### PR DESCRIPTION
### Description

Minor fix in NodeSockFS. According to the [spec](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/releaseLock):

> If the reader's lock is released while it still has pending read requests then the promises returned by the reader's [ReadableStreamDefaultReader.read()](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/read) method are immediately rejected with a TypeError. Unread chunks remain in the stream's internal queue and can be read later by acquiring a new reader.

In our implementation, we were releasing locks without properly checking if there is a pending request. However, this doesn't seem to be implemented in Node.js correctly, so it was making the test silently pass. Meanwhile, in Cloudflare workers which follows this spec were raising errors when the stream is closed while there is a reader running.

This PR fixes it by not releasing the lock in the caller, and let the internal `connect` API handle it.
### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
