### PR TITLE
Retry npm Trusted Publishing (take 3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN if [ $CHROME_VERSION = "latest" ]; then SE_CHROME_VERSION="stable"; \
   && mv $(dirname ${SE_CHROME_DRIVER_PATH}) /opt/chromedriver
 
 
-FROM node:24.7-bookworm-slim AS node-image
+FROM node:24.13-bookworm-slim AS node-image
 FROM golang:1.21-alpine AS golang-image
 
 FROM python:3.14.2-slim-bookworm

--- a/tools/deploy_to_npm.sh
+++ b/tools/deploy_to_npm.sh
@@ -7,6 +7,8 @@ if [[ -z "${NPM_ID_TOKEN}" ]]; then
     exit 1
 fi
 
+npm install -g npm@11.6.2
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/..
 
@@ -20,13 +22,13 @@ PACKAGE_NAME=$(node -p "require('./package.json').name")
 JS_VERSION=$(node -p "require('./package.json').version")
 if [[ -n "${DRY_RUN}" ]]; then
     echo "Dry run: npm publish --tag dev"
-    npm publish --dry-run --tag dev
+    npm publish --dry-run --tag dev --loglevel verbose
 elif [[ ${JS_VERSION} =~ [alpha|beta|rc|dev] ]]; then
     echo "Publishing an unstable release"
-    npm publish --tag next
+    npm publish --tag next --loglevel verbose
 else
     echo "Publishing a stable release"
-    npm publish
+    npm publish --loglevel verbose
     npm dist-tag add "$PACKAGE_NAME"@"$JS_VERSION" next
 fi
 


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Let's try npm Trusted Publishing for our next release. Maybe the third time's the charm! I looked at https://github.com/tibber/tibber-httpclient/pull/63 from the cross-link on https://github.com/npm/cli/issues/9088. It uses CircleCI. Perhaps we can get away with bumping our npm version to 11.6.2 or later, since our current image ships with 11.5.1, which is likely broken.
