### PR TITLE
Exclude zoneinfo Python implementation from stdlib zip

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -83,6 +83,7 @@ export PYZIP_EXCLUDE_FILES=\
 	turtledemo/ \
 	test/ \
 	_pydecimal.py \
+	zoneinfo/_zoneinfo.py \
 	pydoc_data/ \
   _sysconfig_vars__emscripten_wasm32-emscripten.json \
   build-details.json

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -19,6 +19,10 @@ myst:
 
 _June 30, 2026_
 
+- {{ Enhancement }} Reduced the standard library size by excluding the
+  `zoneinfo/_zoneinfo.py` Python implementation; `zoneinfo.ZoneInfo` continues
+  to use the `_zoneinfo` C extension. {pr}`6331`
+
 - {{ Fix }} Fixed a reference-counting bug when copying FFI converters that
   could free a converter's pre/post-convert callback while still in use.
   {pr}`6294`

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,13 +15,15 @@ myst:
 
 # Change Log
 
-## Version 314.0.2
-
-_June 30, 2026_
+## Unreleased
 
 - {{ Enhancement }} Reduced the standard library size by excluding the
   `zoneinfo/_zoneinfo.py` Python implementation; `zoneinfo.ZoneInfo` continues
   to use the `_zoneinfo` C extension. {pr}`6331`
+
+## Version 314.0.2
+
+_June 30, 2026_
 
 - {{ Fix }} Fixed a reference-counting bug when copying FFI converters that
   could free a converter's pre/post-convert callback while still in use.

--- a/src/tests/python_tests.yaml
+++ b/src/tests/python_tests.yaml
@@ -986,8 +986,10 @@
 - test_zipimport
 - test_zipimport_support
 - test_zlib
-- test_zoneinfo.test_zoneinfo
-- test_zoneinfo.test_zoneinfo_property
+- test_zoneinfo.test_zoneinfo:
+    xfail: requires zoneinfo._zoneinfo Python implementation
+- test_zoneinfo.test_zoneinfo_property:
+    xfail: requires zoneinfo._zoneinfo Python implementation
 - test_zstd:
     skip:
     - FreeThreadingMethodTests

--- a/src/tests/test_stdlib_fixes.py
+++ b/src/tests/test_stdlib_fixes.py
@@ -92,6 +92,16 @@ def test_ctypes_util_find_library(selenium):
 
 
 @run_in_pyodide
+def test_zoneinfo_uses_c_extension(selenium):
+    import _zoneinfo
+    import importlib.util
+    from zoneinfo import ZoneInfo
+
+    assert _zoneinfo.ZoneInfo is ZoneInfo
+    assert importlib.util.find_spec("zoneinfo._zoneinfo") is None
+
+
+@run_in_pyodide
 def test_zipimport_traceback(selenium):
     """
     Test that traceback of modules loaded from zip file are shown as intended.


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Fixes #5875.

This PR removes `zoneinfo/_zoneinfo.py` from `python_stdlib.zip`. Pyodide already builds the top-level `_zoneinfo` C extension into the runtime. Since `zoneinfo/__init__.py` imports `ZoneInfo` from `_zoneinfo` first, the public `zoneinfo` API continues to work through the C extension. This PR also marks the affected CPython `test_zoneinfo` suites as expected failures because those tests require both the C extension and the Python implementation, while Pyodide now only ships the C extension path. I also added a small runtime test in `test_stdlib_fixes.py` for the `zoneinfo` import path. If this test does not belong there, I can remove it.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
- [ ] Add new / update outdated documentation
