### PR TITLE
Use utf8 mode

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -11,6 +11,7 @@ initialize_python(int argc, char** argv)
 {
   PyPreConfig preconfig;
   PyPreConfig_InitPythonConfig(&preconfig);
+  preconfig.utf8_mode = 1;
 
   PyStatus status = Py_PreInitializeFromBytesArgs(&preconfig, argc, argv);
   if (PyStatus_Exception(status)) {


### PR DESCRIPTION
The wide string decoder trips asan and I think there's no reason for us not to always use utf8
