### PR TITLE
Don't disable instantiate-wasm in as many cases

### DIFF
--- a/src/js/emscripten-settings.ts
+++ b/src/js/emscripten-settings.ts
@@ -195,14 +195,10 @@ function getInstantiateWasmFunc(
   indexURL: string,
 ): EmscriptenSettings["instantiateWasm"] {
   // @ts-ignore
-  if (SOURCEMAP || typeof WasmOffsetConverter !== "undefined") {
-    // According to the docs:
-    //
-    // "Sanitizers or source map is currently not supported if overriding
-    // WebAssembly instantiation with Module.instantiateWasm."
-    // https://emscripten.org/docs/api_reference/module.html?highlight=instantiatewasm#Module.instantiateWasm
-    //
-    // typeof WasmOffsetConverter !== "undefined" checks for asan.
+  if (DISABLE_INSTANTIATE_WASM) {
+    // Some build configurations don't work with instantiate-wasm.
+    // This will be broken because of the lack of initialization for JsvError stuff.
+    // TODO: Fix this...
     return;
   }
   const { binary, response } = getBinaryResponse(indexURL + "pyodide.asm.wasm");

--- a/src/js/esbuild.config.shared.mjs
+++ b/src/js/esbuild.config.shared.mjs
@@ -3,7 +3,6 @@ import { dirname, join } from "node:path";
 
 const DEBUG = !!process.env.PYODIDE_DEBUG_JS;
 
-
 // According to the docs:
 //
 // "Sanitizers or source map is currently not supported if overriding

--- a/src/js/esbuild.config.shared.mjs
+++ b/src/js/esbuild.config.shared.mjs
@@ -2,9 +2,19 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 const DEBUG = !!process.env.PYODIDE_DEBUG_JS;
-const SOURCEMAP = !!(
-  process.env.PYODIDE_SOURCEMAP || process.env.PYODIDE_SYMBOLS
-);
+
+
+// According to the docs:
+//
+// "Sanitizers or source map is currently not supported if overriding
+// WebAssembly instantiation with Module.instantiateWasm."
+// https://emscripten.org/docs/api_reference/module.html?highlight=instantiatewasm#Module.instantiateWasm
+//
+// But this isn't apparently true anymore with sanitizers, only with
+// `-gseparate-dwarf`. I think builds with DISABLE_INSTANTIATE_WASM are broken
+// anyways...
+// TODO: Fix.
+const DISABLE_INSTANTIATE_WASM = !!process.env.PYODIDE_SOURCEMAP;
 
 const __dirname = dirname(new URL(import.meta.url).pathname);
 
@@ -28,7 +38,11 @@ function toDefines(o, path = "") {
 
 const cdefsFile = join(__dirname, "struct_info_generated.json");
 const origConstants = JSON.parse(readFileSync(cdefsFile));
-const constants = { DEBUG, SOURCEMAP, cDefs: origConstants.defines };
+const constants = {
+  DEBUG,
+  DISABLE_INSTANTIATE_WASM,
+  cDefs: origConstants.defines,
+};
 const DEFINES = Object.fromEntries(toDefines(constants));
 
 export const dest = (output) => join(__dirname, "..", "..", output);


### PR DESCRIPTION
I renamed the config variable DISABLE_INSTANTIATE_WASM and reduced the cases where it is disabled to just separate-dwarf since that seems to be the only remaining case where it is actually broken.

Pyodide won't work at all when this is true because JsvError never is initialized. We should fix this eventually...
