### PR TITLE
Fix sign of jsmemops byte operations

### DIFF
--- a/src/core/jsmemops.h
+++ b/src/core/jsmemops.h
@@ -5,12 +5,11 @@
 // the high bit set (i.e., heap > 2 GB, which Pyodide allows via
 // MAXIMUM_MEMORY=4GB), the value is negative. We must use *unsigned* right
 // shift `>>>` to convert byte address → element index, otherwise the
-// arithmetic shift sign-extends and produces a wildly wrong index. Emscripten
-// wraps the final array index in `>>>0`, which patches up the U8/I8 cases
-// (no shift), but cannot rescue a sign-extended intermediate.
+// arithmetic shift sign-extends and produces a wildly wrong index.
+// In U8/I8 case, use an explicit >>>0 to force correct sign.
 
-#define DEREF_U8(addr, offset) HEAPU8[addr + offset]
-#define DEREF_I8(addr, offset) HEAP8[addr + offset]
+#define DEREF_U8(addr, offset) HEAPU8[(addr >>> 0) + offset]
+#define DEREF_I8(addr, offset) HEAP8[(addr  >>> 0) + offset]
 
 #define DEREF_U16(addr, offset) HEAPU16[(addr >>> 1) + offset]
 #define DEREF_I16(addr, offset) HEAP16[(addr >>> 1) + offset]

--- a/src/core/jsmemops.h
+++ b/src/core/jsmemops.h
@@ -9,7 +9,7 @@
 // In U8/I8 case, use an explicit >>>0 to force correct sign.
 
 #define DEREF_U8(addr, offset) HEAPU8[(addr >>> 0) + offset]
-#define DEREF_I8(addr, offset) HEAP8[(addr  >>> 0) + offset]
+#define DEREF_I8(addr, offset) HEAP8[(addr >>> 0) + offset]
 
 #define DEREF_U16(addr, offset) HEAPU16[(addr >>> 1) + offset]
 #define DEREF_I16(addr, offset) HEAP16[(addr >>> 1) + offset]


### PR DESCRIPTION
In #6217, the other width operations were fixed but the comment says the byte operations get fixed "by Emscripten". This is not true, they need an explicit `>>> 0` to coerce them to positive integers.
