### PR TITLE
Do not overwrite current running loop when new event loop is created

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -21,6 +21,9 @@ myst:
   `zoneinfo/_zoneinfo.py` Python implementation; `zoneinfo.ZoneInfo` continues
   to use the `_zoneinfo` C extension. {pr}`6331`
 
+- {{ Fix }} Fixed a new event loop silently replacing the current running loop when
+  `asyncio.new_event_loop()` is called. {pr}`6342`
+
 ## Version 314.0.2
 
 _June 30, 2026_

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -11,7 +11,7 @@ import weakref
 from asyncio import Future, Task, sleep
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from functools import wraps
-from typing import Any, TypeVar, overload
+from typing import Any, Optional, TypeVar, overload
 
 from .ffi import IN_PYODIDE, can_run_sync, create_once_callable, run_sync
 
@@ -217,7 +217,6 @@ class WebLoop(asyncio.AbstractEventLoop):
 
     def __init__(self):
         self._task_factory = None
-        asyncio._set_running_loop(self)
         self._exception_handler = None
         self._current_handle = None
         self._in_progress = 0
@@ -1078,18 +1077,18 @@ class WebLoopPolicy(asyncio.DefaultEventLoopPolicy):  # type: ignore[name-define
     """
 
     def __init__(self):
-        self._default_loop = None
+        self._default_loop: Optional[WebLoop] = None
 
-    def get_event_loop(self):
+    def get_event_loop(self) -> WebLoop:
         """Get the current event loop"""
-        if self._default_loop:
+        if self._default_loop is not None:
             return self._default_loop
-        return self.new_event_loop()
+        self._default_loop = self.new_event_loop()
+        return self._default_loop
 
     def new_event_loop(self) -> WebLoop:
         """Create a new event loop"""
-        self._default_loop = WebLoop()
-        return self._default_loop
+        return WebLoop()
 
     def set_event_loop(self, loop: Any) -> None:
         """Set the current event loop"""
@@ -1129,7 +1128,8 @@ def _initialize_event_loop():
     time.sleep = _sleep
     policy = WebLoopPolicy()
     asyncio.set_event_loop_policy(policy)
-    policy.get_event_loop()
+    loop = policy.get_event_loop()
+    asyncio._set_running_loop(loop)
 
 
 __all__ = ["WebLoop", "WebLoopPolicy", "PyodideFuture", "PyodideTask"]

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -11,7 +11,7 @@ import weakref
 from asyncio import Future, Task, sleep
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from functools import wraps
-from typing import Any, Optional, TypeVar, overload
+from typing import Any, TypeVar, overload
 
 from .ffi import IN_PYODIDE, can_run_sync, create_once_callable, run_sync
 
@@ -1077,7 +1077,7 @@ class WebLoopPolicy(asyncio.DefaultEventLoopPolicy):  # type: ignore[name-define
     """
 
     def __init__(self):
-        self._default_loop: Optional[WebLoop] = None
+        self._default_loop: WebLoop | None = None
 
     def get_event_loop(self) -> WebLoop:
         """Get the current event loop"""

--- a/src/tests/test_webloop.py
+++ b/src/tests/test_webloop.py
@@ -95,6 +95,28 @@ def test_cancel_handle(selenium_standalone_refresh):
     )
 
 
+@run_in_pyodide
+async def test_new_event_loop_does_not_replace_running_loop(selenium_standalone):
+    import asyncio
+
+    startup_loop = asyncio.get_event_loop()
+    running_at_start = asyncio.events._get_running_loop()
+
+    assert running_at_start is startup_loop
+
+    new_loop = asyncio.new_event_loop()
+    running_after_new = asyncio.events._get_running_loop()
+
+    assert new_loop is not startup_loop
+    assert running_after_new is startup_loop
+    assert asyncio.get_event_loop() is startup_loop
+
+    new_loop.close()
+
+    assert asyncio.events._get_running_loop() is startup_loop
+    assert asyncio.get_event_loop() is startup_loop
+
+
 def test_cancel_unhandled(selenium):
     @run_in_pyodide
     async def test(selenium):


### PR DESCRIPTION
### Description

We were overwriting the current event loop whenever the `WebLoop` instance is created. This behavior was problematic when using `pytest-asyncio` in Pyodide as `pytest-asyncio` creates a event loop per module.

### Checklist

<!-- Note:
     If you think some of these steps are not necessary for your PR,
     remove those checkboxes or check them. If you keep unchecked checkboxes,
     we will assume that your PR is not ready to be merged  -->

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
