### PR TITLE
CI Update npm publish command for stable releases

### DIFF
--- a/tools/deploy_to_npm.sh
+++ b/tools/deploy_to_npm.sh
@@ -41,7 +41,7 @@ elif [[ ${JS_VERSION} =~ (alpha|beta|rc|dev) ]]; then
     npm publish --tag next --loglevel verbose
 else
     echo "Publishing a stable release"
-    npm publish --tag next --tag stable --loglevel verbose
+    npm publish --tag next --loglevel verbose
 fi
 
 rm -f dist/README.md

--- a/tools/deploy_to_npm.sh
+++ b/tools/deploy_to_npm.sh
@@ -41,8 +41,7 @@ elif [[ ${JS_VERSION} =~ (alpha|beta|rc|dev) ]]; then
     npm publish --tag next --loglevel verbose
 else
     echo "Publishing a stable release"
-    npm publish --loglevel verbose
-    npm dist-tag add "$PACKAGE_NAME"@"$JS_VERSION" next
+    npm publish --tag next --tag stable --loglevel verbose
 fi
 
 rm -f dist/README.md

--- a/tools/deploy_to_npm.sh
+++ b/tools/deploy_to_npm.sh
@@ -31,6 +31,7 @@ cp src/js/package.json dist/
 
 cd dist/
 
+JS_VERSION=$(node -p "require('./package.json').version")
 if [[ -n "${DRY_RUN}" ]]; then
     echo "Dry run: npm publish --tag dev"
     npm publish --dry-run --tag dev --loglevel verbose
@@ -42,4 +43,4 @@ else
     npm publish --tag next --loglevel verbose
 fi
 
-rm -f dist/README.md
+rm -f README.md

--- a/tools/deploy_to_npm.sh
+++ b/tools/deploy_to_npm.sh
@@ -31,8 +31,6 @@ cp src/js/package.json dist/
 
 cd dist/
 
-PACKAGE_NAME=$(node -p "require('./package.json').name")
-JS_VERSION=$(node -p "require('./package.json').version")
 if [[ -n "${DRY_RUN}" ]]; then
     echo "Dry run: npm publish --tag dev"
     npm publish --dry-run --tag dev --loglevel verbose


### PR DESCRIPTION
Merge `npm publish` and `npm dist-tag` commands into one. This allows using NPM trusted publishing without logging in.  Previously, `npm publish` succeeded but the `npm dist-tag` failed because `npm dist-tag` does not respect `NPM_ID_TOKEN`