### PR TITLE
docs: Add docstring example for create_once_callable

### DIFF
--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1343,9 +1343,6 @@ def create_once_callable(
     'Function called!'
     >>> proxy()
     Traceback (most recent call last):
-      File "<doctest _pyodide._core_docs.create_once_callable[4]>", line 1, in <module>
-        proxy()
-        ~~~~~^^
     pyodide.ffi.JsException: Error: OnceProxy can only be called once
     """
     return obj  # type:ignore[return-value]

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1332,6 +1332,19 @@ def create_once_callable(
     After being called the proxy will decrement the reference count
     of the Callable. The JavaScript function also has a ``destroy`` API that
     can be used to release the proxy without calling it.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pyodide.ffi import create_once_callable
+        
+        def f():
+            print("Function called!")
+            
+        proxy = create_once_callable(f)
+        proxy()  # Prints: "Function called!"
+        # Calling proxy() a second time will raise an exception
     """
     return obj  # type:ignore[return-value]
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1343,8 +1343,10 @@ def create_once_callable(
     'Function called!'
     >>> proxy()
     Traceback (most recent call last):
-      ...
-    Exception: Object has already been destroyed
+      File "<doctest _pyodide._core_docs.create_once_callable[4]>", line 1, in <module>
+        proxy()
+        ~~~~~^^
+    pyodide.ffi.JsException: Error: OnceProxy can only be called once
     """
     return obj  # type:ignore[return-value]
 

--- a/src/py/_pyodide/_core_docs.py
+++ b/src/py/_pyodide/_core_docs.py
@@ -1335,16 +1335,16 @@ def create_once_callable(
 
     Examples
     --------
-    .. code-block:: python
-
-        from pyodide.ffi import create_once_callable
-        
-        def f():
-            print("Function called!")
-            
-        proxy = create_once_callable(f)
-        proxy()  # Prints: "Function called!"
-        # Calling proxy() a second time will raise an exception
+    >>> from pyodide.ffi import create_once_callable # doctest: +RUN_IN_PYODIDE
+    >>> def f():
+    ...     return "Function called!"
+    >>> proxy = create_once_callable(f)
+    >>> proxy()
+    'Function called!'
+    >>> proxy()
+    Traceback (most recent call last):
+      ...
+    Exception: Object has already been destroyed
     """
     return obj  # type:ignore[return-value]
 


### PR DESCRIPTION
Closes #1955. Adds an example to create_once_callable.