### PR TITLE
Update 314.0.x debug xbuildenv checksums [skip ci]

### DIFF
--- a/metadata/pyodide-cross-build-environments-debug-v2.json
+++ b/metadata/pyodide-cross-build-environments-debug-v2.json
@@ -3,7 +3,7 @@
     "314.0.3": {
       "version": "314.0.3",
       "url": "https://github.com/pyodide/pyodide/releases/download/314.0.3/xbuildenv-debug-314.0.3.tar.gz",
-      "sha256": "706d4ee4a01f016255fc5a878fc3f98bacd67808c80e42fa4125fe28f0826d25",
+      "sha256": "6ab47adbb71d9536df4d364bcaf64a47320f1ebb340f6454aaeda26d4dfcd255",
       "python_version": "3.14.2",
       "emscripten_version": "5.0.3",
       "published_at": "2026-07-24T08:43:00Z",
@@ -12,7 +12,7 @@
     "314.0.2": {
       "version": "314.0.2",
       "url": "https://github.com/pyodide/pyodide/releases/download/314.0.2/xbuildenv-debug-314.0.2.tar.bz2",
-      "sha256": "450c23a3130cc5fdef9a5657805d98920366a5807fa6bc8a0b969ef8c1b47e77",
+      "sha256": "a95af1e574adc36db07e6263a412585e7999c8768a9c30c5ade9fb82b6a972e2",
       "python_version": "3.14.2",
       "emscripten_version": "5.0.3",
       "published_at": "2026-06-30T15:21:47Z",
@@ -21,7 +21,7 @@
     "314.0.1": {
       "version": "314.0.1",
       "url": "https://github.com/pyodide/pyodide/releases/download/314.0.1/xbuildenv-debug-314.0.1.tar.bz2",
-      "sha256": "5c84feac74ada7d9639748af576dfc89a5edc871b864f54be6872a24e044ed44",
+      "sha256": "70a647c6222ffcee4893ddd63b60db35a14cd40362c867e867099456a0a03207",
       "python_version": "3.14.2",
       "emscripten_version": "5.0.3",
       "published_at": "2026-06-26T05:33:26Z",
@@ -30,7 +30,7 @@
     "314.0.0": {
       "version": "314.0.0",
       "url": "https://github.com/pyodide/pyodide/releases/download/314.0.0/xbuildenv-debug-314.0.0.tar.bz2",
-      "sha256": "21741f8e7c1986dbe34e781a3c367faf704e4cf89f436d8bb13529ba69ff5fed",
+      "sha256": "01be0e65d34cc0bcdf51b9a91d9b30748fd16b81d0fb809302d7e1b2909db3c0",
       "python_version": "3.14.2",
       "emscripten_version": "5.0.3",
       "published_at": "2026-06-09T09:56:41Z",


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

The stable-debug xbuildenv archives for 314.0.0 to 314.0.3 unpacked into `xbuildenv-debug/` rather than `xbuildenv/`, which left every install of them with a pyodide-root that did not exist. I have repacked and re-uploaded them with the directory named `xbuildenv/`, so their checksums have changed a bit.

### Checklist

- [x] Open an issue to describe this change in light of transparency for our users (#6379)
