### PR TITLE
Build debug xbuildenvs in a different folder to prevent clashes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,13 +280,12 @@ jobs:
             # Overlay the debug dist on top of the regular dist so that
             # create_xbuildenv.py picks up the PYODIDE_DEBUG=1 build of pyodide.asm.mjs
             cp -r dist-debug/. dist/
-            python tools/create_xbuildenv.py /tmp/xbuildenv-debug-out
-            mv /tmp/xbuildenv-debug-out/xbuildenv ./xbuildenv-debug
+            python tools/create_xbuildenv.py ./debug
 
       - run:
           name: Zip debug xbuild environment
           command: |
-            tar czf xbuildenv-debug.tar.gz ./xbuildenv-debug/
+            tar czf xbuildenv-debug.tar.gz -C ./debug xbuildenv
 
       - store_artifacts:
           path: /root/repo/xbuildenv-debug.tar.gz
@@ -294,7 +293,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ./xbuildenv-debug
+            - ./debug
 
   build-test-pyc-packages:
     <<: *defaults
@@ -512,16 +511,16 @@ jobs:
             mkdir -p /tmp/ghr/dist
             cp -r dist /tmp/ghr/pyodide
             cp -r xbuildenv /tmp/ghr/xbuildenv
-            cp -r xbuildenv-debug /tmp/ghr/xbuildenv-debug
+            cp -r debug /tmp/ghr/debug
             cp -r cpython/installs /tmp/ghr/static-libraries
             cd /tmp/ghr
             tar cjf dist/pyodide-${CIRCLE_TAG}.tar.bz2  pyodide/
             tar cjf dist/pyodide-core-${CIRCLE_TAG}.tar.bz2 pyodide/pyodide{.js,.mjs,.asm.mjs,.asm.wasm} pyodide/*.d.ts pyodide/{package,pyodide-lock}.json pyodide/python_stdlib.zip pyodide/python pyodide/python.bat pyodide/python.exe pyodide/python_cli_entry.mjs
             tar cjf dist/xbuildenv-${CIRCLE_TAG}.tar.bz2  xbuildenv/
-            tar cjf dist/xbuildenv-debug-${CIRCLE_TAG}.tar.bz2  xbuildenv-debug/
+            tar cjf dist/xbuildenv-debug-${CIRCLE_TAG}.tar.bz2  -C debug xbuildenv
             tar cjf dist/static-libraries-${CIRCLE_TAG}.tar.bz2  static-libraries/
             tar czf dist/xbuildenv-${CIRCLE_TAG}.tar.gz  xbuildenv/
-            tar czf dist/xbuildenv-debug-${CIRCLE_TAG}.tar.gz  xbuildenv-debug/
+            tar czf dist/xbuildenv-debug-${CIRCLE_TAG}.tar.gz  -C debug xbuildenv
 
             # If it has an 'a' in the tag it's an alpha so mark it as a prelease
             [[ "${CIRCLE_TAG}" =~ a ]] && export MAYBE_PRE_RELEASE=-prerelease
@@ -605,15 +604,15 @@ jobs:
             mkdir -p /tmp/ghr/dist
             cp -r dist /tmp/ghr/pyodide
             cp -r xbuildenv /tmp/ghr/xbuildenv
-            cp -r xbuildenv-debug /tmp/ghr/xbuildenv-debug
+            cp -r debug /tmp/ghr/debug
             cp -r cpython/installs /tmp/ghr/static-libraries
             cd /tmp/ghr
             tar cjf dist/pyodide-core.tar.bz2 pyodide/pyodide{.js,.mjs,.asm.mjs,.asm.wasm} pyodide/*.d.ts pyodide/{package,pyodide-lock}.json pyodide/python_stdlib.zip pyodide/python pyodide/python.bat pyodide/python.exe pyodide/python_cli_entry.mjs
             tar cjf dist/xbuildenv.tar.bz2  xbuildenv/
-            tar cjf dist/xbuildenv-debug.tar.bz2  xbuildenv-debug/
+            tar cjf dist/xbuildenv-debug.tar.bz2  -C debug xbuildenv
             tar cjf dist/static-libraries.tar.bz2  static-libraries/
             tar czf dist/xbuildenv.tar.gz  xbuildenv/
-            tar czf dist/xbuildenv-debug.tar.gz  xbuildenv-debug/
+            tar czf dist/xbuildenv-debug.tar.gz  -C debug xbuildenv
 
             cd -
             python3 tools/deploy_s3.py /tmp/ghr/dist/ "xbuildenv/dev" --bucket "pyodide-cache" --cache-control 'max-age=3600, public' --overwrite \


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

We were doing this previously because we were building the xbuildenvs in the same folder and did not want to overwrite them. But with what was uncovered in #6378, it's saner to just build in a different folder. The artifact will be named `xbuildenv-debug.tar.gz`, but unpacking it will still yield `xbuildenv`. This PR makes sure that we don't repeat the issue for Pyodide 314.0.4 or any further releases.