### PR TITLE
MNT Run GHA core tests on push only when pushed to main, release, or ABI branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: main
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
       - stable
       # older release branches
       - "[0-9]+.[0-9]+.X"
-      - "[0-9]+.X"
       # slightly longer-lived branches for ABI changes
       - "abi_*"
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,19 @@ name: main
 on:
   push:
     branches:
+      # development branch
       - main
+      # latest release branch
+      - stable
+      # older release branches
+      - "[0-9]+.[0-9]+.X"
+      - "[0-9]+.X"
+      # slightly longer-lived branches for ABI changes
+      - "abi_*"
   pull_request:
 
 concurrency:
-  group: main-${{ github.head_ref }}
+  group: main-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

<!-- Please explain what your PR is about:
     - reasoning for the change
     - some details of updated code
     - any noteworthy choices to be aware of
	Please refer to any related issues by #<issue_id> -->

Currently this triggers tests on GHA by responding to both the `push:` and `pull_request:` events, which means we have duplicate, redundant CI. The `push:` event should be responded to only when commits are pushed to `main`, release, or ABI branches, and `pull_request:` responds to PRs.