### PR TITLE
emcc: Turn off shared library signature check when configuring

### DIFF
--- a/emsdk/patches/0001-Add-useful-error-when-symbol-resolution-fails.patch
+++ b/emsdk/patches/0001-Add-useful-error-when-symbol-resolution-fails.patch
@@ -1,7 +1,7 @@
 From fd2744aac0ac1a4eeb89b344fee1514a8d775fc3 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Fri, 19 May 2023 12:19:00 -0700
-Subject: [PATCH 1/5] Add useful error when symbol resolution fails
+Subject: [PATCH 1/6] Add useful error when symbol resolution fails
 
 Currently if symbol resolution fails, we get:
 ```js

--- a/emsdk/patches/0002-Fix-promise-order.patch
+++ b/emsdk/patches/0002-Fix-promise-order.patch
@@ -1,7 +1,7 @@
 From e475720a093b559ea1a751ed8a2cd064c15cb65b Mon Sep 17 00:00:00 2001
 From: Gyeongjae Choi <def6488@gmail.com>
 Date: Sun, 1 Jun 2025 15:35:17 +0000
-Subject: [PATCH 2/5] Fix promise order
+Subject: [PATCH 2/6] Fix promise order
 
 Upstream PR:
 * https://github.com/emscripten-core/emscripten/pull/24461

--- a/emsdk/patches/0003-Normalize-library-paths-to-prevent-duplicate-loading.patch
+++ b/emsdk/patches/0003-Normalize-library-paths-to-prevent-duplicate-loading.patch
@@ -1,7 +1,7 @@
 From bfd5e19171893f53ef2f7d7f346f3b708f1d08eb Mon Sep 17 00:00:00 2001
 From: Pepijn de Vos <pepijndevos@gmail.com>
 Date: Fri, 6 Mar 2026 08:37:22 +0100
-Subject: [PATCH 3/5] Normalize library paths to prevent duplicate loading
+Subject: [PATCH 3/6] Normalize library paths to prevent duplicate loading
 
 When a shared library in a subdirectory references a dependency via
 $ORIGIN/.. rpath, findLibraryFS resolves it to a non-canonical path

--- a/emsdk/patches/0004-Don-t-bundle-the-LLVM-profile-runtime-into-libcompil.patch
+++ b/emsdk/patches/0004-Don-t-bundle-the-LLVM-profile-runtime-into-libcompil.patch
@@ -1,7 +1,7 @@
 From 4f7deceadf538ad65d5a89cc0033354df56fb80c Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Tue, 7 Jul 2026 16:00:05 -0700
-Subject: [PATCH 4/5] Don't bundle the LLVM profile runtime into libcompiler_rt
+Subject: [PATCH 4/6] Don't bundle the LLVM profile runtime into libcompiler_rt
 
 Emscripten #24160 (released in 4.0.11) started globbing the
 compiler-rt profile runtime (system/lib/compiler-rt/lib/profile/*)

--- a/emsdk/patches/0005-Make-sure-sSIDE_MODULE-1-passes-whole-archive-to-lin.patch
+++ b/emsdk/patches/0005-Make-sure-sSIDE_MODULE-1-passes-whole-archive-to-lin.patch
@@ -1,7 +1,7 @@
 From 34482a0ccf1294ede385e7d9df1b3a6078102a34 Mon Sep 17 00:00:00 2001
 From: Hood Chatham <roberthoodchatham@gmail.com>
 Date: Tue, 28 Jul 2026 12:37:26 +0200
-Subject: [PATCH 5/5] Make sure -sSIDE_MODULE=1 passes --whole-archive to
+Subject: [PATCH 5/6] Make sure -sSIDE_MODULE=1 passes --whole-archive to
  linker
 
 https://github.com/emscripten-core/emscripten/pull/27430

--- a/emsdk/patches/0006-Turn-off-shared-library-signature-check-when-configu.patch
+++ b/emsdk/patches/0006-Turn-off-shared-library-signature-check-when-configu.patch
@@ -1,0 +1,75 @@
+From 5270f28949f81d93897f65f05acf44d50f5ec98f Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Fri, 31 Jul 2026 16:48:39 -0700
+Subject: [PATCH 6/6] Turn off shared library signature check when configuring
+
+`AC_CHECK_LIB(somelib, func)` writes the following to conftest.c:
+
+```C
+char func ();
+
+int main(void) {
+   return func ();
+}
+```
+Then runs `emcc conftest.c -lsomelib` and checks whether it succeeds. With
+static libraries the signature mismatch is just a warning but with shared
+libraries it is a hard error. Before emcc 6.0.0, even if configure tried to make
+a shared library it would make a fake dynamic library instead and we didn't see
+this problem. But since then it makes a real dynamic library and then fails to
+configure.
+
+The fix is if we are configuring pass `-Wl,--no-shlib-sigcheck` to disable the
+signature check.
+---
+ test/test_other.py | 15 +++++++++++++++
+ tools/link.py      |  7 +++++++
+ 2 files changed, 22 insertions(+)
+
+diff --git a/test/test_other.py b/test/test_other.py
+index 27358a9ac..f9a4e7f80 100644
+--- a/test/test_other.py
++++ b/test/test_other.py
+@@ -12409,6 +12409,21 @@ int main () {
+     output = self.run_process([os.path.abspath('a.out')], stdout=PIPE).stdout
+     self.assertContained('Hello, world!', output)
+ 
++  def test_autoconf_check_lib_side_module(self):
++    # AC_CHECK_LIB probes for a symbol using an unprototyped declaration and a
++    # zero-argument call.  Verify that the signature mismatch against the real
++    # function does not make the probe fail when the library is a side module.
++    create_file('libtest.c', 'int identity(int x) { return x; }\n')
++    self.run_process([EMCC, '-fPIC', '-shared', '-o', 'libtest.so', 'libtest.c'])
++    create_file('conftest.c', '''
++      char identity ();
++
++      int main(void) {
++        return identity ();
++      }
++    ''')
++    self.run_process([EMCC, 'conftest.c', 'libtest.so', '-o', 'conftest.js'])
++
+   def test_standalone_export_main(self):
+     # Tests that explicitly exported `_main` does not fail, even though `_start` is the entry
+     # point.
+diff --git a/tools/link.py b/tools/link.py
+index 527996f76..d9317b194 100644
+--- a/tools/link.py
++++ b/tools/link.py
+@@ -884,6 +884,13 @@ def phase_linker_setup(options, linker_args):  # ruff: ignore[complex-structure,
+     # autoconf declares functions without their proper signatures, and STRICT causes that to trip up by passing --fatal-warnings to the linker.
+     if settings.STRICT:
+       exit_with_error('autoconfiguring is not compatible with STRICT')
++    # AC_CHECK_LIB probes for a symbol by declaring it without a prototype
++    # (`char foo ();`) and then calling it with no arguments.  When the symbol
++    # comes from an object file or an archive lld only warns about the
++    # resulting signature mismatch and synthesizes a thunk, but when it comes
++    # from a shared library the mismatch is a hard error. This turns off the
++    # shared library check.
++    linker_args.append('--no-shlib-sigcheck')
+ 
+   if settings.OPT_LEVEL >= 1:
+     default_setting('ASSERTIONS', 0)
+-- 
+2.54.0
+


### PR DESCRIPTION
emscripten-core/emscripten#27470

AC_CHECK_LIB(somelib, func)` writes the following to conftest.c:

```C
char func ();

int main(void) {
   return func ();
}
```
Then runs `emcc conftest.c -lsomelib` and checks whether it succeeds. With static libraries the signature mismatch is just a warning but with shared libraries it is a hard error. Before emcc 6.0.0, even if configure tried to make a shared library it would make a fake dynamic library instead and we didn't see this problem. But since then it makes a real dynamic library and then fails to configure.

The fix is if we are configuring pass `-Wl,--no-shlib-sigcheck` to disable the signature check.