### PR TITLE
Document how to make an extension module a dlopen() target

### DIFF
--- a/docs/development/abi.md
+++ b/docs/development/abi.md
@@ -105,6 +105,48 @@ directory. Like on native platforms, the RPATH of the dependent extension module
 should also be set as appropriate to ensure that the dependency is resolved
 correctly.
 
+### Extension Modules as `dlopen()` Targets
+
+Some packages have a plugin architecture: compiled code inside the package calls
+`dlopen()` at runtime on a separately built shared library, and that library
+needs symbols defined by the package's own extension module. DuckDB's loadable
+extensions work this way.
+
+This does not work by default. Pyodide loads package shared libraries with local
+symbol visibility, the equivalent of `RTLD_LOCAL`, so a module's exports do not
+reach the shared symbol table that a later, unrelated `dlopen()` call searches.
+The `dlopen()` then fails with `Dynamic linking error: cannot resolve symbol
+<name>` even though the symbol really is exported by the already-loaded module.
+
+Resolve this the same way native platforms do, by declaring the dependency
+rather than relying on global symbol visibility. Link the `dlopen()`-ed library
+against the extension module that provides the symbols, so that it records a
+`NEEDED` entry in its dynamic linking section, and set an RPATH so that the
+dependency can be located at runtime:
+
+```
+emcc -sSIDE_MODULE=2 ... \
+    -Wl,-rpath,'$ORIGIN/../..' \
+    path/to/site-packages/mypkg/_core.cpython-314-wasm32-emscripten.so
+```
+
+When the plugin is `dlopen()`-ed, each `NEEDED` entry is resolved against the
+RPATH, the providing module is found to be already loaded, and its exports are
+merged into the plugin's local scope. The symbols do not become globally
+visible, so this does not affect any other module. `$ORIGIN` expands to the
+directory of the library that declares the RPATH.
+
+Two consequences are worth planning for:
+
+- A `NEEDED` entry records the exact filename of the providing module. For a
+  Python extension module that filename contains the ABI tag, as in
+  `_core.cpython-314-wasm32-emscripten.so`, so the plugin is loadable only by
+  the Python version it was built against and must be rebuilt when that changes.
+- The RPATH must resolve to the same path the providing module was originally
+  loaded from, so that the already-loaded module is reused. If it resolves to a
+  different path, a second independent copy of the module is instantiated rather
+  than an error being raised.
+
 ### No pthreads support
 
 `-pthread` must not be used at compile or link time. If `-pthread` is used, the


### PR DESCRIPTION
### Description

Follow-up to #6413, documenting the `NEEDED` + RPATH approach @hoodmane suggested there.

Packages with a plugin architecture — where compiled code inside the package `dlopen()`s a separately built library that needs symbols from the package's own extension module — fail by default, because package shared libraries are loaded with local symbol visibility and their exports never reach the symbol table a later `dlopen()` searches. DuckDB's loadable extensions are the case that prompted this, but nothing about it is DuckDB-specific.

This adds a section to `docs/development/abi.md` covering the fix, next to the existing "Other Library Dependencies" section. It deliberately does **not** document reaching for global symbol visibility, per @hoodmane's point in #6413 that `RTLD_GLOBAL` should be a last resort.

#### What I verified, and what I did not

I confirmed the runtime behaviour end-to-end under Pyodide 314.0.3 (Node, real DuckDB wheel, real loadable extension):

- Without the `NEEDED` entry: `Dynamic linking error: cannot resolve symbol _ZN6duckdb15ExtensionLoader19GetDatabaseInstanceEv`.
- With `WASM_DYLINK_NEEDED` and `WASM_DYLINK_RUNTIME_PATH` subsections present, and **no** promotion to global visibility anywhere: the extension loads and a real query returns correct results. The providing module's `dso.global` stays `false` throughout, and afterwards there is still exactly one instance of it with `refcount: 2`, so the already-loaded module is reused rather than re-instantiated.
- `findLibraryFS()` resolves the bare filename to a path byte-identical to the existing `LDSO.loadedLibsByName` key, with both an absolute RPATH and the `$ORIGIN`-relative form.

**Caveat on the build recipe:** I produced the `NEEDED`/`RUNTIME_PATH` subsections by patching an already-linked binary's `dylink.0` section, because I have no Emscripten toolchain on this machine. I have therefore *not* run the `emcc` invocation shown in the docs. I based it on `-rpath` being listed in `SUPPORTED_LINKER_FLAGS` in `tools/link.py` and `RUNTIME_PATH = 5` being handled in `tools/webassembly.py`, plus emscripten-core/emscripten#22126 being closed. If the exact flags or their spelling are wrong, please correct them — the described mechanism is verified, the specific command line is not.

Happy to adjust the placement, wording, or level of detail.

### Checklist

- [ ] ~Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry~ — documentation only, no user-visible behaviour change
- [ ] ~Add / update tests~ — documentation only
- [x] Add new / update outdated documentation