### PR TITLE
Fix saving and restoring the thread state when stack switching

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -27,7 +27,8 @@ myst:
   - `contextvars` set inside a call that suspends are no longer visible to a
     later unrelated stack switch, and no longer keep the objects they reference
     alive forever.
-  - Calls no longer see `threading.local()` values left behind by unrelated calls.
+  - `threading.local()` is now consistently shared with calls that stack
+    switch.
   - `sys.set_asyncgen_hooks()` now applies inside a call that stack switches, so
     async generators created there are handed to the event loop that has to shut
     them down.

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,29 @@ myst:
 
 # Change Log
 
+## Unreleased
+
+- {{ Fix }} Fixed several bugs in how the Python thread state is managed when
+  stack switching, which made `contextvars` and `threading.local()` behave
+  incorrectly around `pyodide.ffi.run_sync()`:
+
+  - Top level code no longer loses its `contextvars` context,
+    `threading.local()` values and thread dict when suspended stacks resume in a
+    different order than they suspended in.
+  - `contextvars` set inside a call that suspends are no longer visible to a
+    later unrelated stack switch, and no longer keep the objects they reference
+    alive forever.
+  - Calls no longer see `threading.local()` values left behind by unrelated calls.
+  - `sys.set_asyncgen_hooks()` now applies inside a call that stack switches, so
+    async generators created there are handed to the event loop that has to shut
+    them down.
+  - `PyThreadState_Clear()` is now called before `PyThreadState_Delete()`, as
+    the C API requires.
+  - A Python entry point invoked with stack switching enabled now runs
+    with a copy of the `contextvars` context so `ContextVar.set()` calls it makes
+    are never visible to the caller afterwards.
+  {pr}`6421`
+
 ## Version 314.0.4
 
 _Aug 4, 2026_

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -101,15 +101,30 @@ run_main()
 void
 set_suspender(JsVal suspender);
 
+int
+enter_promising_task(void);
+
+void
+exit_promising_task(void);
+
 /**
- * call _pyproxy_apply but save the error flag into the argument so it can't be
- * observed by unrelated Python callframes. callPyObjectKwargsSuspending will
- * restore the error flag before calling pythonexc2js(). See
- * test_stack_switching.test_throw_from_switcher for a detailed explanation.
+ * Run main with stack switching enabled.
+ *
+ * Like _pyproxy_apply_promising, main gets a thread state of its own for its
+ * whole lifetime. See the ownership model at the top of pystate.c.
  */
 EMSCRIPTEN_KEEPALIVE int
 run_main_promising(JsVal suspender)
 {
   set_suspender(suspender);
-  return run_main();
+  if (enter_promising_task() != 0) {
+    PyErr_Print();
+    return 1;
+  }
+  // Note: run_main() may call exit(), in which case control never returns here
+  // and exit_promising_task() is never called. That's okay because the runtime
+  // shuts down.
+  int exitcode = run_main();
+  exit_promising_task();
+  return exitcode;
 }

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -753,11 +753,20 @@ _pyproxy_apply(PyObject* callable,
 void
 set_suspender(JsVal suspender);
 
+int
+enter_promising_task(void);
+
+void
+exit_promising_task(void);
+
 /**
  * call _pyproxy_apply but save the error flag into the argument so it can't be
  * observed by unrelated Python callframes. callPyObjectKwargsSuspending will
  * restore the error flag before calling pythonexc2js(). See
  * test_stack_switching.test_throw_from_switcher for a detailed explanation.
+ *
+ * We also give the task a thread state of its own for its whole lifetime. See
+ * the comment at the top of pystate.c.
  */
 EMSCRIPTEN_KEEPALIVE JsVal
 _pyproxy_apply_promising(JsVal suspender,
@@ -769,9 +778,16 @@ _pyproxy_apply_promising(JsVal suspender,
                          PyObject** exc)
 {
   set_suspender(suspender);
-  JsVal res =
-    _pyproxy_apply(callable, jsargs, numposargs, jskwnames, numkwargs);
-  *exc = PyErr_GetRaisedException();
+  JsVal res = JS_ERROR;
+  if (enter_promising_task() == 0) {
+    res = _pyproxy_apply(callable, jsargs, numposargs, jskwnames, numkwargs);
+    // Take the error flag off of the task thread state before handing control
+    // back, otherwise we'd read the error flag of the main thread state.
+    *exc = PyErr_GetRaisedException();
+    exit_promising_task();
+  } else {
+    *exc = PyErr_GetRaisedException();
+  }
   // In case the result is a thenable, in callPromisingKwargs we only want to
   // await the stack switch not the thenable that Python returned. So we wrap
   // the result in a one-entry list. We'll unwrap it in callPromisingKwargs

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -113,8 +113,9 @@ enter_promising_task(void)
     threading_local = PyObject_CallMethod(threading_module, "local", NULL);
     FAIL_IF_NULL(threading_local);
     // Reading an attribute is what triggers the lazy creation.
-    Py_XSETREF(tmp, PyObject_GetAttrString(threading_local, "__dict__"));
-    FAIL_IF_NULL(threading_local);
+    DECLARE_PY_OBJECT(res);
+    res = PyObject_GetAttrString(threading_local, "__dict__");
+    FAIL_IF_NULL(res);
   }
   DECLARE_PY_OBJECT(tlocal_key);
   tlocal_key = Py_XNewRef(caller_tstate->threading_local_key);
@@ -153,7 +154,7 @@ enter_promising_task(void)
     DECLARE_PY_OBJECT(res);
     res = _PyObject_CallMethodIdOneArg(
       asyncio_module, &PyId__set_running_loop, loop);
-    FAIL_IF_NILL(res);
+    FAIL_IF_NULL(res);
   }
   return 0;
 }

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -5,8 +5,13 @@
 
 // This file manages the Python stack / thread state when stack switching.
 //
-// The functions exported here are used in suspenders.mjs, in save_state,
-// restore_state, and promisingApply.
+// captureThreadState / restoreThreadState are called from JS, in saveState and
+// restoreState in suspenders.c. enter_promising_task / exit_promising_task are
+// called from C, in _pyproxy_apply_promising and run_main_promising.
+//
+// Every in-flight "promising task" owns a PyThreadState for its whole lifetime.
+// We store the main thread state when we swap it out to enter a promising task
+// and we restore it when the promising task suspends or exits.
 //
 // The logic here is inspired by:
 // https://github.com/python-greenlet/greenlet/blob/master/src/greenlet/greenlet_greenlet.hpp
@@ -22,70 +27,166 @@ int pystate_keepalive;
 _Py_IDENTIFIER(get_event_loop);
 _Py_IDENTIFIER(_set_running_loop);
 
-#define THREADSTATE_MAX_FREELIST 10
+/**
+ * The main thread state that the promising task took over from. We'll reinstall
+ * this thread state when the promising task gives up control by suspending or
+ * by returning. It is NULL when the JS event loop is turning or when Python is
+ * executing with no suspender.
+ *
+ * This has to be ambient state rather than a parameter, because a task gives up
+ * control from JsvPromise_Syncify(), which sits arbitrarily deep below
+ * enter_promising_task() with unknown Python frames in between.
+ *
+ * A task can only ever take control from the event loop and always returns
+ * control to the event loop. So this is always the event loop tstate or NULL.
+ * It is a bug to enter or resume a task when this is not NULL.
+ */
+static PyThreadState* handback_tstate = NULL;
 
-static PyThreadState* threadstate_freelist[THREADSTATE_MAX_FREELIST] = {};
-static int threadstate_freelist_len = 0;
-
-static PyThreadState*
-new_tstate(void)
-{
-  if (threadstate_freelist_len > 0) {
-    threadstate_freelist_len--;
-    return threadstate_freelist[threadstate_freelist_len];
-  } else {
-    return PyThreadState_New(PyInterpreterState_Get());
-  }
-}
-
+/**
+ * Dispose of a task's thread state.
+ *
+ * Note that we deliberately don't pool thread states for reuse. A lot of state
+ * is keyed on thread state identity: threading.local() storage hangs off
+ * tstate->threading_local_key, the ContextVar cache is keyed on
+ * (tstate->id, tstate->context_ver), and the running event loop lives in
+ * tstate->asyncio_running_loop. Handing the same thread state to an unrelated
+ * task later means invalidating all of it by hand, which we got wrong before
+ * and which would need re-auditing on every CPython update. A fresh thread
+ * state gets a fresh unique id and PyThreadState_Clear deals with the rest.
+ *
+ * This must be called with a different thread state installed: PyThreadState_
+ * Clear can run Python code (the threading.local() sentinel weakref callback)
+ * and requires that the caller isn't running on `tstate`.
+ */
 static void
 delete_tstate(PyThreadState* tstate)
 {
-  if (threadstate_freelist_len == THREADSTATE_MAX_FREELIST) {
-    PyThreadState_Delete(tstate);
-  } else {
-    threadstate_freelist[threadstate_freelist_len] = tstate;
-    threadstate_freelist_len++;
+  PyThreadState_Clear(tstate);
+  PyThreadState_Delete(tstate);
+}
+
+/**
+ * Install a thread state for the new task and record the main thread state so
+ * we can swap it back in when we suspend or exit.
+ *
+ * The task inherits from its caller:
+ *
+ * - a copy of the contextvars context
+ * - the thread local dict
+ * - the running event loop
+ * - the async generator hooks
+ */
+int
+enter_promising_task(void)
+{
+  FAIL_RETURN_VALUE(-1);
+  DECLARE_PY_OBJECT(asyncio_module);
+  DECLARE_PY_OBJECT(loop);
+  DECLARE_PY_OBJECT(context);
+  DECLARE_PY_OBJECT(thread_dict);
+  DECLARE_PY_OBJECT(agen_firstiter);
+  DECLARE_PY_OBJECT(agen_finalizer);
+  DECLARE_PY_OBJECT(tmp);
+
+  if (handback_tstate != NULL) {
+    // Entering a promising call yields to the event loop first so this should
+    // not be reachable.
+    PyErr_SetString(PyExc_SystemError,
+                    "Cannot enter a promising task from inside another running "
+                    "promising task. This is a bug in Pyodide.");
+    FAIL();
   }
+
+  // 1. Collect everything the task inherits, while we are still running on the
+  //    caller's thread state.
+  asyncio_module = PyImport_ImportModule("asyncio");
+  FAIL_IF_NULL(asyncio_module);
+  loop = _PyObject_CallMethodIdNoArgs(asyncio_module, &PyId_get_event_loop);
+  if (loop == NULL) {
+    // There is no event loop to propagate.
+    PyErr_Clear();
+  }
+  context = PyContext_CopyCurrent();
+  FAIL_IF_NULL(context);
+  // PyThreadState_GetDict() creates the thread dict if it doesn't exist yet, so
+  // the caller and the task share one.
+  thread_dict = Py_XNewRef(PyThreadState_GetDict());
+  // sys.set_asyncgen_hooks() records the hooks on the thread state, so a task
+  // would otherwise run with no hooks installed and async generators it creates
+  // would never be registered with the event loop that is going to have to shut
+  // them down.
+  PyThreadState* caller_tstate = PyThreadState_Get();
+  agen_firstiter = Py_XNewRef(caller_tstate->async_gen_firstiter);
+  agen_finalizer = Py_XNewRef(caller_tstate->async_gen_finalizer);
+  PyThreadState* tstate = PyThreadState_New(PyInterpreterState_Get());
+  FAIL_IF_NULL(tstate);
+
+  // 2. Swap in task thread state
+  handback_tstate = PyThreadState_Swap(tstate);
+
+  // 3. Populate the new thread state
+  assert(tstate->context == NULL);
+  assert(tstate->dict == NULL);
+  Py_XSETREF(tstate->context, context);
+  context = NULL;
+  Py_XSETREF(tstate->dict, thread_dict);
+  thread_dict = NULL;
+  Py_XSETREF(tstate->async_gen_firstiter, agen_firstiter);
+  agen_firstiter = NULL;
+  Py_XSETREF(tstate->async_gen_finalizer, agen_finalizer);
+  agen_finalizer = NULL;
+  if (loop != NULL) {
+    tmp = _PyObject_CallMethodIdOneArg(
+      asyncio_module, &PyId__set_running_loop, loop);
+    if (tmp == NULL) {
+      // Put back main thread state and fail
+      PyErr_Clear();
+      delete_tstate(PyThreadState_Swap(handback_tstate));
+      handback_tstate = NULL;
+      PyErr_SetString(PyExc_SystemError,
+                      "Unexpected error when entering a promising task");
+      FAIL();
+    }
+  }
+  return 0;
+}
+
+/**
+ * Put back the main thread state and dispose of the current thread state.
+ *
+ * Any pending exception must have been moved out of our thread state before
+ * calling this, see _pyproxy_apply_promising.
+ */
+void
+exit_promising_task(void)
+{
+  PyThreadState* mine = PyThreadState_Swap(handback_tstate);
+  handback_tstate = NULL;
+  delete_tstate(mine);
+}
+
+/**
+ * Return task tstate so that saveState can store it in the JS state object.
+ */
+EMSCRIPTEN_KEEPALIVE PyThreadState*
+captureThreadState(void)
+{
+  if (handback_tstate == NULL) {
+    // validSuspender is supposed to prevent this. If it happens anyway, refuse
+    // rather than detaching the thread state entirely.
+    PyErr_SetString(PyExc_SystemError,
+                    "Cannot stack switch: no thread state to hand control back "
+                    "to. This is a bug in Pyodide.");
+    return NULL;
+  }
+  PyThreadState* mine = PyThreadState_Swap(handback_tstate);
+  handback_tstate = NULL;
+  return mine;
 }
 
 EMSCRIPTEN_KEEPALIVE void
 restoreThreadState(PyThreadState* state)
 {
-  delete_tstate(PyThreadState_Swap(state));
-}
-
-EMSCRIPTEN_KEEPALIVE PyThreadState*
-captureThreadState()
-{
-  FAIL_RETURN_VALUE(NULL);
-  DECLARE_PY_OBJECT(asyncio_module);
-  DECLARE_PY_OBJECT(loop);
-  DECLARE_PY_OBJECT(tmp);
-  PyThreadState* result = NULL;
-
-  // We need to set the event loop in the new thread state to be the same as the
-  // event loop in the old thread state.
-
-  // 1. get the event loop from the old thread state
-  asyncio_module = PyImport_ImportModule("asyncio");
-  FAIL_IF_NULL(asyncio_module);
-  loop = _PyObject_CallMethodIdNoArgs(asyncio_module, &PyId_get_event_loop);
-  FAIL_IF_NULL(loop);
-
-  // 2. swap thread state
-  result = PyThreadState_Swap(new_tstate());
-
-  // 3. set the running event loop in the new thread state
-  tmp =
-    _PyObject_CallMethodIdOneArg(asyncio_module, &PyId__set_running_loop, loop);
-  if (tmp == NULL) {
-    PyErr_Clear();
-    restoreThreadState(result);
-    result = NULL;
-    PyErr_SetString(PyExc_SystemError, "Unexpected error when stack switching");
-    FAIL();
-  }
-
-  return result;
+  handback_tstate = PyThreadState_Swap(state);
 }

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -33,10 +33,6 @@ _Py_IDENTIFIER(_set_running_loop);
  * by returning. It is NULL when the JS event loop is turning or when Python is
  * executing with no suspender.
  *
- * This has to be ambient state rather than a parameter, because a task gives up
- * control from JsvPromise_Syncify(), which sits arbitrarily deep below
- * enter_promising_task() with unknown Python frames in between.
- *
  * A task can only ever take control from the event loop and always returns
  * control to the event loop. So this is always the event loop tstate or NULL.
  * It is a bug to enter or resume a task when this is not NULL.
@@ -46,18 +42,9 @@ static PyThreadState* handback_tstate = NULL;
 /**
  * Dispose of a task's thread state.
  *
- * Note that we deliberately don't pool thread states for reuse. A lot of state
- * is keyed on thread state identity: threading.local() storage hangs off
- * tstate->threading_local_key, the ContextVar cache is keyed on
- * (tstate->id, tstate->context_ver), and the running event loop lives in
- * tstate->asyncio_running_loop. Handing the same thread state to an unrelated
- * task later means invalidating all of it by hand, which we got wrong before
- * and which would need re-auditing on every CPython update. A fresh thread
- * state gets a fresh unique id and PyThreadState_Clear deals with the rest.
- *
- * This must be called with a different thread state installed: PyThreadState_
- * Clear can run Python code (the threading.local() sentinel weakref callback)
- * and requires that the caller isn't running on `tstate`.
+ * We used to keep a freelist of thread states but it seems like there is no way
+ * to reuse thread states correctly. It doesn't take very much time to make a
+ * thread state anyways.
  */
 static void
 delete_tstate(PyThreadState* tstate)
@@ -81,14 +68,6 @@ int
 enter_promising_task(void)
 {
   FAIL_RETURN_VALUE(-1);
-  DECLARE_PY_OBJECT(asyncio_module);
-  DECLARE_PY_OBJECT(loop);
-  DECLARE_PY_OBJECT(context);
-  DECLARE_PY_OBJECT(thread_dict);
-  DECLARE_PY_OBJECT(agen_firstiter);
-  DECLARE_PY_OBJECT(agen_finalizer);
-  DECLARE_PY_OBJECT(tmp);
-
   if (handback_tstate != NULL) {
     // Entering a promising call yields to the event loop first so this should
     // not be reachable.
@@ -100,30 +79,62 @@ enter_promising_task(void)
 
   // 1. Collect everything the task inherits, while we are still running on the
   //    caller's thread state.
+  DECLARE_PY_OBJECT(asyncio_module);
   asyncio_module = PyImport_ImportModule("asyncio");
   FAIL_IF_NULL(asyncio_module);
+  DECLARE_PY_OBJECT(loop);
   loop = _PyObject_CallMethodIdNoArgs(asyncio_module, &PyId_get_event_loop);
   if (loop == NULL) {
     // There is no event loop to propagate.
     PyErr_Clear();
   }
+  DECLARE_PY_OBJECT(context);
   context = PyContext_CopyCurrent();
   FAIL_IF_NULL(context);
   // PyThreadState_GetDict() creates the thread dict if it doesn't exist yet, so
   // the caller and the task share one.
+  DECLARE_PY_OBJECT(thread_dict);
   thread_dict = Py_XNewRef(PyThreadState_GetDict());
   // sys.set_asyncgen_hooks() records the hooks on the thread state, so a task
   // would otherwise run with no hooks installed and async generators it creates
   // would never be registered with the event loop that is going to have to shut
   // them down.
   PyThreadState* caller_tstate = PyThreadState_Get();
+  DECLARE_PY_OBJECT(agen_firstiter);
   agen_firstiter = Py_XNewRef(caller_tstate->async_gen_firstiter);
+  DECLARE_PY_OBJECT(agen_finalizer);
   agen_finalizer = Py_XNewRef(caller_tstate->async_gen_finalizer);
+  // All tasks should see the same thread locals since there is only one thread.
+  // Thread locals are created lazily on first use, so force them to exist on
+  // the caller and then share them by reference
+  if (caller_tstate->threading_local_key == NULL) {
+    DECLARE_PY_OBJECT(threading_module);
+    threading_module = PyImport_ImportModule("threading");
+    FAIL_IF_NULL(threading_module);
+    DECLARE_PY_OBJECT(threading_local);
+    threading_local = PyObject_CallMethod(threading_module, "local", NULL);
+    FAIL_IF_NULL(threading_local);
+    // Reading an attribute is what triggers the lazy creation.
+    Py_XSETREF(tmp, PyObject_GetAttrString(threading_local, "__dict__"));
+    FAIL_IF_NULL(threading_local);
+  }
+  DECLARE_PY_OBJECT(tlocal_key);
+  tlocal_key = Py_XNewRef(caller_tstate->threading_local_key);
+  DECLARE_PY_OBJECT(tlocal_sentinel);
+  tlocal_sentinel = Py_XNewRef(caller_tstate->threading_local_sentinel);
   PyThreadState* tstate = PyThreadState_New(PyInterpreterState_Get());
   FAIL_IF_NULL(tstate);
 
   // 2. Swap in task thread state
   handback_tstate = PyThreadState_Swap(tstate);
+  ON_FAIL({
+    // Restore thread state on failure
+    PyErr_Clear();
+    delete_tstate(PyThreadState_Swap(handback_tstate));
+    handback_tstate = NULL;
+    PyErr_SetString(PyExc_SystemError,
+                    "Unexpected error when entering a promising task");
+  });
 
   // 3. Populate the new thread state
   assert(tstate->context == NULL);
@@ -136,18 +147,15 @@ enter_promising_task(void)
   agen_firstiter = NULL;
   Py_XSETREF(tstate->async_gen_finalizer, agen_finalizer);
   agen_finalizer = NULL;
+  Py_XSETREF(tstate->threading_local_key, tlocal_key);
+  tlocal_key = NULL;
+  Py_XSETREF(tstate->threading_local_sentinel, tlocal_sentinel);
+  tlocal_sentinel = NULL;
   if (loop != NULL) {
-    tmp = _PyObject_CallMethodIdOneArg(
+    DECLARE_PY_OBJECT(res);
+    res = _PyObject_CallMethodIdOneArg(
       asyncio_module, &PyId__set_running_loop, loop);
-    if (tmp == NULL) {
-      // Put back main thread state and fail
-      PyErr_Clear();
-      delete_tstate(PyThreadState_Swap(handback_tstate));
-      handback_tstate = NULL;
-      PyErr_SetString(PyExc_SystemError,
-                      "Unexpected error when entering a promising task");
-      FAIL();
-    }
+    FAIL_IF_NILL(res);
   }
   return 0;
 }

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -95,10 +95,8 @@ enter_promising_task(void)
   // the caller and the task share one.
   DECLARE_PY_OBJECT(thread_dict);
   thread_dict = Py_XNewRef(PyThreadState_GetDict());
-  // sys.set_asyncgen_hooks() records the hooks on the thread state, so a task
-  // would otherwise run with no hooks installed and async generators it creates
-  // would never be registered with the event loop that is going to have to shut
-  // them down.
+  // sys.set_asyncgen_hooks() records the hooks on the thread state so we need
+  // to copy them over with the event loop.
   PyThreadState* caller_tstate = PyThreadState_Get();
   DECLARE_PY_OBJECT(agen_firstiter);
   agen_firstiter = Py_XNewRef(caller_tstate->async_gen_firstiter);
@@ -106,7 +104,7 @@ enter_promising_task(void)
   agen_finalizer = Py_XNewRef(caller_tstate->async_gen_finalizer);
   // All tasks should see the same thread locals since there is only one thread.
   // Thread locals are created lazily on first use, so force them to exist on
-  // the caller and then share them by reference
+  // the caller.
   if (caller_tstate->threading_local_key == NULL) {
     DECLARE_PY_OBJECT(threading_module);
     threading_module = PyImport_ImportModule("threading");

--- a/src/core/stack_switching/stack_state.mjs
+++ b/src/core/stack_switching/stack_state.mjs
@@ -95,25 +95,37 @@ export function enterTask() {
   }
 }
 
-function evictStackUpTo(stop) {
+/**
+ * Save and remove every continuation that has data below `stop`, so that the
+ * caller is free to use the arg stack from `stop` downwards.
+ *
+ * self is the continuation we are about to restore, if any. It is on the
+ * stackStates list because save_state put it there when it suspended but there
+ * is no point in saving its data because we are about to restore it.
+ * Technically it would make sense to leave it on the list, but we will add it
+ * back if we suspend again and if we exit normally it gets removed from the
+ * stack.
+ *
+ * @private
+ */
+function evictStackUpTo(stop, self) {
   let total = 0;
+  // Start by removing self from stackStates
+  if (self) {
+    const idx = stackStates.lastIndexOf(self);
+    if (idx !== -1) {
+      stackStates.splice(idx, 1);
+    }
+  }
   // Search up the stack for things that need to be ejected in their entirety
   // and save them
-  while (stackStates.length > 0 && stackStates.at(-1).stop < stop) {
+  while (stackStates.length > 0 && stackStates.at(-1).stop <= stop) {
     total += stackStates.pop()._save();
   }
   // Part of one more object may need to be ejected.
   const last = stackStates.at(-1);
-  if (last && last.stop !== stop) {
+  if (last) {
     total += last._save_up_to(stop);
-  }
-  // If we just saved all of the last stackState it needs to be removed.
-  // Alternatively, the current StackState may be on the stackStates list.
-  // Technically it would make sense to leave it there, but we will add it
-  // back if we suspend again and if we exit normally it gets removed from the
-  // stack.
-  if (last && last.stop === stop) {
-    stackStates.pop();
   }
   return total;
 }
@@ -159,7 +171,7 @@ export class StackState {
    * @returns How much data we copied. (Only for debugging purposes.)
    */
   restore() {
-    let total = evictStackUpTo(this.stop);
+    let total = evictStackUpTo(this.stop, this);
     if (this._copy.length !== 0) {
       // Now that we've saved everything that might be in our way we can restore
       // the current stack data if need be.

--- a/src/core/stack_switching/suspenders.c
+++ b/src/core/stack_switching/suspenders.c
@@ -52,22 +52,24 @@ EM_JS(void, JsvPromise_Syncify_handleError, (void), {
 })
 
 /**
- * Record the current Python thread state and the wasm call stack and argument
- * stack state. This is called by the hiwire_syncify wasm module just prior to
- * suspending the thread. `hiwire_syncify` uses `externref` for the return value
- * so we don't need to wrap this in a hiwire ID.
+ * Record the task thread state and the wasm call stack and argument stack
+ * state. This is called by the JsvPromise_syncify just prior to suspending the
+ * thread.
+ *
+ * _captureThreadState() also restores control to the main thread state, see
+ * pystate.c.
  */
 EM_JS(JsVal, saveState, (void), {
   if (!validSuspender.value) {
     return Module.error;
   }
-  const stackState = new StackState();
   const threadState = _captureThreadState();
   // clang-format off
   if (threadState === 0) {
     return Module.error;
   }
   // clang-format on
+  const stackState = new StackState();
   return {
     threadState,
     stackState,
@@ -77,8 +79,8 @@ EM_JS(JsVal, saveState, (void), {
 
 /**
  * Restore the Python thread state and the wasm argument stack state. This is
- * called by the hiwire_syncify wasm module upon resuming the thread. The
- * argument is the return value from save_state.
+ * called by JsvPromise_syncify upon resuming the thread. The argument is the
+ * return value from save_state.
  */
 EM_JS(void, restoreState, (JsVal state), {
   state.stackState.restore();

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -272,6 +272,20 @@ class WebLoop(asyncio.AbstractEventLoop):
         if not self.is_closed():
             self.call_soon(asyncio.ensure_future, agen.aclose())
 
+    def _install_running_loop(self) -> None:
+        """Make ourselves the running loop on the current thread state.
+
+        asyncio._set_running_loop() records the loop on the thread state, and
+        with stack switching enabled each call runs on a thread state of its
+        own. A loop constructed inside such a call would otherwise only ever be
+        registered as running there, and that thread state goes away when the
+        call finishes. asyncio's enter_task() requires the thread state running
+        a task's callbacks to have that task's loop registered, so we have to
+        claim the spot every time we dispatch a handle.
+        """
+        if asyncio._get_running_loop() is not self:
+            asyncio._set_running_loop(self)
+
     def _install_asyncgen_hooks(self) -> None:
         """Install async generator hooks on the current thread state.
 
@@ -468,6 +482,7 @@ class WebLoop(asyncio.AbstractEventLoop):
             return h
 
         def run_handle():
+            self._install_running_loop()
             self._install_asyncgen_hooks()
 
             if h.cancelled():

--- a/src/py/pyodide/webloop.py
+++ b/src/py/pyodide/webloop.py
@@ -273,11 +273,20 @@ class WebLoop(asyncio.AbstractEventLoop):
             self.call_soon(asyncio.ensure_future, agen.aclose())
 
     def _install_asyncgen_hooks(self) -> None:
-        """Install async generator hooks if not already installed."""
-        if self._old_agen_hooks is not None:
+        """Install async generator hooks on the current thread state.
+
+        sys.set_asyncgen_hooks() records the hooks on the thread state rather
+        than globally, and with stack switching enabled each task runs on a
+        thread state of its own, so we have to check every time instead of only
+        once per loop. Note that bound methods compare equal but are not
+        identical, so this has to be `==`.
+        """
+        current = sys.get_asyncgen_hooks()
+        if current.firstiter == self._asyncgen_firstiter_hook:
             return
 
-        self._old_agen_hooks = sys.get_asyncgen_hooks()
+        if self._old_agen_hooks is None:
+            self._old_agen_hooks = current
         sys.set_asyncgen_hooks(
             firstiter=self._asyncgen_firstiter_hook,
             finalizer=self._asyncgen_finalizer_hook,

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -856,3 +856,594 @@ def test_return_promising_no_crash(selenium):
         task.destroy();
         """
     )
+
+
+# The following tests cover the thread state ownership model described at the
+# top of src/core/stack_switching/pystate.c. A promising task owns a thread
+# state of its own for its whole lifetime.
+
+SUSPEND_ON_PROMISE_SETUP = """
+    pyodide.runPython(`
+        from pyodide.ffi import run_sync
+
+        def suspend_on(p, before=None, after=None):
+            if before is not None:
+                before()
+            run_sync(p)
+            if after is not None:
+                return after()
+    `);
+    // Start a promising call that suspends until we resolve the returned
+    // trigger. Waits until the task has really suspended before returning.
+    const suspend_on = pyodide.globals.get("suspend_on");
+    async function startSuspendedTask(before, after) {
+        let resolve;
+        const p = new Promise((res) => { resolve = res; });
+        const done = suspend_on.callPromising(p, before, after);
+        // callPromising yields to the event loop before it even enters Python, so
+        // we have to wait for the task to actually reach run_sync().
+        await new Promise((res) => setTimeout(res, 50));
+        return { resolve, done };
+    }
+"""
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_contextvars_ambient_context_survives_switch(selenium):
+    """The context of the event loop turn must not be carried off by a task.
+
+    Previously the suspending task took the caller's thread state with it and
+    handed the caller a brand new one, so top level code lost its contextvars for
+    the duration of the switch.
+    """
+    result = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import contextvars
+            cvar = contextvars.ContextVar("cvar", default="<lost>")
+            cvar.set("TOP-LEVEL")
+            observe = lambda: cvar.get()
+            copied = lambda: contextvars.copy_context().get(cvar, "<absent>")
+        `);
+        """
+        + SUSPEND_ON_PROMISE_SETUP
+        + """
+        const observe = pyodide.globals.get("observe");
+        const copied = pyodide.globals.get("copied");
+        const out = { before: observe() };
+        const task = await startSuspendedTask();
+        out.during = observe();
+        out.duringCopyContext = copied();
+        task.resolve();
+        await task.done;
+        out.after = observe();
+        suspend_on.destroy();
+        observe.destroy();
+        copied.destroy();
+        return out;
+        """
+    )
+    assert result == {
+        "before": "TOP-LEVEL",
+        "during": "TOP-LEVEL",
+        "duringCopyContext": "TOP-LEVEL",
+        "after": "TOP-LEVEL",
+    }
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_contextvars_survive_interleaved_switches(selenium):
+    """Stack switches are not properly nested.
+
+    Resume A, finish A, then resume B. Previously each resume destroyed whichever
+    thread state happened to be current, so the event loop's thread state ended up
+    recycled and top level contextvars and threading.local() state were lost.
+    """
+    result = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import contextvars, threading
+            cvar = contextvars.ContextVar("cvar", default="<lost>")
+            cvar.set("TOP-LEVEL")
+            tls = threading.local()
+            tls.value = "TOP-LEVEL-TLS"
+            def observe():
+                return [cvar.get(), getattr(tls, "value", "<lost>")]
+        `);
+        """
+        + SUSPEND_ON_PROMISE_SETUP
+        + """
+        const observe = pyodide.globals.get("observe");
+        const a = await startSuspendedTask();
+        const b = await startSuspendedTask();
+        // Deliberately not LIFO.
+        a.resolve();
+        await a.done;
+        b.resolve();
+        await b.done;
+        const observed = observe();
+        const out = observed.toJs();
+        observed.destroy();
+        suspend_on.destroy();
+        observe.destroy();
+        return out;
+        """
+    )
+    assert result == ["TOP-LEVEL", "TOP-LEVEL-TLS"]
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_contextvars_task_writes_are_isolated(selenium):
+    """A task inherits a *copy* of its caller's context, like asyncio.Task does.
+
+    So it can read what the caller set, but its own writes don't leak back out to
+    the caller or into any later task. Previously a task's writes leaked out
+    through the recycled thread state and showed up in a completely unrelated
+    stack switch.
+    """
+    result = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import contextvars
+            cvar = contextvars.ContextVar("cvar", default="<default>")
+            cvar.set("CALLER")
+            observe = lambda: cvar.get()
+            def poison():
+                cvar.set("TASK-ONLY")
+        `);
+        """
+        + SUSPEND_ON_PROMISE_SETUP
+        + """
+        const observe = pyodide.globals.get("observe");
+        const poison = pyodide.globals.get("poison");
+        const out = {};
+        // A task that reads the caller's context, then overwrites it and keeps the
+        // value set across a suspension.
+        let task = await startSuspendedTask(poison, observe);
+        task.resolve();
+        out.insideTask = await task.done;
+        out.callerAfterTask = observe();
+        // A second, unrelated task must not see the first task's write. It reuses
+        // the first task's thread state via the freelist.
+        task = await startSuspendedTask(undefined, observe);
+        task.resolve();
+        out.insideLaterTask = await task.done;
+        suspend_on.destroy();
+        observe.destroy();
+        poison.destroy();
+        return out;
+        """
+    )
+    assert result == {
+        "insideTask": "TASK-ONLY",
+        "callerAfterTask": "CALLER",
+        "insideLaterTask": "CALLER",
+    }
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_contextvars_released_after_task(selenium):
+    """A recycled thread state must not pin the context it used to hold."""
+    alive = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import contextvars, gc, weakref
+            cvar = contextvars.ContextVar("cvar", default=None)
+            ref = None
+            class Big:
+                pass
+            def poison():
+                global ref
+                o = Big()
+                ref = weakref.ref(o)
+                cvar.set(o)
+            def still_alive():
+                gc.collect()
+                return ref() is not None
+        `);
+        """
+        + SUSPEND_ON_PROMISE_SETUP
+        + """
+        const poison = pyodide.globals.get("poison");
+        const still_alive = pyodide.globals.get("still_alive");
+        let task = await startSuspendedTask(poison);
+        task.resolve();
+        await task.done;
+        // Churn enough tasks to push the thread state out of the freelist too.
+        for (let i = 0; i < 15; i++) {
+            task = await startSuspendedTask();
+            task.resolve();
+            await task.done;
+        }
+        const out = still_alive();
+        suspend_on.destroy();
+        poison.destroy();
+        still_alive.destroy();
+        return out;
+        """
+    )
+    assert alive is False
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+@run_in_pyodide
+async def test_contextvars_concurrent_tasks(selenium):
+    """Concurrent coroutines that syncify in the middle must not see each other's
+    contextvars, and tasks they spawn must inherit the right context."""
+    import asyncio
+    import contextvars
+
+    from js import sleep as js_sleep
+    from pyodide.ffi import run_sync
+
+    request_id = contextvars.ContextVar("request_id", default="<none>")
+
+    async def handle(rid, delay):
+        request_id.set(rid)
+        run_sync(js_sleep(delay))
+        assert request_id.get() == rid, f"after run_sync: {request_id.get()}"
+
+        async def child():
+            return request_id.get()
+
+        assert await asyncio.ensure_future(child()) == rid
+        return request_id.get()
+
+    # B finishes its switch before A does, so the two switches interleave.
+    assert list(await asyncio.gather(handle("REQ-A", 60), handle("REQ-B", 20))) == [
+        "REQ-A",
+        "REQ-B",
+    ]
+    assert request_id.get() == "<none>"
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+@run_in_pyodide
+def test_asyncio_running_loop_in_task(selenium):
+    """The running event loop lives on the thread state, so a task with a thread
+    state of its own has to inherit it from its caller."""
+    import asyncio
+
+    from pyodide.code import run_js
+
+    loop = asyncio.get_event_loop()
+
+    async def test():
+        assert asyncio.get_running_loop() is loop
+        p = run_js("[sleep(50).then(() => 11)]")[0]
+        from pyodide.ffi import run_sync
+
+        assert run_sync(p) == 11
+        assert asyncio.get_running_loop() is loop
+        return 5
+
+    assert loop.run_until_complete(test()) == 5
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_contextvars_three_interleaved_tasks(selenium):
+    """Three tasks, each suspending twice, resumed in an order unrelated to the
+    order they suspended in.
+
+    Each task must keep seeing its own contextvar value across both of its
+    suspensions, must have inherited the caller's value on entry, and must not
+    disturb the caller's value or each other's.
+    """
+    result = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import contextvars
+            from pyodide.ffi import run_sync
+            cvar = contextvars.ContextVar("cvar", default="<unset>")
+            cvar.set("ROOT")
+
+            def task(name, first, second):
+                inherited = cvar.get()
+                cvar.set(name)
+                run_sync(first)
+                after_first = cvar.get()
+                run_sync(second)
+                return [inherited, after_first, cvar.get()]
+
+            observe = lambda: cvar.get()
+        `);
+        const task = pyodide.globals.get("task");
+        const observe = pyodide.globals.get("observe");
+        const tick = () => new Promise((res) => setTimeout(res, 50));
+
+        // Start a task and wait for it to reach its first run_sync().
+        const started = {};
+        function start(name) {
+            let first, second;
+            const p1 = new Promise((res) => { first = res; });
+            const p2 = new Promise((res) => { second = res; });
+            const done = task.callPromising(name, p1, p2);
+            started[name] = { first, second, done };
+        }
+        start("A");
+        start("B");
+        start("C");
+        await tick();
+        const duringAll = observe();
+
+        // Release the first suspension in a different order than they started.
+        started.C.first();
+        await tick();
+        started.A.first();
+        await tick();
+        started.B.first();
+        await tick();
+        const duringSecond = observe();
+
+        // And the second suspension in yet another order.
+        started.B.second();
+        started.C.second();
+        started.A.second();
+        const out = {};
+        for (const name of ["A", "B", "C"]) {
+            const res = await started[name].done;
+            out[name] = res.toJs();
+            res.destroy();
+        }
+        out.duringAll = duringAll;
+        out.duringSecond = duringSecond;
+        out.atEnd = observe();
+        task.destroy();
+        observe.destroy();
+        return out;
+        """
+    )
+    assert result == {
+        # Each task inherits ROOT, then only ever sees its own value.
+        "A": ["ROOT", "A", "A"],
+        "B": ["ROOT", "B", "B"],
+        "C": ["ROOT", "C", "C"],
+        # The event loop turn keeps its own context the whole way through.
+        "duringAll": "ROOT",
+        "duringSecond": "ROOT",
+        "atEnd": "ROOT",
+    }
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_contextvars_task_spawned_from_running_task(selenium):
+    """Two parent tasks that each re-enter Python from JS while running.
+
+    A1 suspends, B1 suspends, A1 resumes and calls out to JS which uses
+    callPromising() to call back into Python and start A2 (without awaiting it),
+    A1 suspends again, A2 starts and suspends. Same for B1/B2. Then they exit in
+    the order A1, B1, A2, B2, i.e. the parents finish before their children and
+    nothing unwinds in the order it was created.
+
+    Note that A2 inherits the event loop turn's context, not A1's, even though
+    A1 is what triggered it. It means callPromising() behaves like "spawn on the
+    event loop" rather than like loop.call_soon(), which captures the caller's
+    context.
+    """
+    order, results, observations = selenium.run_js(
+        """
+        const results = [];
+        const observations = {};
+        pyodide.globals.set("results", results);
+        pyodide.runPython(`
+            import contextvars
+            from pyodide.ffi import run_sync, to_js
+            cvar = contextvars.ContextVar("cvar", default="<unset>")
+            cvar.set("ROOT")
+
+            def parent(name, first, second, spawn):
+                inherited = cvar.get()
+                cvar.set(name)
+                run_sync(first)
+                # Re-enter Python from JS while we are running. This returns a
+                # pending promise; we deliberately don't wait for the child.
+                spawn()
+                mid = cvar.get()
+                run_sync(second)
+                results.append(to_js([name, inherited, mid, cvar.get()]))
+                return name
+
+            def child(name, only):
+                inherited = cvar.get()
+                cvar.set(name)
+                run_sync(only)
+                results.append(to_js([name, inherited, cvar.get()]))
+                return name
+
+            observe = lambda: cvar.get()
+        `);
+        const parent = pyodide.globals.get("parent");
+        const child = pyodide.globals.get("child");
+        const observe = pyodide.globals.get("observe");
+        const tick = () => new Promise((res) => setTimeout(res, 50));
+
+        function trigger() {
+            let release;
+            const promise = new Promise((res) => { release = res; });
+            return { promise, release };
+        }
+        const a1 = { first: trigger(), second: trigger() };
+        const b1 = { first: trigger(), second: trigger() };
+        const a2 = trigger();
+        const b2 = trigger();
+
+        const order = [];
+        const children = {};
+        // Handed to Python and called from inside the running parent.
+        function spawn(name, t) {
+            return () => {
+                children[name] = child.callPromising(name, t.promise);
+            };
+        }
+
+        const a1done = parent.callPromising(
+            "A1", a1.first.promise, a1.second.promise, spawn("A2", a2));
+        await tick();
+        const b1done = parent.callPromising(
+            "B1", b1.first.promise, b1.second.promise, spawn("B2", b2));
+        await tick();
+        observations.a1AndB1Suspended = observe();
+
+        // A1 resumes, spawns A2, suspends again; then A2 starts and suspends.
+        a1.first.release();
+        await tick();
+        // Same for B1/B2.
+        b1.first.release();
+        await tick();
+        observations.allFourSuspended = observe();
+
+        // Exit A1, B1, A2, B2 -- parents before children.
+        a1.second.release();
+        order.push(await a1done);
+        await tick();
+        observations.afterA1AndNothingElse = observe();
+
+        b1.second.release();
+        order.push(await b1done);
+        await tick();
+        observations.afterBothParents = observe();
+
+        a2.release();
+        order.push(await children.A2);
+        await tick();
+        observations.afterA2 = observe();
+
+        b2.release();
+        order.push(await children.B2);
+        await tick();
+        observations.atEnd = observe();
+
+        parent.destroy();
+        child.destroy();
+        observe.destroy();
+        return [order, results, observations];
+        """
+    )
+    assert order == ["A1", "B1", "A2", "B2"]
+    # [name, context inherited on entry, ...context seen after each suspension]
+    assert sorted(results) == [
+        ["A1", "ROOT", "A1", "A1"],
+        ["A2", "ROOT", "A2"],
+        ["B1", "ROOT", "B1", "B1"],
+        ["B2", "ROOT", "B2"],
+    ]
+    # The event loop turn keeps its own context no matter how the four tasks
+    # interleave, including after some of them have exited.
+    assert observations == {
+        "a1AndB1Suspended": "ROOT",
+        "allFourSuspended": "ROOT",
+        "afterA1AndNothingElse": "ROOT",
+        "afterBothParents": "ROOT",
+        "afterA2": "ROOT",
+        "atEnd": "ROOT",
+    }
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_thread_state_not_reused_between_tasks(selenium):
+    """A task must not inherit anything from an unrelated task that ran before.
+
+    threading.local() storage hangs off tstate->threading_local_key rather than
+    off the thread dict, so it follows thread state identity.
+    """
+    seen, top_level = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import threading
+            from pyodide.ffi import run_sync
+            loc = threading.local()
+
+            def task(name, p):
+                before = getattr(loc, "v", "<unset>")
+                loc.v = name
+                run_sync(p)
+                return before
+        `);
+        const task = pyodide.globals.get("task");
+        const seen = [];
+        // Run the tasks one after another so each one is free to pick up the
+        // thread state the previous one finished with.
+        for (const name of ["A", "B", "C"]) {
+            let release;
+            const promise = new Promise((res) => { release = res; });
+            const done = task.callPromising(name, promise);
+            await new Promise((res) => setTimeout(res, 20));
+            release();
+            seen.push(await done);
+        }
+        task.destroy();
+        return [seen, pyodide.runPython(`getattr(loc, "v", "<unset>")`)];
+        """
+    )
+    # Every task starts with an empty threading.local(), including after two
+    # other tasks have set a value and exited.
+    assert seen == ["<unset>", "<unset>", "<unset>"]
+    # ...and top level never sees the tasks' values either.
+    assert top_level == "<unset>"
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_task_inherits_asyncgen_hooks(selenium):
+    """sys.set_asyncgen_hooks() applies inside promising tasks.
+
+    The hooks are recorded on the thread state, and a task runs on a thread
+    state of its own, so it has to inherit them from its caller. Otherwise an
+    async generator created inside a task is never handed to the hook that is
+    supposed to arrange for it to be closed.
+    """
+    seen = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import sys
+            from pyodide.ffi import run_sync
+
+            seen = []
+
+            async def agen():
+                yield 1
+
+            def drive():
+                # Start the async generator on this thread state. The firstiter
+                # hook fires on the first __anext__().
+                g = agen()
+                try:
+                    g.__anext__().send(None)
+                except StopIteration:
+                    pass
+
+            def task(p):
+                # Suspend and resume first, so we also cover the hooks
+                # surviving a round trip through the event loop.
+                run_sync(p)
+                drive()
+                return seen
+
+            sys.set_asyncgen_hooks(
+                firstiter=lambda ag: seen.append(ag.__name__),
+                finalizer=lambda ag: None,
+            )
+        `);
+        const task = pyodide.globals.get("task");
+        let release;
+        const promise = new Promise((res) => { release = res; });
+        const done = task.callPromising(promise);
+        await new Promise((res) => setTimeout(res, 20));
+        release();
+        const res = await done;
+        const out = res.toJs();
+        res.destroy();
+        task.destroy();
+        return out;
+        """
+    )
+    assert seen == ["agen"]

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -1348,46 +1348,58 @@ def test_contextvars_task_spawned_from_running_task(selenium):
 
 @requires_jspi
 @pytest.mark.requires_dynamic_linking
-def test_thread_state_not_reused_between_tasks(selenium):
-    """A task must not inherit anything from an unrelated task that ran before.
+def test_threading_local_shared_with_tasks(selenium):
+    """threading.local() is shared with calls that stack switch.
 
-    threading.local() storage hangs off tstate->threading_local_key rather than
-    off the thread dict, so it follows thread state identity.
+    There is only one thread. threading.get_ident() and
+    threading.current_thread() report the same thing inside a call that stack
+    switches as they do outside one, so threading.local() has to agree with
+    them. That needs doing explicitly: each call runs on a thread state of its
+    own and threading.local() storage is keyed on the thread state (via
+    tstate->threading_local_key) rather than living in the thread dict.
     """
-    seen, top_level = selenium.run_js(
+    ident_match, seen, top_level = selenium.run_js(
         """
         pyodide.runPython(`
             import threading
             from pyodide.ffi import run_sync
             loc = threading.local()
+            loc.v = "TOP"
+            top_ident = threading.get_ident()
 
             def task(name, p):
                 before = getattr(loc, "v", "<unset>")
                 loc.v = name
                 run_sync(p)
-                return before
+                return [before, threading.get_ident() == top_ident]
         `);
         const task = pyodide.globals.get("task");
         const seen = [];
-        // Run the tasks one after another so each one is free to pick up the
-        // thread state the previous one finished with.
-        for (const name of ["A", "B", "C"]) {
+        let identMatch = true;
+        // Run the calls one after another, so each one starts after the
+        // previous one has finished and released its thread state.
+        for (const name of ["A", "B"]) {
             let release;
             const promise = new Promise((res) => { release = res; });
             const done = task.callPromising(name, promise);
             await new Promise((res) => setTimeout(res, 20));
             release();
-            seen.push(await done);
+            const res = await done;
+            seen.push(res.get(0));
+            identMatch = identMatch && res.get(1);
+            res.destroy();
         }
         task.destroy();
-        return [seen, pyodide.runPython(`getattr(loc, "v", "<unset>")`)];
+        return [identMatch, seen, pyodide.runPython(`loc.v`)];
         """
     )
-    # Every task starts with an empty threading.local(), including after two
-    # other tasks have set a value and exited.
-    assert seen == ["<unset>", "<unset>", "<unset>"]
-    # ...and top level never sees the tasks' values either.
-    assert top_level == "<unset>"
+    # The calls really are on the thread they claim to be on.
+    assert ident_match
+    # Each call sees what the previous writer left, whether that was top level
+    # or another call...
+    assert seen == ["TOP", "A"]
+    # ...and top level sees what the calls wrote.
+    assert top_level == "B"
 
 
 @requires_jspi
@@ -1446,3 +1458,45 @@ def test_task_inherits_asyncgen_hooks(selenium):
         """
     )
     assert seen == ["agen"]
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+def test_new_event_loop_inside_task(selenium):
+    """A call that stack switches can create and drive its own event loop.
+
+    WebLoop.__init__ registers itself as the running loop, which records it on
+    the current thread state. A call runs on a thread state of its own, so a
+    loop built there used to be registered only on a thread state that goes
+    away when the call finishes. Its handles run on the event loop's thread
+    state, where asyncio's enter_task() then refused to step the task with
+    "loop ... is not the running loop", and the call hung forever. This is what
+    pytest-asyncio does for every async test.
+    """
+    result = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import asyncio
+
+            async def coro():
+                await asyncio.sleep(0)
+                return "ok"
+
+            def task():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                try:
+                    return loop.run_until_complete(coro())
+                finally:
+                    loop.close()
+        `);
+        const task = pyodide.globals.get("task");
+        const result = await Promise.race([
+            task.callPromising(),
+            new Promise((res) => setTimeout(() => res("<hung>"), 10000)),
+        ]);
+        task.destroy();
+        return result;
+        """
+    )
+    assert result == "ok"

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -1006,8 +1006,7 @@ def test_contextvars_task_writes_are_isolated(selenium):
         task.resolve();
         out.insideTask = await task.done;
         out.callerAfterTask = observe();
-        // A second, unrelated task must not see the first task's write. It reuses
-        // the first task's thread state via the freelist.
+        // A second, unrelated task must not see the first task's write.
         task = await startSuspendedTask(undefined, observe);
         task.resolve();
         out.insideLaterTask = await task.done;
@@ -1053,7 +1052,7 @@ def test_contextvars_released_after_task(selenium):
         let task = await startSuspendedTask(poison);
         task.resolve();
         await task.done;
-        // Churn enough tasks to push the thread state out of the freelist too.
+        // Churn some tasks
         for (let i = 0; i < 15; i++) {
             task = await startSuspendedTask();
             task.resolve();


### PR DESCRIPTION
This fixes several bugs in how the Python thread state is managed when stack switching, which made contextvars misbehave pretty badly when stack switching. It also fixes a few unrelated bugs that turned up while debugging the contextvars.

Previously, contextvars changed around fairly unpredictably and could cross from one task to another unrelated task. This ensures that context variable changes stay local to the current stack switching task.

There were quite a few different problems:

1. We previously called `PyThreadState_Delete()` without calling `PyThreadState_Clear()` which is required per the docs.
2. We used a free list of thread states. These thread states have a bunch of different state on them which propagated from one task to another. We can't clean up the tstate state without calling `PyThreadState_Clear()` but that leaves the thread state in a state where it cannot be used. Thus, to keep state separate, we have to get rid of the free list. The runtime cost of this doesn't seem to be very high anyways.
3. In order to prevent stack switching from unpredictably changing top level contextvars, we need to create a new tstate when we start a promising task, not just when we stack switch. I added a new `enter_promising_task()` and `exit_promising_task()` pair that happen around `promisingApply`. This makes things a lot easier to reason about.
4. In addition to the event loop, we also need to save/restore the context variables, the threading locals, and the async generator hooks.
5. When restoring the spill stack state, we used to detect the current task by comparing `stackState.stop` to the stack states on the stack. However, it's possible that the current task has been completely ejected from the stack but another stack state has exactly the same stack stop. In this case, the logic was buggy. Now we compare by object identity to ensure the correct stack state is ejected.
