### PR TITLE
Stop setting next tag for stable release

### DIFF
--- a/tools/deploy_to_npm.sh
+++ b/tools/deploy_to_npm.sh
@@ -40,7 +40,7 @@ elif [[ ${JS_VERSION} =~ (alpha|beta|rc|dev) ]]; then
     npm publish --tag next --loglevel verbose
 else
     echo "Publishing a stable release"
-    npm publish --tag next --loglevel verbose
+    npm publish --loglevel verbose
 fi
 
 rm -f README.md


### PR DESCRIPTION
Look like adding next tag prevents npm from making the stable release as latest. We probably need to figure out how to handle these tags, but for now removing it for next patch release.