### PR TITLE
Link to changelog inside github release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,21 +522,12 @@ jobs:
             tar czf dist/xbuildenv-${CIRCLE_TAG}.tar.gz  xbuildenv/
             tar czf dist/xbuildenv-debug-${CIRCLE_TAG}.tar.gz  -C debug xbuildenv
 
-            # If it has an 'a' in the tag it's an alpha so mark it as a prelease
-            [[ "${CIRCLE_TAG}" =~ a ]] && export MAYBE_PRE_RELEASE=-prerelease
-
-            # Options have to come first, last two lines have to be
-            # ${CIRCLE_TAG} and dist.
-            # TODO: Should we get rid of -delete?
-            /tmp/ghr-bin \
-              -t "${GITHUB_TOKEN}" \
-              -u "${CIRCLE_PROJECT_USERNAME}" \
-              -r "${CIRCLE_PROJECT_REPONAME}" \
-              -c "${CIRCLE_SHA1}" \
-              -b "See changes at https://pyodide.org/en/stable/project/changelog.html#change-log" \
-              -delete \
-              ${MAYBE_PRE_RELEASE} \
-              "${CIRCLE_TAG}" \
+            python3 ~/repo/tools/make_ghr_release.py \
+              --ghr-bin /tmp/ghr-bin \
+              --tag "${CIRCLE_TAG}" \
+              --commit "${CIRCLE_SHA1}" \
+              --owner "${CIRCLE_PROJECT_USERNAME}" \
+              --repo "${CIRCLE_PROJECT_REPONAME}" \
               dist
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,6 +533,7 @@ jobs:
               -u "${CIRCLE_PROJECT_USERNAME}" \
               -r "${CIRCLE_PROJECT_REPONAME}" \
               -c "${CIRCLE_SHA1}" \
+              -b "See changes at https://pyodide.org/en/stable/project/changelog.html#change-log" \
               -delete \
               ${MAYBE_PRE_RELEASE} \
               "${CIRCLE_TAG}" \

--- a/tools/make_ghr_release.py
+++ b/tools/make_ghr_release.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Create a GitHub release for a Pyodide tag with the ghr tool.
+
+For stable releases, the release body links to the section of the changelog for
+the released version. For alpha releases, we link to the changelog in the
+repository at the tag.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CHANGELOG_PATH = Path(__file__).parents[1] / "docs/project/changelog.md"
+CHANGELOG_URL = "https://pyodide.org/en/stable/project/changelog.html"
+CHANGELOG_TOP_ANCHOR = "change-log"
+CHANGELOG_PRERELEASE_URL = (
+    "https://github.com/pyodide/pyodide/blob/{tag}/docs/project/changelog.md#unreleased"
+)
+
+
+def changelog_anchor(tag: str, changelog_path: Path = CHANGELOG_PATH) -> str:
+    """The anchor of the changelog section for ``tag``.
+
+    Sphinx generates section ids by lowercasing the title and replacing each
+    run of non-alphanumeric characters with a dash.
+
+    >>> changelog_anchor("314.0.3")
+    'version-314-0-3'
+    >>> changelog_anchor("0.29.4")
+    'version-0-29-4'
+
+    If there is no section for the tag, link to the top of the page:
+
+    >>> changelog_anchor("999.0.0")
+    'change-log'
+    """
+    title = f"Version {tag}"
+    if not has_changelog_section(title, changelog_path):
+        return CHANGELOG_TOP_ANCHOR
+    return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+
+
+def has_changelog_section(title: str, changelog_path: Path = CHANGELOG_PATH) -> bool:
+    if not changelog_path.exists():
+        return False
+    pattern = re.compile(rf"^##\s+{re.escape(title)}\s*$", re.MULTILINE)
+    return pattern.search(changelog_path.read_text()) is not None
+
+
+def release_body(tag: str, changelog_path: Path = CHANGELOG_PATH) -> str:
+    """The body of the GitHub release.
+
+    >>> release_body("314.0.3")
+    'See changes at https://pyodide.org/en/stable/project/changelog.html#version-314-0-3'
+    >>> release_body("314.0.0a1")
+    'See changes at https://github.com/pyodide/pyodide/blob/314.0.0a1/docs/project/changelog.md#unreleased'
+    """
+    if is_prerelease(tag):
+        return f"See changes at {CHANGELOG_PRERELEASE_URL.format(tag=tag)}"
+    anchor = changelog_anchor(tag, changelog_path)
+    return f"See changes at {CHANGELOG_URL}#{anchor}"
+
+
+def is_prerelease(tag: str) -> bool:
+    return "a" in tag
+
+
+def ghr_args(
+    tag: str,
+    dist_dir: Path,
+    token: str,
+    owner: str,
+    repo: str,
+    commit: str,
+    ghr_bin: str,
+    changelog_path: Path = CHANGELOG_PATH,
+) -> list[str]:
+    """Build the ghr command line.
+
+    Options have to come first, the last two arguments have to be the tag and
+    the directory with the release assets.
+    """
+    args = [
+        ghr_bin,
+        "-t",
+        token,
+        "-u",
+        owner,
+        "-r",
+        repo,
+        "-c",
+        commit,
+        "-b",
+        release_body(tag, changelog_path),
+        # TODO: Should we get rid of -delete?
+        "-delete",
+    ]
+    if is_prerelease(tag):
+        args.append("-prerelease")
+    args += [tag, str(dist_dir)]
+    return args
+
+
+def redact(args: list[str], token: str) -> str:
+    return " ".join("$GITHUB_TOKEN" if arg == token else arg for arg in args)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dist_dir", type=Path, help="Directory with the release assets to upload"
+    )
+    parser.add_argument("--tag", required=True, help="Tag to release")
+    parser.add_argument("--commit", required=True, help="Commit to release")
+    parser.add_argument("--owner", required=True, help="GitHub owner of the repository")
+    parser.add_argument("--repo", required=True, help="GitHub repository name")
+    parser.add_argument("--ghr-bin", default="ghr", help="Path to the ghr binary")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the ghr command instead of running it",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token and not args.dry_run:
+        sys.exit("GITHUB_TOKEN is not set")
+
+    cmd = ghr_args(
+        tag=args.tag,
+        dist_dir=args.dist_dir,
+        token=token,
+        owner=args.owner,
+        repo=args.repo,
+        commit=args.commit,
+        ghr_bin=args.ghr_bin,
+    )
+    print(redact(cmd, token))
+    if args.dry_run:
+        return
+    sys.exit(subprocess.run(cmd, check=False).returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/test_make_ghr_release.py
+++ b/tools/tests/test_make_ghr_release.py
@@ -1,0 +1,122 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).parents[1]))
+from make_ghr_release import (
+    changelog_anchor,
+    ghr_args,
+    is_prerelease,
+    redact,
+    release_body,
+)
+
+CHANGELOG = """\
+# Change Log
+
+## Version 314.0.3
+
+_August 4, 2026_
+
+- Something changed
+
+## Version 0.29.4
+
+- Something else changed
+"""
+
+
+@pytest.fixture
+def changelog_path(tmp_path):
+    path = tmp_path / "changelog.md"
+    path.write_text(CHANGELOG)
+    return path
+
+
+@pytest.mark.parametrize(
+    "tag, anchor",
+    [
+        ("314.0.3", "version-314-0-3"),
+        ("0.29.4", "version-0-29-4"),
+        ("314.0.4", "change-log"),
+    ],
+)
+def test_changelog_anchor(changelog_path, tag, anchor):
+    assert changelog_anchor(tag, changelog_path) == anchor
+
+
+def test_changelog_anchor_no_changelog(tmp_path):
+    assert changelog_anchor("314.0.3", tmp_path / "nope.md") == "change-log"
+
+
+def test_release_body(changelog_path):
+    assert release_body("314.0.3", changelog_path) == (
+        "See changes at "
+        "https://pyodide.org/en/stable/project/changelog.html#version-314-0-3"
+    )
+
+
+def test_release_body_prerelease(changelog_path):
+    # Alphas aren't in the published docs, link to the repo at the tag
+    assert release_body("314.0.0a1", changelog_path) == (
+        "See changes at "
+        "https://github.com/pyodide/pyodide/blob/314.0.0a1/docs/project/changelog.md#unreleased"
+    )
+
+
+def test_ghr_args(changelog_path):
+    args = ghr_args(
+        tag="314.0.3",
+        dist_dir=Path("dist"),
+        token="secret",
+        owner="pyodide",
+        repo="pyodide",
+        commit="abc123",
+        ghr_bin="/tmp/ghr-bin",
+        changelog_path=changelog_path,
+    )
+    assert args == [
+        "/tmp/ghr-bin",
+        "-t",
+        "secret",
+        "-u",
+        "pyodide",
+        "-r",
+        "pyodide",
+        "-c",
+        "abc123",
+        "-b",
+        "See changes at "
+        "https://pyodide.org/en/stable/project/changelog.html#version-314-0-3",
+        "-delete",
+        "314.0.3",
+        "dist",
+    ]
+
+
+def test_ghr_args_prerelease(changelog_path):
+    args = ghr_args(
+        tag="314.0.0a1",
+        dist_dir=Path("dist"),
+        token="secret",
+        owner="pyodide",
+        repo="pyodide",
+        commit="abc123",
+        ghr_bin="/tmp/ghr-bin",
+        changelog_path=changelog_path,
+    )
+    assert args[-3:] == ["-prerelease", "314.0.0a1", "dist"]
+    assert args[args.index("-b") + 1] == (
+        "See changes at "
+        "https://github.com/pyodide/pyodide/blob/314.0.0a1/docs/project/changelog.md#unreleased"
+    )
+
+
+def test_redact():
+    assert redact(["ghr", "-t", "secret", "0.29.4"], "secret") == "ghr -t $GITHUB_TOKEN 0.29.4"
+
+
+def test_changelog_anchor_current_changelog():
+    # The real changelog should have a section for a released version
+    assert changelog_anchor("314.0.3") == "version-314-0-3"

--- a/tools/tests/test_make_ghr_release.py
+++ b/tools/tests/test_make_ghr_release.py
@@ -7,7 +7,6 @@ sys.path.append(str(Path(__file__).parents[1]))
 from make_ghr_release import (
     changelog_anchor,
     ghr_args,
-    is_prerelease,
     redact,
     release_body,
 )
@@ -114,7 +113,10 @@ def test_ghr_args_prerelease(changelog_path):
 
 
 def test_redact():
-    assert redact(["ghr", "-t", "secret", "0.29.4"], "secret") == "ghr -t $GITHUB_TOKEN 0.29.4"
+    assert (
+        redact(["ghr", "-t", "secret", "0.29.4"], "secret")
+        == "ghr -t $GITHUB_TOKEN 0.29.4"
+    )
 
 
 def test_changelog_anchor_current_changelog():


### PR DESCRIPTION
<!-- Thank you for contributing to Pyodide! All improvements are welcome,
     so don't be afraid to make a PR. -->

### Description

I mentioned this in discord earlier and got to open a PR (or issue): a direct link to the changelog, so seeing the release in the github feed makes it easier to learn about changes.

Note, I am not familiar with your ci, so this is what I found might be it. I looked up the [options for ghr](https://github.com/tcnksm/ghr#options) to make the addition.

This was not tested. I did not change the dev release job or markdown format as hyperlink.

Feel free to close, make changes to or ignore. I can also file this as an issue if you prefer.


### Checklist

- [x] Add / update tests
