### PR TITLE
Raise a clear error when loadPackage is given a requirement specifier

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -15,6 +15,12 @@ myst:
 
 # Change Log
 
+## Unreleased
+
+- {{ Fix }} Fixed `loadPackage()` reporting `No known package with name` when it
+  is given a requirement specifier such as `numpy>=1.0`. It now points at
+  `micropip.install()`, which does accept them. See {issue}`5135`. {pr}`6432`
+
 ## Version 314.0.5
 
 _August 15, 2026_

--- a/src/js/load-package.ts
+++ b/src/js/load-package.ts
@@ -14,6 +14,7 @@ import { createResolvable } from "./common/resolveable";
 import { createLock } from "./common/lock";
 import {
   canonicalizePackageName,
+  isValidPackageName,
   uriToPackageData,
   base16ToBase64,
 } from "./packaging-utils";
@@ -340,6 +341,13 @@ export class PackageManager {
     name: string,
     toLoad: Map<string, PackageLoadMetadata>,
   ) {
+    if (!isValidPackageName(name)) {
+      throw new Error(
+        `'${name}' is not a valid package name or URL. loadPackage() takes an ` +
+          `exact package name or a wheel URL, and micropip.install() handles ` +
+          `requirement specifiers such as version constraints or extras.`,
+      );
+    }
     const normalizedName = canonicalizePackageName(name);
     if (toLoad.has(normalizedName)) {
       return;

--- a/src/js/packaging-utils.ts
+++ b/src/js/packaging-utils.ts
@@ -15,6 +15,19 @@ export function canonicalizePackageName(name: string): string {
   return name.replace(canonicalizeNameRegex, "-").toLowerCase();
 }
 
+// Regexp for a bare package name, per the PEP 503 name format
+const packageNameRegex = /^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+
+/**
+ * Check whether a string is a bare package name, as opposed to a requirement specifier.
+ * @param name The string to check.
+ * @returns Whether the string is a valid bare package name.
+ * @private
+ */
+export function isValidPackageName(name: string): boolean {
+  return packageNameRegex.test(name);
+}
+
 type ParsedPackageData = {
   name: string;
   version: string;

--- a/src/js/test/unit/package-manager.test.ts
+++ b/src/js/test/unit/package-manager.test.ts
@@ -223,3 +223,13 @@ describe("calculateInstallBaseUrl", () => {
     assert.equal(result, "https://user:pass@cdn.example.com/pyodide/");
   });
 });
+
+describe("loadPackage", () => {
+  it("Should reject a requirement specifier with a clear error", async () => {
+    const pm = new PackageManager(genMockAPI(), genMockModule());
+    await assert.rejects(
+      () => pm.loadPackage(["jsonpointer==3.0.0"]),
+      /micropip\.install\(\) handles requirement specifiers/,
+    );
+  });
+});

--- a/src/js/test/unit/packaging-utils.test.ts
+++ b/src/js/test/unit/packaging-utils.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   canonicalizePackageName,
+  isValidPackageName,
   uriToPackageData,
 } from "../../packaging-utils";
 
@@ -17,6 +18,23 @@ describe("canonicalizePackageName", () => {
       "pytest-benchmark",
     );
     assert.equal(canonicalizePackageName("a_b-c.d"), "a-b-c-d");
+  });
+});
+
+describe("isValidPackageName", () => {
+  it("should accept bare package names", () => {
+    assert.equal(isValidPackageName("jsonpointer"), true);
+    assert.equal(isValidPackageName("ruamel.yaml"), true);
+    assert.equal(isValidPackageName("pytest-pyodide"), true);
+    assert.equal(isValidPackageName("a_b-c.d"), true);
+  });
+  it("should reject requirement specifiers and malformed names", () => {
+    assert.equal(isValidPackageName("jsonpointer==3.0.0"), false);
+    assert.equal(isValidPackageName("numpy>=1.0"), false);
+    assert.equal(isValidPackageName("requests[security]"), false);
+    assert.equal(isValidPackageName("foo bar"), false);
+    assert.equal(isValidPackageName("_foo"), false);
+    assert.equal(isValidPackageName("foo."), false);
   });
 });
 

--- a/src/tests/test_package_loading.py
+++ b/src/tests/test_package_loading.py
@@ -112,12 +112,12 @@ def test_uri_mismatch(selenium_standalone_refresh):
 def test_invalid_package_name(selenium):
     with pytest.raises(
         selenium.JavascriptException,
-        match=r"No known package with name 'wrong name\+\$'",
+        match=r"'wrong name\+\$' is not a valid package name or URL",
     ):
         selenium.load_package("wrong name+$")
     with pytest.raises(
         selenium.JavascriptException,
-        match="No known package with name 'tcp://some_url'",
+        match="'tcp://some_url' is not a valid package name or URL",
     ):
         selenium.load_package("tcp://some_url")
 


### PR DESCRIPTION
### Description

Refs #5135.

`loadPackage(["jsonpointer==3.0.0"])` fails with `No known package with name 'jsonpointer==3.0.0'`. That reads as if the package were missing. It is in the lockfile, and only the pinned specifier stops it resolving. The case comes up with `micropip.freeze()` output, where pinned names get handed straight to `loadPackage`.

`addPackageToLoad` now rejects anything not shaped like a PEP 503 name, which is the starting point agreed in the issue. The message points at `micropip.install()`, since that does accept the pinned form the user typed.

I kept the dot that the suggested `[a-zA-Z0-9_-]` leaves out. Without it `ruamel.yaml`, `bilby.cython` and `bilby.cython-tests` stop loading, and `demes` depends on `ruamel.yaml`. Wheel URLs never reach the check, because `uriToPackageData` handles them earlier.

Pinned specifiers still do not resolve to a version, so this is Refs and not Fixes.

### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry
- [x] Add / update tests
