### PR TITLE
Fix stack switching + tracing/profiling and event loop handling

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -21,6 +21,14 @@ myst:
   stack switching caused by {pr}`6421`.
   {pr}`6435`
 
+- {{ Fix }} `sys.settrace()` and `sys.setprofile()` callbacks are now correctly
+  handled when stack switching.
+  {pr}`6435`
+
+- {{ Fix }} {py:func}`asyncio.get_running_loop` no longer reports a loop that is
+  not actually running from inside a function called with stack switching
+  enabled. {pr}`6435`
+
 - {{ Fix }} Fixed `loadPackage()` reporting `No known package with name` when it
   is given a requirement specifier such as `numpy>=1.0`. It now points at
   `micropip.install()`, which does accept them. See {issue}`5135`. {pr}`6432`

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -140,8 +140,8 @@ enter_promising_task(void)
   Py_tracefunc profilefunc = caller_tstate->c_profilefunc;
   DECLARE_PY_OBJECT(profileobj);
   profileobj = Py_XNewRef(caller_tstate->c_profileobj);
-  // pystate_threadstate_new copies the event loop over because doing so requires
-  // internal headers.
+  // pystate_threadstate_new copies the event loop over because doing so
+  // requires internal headers.
   PyThreadState* tstate = pystate_threadstate_new(caller_tstate);
   FAIL_IF_NULL(tstate);
 

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -36,10 +36,10 @@ int pystate_keepalive;
 
 // Defined in pystate_pycore.c since they require internal headers.
 PyThreadState*
-pystate_tstate_new(PyThreadState* from);
+pystate_threadstate_new(PyThreadState* from);
 
 PyThreadState*
-pystate_tstate_swap(PyThreadState* new_tstate);
+pystate_threadstate_swap(PyThreadState* new_tstate);
 
 /**
  * The main thread state that the promising task took over from. We'll reinstall
@@ -140,17 +140,17 @@ enter_promising_task(void)
   Py_tracefunc profilefunc = caller_tstate->c_profilefunc;
   DECLARE_PY_OBJECT(profileobj);
   profileobj = Py_XNewRef(caller_tstate->c_profileobj);
-  // pystate_tstate_new copies the event loop over because doing so requires
+  // pystate_threadstate_new copies the event loop over because doing so requires
   // internal headers.
-  PyThreadState* tstate = pystate_tstate_new(caller_tstate);
+  PyThreadState* tstate = pystate_threadstate_new(caller_tstate);
   FAIL_IF_NULL(tstate);
 
   // 2. Swap in task thread state
-  handback_tstate = pystate_tstate_swap(tstate);
+  handback_tstate = pystate_threadstate_swap(tstate);
   ON_FAIL({
     // Restore thread state on failure
     PyErr_Clear();
-    delete_tstate(pystate_tstate_swap(handback_tstate));
+    delete_tstate(pystate_threadstate_swap(handback_tstate));
     handback_tstate = NULL;
     PyErr_SetString(PyExc_SystemError,
                     "Unexpected error when entering a promising task");
@@ -192,7 +192,7 @@ enter_promising_task(void)
 void
 exit_promising_task(void)
 {
-  PyThreadState* mine = pystate_tstate_swap(handback_tstate);
+  PyThreadState* mine = pystate_threadstate_swap(handback_tstate);
   handback_tstate = NULL;
   delete_tstate(mine);
 }
@@ -211,7 +211,7 @@ captureThreadState(void)
                     "to. This is a bug in Pyodide.");
     return NULL;
   }
-  PyThreadState* mine = pystate_tstate_swap(handback_tstate);
+  PyThreadState* mine = pystate_threadstate_swap(handback_tstate);
   handback_tstate = NULL;
   return mine;
 }
@@ -220,5 +220,5 @@ EMSCRIPTEN_KEEPALIVE void
 restoreThreadState(PyThreadState* state)
 {
   assert(handback_tstate == NULL);
-  handback_tstate = pystate_tstate_swap(state);
+  handback_tstate = pystate_threadstate_swap(state);
 }

--- a/src/core/stack_switching/pystate.c
+++ b/src/core/stack_switching/pystate.c
@@ -1,9 +1,5 @@
-#include "Python.h"
-#include "emscripten.h"
-#include "error_handling.h"
-#include "python_unexposed.h"
-
-// This file manages the Python stack / thread state when stack switching.
+// Note: This file manages the Python stack / thread state when stack switching.
+// It needs to be audited on every Python update.
 //
 // captureThreadState / restoreThreadState are called from JS, in saveState and
 // restoreState in suspenders.c. enter_promising_task / exit_promising_task are
@@ -13,23 +9,37 @@
 // We store the main thread state when we swap it out to enter a promising task
 // and we restore it when the promising task suspends or exits.
 //
-// The logic here is inspired by:
-// https://github.com/python-greenlet/greenlet/blob/master/src/greenlet/greenlet_greenlet.hpp
+// Because each task has a thread state of its own, parts of the threadstate
+// that should be shared between tasks have to be copied by hand.
 //
-// When updating the major Python version it will be necessary to look at that
-// file.
+// The logic is inspired by greenlet, but greenlet makes the opposite choice: it
+// keeps one thread state per thread and saves and restores the fields that
+// should be private to the task. See
+// https://github.com/python-greenlet/greenlet/blob/master/src/greenlet/TPythonState.cpp
+//
+// TODO: Perhaps aligning with greenlet could reduce the amount of effort to
+// maintain this?
+//
+// Whenever updating the Python version, look at the new fields added to
+// PyThreadState and classify them as to whether they should be per-task or
+// per-thread (i.e., global since we have only one thread). Whenever possible,
+// we can see what Greenlet does and copy that.
 //
 // See also https://github.com/python/cpython/pull/32303 which would move more
 // of this logic into upstream CPython
 
+#include "Python.h"
+#include "emscripten.h"
+#include "error_handling.h"
+
 int pystate_keepalive;
 
-// Defined in pystate_pycore.c since it requires an internal header.
+// Defined in pystate_pycore.c since they require internal headers.
 PyThreadState*
-pystate_threadstate_swap(PyThreadState* new_tstate);
+pystate_tstate_new(PyThreadState* from);
 
-_Py_IDENTIFIER(get_event_loop);
-_Py_IDENTIFIER(_set_running_loop);
+PyThreadState*
+pystate_tstate_swap(PyThreadState* new_tstate);
 
 /**
  * The main thread state that the promising task took over from. We'll reinstall
@@ -67,6 +77,11 @@ delete_tstate(PyThreadState* tstate)
  * - the thread local dict
  * - the running event loop
  * - the async generator hooks
+ * - the trace and profile functions
+ *
+ * All of these live on the thread state but are shared between all tasks. This
+ * list has to be rechecked against the PyThreadState struct every time we
+ * update Python.
  */
 int
 enter_promising_task(void)
@@ -83,15 +98,6 @@ enter_promising_task(void)
 
   // 1. Collect everything the task inherits, while we are still running on the
   //    caller's thread state.
-  DECLARE_PY_OBJECT(asyncio_module);
-  asyncio_module = PyImport_ImportModule("asyncio");
-  FAIL_IF_NULL(asyncio_module);
-  DECLARE_PY_OBJECT(loop);
-  loop = _PyObject_CallMethodIdNoArgs(asyncio_module, &PyId_get_event_loop);
-  if (loop == NULL) {
-    // There is no event loop to propagate.
-    PyErr_Clear();
-  }
   DECLARE_PY_OBJECT(context);
   context = PyContext_CopyCurrent();
   FAIL_IF_NULL(context);
@@ -125,15 +131,26 @@ enter_promising_task(void)
   tlocal_key = Py_XNewRef(caller_tstate->threading_local_key);
   DECLARE_PY_OBJECT(tlocal_sentinel);
   tlocal_sentinel = Py_XNewRef(caller_tstate->threading_local_sentinel);
-  PyThreadState* tstate = PyThreadState_New(PyInterpreterState_Get());
+  // sys.settrace() and sys.setprofile() also record their state on the thread
+  // state. We read these last since everything above can run Python, which
+  // could in theory call sys.settrace().
+  Py_tracefunc tracefunc = caller_tstate->c_tracefunc;
+  DECLARE_PY_OBJECT(traceobj);
+  traceobj = Py_XNewRef(caller_tstate->c_traceobj);
+  Py_tracefunc profilefunc = caller_tstate->c_profilefunc;
+  DECLARE_PY_OBJECT(profileobj);
+  profileobj = Py_XNewRef(caller_tstate->c_profileobj);
+  // pystate_tstate_new copies the event loop over because doing so requires
+  // internal headers.
+  PyThreadState* tstate = pystate_tstate_new(caller_tstate);
   FAIL_IF_NULL(tstate);
 
   // 2. Swap in task thread state
-  handback_tstate = pystate_threadstate_swap(tstate);
+  handback_tstate = pystate_tstate_swap(tstate);
   ON_FAIL({
     // Restore thread state on failure
     PyErr_Clear();
-    delete_tstate(pystate_threadstate_swap(handback_tstate));
+    delete_tstate(pystate_tstate_swap(handback_tstate));
     handback_tstate = NULL;
     PyErr_SetString(PyExc_SystemError,
                     "Unexpected error when entering a promising task");
@@ -154,11 +171,14 @@ enter_promising_task(void)
   tlocal_key = NULL;
   Py_XSETREF(tstate->threading_local_sentinel, tlocal_sentinel);
   tlocal_sentinel = NULL;
-  if (loop != NULL) {
-    DECLARE_PY_OBJECT(res);
-    res = _PyObject_CallMethodIdOneArg(
-      asyncio_module, &PyId__set_running_loop, loop);
-    FAIL_IF_NULL(res);
+  // These have to be installed with the task's thread state current, so they
+  // come last. They return void and report failures through
+  // PyErr_FormatUnraisable().
+  if (profilefunc != NULL) {
+    PyEval_SetProfile(profilefunc, profileobj);
+  }
+  if (tracefunc != NULL) {
+    PyEval_SetTrace(tracefunc, traceobj);
   }
   return 0;
 }
@@ -172,7 +192,7 @@ enter_promising_task(void)
 void
 exit_promising_task(void)
 {
-  PyThreadState* mine = pystate_threadstate_swap(handback_tstate);
+  PyThreadState* mine = pystate_tstate_swap(handback_tstate);
   handback_tstate = NULL;
   delete_tstate(mine);
 }
@@ -191,7 +211,7 @@ captureThreadState(void)
                     "to. This is a bug in Pyodide.");
     return NULL;
   }
-  PyThreadState* mine = pystate_threadstate_swap(handback_tstate);
+  PyThreadState* mine = pystate_tstate_swap(handback_tstate);
   handback_tstate = NULL;
   return mine;
 }
@@ -199,5 +219,6 @@ captureThreadState(void)
 EMSCRIPTEN_KEEPALIVE void
 restoreThreadState(PyThreadState* state)
 {
-  handback_tstate = pystate_threadstate_swap(state);
+  assert(handback_tstate == NULL);
+  handback_tstate = pystate_tstate_swap(state);
 }

--- a/src/core/stack_switching/pystate_pycore.c
+++ b/src/core/stack_switching/pystate_pycore.c
@@ -1,14 +1,73 @@
+// Note: This file manages the Python stack / thread state when stack switching.
+// It needs to be audited on every Python update.
+//
+// Separated into its own file because it touches internal headers.
+//
+// This file exposes two functions: pystate_tstate_new(), which builds the
+// thread state for a new task, and pystate_tstate_swap(), which fixes up the
+// runtime when one thread state takes over from another.
+//
+// Some things to check on Python version update:
+// - The eval_breaker bit list in pycore_ceval.h. Each new bit needs to be
+//   classified as interpreter-wide or per thread state.
+// - That take_gil() still recomputes _PY_CALLS_TO_DO_BIT and refreshes the
+//   instrumentation version on attach.
+
 // All internal headers require Py_BUILD_CORE_MODULE to be defined.
 #define Py_BUILD_CORE_MODULE 1
 
 #include "Python.h"
 #include "internal/pycore_ceval.h"
 #include "internal/pycore_runtime.h"
+#include "internal/pycore_tstate.h"
 
+/**
+ * asyncio records the loop it is running and the task whose step is currently
+ * executing on the thread state, so a task with a thread state of its own has
+ * to inherit both from its caller.
+ *
+ * The running task is NULL because callPromising() yields to the event loop
+ * before it enters Python.
+ */
+static void
+inherit_asyncio_state(PyThreadState* from, PyThreadState* to)
+{
+  _PyThreadStateImpl* from_impl = (_PyThreadStateImpl*)from;
+  _PyThreadStateImpl* to_impl = (_PyThreadStateImpl*)to;
+  assert(to_impl->asyncio_running_loop == NULL);
+  assert(to_impl->asyncio_running_task == NULL);
+  // Double check that running_task is NULL.
+  assert(from_impl->asyncio_running_task == NULL);
+  to_impl->asyncio_running_loop = Py_XNewRef(from_impl->asyncio_running_loop);
+}
+
+/**
+ * Build the thread state for a new task, inheriting from `from` the per-thread
+ * state that can only be reached through internal headers. The rest of what a
+ * task inherits is handled by enter_promising_task().
+ */
+PyThreadState*
+pystate_tstate_new(PyThreadState* from)
+{
+  PyThreadState* tstate = PyThreadState_New(from->interp);
+  if (tstate == NULL) {
+    return NULL;
+  }
+  inherit_asyncio_state(from, tstate);
+  return tstate;
+}
+
+#define TRANSFERABLE_EVAL_BREAKER_BITS                                         \
+  ((uintptr_t)(_PY_SIGNALS_PENDING_BIT | _PY_GC_SCHEDULED_BIT))
+
+/**
+ * Move the eval_breaker bits that mean "the interpreter has work to do" as
+ * opposed to "this particular thread state has work to do".
+ */
 static void
 transfer_eval_breaker(PyThreadState* from, PyThreadState* to)
 {
-  uintptr_t bits = from->eval_breaker & _PY_SIGNALS_PENDING_BIT;
+  uintptr_t bits = from->eval_breaker & TRANSFERABLE_EVAL_BREAKER_BITS;
   if (bits == 0) {
     return;
   }
@@ -17,7 +76,7 @@ transfer_eval_breaker(PyThreadState* from, PyThreadState* to)
 }
 
 PyThreadState*
-pystate_threadstate_swap(PyThreadState* new_tstate)
+pystate_tstate_swap(PyThreadState* new_tstate)
 {
   PyThreadState* orig_tstate = PyThreadState_Swap(new_tstate);
 
@@ -28,6 +87,9 @@ pystate_threadstate_swap(PyThreadState* new_tstate)
   // always set the current tstate as the main tstate and copy the eval_breaker
   // flags.
   _PyRuntime.main_tstate = new_tstate;
-  transfer_eval_breaker(orig_tstate, new_tstate);
+
+  if (orig_tstate != NULL) {
+    transfer_eval_breaker(orig_tstate, new_tstate);
+  }
   return orig_tstate;
 }

--- a/src/core/stack_switching/pystate_pycore.c
+++ b/src/core/stack_switching/pystate_pycore.c
@@ -3,8 +3,8 @@
 //
 // Separated into its own file because it touches internal headers.
 //
-// This file exposes two functions: pystate_tstate_new(), which builds the
-// thread state for a new task, and pystate_tstate_swap(), which fixes up the
+// This file exposes two functions: pystate_threadstate_new(), which builds the
+// thread state for a new task, and pystate_threadstate_swap(), which fixes up the
 // runtime when one thread state takes over from another.
 //
 // Some things to check on Python version update:
@@ -47,7 +47,7 @@ inherit_asyncio_state(PyThreadState* from, PyThreadState* to)
  * task inherits is handled by enter_promising_task().
  */
 PyThreadState*
-pystate_tstate_new(PyThreadState* from)
+pystate_threadstate_new(PyThreadState* from)
 {
   PyThreadState* tstate = PyThreadState_New(from->interp);
   if (tstate == NULL) {
@@ -76,7 +76,7 @@ transfer_eval_breaker(PyThreadState* from, PyThreadState* to)
 }
 
 PyThreadState*
-pystate_tstate_swap(PyThreadState* new_tstate)
+pystate_threadstate_swap(PyThreadState* new_tstate)
 {
   PyThreadState* orig_tstate = PyThreadState_Swap(new_tstate);
 

--- a/src/core/stack_switching/pystate_pycore.c
+++ b/src/core/stack_switching/pystate_pycore.c
@@ -4,8 +4,8 @@
 // Separated into its own file because it touches internal headers.
 //
 // This file exposes two functions: pystate_threadstate_new(), which builds the
-// thread state for a new task, and pystate_threadstate_swap(), which fixes up the
-// runtime when one thread state takes over from another.
+// thread state for a new task, and pystate_threadstate_swap(), which fixes up
+// the runtime when one thread state takes over from another.
 //
 // Some things to check on Python version update:
 // - The eval_breaker bit list in pycore_ceval.h. Each new bit needs to be

--- a/src/core/stack_switching/pystate_pycore.c
+++ b/src/core/stack_switching/pystate_pycore.c
@@ -64,7 +64,8 @@ pystate_threadstate_new(PyThreadState* from)
 static void
 transfer_eval_breaker(PyThreadState* from, PyThreadState* to)
 {
-  uintptr_t bits = from->eval_breaker & (_PY_SIGNALS_PENDING_BIT | _PY_GC_SCHEDULED_BIT);
+  uintptr_t bits =
+    from->eval_breaker & (_PY_SIGNALS_PENDING_BIT | _PY_GC_SCHEDULED_BIT);
   if (bits == 0) {
     return;
   }

--- a/src/core/stack_switching/pystate_pycore.c
+++ b/src/core/stack_switching/pystate_pycore.c
@@ -57,9 +57,6 @@ pystate_threadstate_new(PyThreadState* from)
   return tstate;
 }
 
-#define TRANSFERABLE_EVAL_BREAKER_BITS                                         \
-  ((uintptr_t)(_PY_SIGNALS_PENDING_BIT | _PY_GC_SCHEDULED_BIT))
-
 /**
  * Move the eval_breaker bits that mean "the interpreter has work to do" as
  * opposed to "this particular thread state has work to do".
@@ -67,7 +64,7 @@ pystate_threadstate_new(PyThreadState* from)
 static void
 transfer_eval_breaker(PyThreadState* from, PyThreadState* to)
 {
-  uintptr_t bits = from->eval_breaker & TRANSFERABLE_EVAL_BREAKER_BITS;
+  uintptr_t bits = from->eval_breaker & (_PY_SIGNALS_PENDING_BIT | _PY_GC_SCHEDULED_BIT);
   if (bits == 0) {
     return;
   }
@@ -87,9 +84,6 @@ pystate_threadstate_swap(PyThreadState* new_tstate)
   // always set the current tstate as the main tstate and copy the eval_breaker
   // flags.
   _PyRuntime.main_tstate = new_tstate;
-
-  if (orig_tstate != NULL) {
-    transfer_eval_breaker(orig_tstate, new_tstate);
-  }
+  transfer_eval_breaker(orig_tstate, new_tstate);
   return orig_tstate;
 }

--- a/src/tests/test_stack_switching.py
+++ b/src/tests/test_stack_switching.py
@@ -1127,6 +1127,63 @@ def test_asyncio_running_loop_in_task(selenium):
 
 @requires_jspi
 @pytest.mark.requires_dynamic_linking
+def test_task_does_not_invent_a_running_loop(selenium):
+    """A task inherits the loop that is really running, not get_event_loop().
+
+    The running loop is recorded on the thread state, so a task has to inherit
+    it from its caller. We used to fetch it with asyncio.get_event_loop(), which
+    falls back to the thread's *current* loop when nothing is running, and then
+    registered whatever came back as the running loop on the task. That made
+    asyncio.get_running_loop() incorrectly report a loop that was not running.
+    """
+    result = selenium.run_js(
+        """
+        pyodide.runPython(`
+            import asyncio
+
+            def report():
+                try:
+                    return type(asyncio.get_running_loop()).__name__
+                except RuntimeError as e:
+                    return f"RuntimeError: {e}"
+        `);
+        const report = pyodide.globals.get("report");
+        try {
+            // WebLoop registers itself as the running loop when it is
+            // constructed. Take it back off, so that there is a current event
+            // loop for get_event_loop() to fall back to but nothing running.
+            const hadRunningLoop = pyodide.runPython(`
+                _saved_loop = asyncio._get_running_loop()
+                asyncio._set_running_loop(None)
+                _saved_loop is not None
+            `);
+            const clearedOnMain = pyodide.runPython("report()");
+            const inTask = await report.callPromising();
+            const fallbackLoop = pyodide.runPython(
+                "type(asyncio.get_event_loop()).__name__"
+            );
+            return { hadRunningLoop, clearedOnMain, inTask, fallbackLoop };
+        } finally {
+            pyodide.runPython(`
+                if "_saved_loop" in globals():
+                    asyncio._set_running_loop(_saved_loop)
+                    del _saved_loop
+            `);
+            report.destroy();
+        }
+        """
+    )
+    # Preconditions: there was a running loop to remove, removing it worked, and
+    # get_event_loop() still has something to fall back to.
+    assert result["hadRunningLoop"]
+    assert result["clearedOnMain"] == "RuntimeError: no running event loop"
+    assert result["fallbackLoop"] == "WebLoop"
+    # The task must report the same thing its caller would, not the fallback.
+    assert result["inTask"] == "RuntimeError: no running event loop"
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
 def test_contextvars_three_interleaved_tasks(selenium):
     """Three tasks, each suspending twice, resumed in an order unrelated to the
     order they suspended in.
@@ -1458,6 +1515,72 @@ def test_task_inherits_asyncgen_hooks(selenium):
         """
     )
     assert seen == ["agen"]
+
+
+@requires_jspi
+@pytest.mark.requires_dynamic_linking
+@pytest.mark.parametrize("hook", ["trace", "profile"])
+def test_task_inherits_trace_and_profile_hooks(selenium, hook):
+    """settrace() and setprofile() callbacks should fire in promising tasks"""
+    result = selenium.run_js(
+        f'const hookName = "{hook}";\n'
+        """
+        pyodide.runPython(`
+            import sys
+            from pyodide.ffi import run_sync
+
+            calls = []
+
+            def hook(frame, event, arg):
+                # Only trace call events
+                if event == "call":
+                    calls.append(frame.f_code.co_name)
+                return None
+
+            def inside_task():
+                return 1
+
+            def after_removal():
+                return 1
+
+            def task(p):
+                # Suspend and resume before doing any work to ensure that the
+                # hook survives a round trip through the event loop
+                run_sync(p)
+                inside_task()
+
+            def install(name):
+                getattr(sys, "set" + name)(hook)
+
+            def remove(name):
+                getattr(sys, "set" + name)(None)
+        `);
+        const task = pyodide.globals.get("task");
+        const install = pyodide.globals.get("install");
+        const remove = pyodide.globals.get("remove");
+        try {
+            install(hookName);
+            const {promise, resolve} = Promise.withResolvers();
+            const done = task.callPromising(promise);
+            await sleep(20);
+            resolve();
+            await done;
+            const sawInsideTask = pyodide.runPython("'inside_task' in calls");
+            remove(hookName);
+            pyodide.runPython("calls.clear()");
+            pyodide.runPython("after_removal()");
+            const sawAfterRemoval = pyodide.runPython("'after_removal' in calls");
+            return { sawInsideTask, sawAfterRemoval };
+        } finally {
+            remove(hookName);
+            task.destroy();
+            install.destroy();
+            remove.destroy();
+        }
+        """
+    )
+    assert result["sawInsideTask"]
+    assert not result["sawAfterRemoval"]
 
 
 @requires_jspi


### PR DESCRIPTION
Fixes two more minor stack switching bugs:
1. tracing/profiling hooks were not shared across tasks
2. if no event loop is active in the main task, it would incorrectly set an inactive event loop as active in other tasks
