### PR TITLE
Rework the union in JsProxy to fix violation of strict aliasing rule

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -151,23 +151,24 @@ struct ObjectMapFields
 
 // clang-format off
 
-// dict and js fields always needs to be in the same place.
-// dict field is part of PyBaseExceptionObject, so it should go up top.
-// The js field has to come after ExceptionFields so we get the memory layout
-// right so we put it at the end
+// dict field needs to be in same position as it is in PyBaseExceptionObject.
 // In between we have a union with the extra fields that are used by just by one
-// of JsBuffer, JsCallable, and JsException
+// of JsBuffer, JsCallable, or JsObjectMap
 
 typedef struct
 {
-  PyObject_HEAD
-  PyObject* dict;
   union {
-    struct BufferFields bf;
-    struct MethodFields mf;
-    struct ExceptionFields ef;
-    struct ObjectMapFields omf;
-  } tf;
+    PyBaseExceptionObject exc;
+    struct {
+      PyObject_HEAD
+      PyObject* dict;
+      union {
+        struct BufferFields bf;
+        struct MethodFields mf;
+        struct ObjectMapFields omf;
+      } tf;
+    };
+  };
   JsRef js;
   PyObject* signature;
   // Cache for the type's _js_type_flags, computed lazily by JsProxy_getflags.
@@ -181,34 +182,9 @@ typedef struct
 
 #define JS_TYPE_FLAGS_UNCACHED (-2)
 
-// Layout of dict and ExceptionFields needs to exactly match the layout of the
-// same-name fields of BaseException. Otherwise bad things will happen. Check it
-// with static asserts!
+// Position of dict needs to match between exception objects and other cases.
 _Static_assert(offsetof(PyBaseExceptionObject, dict) == offsetof(JsProxy, dict),
                "dict layout conflict between JsProxy and PyExc_BaseException");
-
-#define CHECK_EXC_FIELD(field)                                                 \
-  _Static_assert(                                                              \
-    offsetof(PyBaseExceptionObject, field) ==                                  \
-      offsetof(JsProxy, tf) + offsetof(struct ExceptionFields, field),         \
-    "'" #field "' layout conflict between JsProxy and PyExc_BaseException");
-
-CHECK_EXC_FIELD(args);
-CHECK_EXC_FIELD(notes);
-CHECK_EXC_FIELD(traceback);
-CHECK_EXC_FIELD(context);
-CHECK_EXC_FIELD(cause);
-CHECK_EXC_FIELD(suppress_context);
-
-#undef CHEC_EXC_FIELD
-
-#define FIELD_SIZE(type, field) sizeof(((type*)0)->field)
-
-_Static_assert(sizeof(PyBaseExceptionObject) ==
-                 sizeof(PyObject) + FIELD_SIZE(JsProxy, dict) +
-                   sizeof(struct ExceptionFields),
-               "size conflict between JsProxy and PyExc_BaseException");
-#undef FIELD_SIZE
 
 #define JsProxy_REF(x) ((JsProxy*)x)->js
 #define JsProxy_VAL(x) hiwire_get(JsProxy_REF(x))
@@ -219,7 +195,7 @@ _Static_assert(sizeof(PyBaseExceptionObject) ==
 #define JsMethod_THIS(x) JsRef_toVal(JsMethod_THIS_REF(x))
 #define JsMethod_VECTORCALL(x) (((JsProxy*)x)->tf.mf.vectorcall)
 
-#define JsException_ARGS(x) (((JsProxy*)x)->tf.ef.args)
+#define JsException_ARGS(x) (((JsProxy*)x)->exc.args)
 
 #define JsBuffer_FORMAT(x) (((JsProxy*)x)->tf.bf.format)
 #define JsBuffer_BYTE_LENGTH(x) (((JsProxy*)x)->tf.bf.byteLength)


### PR DESCRIPTION
JsProxy was set up so that its prefix had identical memory layout to a `PyBaseExceptionObject` but it was not actually a `PyBaseExceptionObject` and so treating it as one causes type punning between incompatible struct types which is undefined behavior. This changes JsProxy to start with a union with a `PyBaseExceptionObject` branch as a prefix. This makes the cast defined behavior and also simplifies the memory layout checks since now we only have to check that the dict is in the right place.