### PR TITLE
Add Pyodios iOS app to related projects list

### DIFF
--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -39,6 +39,7 @@
   community, and patches to support loading and working with large (remote) datasets.
 - [Cubite](https://cubite.io) is a multi-tenant LMS platform that uses Pyodide for in-browser Python execution in course content via a custom [EditorJS plugin](https://github.com/amirtds/editorjs-code-editor). Read more about [how Cubite uses Pyodide for interactive learning](https://cubite.io/blogs/run-python-in-browser-pyodide-editorjs).
 - [codeplug.org](https://codeplug.org) is an in-browser suite for programming amateur radio transceivers. It leverages [CHIRP](https://chirpmyradio.com/projects/chirp/wiki/Home)'s radio drivers using Pyodide and WebSerial to let the user program radios from anywhere.
+- [Pyodios](https://apps.apple.com/us/app/pyodios/id6762922366) is an iOS application that uses Pyodide to run Python code locally on your iPhone and iPad. For examples of the app, see the [documentation website](https://pyodios.caffeinatedmath.com/).
 
 ## Workarounds for common WASM and browser limitations
 


### PR DESCRIPTION
### Description

Adds a link to [Pyodios](https://pyodios.caffeinatedmath.com) on [App Store](https://apps.apple.com/us/app/pyodios/id6762922366). It uses Pyodide to handle running Python locally on Phone/iPad iOS 26+.