### PR TITLE
Let the npm publish dry run pass on pull requests from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,8 +431,14 @@ jobs:
       - run:
           name: test npm deploy (dry run)
           command: |
-            # Fetch OIDC token to verify it's still valid, even for dry run
-            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            # Fetch OIDC token to verify it's still valid, even for dry run.
+            # CircleCI does not issue OIDC tokens to pull requests from forks, and a
+            # dry run publishes nothing, so those runs go without one.
+            if [ -z "${CIRCLE_PR_NUMBER:-}" ]; then
+              export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            else
+              echo "Pull request from a fork: skipping the OIDC token, the dry run does not need it."
+            fi
             DRY_RUN=1 ./tools/deploy_to_npm.sh
 
   test-d8:

--- a/tools/deploy_to_npm.sh
+++ b/tools/deploy_to_npm.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z "${NPM_ID_TOKEN}" ]]; then
+if [[ -z "${NPM_ID_TOKEN}" && -z "${DRY_RUN}" ]]; then
     echo "Error: NPM_ID_TOKEN is not set. OIDC token is required for npm trusted publishing." >&2
     exit 1
 fi


### PR DESCRIPTION
### Description

The `test-js` job ends with a dry run of `tools/deploy_to_npm.sh` and first fetches an OIDC token to prove trusted publishing still works. CircleCI does not issue OIDC tokens to pull requests from forks (`failed to get oidc token: this project does not allow issuing tokens to forks`), so every fork PR fails that step after its types, unit, node and browser tests have passed; #6448 and #6446 are the two most recent.

This skips the token fetch when `CIRCLE_PR_NUMBER` marks a fork PR and lets the script accept a missing token when `DRY_RUN` is set. A dry run publishes nothing and needs no credential; a real publish still refuses to start without one. Runs on the project's own branches keep fetching the token, so the trusted-publishing check is unchanged there.

Verified: the YAML parses and the script passes `bash -n`; the behaviour itself can only be shown by this PR's own `test-js` run, which comes from a fork.

The change was prepared with AI assistance under my direction; I am responsible for it.

### Checklist

- [x] Add a [CHANGELOG](https://github.com/pyodide/pyodide/blob/main/docs/project/changelog.md) entry (not applicable: CI only)
- [x] Add / update tests (not applicable: the job itself is the test)
- [x] Add new / update outdated documentation (not applicable)
