### PR TITLE
Update packages set to 20260911

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -12,7 +12,7 @@ export RUST_TOOLCHAIN ?= 1.97.1
 export RUSTFLAGS =
 
 # URL to the prebuilt packages
-export PYODIDE_PREBUILT_PACKAGES_BASE=https://github.com/pyodide/pyodide-recipes/releases/download/314-20260815
+export PYODIDE_PREBUILT_PACKAGES_BASE=https://github.com/pyodide/pyodide-recipes/releases/download/314-20260911
 export PYODIDE_PREBUILT_PACKAGES_URL=$(PYODIDE_PREBUILT_PACKAGES_BASE)/packages.tar.gz
 export PYODIDE_PREBUILT_PACKAGES_LOCKFILE=$(PYODIDE_PREBUILT_PACKAGES_BASE)/pyodide-lock.json
 export ENABLE_PREBUILT_PACKAGES ?= 0

--- a/packages/_tests/test_packages_common.py
+++ b/packages/_tests/test_packages_common.py
@@ -26,6 +26,7 @@ XFAIL_PACKAGES: dict[str, str] = {
     "numpy-tests": "test only package",
     "coolprop": "slow",
     "psycopg-c": "the psycopg package should be imported before psycopg_c",
+    "psycopg-binary": "the psycopg package should be imported before psycopg_binary",
 }
 
 LOCKFILE_PATH = PYODIDE_ROOT / "dist" / "pyodide-lock.json"


### PR DESCRIPTION
Added packages:
  - asyncpg (0.31.0)
  - psycopg-binary (3.3.5)

Removed packages:
  - PyMuPDF (1.27.2.2)

Changed packages:
  - psycopg-c: 3.3.4 -> 3.3.5
  - lxml: 6.0.2 -> 6.1.3
  - psycopg: 3.3.4 -> 3.3.5
  - yt: 4.4.0 -> 4.4.2
  - scikit-image: 0.25.2 -> 0.26.0